### PR TITLE
PR1: Website shell and landing page copy -> PolyStore

### DIFF
--- a/nil-website/index.html
+++ b/nil-website/index.html
@@ -10,7 +10,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preload" href="/wasm/nil_core_bg.wasm" as="fetch" type="application/wasm" />
     <link rel="preload" href="/trusted_setup.txt" as="fetch" />
-    <title>NilStore Network</title>
+    <title>PolyStore Network</title>
   </head>
   <body>
     <div id="root"></div>

--- a/nil-website/src/components/BenchmarkSection.tsx
+++ b/nil-website/src/components/BenchmarkSection.tsx
@@ -8,7 +8,7 @@ export const BenchmarkSection = () => {
         <div className="mb-16 text-center">
           <h2 className="text-3xl font-bold mb-4">Performance Benchmarks</h2>
           <p className="text-muted-foreground max-w-2xl mx-auto">
-            We benchmarked our core verification primitives. NilStore is designed to be unsealed: verification is cheap, and incentives come from serving speed (the Performance Market).
+            We benchmarked our core verification primitives. PolyStore is designed to be unsealed: verification is cheap, and incentives come from serving speed (the Performance Market).
           </p>
         </div>
 

--- a/nil-website/src/components/Hero.tsx
+++ b/nil-website/src/components/Hero.tsx
@@ -15,7 +15,7 @@ export const Hero = () => {
               The Future of Decentralized Storage
             </h1>
             <p className="text-xl text-muted-foreground mb-12 max-w-2xl mx-auto">
-              NilStore leverages <strong>KZG Commitments</strong> and a <strong>Performance Market</strong> (no sealing) to deliver verifiable, secure, and low-latency decentralized storage.
+              PolyStore leverages <strong>KZG Commitments</strong> and a <strong>Performance Market</strong> (no sealing) to deliver verifiable, secure, and low-latency decentralized storage.
             </p>
           </motion.div>
 

--- a/nil-website/src/components/Layout.tsx
+++ b/nil-website/src/components/Layout.tsx
@@ -123,18 +123,18 @@ export const Layout = () => {
                   src="/brand/logo-light-36.png"
                   srcSet="/brand/logo-light-36.png 1x, /brand/logo-light-72.png 2x"
                   className="absolute inset-0 w-full h-full object-contain transition-opacity duration-200 opacity-100 dark:opacity-0"
-                  alt="NilStore Logo"
+                  alt="PolyStore Logo"
                 />
                 <img
                   src="/brand/logo-dark-36.png"
                   srcSet="/brand/logo-dark-36.png 1x, /brand/logo-dark-72.png 2x"
                   className="absolute inset-0 w-full h-full object-contain transition-opacity duration-200 opacity-0 dark:opacity-100"
-                  alt="NilStore Logo"
+                  alt="PolyStore Logo"
                 />
               </div>
               <div className="hidden sm:flex items-center leading-none">
                 <div className="text-[1.9rem] font-extrabold tracking-tight">
-                  <span className="text-foreground">Nil</span>
+                  <span className="text-foreground">Poly</span>
                   <span className="text-primary">Store</span>
                 </div>
               </div>
@@ -297,7 +297,7 @@ export const Layout = () => {
               </ul>
             </div>
           </div>
-          <p className="opacity-60">© 2025 NilStore Network. Open Source.</p>
+          <p className="opacity-60">© 2025 PolyStore Network. Open Source.</p>
           {shortCommit ? (
             <p className="mt-2 font-mono-data text-[10px] uppercase tracking-[0.2em] opacity-60">Build {shortCommit}</p>
           ) : null}

--- a/nil-website/src/pages/Home.tsx
+++ b/nil-website/src/pages/Home.tsx
@@ -18,7 +18,7 @@ const audienceTracks = [
     eyebrow: "For Data Users",
     title: "Store a file. Retrieve it back. Verify the full path.",
     description:
-      "Upload data to NilStore testnet, commit it on-chain, and pull it back through the same network. This is the shortest path for users validating storage end to end.",
+      "Upload data to PolyStore testnet, commit it on-chain, and pull it back through the same network. This is the shortest path for users validating storage end to end.",
     bullets: ["Browser-first upload flow", "Wallet-funded testnet path", "Retrieval loop included"],
     cta: { to: "/alpha/storage", label: "Store a File" },
     icon: Database,
@@ -82,25 +82,25 @@ export const Home = () => {
                   <img
                     src="/brand/logo-light-256.png"
                     srcSet="/brand/logo-light-256.png 1x, /brand/logo-light-512.png 2x"
-                    alt="NilStore Logo (Light)"
+                    alt="PolyStore Logo (Light)"
                     className="absolute inset-0 h-full w-full object-contain opacity-100 transition-opacity dark:opacity-0"
                   />
                   <img
                     src="/brand/logo-dark-256.png"
                     srcSet="/brand/logo-dark-256.png 1x, /brand/logo-dark-512.png 2x"
-                    alt="NilStore Logo (Dark)"
+                    alt="PolyStore Logo (Dark)"
                     className="absolute inset-0 h-full w-full object-contain opacity-0 transition-opacity dark:opacity-100"
                   />
                 </div>
                 <div className="text-[2.25rem] font-extrabold tracking-tight sm:text-6xl md:text-7xl leading-none">
-                  <span className="text-foreground">Nil</span>
+                  <span className="text-foreground">Poly</span>
                   <span className="text-primary">Store</span>
                 </div>
               </div>
 
               <div className="mt-8 space-y-5">
                 <h1 className="nil-hero-title">
-                  Store data. Run providers. Join the NilStore testnet.
+                  Store data. Run providers. Join the PolyStore testnet.
                 </h1>
                 <p className="nil-hero-description">
                   Choose the path that matches your role.

--- a/nil-website/src/pages/LogoShowcase.tsx
+++ b/nil-website/src/pages/LogoShowcase.tsx
@@ -16,19 +16,19 @@ export const LogoShowcase = () => {
             <img
               src="/brand/logo-light-256.png"
               className="absolute inset-0 h-full w-full object-contain opacity-100 dark:opacity-0 transition-opacity"
-              alt="NilStore Logo (Light)"
+              alt="PolyStore Logo (Light)"
             />
             <img
               src="/brand/logo-dark-256.png"
               className="absolute inset-0 h-full w-full object-contain opacity-0 dark:opacity-100 transition-opacity"
-              alt="NilStore Logo (Dark)"
+              alt="PolyStore Logo (Dark)"
             />
           </div>
 
           {/* Wordmark */}
           <div className="space-y-3">
             <div className="text-4xl sm:text-5xl font-extrabold tracking-tight">
-              <span className="text-foreground">NIL</span>
+              <span className="text-foreground">POLY</span>
               <span className="text-primary">STORE</span>
             </div>
             <p className="text-[10px] font-bold uppercase tracking-[0.5em] font-mono-data text-muted-foreground">


### PR DESCRIPTION
Closes #2

## Summary
- rename website shell brand text from NilStore to PolyStore
- update homepage and logo showcase copy for the new name
- keep repo links, wallet/network labels, and runtime config for later stacked PRs

## Verification
- cd nil-website && npm run build