### PR TITLE
PR21: Rename PolyStore address surfaces

### DIFF
--- a/docs/onboarding-prompts/storage.md
+++ b/docs/onboarding-prompts/storage.md
@@ -117,7 +117,7 @@ Your job:
    - verify local gateway `/health`; use `/status` only if it exists or if debugging is needed
    - if `POLYSTORE_BURNER_KEYSTORE_PASSWORD` is unset, ask the user for the keystore import password before invoking `scripts/testnet_burner_upload.sh`
    - create a temporary tiny file locally and complete `scripts/testnet_burner_upload.sh <file_path>`
-   - capture wallet address, nil address, keystore path, deal ID, manifest root, file name, file size, create tx hash, and commit tx hash
+   - capture wallet address, PolyStore address (`nil1...` for now), keystore path, deal ID, manifest root, file name, file size, create tx hash, and commit tx hash
 4. Milestone 2, MetaMask Handoff:
    - guide keystore import
    - confirm MetaMask address exactly matches the bootstrap address before moving on

--- a/ops/systemd/README.md
+++ b/ops/systemd/README.md
@@ -33,7 +33,7 @@ sudo systemctl enable --now polystore-gateway-router
 sudo systemctl enable --now polystore-faucet
 ```
 
-### Nilchaind redeploy workflow
+### Polystorechaind Redeploy Workflow
 
 For recurring chain binary updates (build -> backup/install -> restart -> verify), use:
 

--- a/ops/systemd/README.md
+++ b/ops/systemd/README.md
@@ -33,7 +33,7 @@ sudo systemctl enable --now polystore-gateway-router
 sudo systemctl enable --now polystore-faucet
 ```
 
-### Polystorechaind Redeploy Workflow
+### `polystorechaind` Redeploy Workflow
 
 For recurring chain binary updates (build -> backup/install -> restart -> verify), use:
 

--- a/polystore-website/scripts/benchmark_prepare.ts
+++ b/polystore-website/scripts/benchmark_prepare.ts
@@ -447,8 +447,8 @@ for (let i = 0; i < measureRuns; i += 1) {
 
 for (let runIndex = 0; runIndex < splitPolyStoreRuns.length; runIndex += 1) {
   const integratedRoots = integratedRuns[runIndex].records.map((record) => record.mdu_root_hex)
-  const splitNilRoots = splitPolyStoreRuns[runIndex].records.map((record) => record.mdu_root_hex)
-  if (JSON.stringify(integratedRoots) !== JSON.stringify(splitNilRoots)) {
+  const splitPolyStoreRoots = splitPolyStoreRuns[runIndex].records.map((record) => record.mdu_root_hex)
+  if (JSON.stringify(integratedRoots) !== JSON.stringify(splitPolyStoreRoots)) {
     throw new Error(`split polystore_wasm roots diverged on run ${runIndex + 1}`)
   }
   if (kzgResolution.supported) {
@@ -475,8 +475,8 @@ const summary = {
     ? { supported: true, source: kzgResolution.source }
     : { supported: false, reason: kzgResolution.reason },
   variants: {
-    integrated_nil_wasm: summarizeRuns('integrated_nil_wasm', integratedRuns),
-    split_nil_wasm: summarizeRuns('split_nil_wasm', splitPolyStoreRuns),
+    integrated_polystore_wasm: summarizeRuns('integrated_polystore_wasm', integratedRuns),
+    split_polystore_wasm: summarizeRuns('split_polystore_wasm', splitPolyStoreRuns),
     split_kzg_wasm: kzgResolution.supported
       ? summarizeRuns('split_kzg_wasm', splitKzgRuns)
       : null,

--- a/polystore-website/scripts/testnet_burner_wallet.ts
+++ b/polystore-website/scripts/testnet_burner_wallet.ts
@@ -5,7 +5,7 @@ import { resolve } from 'node:path'
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
 import { concat, type Hex, hexToBytes, keccak256 } from 'viem'
 
-import { ethToNil } from '../src/lib/address'
+import { ethToPolystoreAddress } from '../src/lib/address'
 
 type Mode = 'generate' | 'export-keystore'
 
@@ -36,12 +36,12 @@ function normalizePrivateKey(raw: string): Hex {
 function generateWallet() {
   const privateKey = generatePrivateKey()
   const account = privateKeyToAccount(privateKey)
-  const nilAddress = ethToNil(account.address)
+  const polystoreAddress = ethToPolystoreAddress(account.address)
   process.stdout.write(
     JSON.stringify({
       private_key: privateKey,
       address: account.address,
-      polystore_address: nilAddress,
+      polystore_address: polystoreAddress,
     }),
   )
 }
@@ -108,7 +108,7 @@ function exportKeystore() {
   process.stdout.write(
     JSON.stringify({
       address: account.address,
-      polystore_address: ethToNil(account.address),
+      polystore_address: ethToPolystoreAddress(account.address),
       keystore_path: outPath,
     }),
   )

--- a/polystore-website/src/components/Dashboard.tsx
+++ b/polystore-website/src/components/Dashboard.tsx
@@ -88,7 +88,7 @@ export function Dashboard() {
   const {
     address,
     isConnected,
-    nilAddress,
+    polystoreAddress,
     hasFunds,
     isWrongNetwork,
     walletChainId,
@@ -223,8 +223,8 @@ export function Dashboard() {
   }, [refreshWalletNetwork, switchNetwork])
 
   const handleRefreshSummary = async () => {
-    if (!nilAddress) return
-    await Promise.allSettled([fetchDeals(nilAddress), fetchBalances(nilAddress), fetchProviders()])
+    if (!polystoreAddress) return
+    await Promise.allSettled([fetchDeals(polystoreAddress), fetchBalances(polystoreAddress), fetchProviders()])
   }
 
 
@@ -320,7 +320,7 @@ export function Dashboard() {
   const [, setRetrievalParamsError] = useState<string | null>(null)
 
   useEffect(() => {
-    if (!nilAddress) {
+    if (!polystoreAddress) {
       setRetrievalSessions([])
       setRetrievalSessionsError(null)
       setRetrievalSessionsLoading(false)
@@ -334,7 +334,7 @@ export function Dashboard() {
       setRetrievalSessionsLoading(true)
       try {
         const url = `${appConfig.lcdBase}/polystorechain/polystorechain/v1/retrieval-sessions/by-owner/${encodeURIComponent(
-          nilAddress,
+          polystoreAddress,
         )}?pagination.limit=1000`
         const res = await fetch(url)
         if (!res.ok) {
@@ -388,7 +388,7 @@ export function Dashboard() {
         document.removeEventListener('visibilitychange', handleVisibility)
       }
     }
-  }, [nilAddress])
+  }, [polystoreAddress])
 
   useEffect(() => {
     let cancelled = false
@@ -447,8 +447,8 @@ export function Dashboard() {
   }, [])
 
   const ownedDeals = useMemo(
-    () => (nilAddress ? deals.filter((deal) => deal.owner === nilAddress) : deals),
-    [deals, nilAddress],
+    () => (polystoreAddress ? deals.filter((deal) => deal.owner === polystoreAddress) : deals),
+    [deals, polystoreAddress],
   )
   const targetDeal = useMemo(() => {
     if (!targetDealId) return null
@@ -515,12 +515,12 @@ export function Dashboard() {
 
   useEffect(() => {
     if (targetDealId) return
-    if (!nilAddress) return
+    if (!polystoreAddress) return
     if (ownedDeals.length === 0) return
     const newestDeal = ownedDeals[ownedDeals.length - 1]
     if (!newestDeal?.id) return
     setTargetDealId(String(newestDeal.id))
-  }, [nilAddress, ownedDeals, targetDealId])
+  }, [polystoreAddress, ownedDeals, targetDealId])
 
   const mode2Config = useMemo(() => {
     if (placementProfile !== 'custom') return { slots: null as number | null, error: null as string | null }
@@ -600,10 +600,10 @@ export function Dashboard() {
   }, [targetDealId])
 
   useEffect(() => {
-    if (address && nilAddress) {
+    if (address && polystoreAddress) {
       optimisticCidOverridesRef.current = {}
-      fetchDeals(nilAddress)
-      fetchBalances(nilAddress)
+      fetchDeals(polystoreAddress)
+      fetchBalances(polystoreAddress)
       fetchProviders()
     } else {
       optimisticCidOverridesRef.current = {}
@@ -611,7 +611,7 @@ export function Dashboard() {
       setAllDeals([])
       setProviders([])
     }
-  }, [address, nilAddress])
+  }, [address, polystoreAddress])
 
   async function fetchDeals(owner?: string): Promise<Deal[]> {
     setLoading(true)
@@ -1001,9 +1001,9 @@ export function Dashboard() {
       setStatusTone('success')
       setStatusMsg(`Capacity Allocated. Deal ID: ${res.deal_id}. Now verify via content tab.`)
       setShowCreateDeal(false)
-      if (nilAddress) {
-        await refreshDealsAfterCreate(nilAddress, String(res.deal_id))
-        await fetchBalances(nilAddress)
+      if (polystoreAddress) {
+        await refreshDealsAfterCreate(polystoreAddress, String(res.deal_id))
+        await fetchBalances(polystoreAddress)
         // Auto-switch to content tab and pre-fill deal ID
         setTargetDealId(String(res.deal_id))
         setActiveTab('mdu')
@@ -1123,7 +1123,7 @@ export function Dashboard() {
         setAllDeals((prev) =>
           prev.map((d) => (String(d.id) === String(targetDealId) ? { ...d, cid: manifestHex } : d)),
         )
-        if (nilAddress) await refreshDealsAfterContentCommit(nilAddress, targetDealId, manifestHex)
+        if (polystoreAddress) await refreshDealsAfterContentCommit(polystoreAddress, targetDealId, manifestHex)
         recordUpload('success')
         return true
     } catch (e) {
@@ -1183,8 +1183,8 @@ export function Dashboard() {
       prev.map((d) => (String(d.id) === String(dealId) ? { ...d, cid: manifestHex } : d)),
     )
 
-    if (nilAddress) {
-      refreshDealsAfterContentCommit(nilAddress, dealId, manifestHex)
+    if (polystoreAddress) {
+      refreshDealsAfterContentCommit(polystoreAddress, dealId, manifestHex)
     }
     if (fileMeta?.filePath) {
       upsertRecentFile({
@@ -1232,12 +1232,12 @@ export function Dashboard() {
     if (faucetTxStatus === 'confirmed' && faucetTx) {
       setStatusTone('success')
       setStatusMsg(`Faucet tx ${faucetTx} confirmed.`)
-      if (nilAddress) fetchBalances(nilAddress)
+      if (polystoreAddress) fetchBalances(polystoreAddress)
     } else if (faucetTxStatus === 'failed' && faucetTx) {
       setStatusTone('error')
       setStatusMsg(`Faucet tx ${faucetTx} failed.`)
     }
-  }, [faucetTxStatus, faucetTx, nilAddress])
+  }, [faucetTxStatus, faucetTx, polystoreAddress])
 
   if (!isConnected)
     return (
@@ -1725,7 +1725,7 @@ export function Dashboard() {
             ) : targetDeal ? (
               <DealDetail
                 deal={targetDeal}
-                nilAddress={nilAddress}
+                polystoreAddress={polystoreAddress}
                 onFileActivity={recordRecentActivity}
                 topPanel={dealExplorerTopPanel}
                 uploadWorkflowActive={selectedDealUploadActive}

--- a/polystore-website/src/components/DealDetail.tsx
+++ b/polystore-website/src/components/DealDetail.tsx
@@ -187,7 +187,7 @@ async function ensureWasmReady(): Promise<void> {
 
 interface DealDetailProps {
   deal: LcdDeal
-  nilAddress: string
+  polystoreAddress: string
   onFileActivity?: (activity: FileActivity) => void
   topPanel?: ReactNode
   uploadWorkflowActive?: boolean
@@ -973,7 +973,7 @@ function FileRow({
 
 export function DealDetail({
   deal,
-  nilAddress,
+  polystoreAddress,
   onFileActivity,
   topPanel,
   uploadWorkflowActive = false,
@@ -983,7 +983,7 @@ export function DealDetail({
   const serviceHint = parseServiceHint(deal?.service_hint)
   const dealOwner = String(deal.owner || '').trim()
   const fallbackManifestRoot = normalizeManifestRoot(String(deal.cid || ''))
-  const fallbackOwner = dealOwner || String(nilAddress || '').trim()
+  const fallbackOwner = dealOwner || String(polystoreAddress || '').trim()
   const [authoritativeManifestRoot, setAuthoritativeManifestRoot] = useState<string>(fallbackManifestRoot)
   const [authoritativeOwner, setAuthoritativeOwner] = useState<string>(fallbackOwner)
   const [authoritativeDealLoaded, setAuthoritativeDealLoaded] = useState(false)
@@ -1219,7 +1219,7 @@ export function DealDetail({
   const dealProviders = useMemo(() => deal.providers || [], [deal.providers])
   const dealProvidersKey = dealProviders.join(',')
   const primaryProvider = dealProviders[0] || ''
-  const isDealOwner = Boolean(nilAddress && dealOwner === String(nilAddress).trim())
+  const isDealOwner = Boolean(polystoreAddress && dealOwner === String(polystoreAddress).trim())
   const [routeOverride, setRouteOverride] = useState<string>('')
   const [, setRouteModeOverride] = useState<string>('')
   const [cacheSourceOverride, setCacheSourceOverride] = useState<string>('')
@@ -3025,7 +3025,7 @@ export function DealDetail({
                           disabled={!selectedMduRecord || !explorerManifestRoot || loadingMduKzg}
                           onClick={() => {
                             if (!selectedMduRecord || !explorerManifestRoot) return
-                            void fetchMduKzg(explorerManifestRoot, selectedMduRecord.mdu_index, deal.id, nilAddress)
+                            void fetchMduKzg(explorerManifestRoot, selectedMduRecord.mdu_index, deal.id, polystoreAddress)
                           }}
                           className="text-[10px] px-3 py-2 rounded-none border border-border bg-secondary hover:bg-secondary/70 text-foreground transition-colors disabled:opacity-50"
                         >
@@ -3241,7 +3241,7 @@ export function DealDetail({
                                 onClick={() => {
                                   setSelectedMdu(record.mdu_index)
                                   if (explorerManifestRoot) {
-                                    void fetchMduKzg(explorerManifestRoot, record.mdu_index, deal.id, nilAddress)
+                                    void fetchMduKzg(explorerManifestRoot, record.mdu_index, deal.id, polystoreAddress)
                                   }
                                 }}
                                 className="shrink-0 text-[10px] px-2 py-1 rounded-none border border-border bg-secondary hover:bg-secondary/70 text-foreground transition-colors"

--- a/polystore-website/src/components/NavSessionStatus.tsx
+++ b/polystore-website/src/components/NavSessionStatus.tsx
@@ -55,8 +55,8 @@ export function NavSessionStatus({
       <ConnectWallet compact={compact} responsive={responsive} />
       {session.isConnected ? (
         <div className="sr-only" aria-hidden="true">
-          <span data-testid="cosmos-identity">{session.nilAddress}</span>
-          <span data-testid="cosmos-stake-balance">{stakeBalanceLabel}</span>
+          <span data-testid="polystore-identity">{session.polystoreAddress}</span>
+          <span data-testid="polystore-stake-balance">{stakeBalanceLabel}</span>
         </div>
       ) : null}
 

--- a/polystore-website/src/e2e/dealFlow.e2e.test.ts
+++ b/polystore-website/src/e2e/dealFlow.e2e.test.ts
@@ -8,7 +8,7 @@ import {
   buildRetrievalRequestTypedData,
   buildUpdateContentTypedData,
 } from '../lib/eip712'
-import { ethToNil } from '../lib/address'
+import { ethToPolystoreAddress } from '../lib/address'
 import { gatewayFetchSlabLayout, gatewayListFiles } from '../api/gatewayClient'
 import { lcdFetchDeals } from '../api/lcdClient'
 import { hexToBytes } from '../lib/merkle'
@@ -51,7 +51,7 @@ test(
       (process.env.POLYSTORE_E2E_PRIVKEY ??
         '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113b37a2b2d6f6fcf7e9f59b5f1') as `0x${string}`,
     )
-    const ownerNil = ethToNil(account.address)
+    const ownerPolystoreAddress = ethToPolystoreAddress(account.address)
 
     // 1) Create Deal
     const dealIntent = {
@@ -85,7 +85,7 @@ test(
     const content = Buffer.from('hello polyfs\n', 'utf8')
     const form = new FormData()
     form.append('file', new Blob([content]), 'hello.txt')
-    form.append('owner', ownerNil)
+    form.append('owner', ownerPolystoreAddress)
     form.append('deal_id', dealId)
 
     const uploadRes = await fetch(`${gatewayBase}/gateway/upload?deal_id=${encodeURIComponent(dealId)}`, {
@@ -128,11 +128,11 @@ test(
     }
 
     // 4) Verify slab layout + file list via the same TS clients used by the UI.
-    const slab = await gatewayFetchSlabLayout(gatewayBase, manifestRoot, { dealId, owner: ownerNil })
+    const slab = await gatewayFetchSlabLayout(gatewayBase, manifestRoot, { dealId, owner: ownerPolystoreAddress })
     assert.ok(slab.total_mdus >= 1)
     assert.equal(slab.manifest_root, manifestRoot)
 
-    const files = await gatewayListFiles(gatewayBase, manifestRoot, { dealId, owner: ownerNil })
+    const files = await gatewayListFiles(gatewayBase, manifestRoot, { dealId, owner: ownerPolystoreAddress })
     assert.equal(files.some((f) => f.path === 'hello.txt'), true)
 
     // 5) Verify deal shows committed CID on LCD (best-effort; may take a moment).
@@ -183,7 +183,7 @@ test(
 
     const fetchUrl = `${retrievalBase}/sp/retrieval/fetch/${encodeURIComponent(
       manifestRoot,
-    )}?deal_id=${encodeURIComponent(dealId)}&owner=${encodeURIComponent(ownerNil)}&file_path=${encodeURIComponent(
+    )}?deal_id=${encodeURIComponent(dealId)}&owner=${encodeURIComponent(ownerPolystoreAddress)}&file_path=${encodeURIComponent(
       filePath,
     )}`
     const fetchRes = await fetch(fetchUrl, {

--- a/polystore-website/src/hooks/useFaucet.ts
+++ b/polystore-website/src/hooks/useFaucet.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { ethToNil } from '../lib/address'
+import { ethToPolystoreAddress } from '../lib/address'
 import { appConfig } from '../config'
 import { getFaucetAuthToken } from '../lib/faucetAuthToken'
 
@@ -20,7 +20,7 @@ export function useFaucet() {
     setTxStatus('idle')
     try {
         // Convert to Bech32 if it's an 0x address
-        const targetAddress = address.startsWith('0x') ? ethToNil(address) : address
+        const targetAddress = address.startsWith('0x') ? ethToPolystoreAddress(address) : address
 
         const maxAttempts = 5
         let lastError: Error | null = null

--- a/polystore-website/src/hooks/useFetch.ts
+++ b/polystore-website/src/hooks/useFetch.ts
@@ -3,7 +3,7 @@ import { useAccount, usePublicClient, useWalletClient } from 'wagmi'
 import { type Hex } from 'viem'
 
 import { appConfig } from '../config'
-import { ethToNil } from '../lib/address'
+import { ethToPolystoreAddress } from '../lib/address'
 import { normalizeDealId } from '../lib/dealId'
 import { buildRetrievalRequestTypedData } from '../lib/eip712'
 import { waitForTransactionReceipt } from '../lib/evmRpc'
@@ -514,8 +514,8 @@ export function useFetch() {
         }
       }
 
-      const callerNil = ethToNil(signerAddress)
-      const isDealOwner = callerNil && callerNil === owner
+      const callerPolystoreAddress = ethToPolystoreAddress(signerAddress)
+      const isDealOwner = callerPolystoreAddress && callerPolystoreAddress === owner
       const sponsoredAuth = input.sponsoredAuth ?? { type: 'none' }
       const authType =
         sponsoredAuth.type === 'allowlist' ? 1 : sponsoredAuth.type === 'voucher' ? 2 : 0

--- a/polystore-website/src/hooks/useSessionStatus.ts
+++ b/polystore-website/src/hooks/useSessionStatus.ts
@@ -2,7 +2,7 @@ import { createContext, createElement, useCallback, useContext, useEffect, useMe
 import { useAccount, useBalance } from 'wagmi'
 import { formatUnits } from 'viem'
 
-import { ethToNil } from '../lib/address'
+import { ethToPolystoreAddress } from '../lib/address'
 import { appConfig } from '../config'
 import { useFaucet } from './useFaucet'
 import { useLocalGateway } from './useLocalGateway'
@@ -28,7 +28,7 @@ export type UseSessionStatusOptions = {
 export type SessionStatus = {
   isConnected: boolean
   address: string | undefined
-  nilAddress: string
+  polystoreAddress: string
   walletAddressShort: string
   balance: ReturnType<typeof useBalance>['data']
   balanceLabel: string
@@ -82,9 +82,9 @@ function useSessionStatusValue(options?: UseSessionStatusOptions): SessionStatus
   })
   const balance = balanceQuery.data
 
-  const nilAddress = useMemo(() => {
+  const polystoreAddress = useMemo(() => {
     if (!address) return ''
-    return address.startsWith('0x') ? ethToNil(address) : address
+    return address.startsWith('0x') ? ethToPolystoreAddress(address) : address
   }, [address])
   const [lcdStakeBalance, setLcdStakeBalance] = useState<string | null>(null)
   const [lcdBalanceLoaded, setLcdBalanceLoaded] = useState(false)
@@ -103,7 +103,7 @@ function useSessionStatusValue(options?: UseSessionStatusOptions): SessionStatus
   }, [balance?.value])
 
   useEffect(() => {
-    if (!nilAddress) {
+    if (!polystoreAddress) {
       setLcdStakeBalance(null)
       setLcdBalanceLoaded(false)
       return
@@ -114,7 +114,7 @@ function useSessionStatusValue(options?: UseSessionStatusOptions): SessionStatus
 
     const load = async () => {
       try {
-        const res = await fetch(`${appConfig.lcdBase}/cosmos/bank/v1beta1/balances/${nilAddress}`)
+        const res = await fetch(`${appConfig.lcdBase}/cosmos/bank/v1beta1/balances/${polystoreAddress}`)
         const json = await res.json()
         const balances = Array.isArray(json?.balances) ? json.balances : []
         const match = balances.find(
@@ -149,7 +149,7 @@ function useSessionStatusValue(options?: UseSessionStatusOptions): SessionStatus
       cancelled = true
       if (timer !== null) window.clearTimeout(timer)
     }
-  }, [nilAddress, faucetTxStatus, options?.lcdBalancePollMs])
+  }, [polystoreAddress, faucetTxStatus, options?.lcdBalancePollMs])
 
   const hasFunds = useMemo(() => {
     if (!lcdBalanceLoaded) return evmHasFunds
@@ -201,7 +201,7 @@ function useSessionStatusValue(options?: UseSessionStatusOptions): SessionStatus
   return {
     isConnected,
     address,
-    nilAddress,
+    polystoreAddress,
     walletAddressShort,
     balance,
     balanceLabel,

--- a/polystore-website/src/hooks/useUpload.ts
+++ b/polystore-website/src/hooks/useUpload.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { ethToNil } from '../lib/address'
+import { ethToPolystoreAddress } from '../lib/address'
 import { useTransportRouter } from './useTransportRouter'
 
 export interface UploadResult {
@@ -32,7 +32,7 @@ export function useUpload() {
 
     setLoading(true)
     try {
-      const owner = address.startsWith('0x') ? ethToNil(address) : address
+      const owner = address.startsWith('0x') ? ethToPolystoreAddress(address) : address
       const result = await transport.uploadFile({
         file,
         owner,

--- a/polystore-website/src/lib/address.ts
+++ b/polystore-website/src/lib/address.ts
@@ -1,12 +1,12 @@
 import { bech32 } from 'bech32'
 
 /**
- * Converts an Ethereum 0x address to a Cosmos bech32 address.
+ * Converts an Ethereum 0x address to the current PolyStore Chain bech32 address.
  * @param ethAddress The Ethereum address (e.g. 0x123...)
- * @param prefix The Bech32 prefix (default: 'nil')
- * @returns The Bech32 address (e.g. nil1...)
+ * @param prefix The current Bech32 HRP (default: 'nil')
+ * @returns The current PolyStore Chain address (for example `nil1...`)
  */
-export function ethToNil(ethAddress: string, prefix: string = 'nil'): string {
+export function ethToPolystoreAddress(ethAddress: string, prefix: string = 'nil'): string {
   try {
     const clean = ethAddress.replace(/^0x/, '')
     const bytes = new Uint8Array(clean.match(/.{1,2}/g)!.map(byte => parseInt(byte, 16)))

--- a/polystore-website/src/lib/providerPairing.test.ts
+++ b/polystore-website/src/lib/providerPairing.test.ts
@@ -18,7 +18,7 @@ function jsonResponse(status: number, body: unknown): Response {
   })
 }
 
-test('operatorAddressFromWalletAddress converts wallet address into nil bech32', () => {
+test('operatorAddressFromWalletAddress converts wallet address into the current PolyStore bech32 format', () => {
   assert.equal(
     operatorAddressFromWalletAddress('0x0000000000000000000000000000000000000001'),
     'nil1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqp3x4xu4',

--- a/polystore-website/src/lib/providerPairing.ts
+++ b/polystore-website/src/lib/providerPairing.ts
@@ -6,7 +6,7 @@ import {
 } from '../api/lcdClient'
 import { appConfig } from '../config'
 import type { LcdPendingProviderLink, LcdProviderPairing } from '../domain/lcd'
-import { ethToNil } from './address'
+import { ethToPolystoreAddress } from './address'
 
 function normalizeNonEmpty(input: string): string {
   return String(input || '').trim()
@@ -15,8 +15,8 @@ function normalizeNonEmpty(input: string): string {
 export function operatorAddressFromWalletAddress(walletAddress: string): string | null {
   const normalized = normalizeNonEmpty(walletAddress)
   if (!normalized) return null
-  const nilAddress = ethToNil(normalized)
-  return nilAddress || null
+  const polystoreAddress = ethToPolystoreAddress(normalized)
+  return polystoreAddress || null
 }
 
 export async function fetchProviderPairing(

--- a/polystore-website/src/lib/storageOnboarding.ts
+++ b/polystore-website/src/lib/storageOnboarding.ts
@@ -118,7 +118,7 @@ Your job:
    - verify local gateway \`/health\`; use \`/status\` only if it exists or if debugging is needed
    - if \`POLYSTORE_BURNER_KEYSTORE_PASSWORD\` is unset, ask the user for the keystore import password before invoking \`scripts/testnet_burner_upload.sh\`
    - create a temporary tiny file locally and complete \`scripts/testnet_burner_upload.sh <file_path>\`
-   - capture wallet address, nil address, keystore path, deal ID, manifest root, file name, file size, create tx hash, and commit tx hash
+   - capture wallet address, PolyStore address (\`nil1...\` for now), keystore path, deal ID, manifest root, file name, file size, create tx hash, and commit tx hash
 4. Milestone 2, MetaMask Handoff:
    - guide keystore import
    - confirm MetaMask address exactly matches the bootstrap address before moving on

--- a/polystore-website/src/pages/FirstFile.tsx
+++ b/polystore-website/src/pages/FirstFile.tsx
@@ -36,7 +36,7 @@ export function FirstFile() {
   const {
     address,
     isConnected,
-    nilAddress,
+    polystoreAddress,
     hasFunds,
     balanceLabel,
     isWrongNetwork,
@@ -70,9 +70,9 @@ export function FirstFile() {
   }, [address])
 
   useEffect(() => {
-    if (!nilAddress) return
+    if (!polystoreAddress) return
     let canceled = false
-    const owner = nilAddress
+    const owner = polystoreAddress
 
     void lcdFetchDeals(appConfig.lcdBase)
       .then((all) => {
@@ -93,7 +93,7 @@ export function FirstFile() {
     return () => {
       canceled = true
     }
-  }, [dealId, nilAddress])
+  }, [dealId, polystoreAddress])
 
   const step2Ready = isConnected && !isWrongNetwork
   const funded = hasFunds || faucetTxStatus === 'confirmed'

--- a/polystore-website/src/pages/SpDashboard.tsx
+++ b/polystore-website/src/pages/SpDashboard.tsx
@@ -96,7 +96,7 @@ export function SpDashboard() {
   const { unpairProvider, loading: unpairingProvider } = useUnpairProvider()
   const session = useSessionStatus()
   const {
-    nilAddress,
+    polystoreAddress,
     walletAddressShort,
     isConnected,
     isWrongNetwork,
@@ -122,7 +122,7 @@ export function SpDashboard() {
   const [adminResponse, setAdminResponse] = useState<ProviderAdminResponse | null>(null)
 
   const load = useCallback(async () => {
-    if (!nilAddress) {
+    if (!polystoreAddress) {
       setPairings([])
       setProviders([])
       setError(null)
@@ -133,7 +133,7 @@ export function SpDashboard() {
     setError(null)
     try {
       const [nextPairings, nextProviders] = await Promise.all([
-        lcdFetchProvidersByOperator(appConfig.lcdBase, nilAddress),
+        lcdFetchProvidersByOperator(appConfig.lcdBase, polystoreAddress),
         lcdFetchProviders(appConfig.lcdBase),
       ])
       setPairings(nextPairings)
@@ -145,10 +145,10 @@ export function SpDashboard() {
     } finally {
       setLoading(false)
     }
-  }, [nilAddress])
+  }, [polystoreAddress])
 
   useEffect(() => {
-    if (!nilAddress) {
+    if (!polystoreAddress) {
       setPairings([])
       setProviders([])
       return
@@ -159,7 +159,7 @@ export function SpDashboard() {
       void load()
     }, 10000)
     return () => window.clearInterval(timer)
-  }, [load, nilAddress])
+  }, [load, polystoreAddress])
 
   const records = useMemo(() => buildOperatorProviderRecords(pairings, providers), [pairings, providers])
   const selectedRecord = useMemo(
@@ -436,7 +436,7 @@ export function SpDashboard() {
           </div>
           <div className="space-y-1">
             <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">PolyStore operator</div>
-            <div className="break-all font-mono-data text-foreground">{nilAddress || '—'}</div>
+            <div className="break-all font-mono-data text-foreground">{polystoreAddress || '—'}</div>
           </div>
           <div className="space-y-1">
             <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Paired providers</div>

--- a/polystore-website/src/pages/SpOnboarding.tsx
+++ b/polystore-website/src/pages/SpOnboarding.tsx
@@ -216,7 +216,7 @@ export function SpOnboarding() {
   const session = useSessionStatus()
   const {
     address,
-    nilAddress,
+    polystoreAddress,
     walletAddressShort,
     isConnected,
     hasFunds,
@@ -311,12 +311,12 @@ export function SpOnboarding() {
   )
 
   const confirmedPairing = useMemo(
-    () => findConfirmedProviderPairing(operatorPairings, nilAddress || ''),
-    [nilAddress, operatorPairings],
+    () => findConfirmedProviderPairing(operatorPairings, polystoreAddress || ''),
+    [polystoreAddress, operatorPairings],
   )
   const pendingLink = useMemo(
-    () => findMostRecentPendingProviderLink(pendingLinks, nilAddress || ''),
-    [nilAddress, pendingLinks],
+    () => findMostRecentPendingProviderLink(pendingLinks, polystoreAddress || ''),
+    [polystoreAddress, pendingLinks],
   )
   const activeProviderAddress = useMemo(
     () =>
@@ -378,7 +378,7 @@ export function SpOnboarding() {
   const authTokenOverride = String(authToken || '').trim()
   const effectiveGatewayAuthToken = authTokenOverride || DEVNET_SHARED_GATEWAY_AUTH_TOKEN
   const hasCustomAuthToken = Boolean(authTokenOverride)
-  const hasOperatorAddress = Boolean(String(nilAddress || '').trim())
+  const hasOperatorAddress = Boolean(String(polystoreAddress || '').trim())
   const providerKeyLabel = String(providerKey || '').trim()
   const providerKeyReady = Boolean(providerKeyLabel)
   const selectedCloneOption = CLONE_METHOD_OPTIONS.find((option) => option.id === cloneMethod) ?? CLONE_METHOD_OPTIONS[0]
@@ -442,13 +442,13 @@ export function SpOnboarding() {
         endpointMode,
         endpointValue,
         publicPort: Number(publicPort),
-        operatorAddress: nilAddress || '',
+        operatorAddress: polystoreAddress || '',
         providerKey,
         authToken: authTokenOverride,
         providerEndpoint: effectiveEndpointPlan?.providerEndpoint || '',
         expectedProviderAddress: approvedProviderAddress || '',
       }),
-    [approvedProviderAddress, authTokenOverride, effectiveEndpointPlan?.providerEndpoint, endpointMode, endpointValue, hostMode, nilAddress, providerKey, publicPort],
+    [approvedProviderAddress, authTokenOverride, effectiveEndpointPlan?.providerEndpoint, endpointMode, endpointValue, hostMode, polystoreAddress, providerKey, publicPort],
   )
   const healthCommands = useMemo(
     () => buildProviderHealthCommands(authoritativePublicBase, providerKey),
@@ -484,16 +484,16 @@ export function SpOnboarding() {
     ].join('\n')
   }, [effectiveEndpointPlan?.normalizedHost, tunnelName])
   const pairCommand = useMemo(
-    () => buildProviderPairCommand(providerKey, nilAddress || ''),
-    [nilAddress, providerKey],
+    () => buildProviderPairCommand(providerKey, polystoreAddress || ''),
+    [polystoreAddress, providerKey],
   )
   const linkRepairCommand = useMemo(
-    () => buildProviderLinkCommand(providerKey, nilAddress || ''),
-    [nilAddress, providerKey],
+    () => buildProviderLinkCommand(providerKey, polystoreAddress || ''),
+    [polystoreAddress, providerKey],
   )
   const wrongProviderFix = useMemo(() => {
     const normalizedProviderKey = String(providerKeyLabel || '').trim()
-    const normalizedOperatorAddress = String(nilAddress || '').trim()
+    const normalizedOperatorAddress = String(polystoreAddress || '').trim()
     const normalizedProviderEndpoint = String(effectiveEndpointPlan?.providerEndpoint || '').trim()
     const normalizedStatusBase = String(authoritativePublicBase || effectivePublicBase || '').trim()
     const normalizedApprovedProviderAddress = String(approvedProviderAddress || '').trim()
@@ -535,18 +535,18 @@ export function SpOnboarding() {
     effectiveEndpointPlan?.providerEndpoint,
     effectiveGatewayAuthToken,
     effectivePublicBase,
-    nilAddress,
+    polystoreAddress,
     providerKeyLabel,
   ])
   const agentPrompt = useMemo(
     () =>
       buildProviderAgentPrompt({
-        operatorAddress: nilAddress || '',
+        operatorAddress: polystoreAddress || '',
         providerEndpoint: effectiveEndpointPlan?.providerEndpoint,
         publicBase: authoritativePublicBase,
         providerKey,
       }),
-    [authoritativePublicBase, effectiveEndpointPlan?.providerEndpoint, nilAddress, providerKey],
+    [authoritativePublicBase, effectiveEndpointPlan?.providerEndpoint, polystoreAddress, providerKey],
   )
 
   const handleCopy = useCallback(async (label: string, text: string) => {
@@ -565,8 +565,8 @@ export function SpOnboarding() {
     try {
       const [height, pending, pairings] = await Promise.all([
         lcdFetchLatestHeight(appConfig.lcdBase).catch(() => null),
-        nilAddress ? lcdFetchPendingProviderLinksByOperator(appConfig.lcdBase, nilAddress).catch(() => []) : Promise.resolve([]),
-        nilAddress ? lcdFetchProvidersByOperator(appConfig.lcdBase, nilAddress).catch(() => []) : Promise.resolve([]),
+        polystoreAddress ? lcdFetchPendingProviderLinksByOperator(appConfig.lcdBase, polystoreAddress).catch(() => []) : Promise.resolve([]),
+        polystoreAddress ? lcdFetchProvidersByOperator(appConfig.lcdBase, polystoreAddress).catch(() => []) : Promise.resolve([]),
       ])
 
       setLatestHeight(height)
@@ -582,7 +582,7 @@ export function SpOnboarding() {
     } finally {
       setLoadingLiveState(false)
     }
-  }, [nilAddress])
+  }, [polystoreAddress])
 
   const refreshPublicStatus = useCallback(async (base: string) => {
     const normalizedBase = String(base || '').trim().replace(/\/$/, '')
@@ -632,7 +632,7 @@ export function SpOnboarding() {
   }, [])
 
   useEffect(() => {
-    if (!nilAddress) {
+    if (!polystoreAddress) {
       setPendingLinks([])
       setOperatorPairings([])
       setProviders([])
@@ -646,7 +646,7 @@ export function SpOnboarding() {
     }, 8000)
 
     return () => window.clearInterval(timer)
-  }, [nilAddress, refreshLiveState])
+  }, [polystoreAddress, refreshLiveState])
 
   useEffect(() => {
     if (!effectivePublicBase || !pairingConfirmed) {
@@ -948,7 +948,7 @@ export function SpOnboarding() {
                     </div>
                     <div className="border border-border bg-background/40 p-3">
                       <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">PolyStore address</div>
-                      <div className="mt-2 break-all font-mono-data text-foreground">{nilAddress || '—'}</div>
+                      <div className="mt-2 break-all font-mono-data text-foreground">{polystoreAddress || '—'}</div>
                     </div>
                     <div className="border border-border bg-background/40 p-3">
                       <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Balance</div>
@@ -1146,7 +1146,7 @@ export function SpOnboarding() {
                   <div className="grid gap-3 border border-border bg-background p-4 text-sm text-muted-foreground md:grid-cols-3">
                     <div className="min-w-0">
                       <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Operator address</div>
-                      <div className="mt-1 break-all font-mono-data text-foreground">{nilAddress || 'required from Step 1'}</div>
+                      <div className="mt-1 break-all font-mono-data text-foreground">{polystoreAddress || 'required from Step 1'}</div>
                     </div>
                     <div className="min-w-0">
                       <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Provider key</div>
@@ -1437,7 +1437,7 @@ export function SpOnboarding() {
                       : !pairingConfirmed
                         ? 'Finish Step 3 by running the pair command and approving the provider link before bootstrap.'
                       : !hasOperatorAddress
-                        ? 'Finish Step 1 so the website can capture the connected operator wallet nil address.'
+                        ? 'Finish Step 1 so the website can capture the connected operator wallet PolyStore address.'
                         : !endpointReady
                         ? 'Describe the public endpoint so the website can derive the provider endpoint and health URL.'
                         : 'Endpoint is ready. Run bootstrap and watch registration plus health converge below.'}
@@ -1731,7 +1731,7 @@ export function SpOnboarding() {
                   </div>
                   <div className="min-w-0">
                     <span>Operator address</span>
-                    <div className="mt-1 break-all font-mono-data text-foreground">{nilAddress || 'required'}</div>
+                    <div className="mt-1 break-all font-mono-data text-foreground">{polystoreAddress || 'required'}</div>
                   </div>
                   <div className="min-w-0">
                     <span>Provider endpoint</span>

--- a/polystore-website/src/pages/TestnetDocs.tsx
+++ b/polystore-website/src/pages/TestnetDocs.tsx
@@ -5,7 +5,7 @@ import { FileSharder } from "../components/FileSharder";
 import { FaucetWidget } from "../components/FaucetWidget";
 import { FaucetAuthTokenInput } from "../components/FaucetAuthTokenInput";
 import { appConfig } from "../config";
-import { ethToNil } from "../lib/address";
+import { ethToPolystoreAddress } from "../lib/address";
 import { lcdFetchDeals } from "../api/lcdClient";
 import type { LcdDeal as Deal } from "../domain/lcd";
 
@@ -17,9 +17,9 @@ export const TestnetDocs = () => {
 
   useEffect(() => {
     if (address) {
-      const cosmosAddress = ethToNil(address);
+      const polystoreAddress = ethToPolystoreAddress(address);
       lcdFetchDeals(appConfig.lcdBase).then((all) => {
-        const filtered = all.filter((d) => d.owner === cosmosAddress);
+        const filtered = all.filter((d) => d.owner === polystoreAddress);
         setDeals(filtered);
       });
     } else {

--- a/polystore-website/tests/deal-explorer-browser-download-network.spec.ts
+++ b/polystore-website/tests/deal-explorer-browser-download-network.spec.ts
@@ -8,7 +8,7 @@ import { POLYSTORE_PRECOMPILE_ABI } from '../src/lib/polystorePrecompile'
 const path = process.env.E2E_PATH || '/#/dashboard'
 const precompile = '0x0000000000000000000000000000000000000900'
 
-function ethToNil(ethAddress: string): string {
+function ethToPolystoreAddress(ethAddress: string): string {
   const data = Buffer.from(ethAddress.replace(/^0x/, ''), 'hex')
   const words = bech32.toWords(data)
   return bech32.encode('nil', words)
@@ -21,7 +21,7 @@ test('Deal Explorer: stale browser cache does not bypass required provider sync'
   const account = privateKeyToAccount(randomPk)
   const chainId = Number(process.env.CHAIN_ID || 20260211)
   const chainIdHex = `0x${chainId.toString(16)}`
-  const nilAddress = ethToNil(account.address)
+  const polystoreAddress = ethToPolystoreAddress(account.address)
 
   const dealId = '1'
   const manifestRoot = `0x${'bb'.repeat(48)}`
@@ -50,7 +50,7 @@ test('Deal Explorer: stale browser cache does not bypass required provider sync'
         deals: [
           {
             id: dealId,
-            owner: nilAddress,
+            owner: polystoreAddress,
             cid: manifestRoot,
             size: String(24 * 1024 * 1024),
             escrow_balance: '1000000',
@@ -69,7 +69,7 @@ test('Deal Explorer: stale browser cache does not bypass required provider sync'
       body: JSON.stringify({
         deal: {
           id: dealId,
-          owner: nilAddress,
+          owner: polystoreAddress,
           manifest_root: Buffer.from(manifestRoot.slice(2), 'hex').toString('base64'),
           size: String(24 * 1024 * 1024),
           escrow_balance: '1000000',
@@ -219,7 +219,7 @@ test('Deal Explorer: stale browser cache does not bypass required provider sync'
       headers: { 'Access-Control-Allow-Origin': '*' },
       body: JSON.stringify({
         deal_id: Number(dealId),
-        owner: nilAddress,
+        owner: polystoreAddress,
         provider: 'nil1provider',
         manifest_root: manifestRoot,
         file_path: filePath,
@@ -238,7 +238,7 @@ test('Deal Explorer: stale browser cache does not bypass required provider sync'
       headers: { 'Access-Control-Allow-Origin': '*' },
       body: JSON.stringify({
         deal_id: Number(dealId),
-        owner: nilAddress,
+        owner: polystoreAddress,
         provider: 'nil1provider',
         manifest_root: manifestRoot,
         file_path: filePath,

--- a/polystore-website/tests/deal-explorer-debug.spec.ts
+++ b/polystore-website/tests/deal-explorer-debug.spec.ts
@@ -8,7 +8,7 @@ import { POLYSTORE_PRECOMPILE_ABI } from '../src/lib/polystorePrecompile'
 const path = process.env.E2E_PATH || '/#/dashboard'
 const precompile = '0x0000000000000000000000000000000000000900'
 
-function ethToNil(ethAddress: string): string {
+function ethToPolystoreAddress(ethAddress: string): string {
   const data = Buffer.from(ethAddress.replace(/^0x/, ''), 'hex')
   const words = bech32.toWords(data)
   return bech32.encode('nil', words)
@@ -21,7 +21,7 @@ test('Deal Explorer debug: after provider sync, default download prefers browser
   const account = privateKeyToAccount(randomPk)
   const chainId = Number(process.env.CHAIN_ID || 20260211)
   const chainIdHex = `0x${chainId.toString(16)}`
-  const nilAddress = ethToNil(account.address)
+  const polystoreAddress = ethToPolystoreAddress(account.address)
 
   const dealId = '1'
   const manifestRoot = '0xae5359579124255db62f04c55f1d1490655ed5479988a528bbca9f5a2245de9286452e5ffd8e76e05763c8241632c517'
@@ -51,7 +51,7 @@ test('Deal Explorer debug: after provider sync, default download prefers browser
         deals: [
           {
             id: dealId,
-            owner: nilAddress,
+            owner: polystoreAddress,
             cid: manifestRoot,
             size: String(24 * 1024 * 1024),
             escrow_balance: '1000000',
@@ -70,7 +70,7 @@ test('Deal Explorer debug: after provider sync, default download prefers browser
       body: JSON.stringify({
         deal: {
           id: dealId,
-          owner: nilAddress,
+          owner: polystoreAddress,
           manifest_root: Buffer.from(manifestRoot.slice(2), 'hex').toString('base64'),
           size: String(24 * 1024 * 1024),
           escrow_balance: '1000000',
@@ -169,7 +169,7 @@ test('Deal Explorer debug: after provider sync, default download prefers browser
       headers: { 'Access-Control-Allow-Origin': '*' },
       body: JSON.stringify({
         deal_id: Number(dealId),
-        owner: nilAddress,
+        owner: polystoreAddress,
         provider: 'nil1provider',
         manifest_root: manifestRoot,
         file_path: filePath,

--- a/polystore-website/tests/deal-explorer-manifest-opfs-fallback.spec.ts
+++ b/polystore-website/tests/deal-explorer-manifest-opfs-fallback.spec.ts
@@ -4,7 +4,7 @@ import { bech32 } from 'bech32'
 
 const path = process.env.E2E_PATH || '/#/dashboard'
 
-function ethToNil(ethAddress: string): string {
+function ethToPolystoreAddress(ethAddress: string): string {
   const data = Buffer.from(ethAddress.replace(/^0x/, ''), 'hex')
   const words = bech32.toWords(data)
   return bech32.encode('nil', words)
@@ -15,7 +15,7 @@ test('Deal Explorer: manifest + mdu commitments fall back to OPFS when gateway m
 
   const dealId = '1'
   const ethAddress = '0x' + '11'.repeat(20)
-  const nilAddress = ethToNil(ethAddress)
+  const polystoreAddress = ethToPolystoreAddress(ethAddress)
   const chainId = Number(process.env.CHAIN_ID || 31337)
   const chainIdHex = `0x${chainId.toString(16)}`
   const manifestRoot = `0x${'cc'.repeat(48)}`
@@ -30,7 +30,7 @@ test('Deal Explorer: manifest + mdu commitments fall back to OPFS when gateway m
         deals: [
           {
             id: dealId,
-            owner: nilAddress,
+            owner: polystoreAddress,
             cid: manifestRoot,
             size: String(24 * 1024 * 1024),
             escrow_balance: '1000000',

--- a/polystore-website/tests/deal-explorer-provider-base.spec.ts
+++ b/polystore-website/tests/deal-explorer-provider-base.spec.ts
@@ -14,7 +14,7 @@ const FILE_TABLE_HEADER_SIZE = 128
 const FILE_RECORD_SIZE = 256
 const FILE_RECORD_PATH_BYTES = FILE_RECORD_SIZE - 24
 
-function ethToNil(ethAddress: string): string {
+function ethToPolystoreAddress(ethAddress: string): string {
   const data = Buffer.from(ethAddress.replace(/^0x/, ''), 'hex')
   const words = bech32.toWords(data)
   return bech32.encode('nil', words)
@@ -41,7 +41,7 @@ test('Deal Explorer: missing local index requires provider sync before file view
   const account = privateKeyToAccount(randomPk)
   const chainId = Number(process.env.CHAIN_ID || 20260211)
   const chainIdHex = `0x${chainId.toString(16)}`
-  const nilAddress = ethToNil(account.address)
+  const polystoreAddress = ethToPolystoreAddress(account.address)
 
   const dealId = '1'
   const filePath = 'provider-base.txt'
@@ -70,7 +70,7 @@ test('Deal Explorer: missing local index requires provider sync before file view
         deals: [
           {
             id: dealId,
-            owner: nilAddress,
+            owner: polystoreAddress,
             cid: staleManifestRoot,
             size: String(24 * 1024 * 1024),
             escrow_balance: '1000000',
@@ -89,7 +89,7 @@ test('Deal Explorer: missing local index requires provider sync before file view
       body: JSON.stringify({
         deal: {
           id: dealId,
-          owner: nilAddress,
+          owner: polystoreAddress,
           manifest_root: manifestRootBase64,
           size: String(24 * 1024 * 1024),
           escrow_balance: '1000000',

--- a/polystore-website/tests/deal-id-zero.spec.ts
+++ b/polystore-website/tests/deal-id-zero.spec.ts
@@ -8,7 +8,7 @@ import { dismissCreateDealDrawer, ensureCreateDealDrawerOpen } from './utils/das
 const path = process.env.E2E_PATH || '/#/dashboard'
 const precompile = '0x0000000000000000000000000000000000000900'
 
-function ethToNil(ethAddress: string): string {
+function ethToPolystoreAddress(ethAddress: string): string {
   const data = Buffer.from(ethAddress.replace(/^0x/, ''), 'hex')
   const words = bech32.toWords(data)
   return bech32.encode('nil', words)
@@ -24,12 +24,12 @@ test('repro bug: download from commit content widget', async ({
   const account = privateKeyToAccount(randomPk)
   const chainId = Number(process.env.CHAIN_ID || 31337)
   const chainIdHex = `0x${chainId.toString(16)}`
-  const nilAddress = ethToNil(account.address)
+  const polystoreAddress = ethToPolystoreAddress(account.address)
   const txCreate = (`0x${'11'.repeat(32)}` as Hex)
   const txUpdate = (`0x${'22'.repeat(32)}` as Hex)
   const txProve = (`0x${'33'.repeat(32)}` as Hex)
   
-  console.log(`Using random E2E wallet: ${account.address} -> ${nilAddress}`)
+  console.log(`Using random E2E wallet: ${account.address} -> ${polystoreAddress}`)
 
   // Mock EVM RPC receipts for the precompile-based flow.
   const dealCreatedEvent = getAbiItem({ abi: POLYSTORE_PRECOMPILE_ABI, name: 'DealCreated' }) as any
@@ -245,7 +245,7 @@ test('repro bug: download from commit content widget', async ({
                     id: '0',
                     cid: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
                     size: '1024',
-                    owner: nilAddress,
+                    owner: polystoreAddress,
                     escrow: '1000',
                     end_block: '99999999',
                     start_block: '1',
@@ -426,7 +426,7 @@ test('repro bug: download from commit content widget', async ({
 
   console.log('Requesting faucet...')
   await page.getByTestId('faucet-request').click()
-  await expect(page.getByTestId('cosmos-stake-balance')).not.toHaveText('—', { timeout: 90_000 })
+  await expect(page.getByTestId('polystore-stake-balance')).not.toHaveText('—', { timeout: 90_000 })
   console.log('Faucet received.')
 
   console.log('Creating deal...')

--- a/polystore-website/tests/deal-setup-readiness.spec.ts
+++ b/polystore-website/tests/deal-setup-readiness.spec.ts
@@ -5,7 +5,7 @@ import { bech32 } from 'bech32'
 
 const dashboardPath = process.env.E2E_PATH || '/#/dashboard'
 
-function ethToNil(ethAddress: string): string {
+function ethToPolystoreAddress(ethAddress: string): string {
   const data = Buffer.from(ethAddress.replace(/^0x/, ''), 'hex')
   const words = bech32.toWords(data)
   return bech32.encode('nil', words)
@@ -15,7 +15,7 @@ test('upload stays blocked until a newly selected deal resolves through detail l
   const account = privateKeyToAccount(generatePrivateKey())
   const chainId = Number(process.env.CHAIN_ID || 20260211)
   const chainIdHex = `0x${chainId.toString(16)}`
-  const nilAddress = ethToNil(account.address)
+  const polystoreAddress = ethToPolystoreAddress(account.address)
   const dealId = '32'
   let gatewayProbeAttempts = 0
   let detailAttempts = 0
@@ -81,7 +81,7 @@ test('upload stays blocked until a newly selected deal resolves through detail l
 
     const deal = {
       id: dealId,
-      owner: nilAddress,
+      owner: polystoreAddress,
       cid: '',
       size: '0',
       escrow_balance: '1000000',

--- a/polystore-website/tests/deal-smoke.spec.ts
+++ b/polystore-website/tests/deal-smoke.spec.ts
@@ -9,7 +9,7 @@ import { dismissCreateDealDrawer, ensureCreateDealDrawerOpen } from './utils/das
 const path = process.env.E2E_PATH || '/#/dashboard'
 const precompile = '0x0000000000000000000000000000000000000900'
 
-function ethToNil(ethAddress: string): string {
+function ethToPolystoreAddress(ethAddress: string): string {
   const data = Buffer.from(ethAddress.replace(/^0x/, ''), 'hex')
   const words = bech32.toWords(data)
   return bech32.encode('nil', words)
@@ -22,7 +22,7 @@ test('deal lifecycle smoke (connect → fund → create → upload → commit �
   const account = privateKeyToAccount(randomPk)
   const chainId = Number(process.env.CHAIN_ID || 31337)
   const chainIdHex = `0x${chainId.toString(16)}`
-  const nilAddress = ethToNil(account.address)
+  const polystoreAddress = ethToPolystoreAddress(account.address)
 
   const txHash = (`0x${'11'.repeat(32)}` as Hex)
   const dealId = '1'
@@ -30,7 +30,7 @@ test('deal lifecycle smoke (connect → fund → create → upload → commit �
   const filePath = 'e2e.txt'
   const fileBytes = Buffer.alloc(1024 * 1024, 'A')
 
-  console.log(`Using random E2E wallet: ${account.address} -> ${nilAddress}`)
+  console.log(`Using random E2E wallet: ${account.address} -> ${polystoreAddress}`)
 
   // Mock LCD balances + deals + providers (CI runs Vite only; no chain/gateway).
   await page.route('**/cosmos/bank/v1beta1/balances/*', async (route) => {
@@ -52,7 +52,7 @@ test('deal lifecycle smoke (connect → fund → create → upload → commit �
         deals: [
           {
             id: dealId,
-            owner: nilAddress,
+            owner: polystoreAddress,
             cid: manifestRoot,
             size: String(fileBytes.length),
             escrow_balance: '1000000',
@@ -244,10 +244,10 @@ test('deal lifecycle smoke (connect → fund → create → upload → commit �
     await expect(page.locator('[data-testid="wallet-address"], [data-testid="wallet-address-full"]').first()).toBeVisible()
   }
 
-  await expect(page.getByTestId('cosmos-identity')).toContainText('nil1')
+  await expect(page.getByTestId('polystore-identity')).toContainText('nil1')
 
   await page.getByTestId('faucet-request').click()
-  await expect(page.getByTestId('cosmos-stake-balance')).not.toHaveText('—', { timeout: 90_000 })
+  await expect(page.getByTestId('polystore-stake-balance')).not.toHaveText('—', { timeout: 90_000 })
 
   await ensureCreateDealDrawerOpen(page)
   const placementSelect = page.getByTestId('alloc-placement-profile')

--- a/polystore-website/tests/direct-upload-sparse.spec.ts
+++ b/polystore-website/tests/direct-upload-sparse.spec.ts
@@ -11,7 +11,7 @@ const largeUploadTimeoutMs = uploadSizeBytes > 32 * 1024 * 1024 ? 900_000 : 120_
 const capturePreparePerf = process.env.CAPTURE_PREPARE_PERF === '1'
 const stopAfterPreparePerf = process.env.STOP_AFTER_PREPARE_PERF === '1'
 
-function ethToNil(ethAddress: string): string {
+function ethToPolystoreAddress(ethAddress: string): string {
   const data = Buffer.from(ethAddress.replace(/^0x/, ''), 'hex')
   const words = bech32.toWords(data)
   return bech32.encode('nil', words)
@@ -24,7 +24,7 @@ test('Thick Client: no-gateway Mode 2 browser upload sends sparse MDU, manifest,
   const account = privateKeyToAccount(randomPk)
   const chainId = Number(process.env.CHAIN_ID || 20260211)
   const chainIdHex = `0x${chainId.toString(16)}`
-  const nilAddress = ethToNil(account.address)
+  const polystoreAddress = ethToPolystoreAddress(account.address)
 
   const mduUploads: Array<{ bodyLen: number; fullSize: number | null; mduIndex: string }> = []
   const manifestUploads: Array<{ bodyLen: number; fullSize: number | null }> = []
@@ -174,7 +174,7 @@ test('Thick Client: no-gateway Mode 2 browser upload sends sparse MDU, manifest,
 
     const deal = {
       id: '1',
-      owner: nilAddress,
+      owner: polystoreAddress,
       cid: '',
       size: '0',
       escrow_balance: '1000000',

--- a/polystore-website/tests/direct-upload.spec.ts
+++ b/polystore-website/tests/direct-upload.spec.ts
@@ -6,7 +6,7 @@ import { type Hex } from 'viem'
 
 const path = process.env.E2E_PATH || '/#/dashboard'
 
-function ethToNil(ethAddress: string): string {
+function ethToPolystoreAddress(ethAddress: string): string {
   const data = Buffer.from(ethAddress.replace(/^0x/, ''), 'hex')
   const words = bech32.toWords(data)
   return bech32.encode('nil', words)
@@ -20,11 +20,11 @@ test('Thick Client: Direct Upload and Commit', async ({ page }) => {
   const account = privateKeyToAccount(randomPk)
   const chainId = Number(process.env.CHAIN_ID || 31337)
   const chainIdHex = `0x${chainId.toString(16)}`
-  const nilAddress = ethToNil(account.address)
+  const polystoreAddress = ethToPolystoreAddress(account.address)
   // We need distinct transaction hashes for commit content
   const txCommit = (`0x${'44'.repeat(32)}` as Hex)
 
-  console.log(`Using random E2E wallet: ${account.address} -> ${nilAddress}`)
+  console.log(`Using random E2E wallet: ${account.address} -> ${polystoreAddress}`)
 
   let manifestUploadCalls = 0
   let dealCid = ''
@@ -157,7 +157,7 @@ test('Thick Client: Direct Upload and Commit', async ({ page }) => {
 
     const deal = {
       id: '1',
-      owner: nilAddress,
+      owner: polystoreAddress,
       cid: dealCid,
       size: '0',
       escrow_balance: '1000000',
@@ -360,16 +360,16 @@ test('Thick Client: Direct Upload and Commit', async ({ page }) => {
 
   await page.reload({ waitUntil: 'networkidle' })
 
-  await page.waitForSelector('[data-testid="connect-wallet"], [data-testid="wallet-address"], [data-testid="wallet-address-full"], [data-testid="cosmos-identity"]', {
+  await page.waitForSelector('[data-testid="connect-wallet"], [data-testid="wallet-address"], [data-testid="wallet-address-full"], [data-testid="polystore-identity"]', {
     timeout: 60_000,
     state: 'attached',
   })
 
   const walletAddress = page.locator('[data-testid="wallet-address"], [data-testid="wallet-address-full"]').first()
-  const cosmosIdentity = page.getByTestId('cosmos-identity')
-  if (!(await walletAddress.isVisible().catch(() => false)) && !(await cosmosIdentity.isVisible().catch(() => false))) {
+  const polystoreIdentity = page.getByTestId('polystore-identity')
+  if (!(await walletAddress.isVisible().catch(() => false)) && !(await polystoreIdentity.isVisible().catch(() => false))) {
     await page.getByTestId('connect-wallet').first().click({ force: true })
-    await expect(page.locator('[data-testid="wallet-address"], [data-testid="cosmos-identity"]')).toBeVisible({ timeout: 60_000 })
+    await expect(page.locator('[data-testid="wallet-address"], [data-testid="polystore-identity"]')).toBeVisible({ timeout: 60_000 })
   }
 
   // Regression: after commit, Deal Explorer should show the PolyFS file list (from local OPFS fallback).

--- a/polystore-website/tests/gateway-absent-ui.spec.ts
+++ b/polystore-website/tests/gateway-absent-ui.spec.ts
@@ -134,17 +134,17 @@ test.describe('gateway absent', () => {
 
     await page.waitForSelector('#root', { timeout: 60_000 })
     await page.waitForSelector(
-      '[data-testid="connect-wallet"], [data-testid="wallet-address"], [data-testid="wallet-address-full"], [data-testid="cosmos-identity"]',
+      '[data-testid="connect-wallet"], [data-testid="wallet-address"], [data-testid="wallet-address-full"], [data-testid="polystore-identity"]',
       {
         timeout: 60_000,
         state: 'attached',
       },
     )
     const walletAddress = page.locator('[data-testid="wallet-address"], [data-testid="wallet-address-full"]').first()
-    const cosmosIdentity = page.getByTestId('cosmos-identity')
+    const polystoreIdentity = page.getByTestId('polystore-identity')
     const connected =
       (await walletAddress.isVisible().catch(() => false)) ||
-      (await cosmosIdentity.isVisible().catch(() => false))
+      (await polystoreIdentity.isVisible().catch(() => false))
     if (!connected) {
       const connectButton = page.getByTestId('connect-wallet').first()
       await connectButton.click({ force: true })
@@ -155,7 +155,7 @@ test.describe('gateway absent', () => {
         }
         await eth.request({ method: 'eth_requestAccounts' })
       })
-      await expect(page.locator('[data-testid="wallet-address"], [data-testid="wallet-address-full"], [data-testid="cosmos-identity"]')).toBeVisible({
+      await expect(page.locator('[data-testid="wallet-address"], [data-testid="wallet-address-full"], [data-testid="polystore-identity"]')).toBeVisible({
         timeout: 60_000,
       })
     }

--- a/polystore-website/tests/gateway-flow.spec.ts
+++ b/polystore-website/tests/gateway-flow.spec.ts
@@ -25,22 +25,22 @@ test.describe('gateway flow', () => {
       }
     }
 
-    await page.waitForSelector('[data-testid="connect-wallet"], [data-testid="wallet-address"], [data-testid="wallet-address-full"], [data-testid="cosmos-identity"]', {
+    await page.waitForSelector('[data-testid="connect-wallet"], [data-testid="wallet-address"], [data-testid="wallet-address-full"], [data-testid="polystore-identity"]', {
       timeout: 60_000,
       state: 'attached',
     })
     const walletAddress = page.locator('[data-testid="wallet-address"], [data-testid="wallet-address-full"]').first()
-    const cosmosIdentity = page.getByTestId('cosmos-identity')
-    if (!(await walletAddress.isVisible().catch(() => false)) && !(await cosmosIdentity.isVisible().catch(() => false))) {
+    const polystoreIdentity = page.getByTestId('polystore-identity')
+    if (!(await walletAddress.isVisible().catch(() => false)) && !(await polystoreIdentity.isVisible().catch(() => false))) {
       const connectBtn = page.getByTestId('connect-wallet').first()
       if (await connectBtn.isVisible().catch(() => false)) {
         await connectBtn.click()
       }
-      await expect(page.locator('[data-testid="wallet-address"], [data-testid="cosmos-identity"]')).toBeVisible({ timeout: 60_000 })
+      await expect(page.locator('[data-testid="wallet-address"], [data-testid="polystore-identity"]')).toBeVisible({ timeout: 60_000 })
     }
 
     await page.getByTestId('faucet-request').click()
-    await expect(page.getByTestId('cosmos-stake-balance')).not.toHaveText(/^(?:—|0 stake)$/, { timeout: 180_000 })
+    await expect(page.getByTestId('polystore-stake-balance')).not.toHaveText(/^(?:—|0 stake)$/, { timeout: 180_000 })
 
     await ensureCreateDealDrawerOpen(page)
     await page.getByTestId('workspace-advanced-toggle').click()

--- a/polystore-website/tests/libp2p-fetch.spec.ts
+++ b/polystore-website/tests/libp2p-fetch.spec.ts
@@ -62,7 +62,7 @@ test.describe('libp2p fetch', () => {
     await transportSelect.selectOption('prefer_p2p')
 
     await page.getByTestId('faucet-request').click()
-    await expect(page.getByTestId('cosmos-stake-balance')).not.toHaveText(/^(?:—|0 stake)$/, { timeout: 180_000 })
+    await expect(page.getByTestId('polystore-stake-balance')).not.toHaveText(/^(?:—|0 stake)$/, { timeout: 180_000 })
 
     const placementSelect = page.getByTestId('alloc-placement-profile')
     if (!(await placementSelect.isVisible().catch(() => false))) {

--- a/polystore-website/tests/libp2p-relay-fetch.spec.ts
+++ b/polystore-website/tests/libp2p-relay-fetch.spec.ts
@@ -34,8 +34,8 @@ test.describe('libp2p fetch (relay)', () => {
         await page.waitForSelector('body', { state: 'attached' })
         const hasConnect = await page.getByTestId('connect-wallet').count().catch(() => 0)
         const hasAddress = await page.locator('[data-testid="wallet-address"], [data-testid="wallet-address-full"]').count()
-        const hasCosmosIdentity = await page.getByTestId('cosmos-identity').count().catch(() => 0)
-        if (hasConnect > 0 || hasAddress > 0 || hasCosmosIdentity > 0) return
+        const hasPolystoreIdentity = await page.getByTestId('polystore-identity').count().catch(() => 0)
+        if (hasConnect > 0 || hasAddress > 0 || hasPolystoreIdentity > 0) return
         await page.waitForTimeout(1000)
         await page.reload({ waitUntil: 'networkidle' })
       }
@@ -44,13 +44,13 @@ test.describe('libp2p fetch (relay)', () => {
 
     await waitForWalletControls()
     const walletAddress = page.locator('[data-testid="wallet-address"], [data-testid="wallet-address-full"]').first()
-    const cosmosIdentity = page.getByTestId('cosmos-identity')
+    const polystoreIdentity = page.getByTestId('polystore-identity')
     const connected =
       (await walletAddress.isVisible().catch(() => false)) ||
-      (await cosmosIdentity.isVisible().catch(() => false))
+      (await polystoreIdentity.isVisible().catch(() => false))
     if (!connected) {
       await page.getByTestId('connect-wallet').first().click()
-      await expect(page.locator('[data-testid="wallet-address"], [data-testid="wallet-address-full"], [data-testid="cosmos-identity"]')).toBeVisible({
+      await expect(page.locator('[data-testid="wallet-address"], [data-testid="wallet-address-full"], [data-testid="polystore-identity"]')).toBeVisible({
         timeout: 60_000,
       })
     }
@@ -68,7 +68,7 @@ test.describe('libp2p fetch (relay)', () => {
     await transportSelect.selectOption('prefer_p2p')
 
     await page.getByTestId('faucet-request').click()
-    await expect(page.getByTestId('cosmos-stake-balance')).not.toHaveText(/^(?:—|0 stake)$/, { timeout: 180_000 })
+    await expect(page.getByTestId('polystore-stake-balance')).not.toHaveText(/^(?:—|0 stake)$/, { timeout: 180_000 })
 
     const placementSelect = page.getByTestId('alloc-placement-profile')
     if (!(await placementSelect.isVisible().catch(() => false))) {

--- a/polystore-website/tests/mode2-bootstrap-append.spec.ts
+++ b/polystore-website/tests/mode2-bootstrap-append.spec.ts
@@ -9,7 +9,7 @@ import { POLYSTORE_PRECOMPILE_ABI } from '../src/lib/polystorePrecompile'
 
 const path = process.env.E2E_PATH || '/#/dashboard'
 
-function ethToNil(ethAddress: string): string {
+function ethToPolystoreAddress(ethAddress: string): string {
   const data = Buffer.from(ethAddress.replace(/^0x/, ''), 'hex')
   const words = bech32.toWords(data)
   return bech32.encode('nil', words)
@@ -120,7 +120,7 @@ test('Thick Client: fresh browser bootstraps committed slab before Mode 2 append
   const account = privateKeyToAccount(randomPk)
   const chainId = Number(process.env.CHAIN_ID || 20260211)
   const chainIdHex = `0x${chainId.toString(16)}`
-  const nilAddress = ethToNil(account.address)
+  const polystoreAddress = ethToPolystoreAddress(account.address)
 
   const txHashFor = (n: number): Hex => (`0x${n.toString(16).padStart(64, '4')}` as Hex)
 
@@ -364,7 +364,7 @@ test('Thick Client: fresh browser bootstraps committed slab before Mode 2 append
 
     const deal = {
       id: dealId,
-      owner: nilAddress,
+      owner: polystoreAddress,
       cid: dealCid,
       size: '0',
       escrow_balance: '1000000',

--- a/polystore-website/tests/mode2-sparse-live.spec.ts
+++ b/polystore-website/tests/mode2-sparse-live.spec.ts
@@ -8,10 +8,10 @@ const hasLocalStack = process.env.E2E_LOCAL_STACK === '1'
 async function ensureWalletConnected(page: Page): Promise<void> {
   const walletAddressSelector = '[data-testid="wallet-address"], [data-testid="wallet-address-full"]'
   const walletAddress = page.locator(walletAddressSelector).first()
-  const cosmosIdentity = page.getByTestId('cosmos-identity')
+  const polystoreIdentity = page.getByTestId('polystore-identity')
   const connectBtn = page.getByTestId('connect-wallet').first()
 
-  await page.waitForSelector(`${walletAddressSelector}, [data-testid="cosmos-identity"], [data-testid="connect-wallet"]`, {
+  await page.waitForSelector(`${walletAddressSelector}, [data-testid="polystore-identity"], [data-testid="connect-wallet"]`, {
     timeout: 60_000,
     state: 'attached',
   })
@@ -20,8 +20,8 @@ async function ensureWalletConnected(page: Page): Promise<void> {
     const walletVisible = await walletAddress.isVisible().catch(() => false)
     if (walletVisible) return true
 
-    if (await cosmosIdentity.isVisible().catch(() => false)) {
-      const raw = ((await cosmosIdentity.textContent().catch(() => '')) || '').trim()
+    if (await polystoreIdentity.isVisible().catch(() => false)) {
+      const raw = ((await polystoreIdentity.textContent().catch(() => '')) || '').trim()
       if (raw && raw !== '—' && !/^not\s+connected$/i.test(raw)) return true
     }
     return false
@@ -49,7 +49,7 @@ async function ensureWalletConnected(page: Page): Promise<void> {
 }
 
 async function ensureWalletFunded(page: Page, timeout = 120_000): Promise<void> {
-  const stakeBalance = page.getByTestId('cosmos-stake-balance')
+  const stakeBalance = page.getByTestId('polystore-stake-balance')
   const current = ((await stakeBalance.textContent().catch(() => '')) || '').trim()
   if (current && !/^(?:—|0 stake)$/.test(current)) return
 

--- a/polystore-website/tests/mode2-stripe.spec.ts
+++ b/polystore-website/tests/mode2-stripe.spec.ts
@@ -32,7 +32,7 @@ async function waitForGatewayConnected(page: Page): Promise<void> {
 }
 
 async function ensureWalletFunded(page: Page, timeout: number): Promise<void> {
-  const stakeBalance = page.getByTestId('cosmos-stake-balance')
+  const stakeBalance = page.getByTestId('polystore-stake-balance')
   const current = ((await stakeBalance.textContent().catch(() => '')) || '').trim()
   if (current && !/^(?:—|0 stake)$/.test(current)) return
 
@@ -407,10 +407,10 @@ function resolveRouterUploadDir(): string {
 async function ensureWalletConnected(page: Page): Promise<void> {
   const walletAddressSelector = '[data-testid="wallet-address"], [data-testid="wallet-address-full"]'
   const walletAddress = page.locator(walletAddressSelector).first()
-  const cosmosIdentity = page.getByTestId('cosmos-identity')
+  const polystoreIdentity = page.getByTestId('polystore-identity')
   const connectBtn = page.getByTestId('connect-wallet').first()
 
-  await page.waitForSelector(`${walletAddressSelector}, [data-testid="cosmos-identity"], [data-testid="connect-wallet"]`, {
+  await page.waitForSelector(`${walletAddressSelector}, [data-testid="polystore-identity"], [data-testid="connect-wallet"]`, {
     timeout: 60_000,
     state: 'attached',
   })
@@ -419,8 +419,8 @@ async function ensureWalletConnected(page: Page): Promise<void> {
     const walletVisible = await walletAddress.first().isVisible().catch(() => false)
     if (walletVisible) return true
 
-    if (await cosmosIdentity.isVisible().catch(() => false)) {
-      const raw = (await cosmosIdentity.textContent().catch(() => ''))?.trim()
+    if (await polystoreIdentity.isVisible().catch(() => false)) {
+      const raw = (await polystoreIdentity.textContent().catch(() => ''))?.trim()
       if (raw && raw !== '—' && !/^(?:—|—)$/.test(raw) && !/^not\s+connected$/i.test(raw)) {
         return true
       }

--- a/polystore-website/tests/multitab-local-download.spec.ts
+++ b/polystore-website/tests/multitab-local-download.spec.ts
@@ -6,7 +6,7 @@ import { type Hex } from 'viem'
 
 const path = process.env.E2E_PATH || '/#/dashboard'
 
-function ethToNil(ethAddress: string): string {
+function ethToPolystoreAddress(ethAddress: string): string {
   const data = Buffer.from(ethAddress.replace(/^0x/, ''), 'hex')
   const words = bech32.toWords(data)
   return bech32.encode('nil', words)
@@ -81,7 +81,7 @@ test('Thick Client: committed slab is visible and downloadable across tabs (no g
   const account = privateKeyToAccount(randomPk)
   const chainId = Number(process.env.CHAIN_ID || 31337)
   const chainIdHex = `0x${chainId.toString(16)}`
-  const nilAddress = ethToNil(account.address)
+  const polystoreAddress = ethToPolystoreAddress(account.address)
   const txCommit = (`0x${'44'.repeat(32)}` as Hex)
 
   const dealId = '1'
@@ -178,7 +178,7 @@ test('Thick Client: committed slab is visible and downloadable across tabs (no g
         deals: [
           {
             id: dealId,
-            owner: nilAddress,
+            owner: polystoreAddress,
             cid: '',
             size: '0',
             escrow_balance: '1000000',
@@ -198,7 +198,7 @@ test('Thick Client: committed slab is visible and downloadable across tabs (no g
       body: JSON.stringify({
         deal: {
           id: dealId,
-          owner: nilAddress,
+          owner: polystoreAddress,
           manifest_root: committedRoot ? Buffer.from(committedRoot.slice(2), 'hex').toString('base64') : '',
           size: committedRoot ? String(24 * 1024 * 1024) : '0',
           escrow_balance: '1000000',
@@ -349,7 +349,7 @@ test('Thick Client: committed slab is visible and downloadable across tabs (no g
         deals: [
           {
             id: dealId,
-            owner: nilAddress,
+            owner: polystoreAddress,
             cid: committedRoot,
             size: String(24 * 1024 * 1024),
             escrow_balance: '1000000',
@@ -369,7 +369,7 @@ test('Thick Client: committed slab is visible and downloadable across tabs (no g
       body: JSON.stringify({
         deal: {
           id: dealId,
-          owner: nilAddress,
+          owner: polystoreAddress,
           manifest_root: committedRoot ? Buffer.from(committedRoot.slice(2), 'hex').toString('base64') : '',
           size: String(24 * 1024 * 1024),
           escrow_balance: '1000000',

--- a/polystore-website/tests/parity.spec.ts
+++ b/polystore-website/tests/parity.spec.ts
@@ -9,7 +9,7 @@ import { bech32 } from 'bech32';
 const POLYSTORE_CLI_PATH = path.resolve('..', 'polystore_cli/target/release/polystore_cli');
 const TEST_FILE_SIZE = 1024 * 1024; // 1MB
 
-function ethToNil(ethAddress: string): string {
+function ethToPolystoreAddress(ethAddress: string): string {
   const data = Buffer.from(ethAddress.replace(/^0x/, ''), 'hex');
   const words = bech32.toWords(data);
   return bech32.encode('nil', words);
@@ -66,7 +66,7 @@ test('WASM Parity: Client-side sharding matches polystore_cli', async ({ page },
   const randomPk = generatePrivateKey();
   const account = privateKeyToAccount(randomPk);
   const chainIdHex = '0x7A69'; // 31337
-  const nilAddress = ethToNil(account.address);
+  const polystoreAddress = ethToPolystoreAddress(account.address);
 
   // Mock LCD Deals to allow selection
   await page.route('**/polystorechain/polystorechain/v1/deals**', async route => {
@@ -76,7 +76,7 @@ test('WASM Parity: Client-side sharding matches polystore_cli', async ({ page },
               deals: [
                   {
                       id: '1',
-                      owner: nilAddress,
+                      owner: polystoreAddress,
                       cid: '',
                       size: '0',
                       escrow_balance: '1000000',

--- a/polystore-website/tests/sp-dashboard.spec.ts
+++ b/polystore-website/tests/sp-dashboard.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test'
 import { privateKeyToAccount, generatePrivateKey } from 'viem/accounts'
 import { bech32 } from 'bech32'
 
-function ethToNil(ethAddress: string): string {
+function ethToPolystoreAddress(ethAddress: string): string {
   const data = Buffer.from(ethAddress.replace(/^0x/, ''), 'hex')
   const words = bech32.toWords(data)
   return bech32.encode('nil', words)
@@ -13,7 +13,7 @@ test('provider dashboard uses provider-daemon status and can unpair a provider',
   const account = privateKeyToAccount(generatePrivateKey())
   const chainId = Number(process.env.CHAIN_ID || 20260211)
   const chainIdHex = `0x${chainId.toString(16)}`
-  const nilAddress = ethToNil(account.address)
+  const polystoreAddress = ethToPolystoreAddress(account.address)
   const providerAddress = 'nil1providerdashboard000000000000000000000000'
   const publicBase = 'https://sp-dashboard.example.com'
   const txHash = '0x0000000000000000000000000000000000000000000000000000000000000abc'
@@ -128,7 +128,7 @@ test('provider dashboard uses provider-daemon status and can unpair a provider',
     })
   })
 
-  await page.route(`**/polystorechain/polystorechain/v1/provider-pairings/by-operator/${nilAddress}`, async (route) => {
+  await page.route(`**/polystorechain/polystorechain/v1/provider-pairings/by-operator/${polystoreAddress}`, async (route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -138,7 +138,7 @@ test('provider dashboard uses provider-daemon status and can unpair a provider',
           : [
               {
                 provider: providerAddress,
-                operator: nilAddress,
+                operator: polystoreAddress,
                 paired_height: '91',
               },
             ],
@@ -173,7 +173,7 @@ test('provider dashboard uses provider-daemon status and can unpair a provider',
           address: providerAddress,
           key_name: 'provider-main',
           pairing_status: 'paired',
-          paired_operator: nilAddress,
+          paired_operator: polystoreAddress,
           registration_status: 'registered',
           public_base: publicBase,
           public_health_ok: true,

--- a/polystore-website/tests/sp-onboarding.spec.ts
+++ b/polystore-website/tests/sp-onboarding.spec.ts
@@ -3,7 +3,7 @@ import { test, expect, type Page, type Route } from '@playwright/test'
 import { privateKeyToAccount, generatePrivateKey } from 'viem/accounts'
 import { bech32 } from 'bech32'
 
-function ethToNil(ethAddress: string): string {
+function ethToPolystoreAddress(ethAddress: string): string {
   const data = Buffer.from(ethAddress.replace(/^0x/, ''), 'hex')
   const words = bech32.toWords(data)
   return bech32.encode('nil', words)
@@ -59,7 +59,7 @@ async function setupSpOnboardingFixture(page: Page, options: SpOnboardingFixture
   const account = privateKeyToAccount(generatePrivateKey())
   const chainId = Number(process.env.CHAIN_ID || 20260211)
   const chainIdHex = `0x${chainId.toString(16)}`
-  const nilAddress = ethToNil(account.address)
+  const polystoreAddress = ethToPolystoreAddress(account.address)
   const providerAddress = options.draft?.providerAddress || 'nil1provideronboarding0000000000000000000000000'
   const defaultPublicBase = options.draft?.endpointMode === 'ipv4'
     ? `http://${options.draft.endpointValue || '203.0.113.10'}:${options.draft.publicPort || '8091'}`
@@ -81,14 +81,14 @@ async function setupSpOnboardingFixture(page: Page, options: SpOnboardingFixture
   const pendingLinks = options.pendingLinks ?? [
     {
       provider: providerAddress,
-      operator: nilAddress,
+      operator: polystoreAddress,
       requested_height: '95',
     },
   ]
   const pairings = options.pairings ?? [
     {
       provider: providerAddress,
-      operator: nilAddress,
+      operator: polystoreAddress,
       paired_height: '90',
     },
   ]
@@ -195,7 +195,7 @@ async function setupSpOnboardingFixture(page: Page, options: SpOnboardingFixture
     })
   })
 
-  await page.route(`**/polystorechain/polystorechain/v1/provider-pairings/pending-by-operator/${nilAddress}`, async (route) => {
+  await page.route(`**/polystorechain/polystorechain/v1/provider-pairings/pending-by-operator/${polystoreAddress}`, async (route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -203,7 +203,7 @@ async function setupSpOnboardingFixture(page: Page, options: SpOnboardingFixture
     })
   })
 
-  await page.route(`**/polystorechain/polystorechain/v1/provider-pairings/by-operator/${nilAddress}`, async (route) => {
+  await page.route(`**/polystorechain/polystorechain/v1/provider-pairings/by-operator/${polystoreAddress}`, async (route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -230,7 +230,7 @@ async function setupSpOnboardingFixture(page: Page, options: SpOnboardingFixture
           provider: {
             address: providerAddress,
             pairing_status: pairings.length ? 'paired' : pendingLinks.length ? 'pending' : 'unpaired',
-            paired_operator: nilAddress,
+            paired_operator: polystoreAddress,
             registration_status: providers.length ? 'registered' : 'pending',
             public_base: publicBase,
             public_health_url: `${publicBase}/health`,
@@ -255,11 +255,11 @@ async function setupSpOnboardingFixture(page: Page, options: SpOnboardingFixture
   await page.goto('/#/sp-onboarding', { waitUntil: 'networkidle' })
   await connectWalletIfNeeded(page)
 
-  return { account, nilAddress, providerAddress, publicBase, providerDraft }
+  return { account, polystoreAddress, providerAddress, publicBase, providerDraft }
 }
 
 test('provider onboarding renders the revised five-step happy path and preserves auth across refresh', async ({ page }) => {
-  const { nilAddress } = await setupSpOnboardingFixture(page, {
+  const { polystoreAddress } = await setupSpOnboardingFixture(page, {
     authToken: 'shared-provider-secret',
   })
 
@@ -275,7 +275,7 @@ test('provider onboarding renders the revised five-step happy path and preserves
 
   await expect(page.getByTestId('provider-auth-token')).toHaveValue('shared-provider-secret')
   const hostCommands = await page.getByTestId('provider-host-commands').textContent()
-  expect(hostCommands).toContain(`OPERATOR_ADDRESS='${nilAddress}'`)
+  expect(hostCommands).toContain(`OPERATOR_ADDRESS='${polystoreAddress}'`)
   expect(hostCommands).toContain("./scripts/run_devnet_provider.sh bootstrap")
   expect(hostCommands).toContain("POLYSTORE_GATEWAY_SP_AUTH='shared-provider-secret'")
   expect(hostCommands).not.toMatch(/BOOTSTRAP_ALLOW_PARTIAL=1\s*\\/i)

--- a/polystore-website/website-spec.md
+++ b/polystore-website/website-spec.md
@@ -219,7 +219,7 @@ This layer encapsulates MetaMask transactions, transport routing, and gateway/SP
 ### 4.3 `useUpload` (`src/hooks/useUpload.ts`)
 *   **Purpose:** Handles thin-client file upload via the transport router (gateway or direct SP).
 *   **Logic:**
-    1.  Converts EVM address to Cosmos (Bech32) format if needed using `ethToNil`.
+    1.  Converts EVM address to the current PolyStore Chain bech32 format if needed using `ethToPolystoreAddress`.
     2.  Constructs `FormData` with `file`, `owner`, and optional controls (`deal_id`, `max_user_mdus`, `file_path`).
     3.  Calls `transport.uploadFile(...)` which selects `gatewayBase` or `spBase` based on routing preference and availability.
 *   **Returns:** `{ manifestRoot, sizeBytes, fileSizeBytes, allocatedLength?, filename }`.
@@ -262,7 +262,7 @@ The central hub for deal management.
     *   `activeTab`: 'alloc' (Allocation), 'content' (Commitment), 'mdu' (Thick client).
     *   `deals`: List of user's deals (fetched from LCD).
     *   `providers`: Active SP list.
-    *   `nilAddress`: Derived Cosmos address from connected EVM wallet.
+    *   `polystoreAddress`: Derived PolyStore Chain address from the connected EVM wallet.
 *   **Key Interactions:**
     *   **Allocation:** Form -> `useCreateDeal` (Mode 1 or Mode 2 with RS selector).
     *   **Commitment (Content tab):** File Input -> `useUpload` -> `useUpdateDealContent`.
@@ -362,7 +362,7 @@ The central hub for deal management.
 ## 7. Utilities & Libraries
 
 ### 7.1 Address (`src/lib/address.ts`)
-*   `ethToNil(ethAddress: string)`: Converts 0x Ethereum addresses to `nil1...` Bech32 format.
+*   `ethToPolystoreAddress(ethAddress: string)`: Converts 0x Ethereum addresses to the current PolyStore Chain bech32 format (`nil1...` today).
 
 ### 7.2 Status (`src/lib/status.ts`)
 *   `fetchStatus(chainId)`: Aggregates health checks from LCD, EVM RPC, and Faucet.

--- a/polystore_gateway/keyring_helpers.go
+++ b/polystore_gateway/keyring_helpers.go
@@ -21,7 +21,7 @@ func resolveKeyNameForAddress(ctx context.Context, addrOrName string) (string, e
 	if signer == "" {
 		return "", fmt.Errorf("empty signer")
 	}
-	// If it doesn't look like a nil bech32 address, assume it's already a key name.
+	// If it doesn't look like the current PolyStore nil1 bech32 address, assume it's already a key name.
 	if !strings.HasPrefix(signer, "nil1") {
 		return signer, nil
 	}

--- a/polystore_gateway/main.go
+++ b/polystore_gateway/main.go
@@ -429,7 +429,7 @@ func extractDealID(logs []txLog, events []txEvent) string {
 	return find(events)
 }
 
-func evmHexToNilAddress(hexAddr string) (string, error) {
+func evmHexToPolystoreAddress(hexAddr string) (string, error) {
 	trimmed := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(hexAddr)), "0x")
 	raw, err := hex.DecodeString(trimmed)
 	if err != nil {
@@ -442,6 +442,7 @@ func evmHexToNilAddress(hexAddr string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	// The current chain HRP is still `nil` even though product branding is PolyStore.
 	return bech32.Encode("nil", converted)
 }
 
@@ -2025,16 +2026,16 @@ func GatewayCreateDealFromEvm(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if creatorNil, err := evmHexToNilAddress(rawCreator); err == nil {
+	if creatorPolystoreAddress, err := evmHexToPolystoreAddress(rawCreator); err == nil {
 		// Only hit the faucet if the creator has no on-chain balance.
 		// This avoids bumping the faucet key sequence right before we submit
 		// MsgCreateDealFromEvm (which also signs with faucet), preventing
 		// avoidable account-sequence retries.
-		if ok, berr := creatorHasSomeBalance(creatorNil); berr != nil {
-			log.Printf("GatewayCreateDealFromEvm: balance check failed for %s: %v", creatorNil, berr)
+		if ok, berr := creatorHasSomeBalance(creatorPolystoreAddress); berr != nil {
+			log.Printf("GatewayCreateDealFromEvm: balance check failed for %s: %v", creatorPolystoreAddress, berr)
 		} else if !ok {
 			if autoFaucetEnabled {
-				fundAddressOnce(creatorNil)
+				fundAddressOnce(creatorPolystoreAddress)
 			} else {
 				http.Error(w, "creator has no on-chain balance; faucet disabled", http.StatusBadRequest)
 				return
@@ -4987,11 +4988,11 @@ func verifyRetrievalRequestSignature(dealOwner string, dealID uint64, filePath s
 	if err != nil {
 		return fmt.Errorf("failed to recover request signer: %w", err)
 	}
-	nilAddr, err := evmHexToNilAddress(evmAddr.Hex())
+	polystoreAddr, err := evmHexToPolystoreAddress(evmAddr.Hex())
 	if err != nil {
-		return fmt.Errorf("failed to map request signer to nil address: %w", err)
+		return fmt.Errorf("failed to map request signer to PolyStore address: %w", err)
 	}
-	if strings.TrimSpace(nilAddr) != strings.TrimSpace(dealOwner) {
+	if strings.TrimSpace(polystoreAddr) != strings.TrimSpace(dealOwner) {
 		return fmt.Errorf("request signer is not deal owner")
 	}
 	return nil
@@ -5050,7 +5051,7 @@ func resolveKeyAddress(ctx context.Context, name string) (string, error) {
 	if addr := extractNilAddress(trimmed); addr != "" {
 		return addr, nil
 	}
-	return "", fmt.Errorf("keys show returned no nil bech32 address (%q)", trimmed)
+	return "", fmt.Errorf("keys show returned no PolyStore bech32 address (%q)", trimmed)
 }
 
 // submitRetrievalProof submits a retrieval proof for the given deal and file

--- a/polystore_gateway/main.go
+++ b/polystore_gateway/main.go
@@ -4663,7 +4663,7 @@ func shardFile(ctx context.Context, path string, raw bool, savePrefix string) (*
 	// Use execPolystoreCli which now returns ([]byte, error)
 	outBytes, err := execPolystoreCli(ctx, args...)
 	if err != nil {
-		return nil, fmt.Errorf("nil-cli shard failed: %w", err)
+		return nil, fmt.Errorf("polystore_cli shard failed: %w", err)
 	}
 
 	// polystore_cli with --out writes to file, but might print logs to stdout.

--- a/polystore_gateway/main_test.go
+++ b/polystore_gateway/main_test.go
@@ -128,11 +128,11 @@ func testDealOwner(t *testing.T) string {
 	if err != nil {
 		t.Fatalf("HexToECDSA failed: %v", err)
 	}
-	nilAddr, err := evmHexToNilAddress(ethcrypto.PubkeyToAddress(key.PublicKey).Hex())
+	polystoreAddr, err := evmHexToPolystoreAddress(ethcrypto.PubkeyToAddress(key.PublicKey).Hex())
 	if err != nil {
-		t.Fatalf("evmHexToNilAddress failed: %v", err)
+		t.Fatalf("evmHexToPolystoreAddress failed: %v", err)
 	}
-	return nilAddr
+	return polystoreAddr
 }
 
 func signRetrievalRequest(t *testing.T, dealID uint64, filePath string, rangeStart uint64, rangeLen uint64, nonce uint64, expiresAt uint64) string {

--- a/polystore_gateway/provider_admin.go
+++ b/polystore_gateway/provider_admin.go
@@ -246,9 +246,9 @@ func verifyProviderAdminRequest(ctx context.Context, req *providerAdminRequest, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to recover operator signer: %w", err)
 	}
-	operatorAddr, err := evmHexToNilAddress(evmAddr.Hex())
+	operatorAddr, err := evmHexToPolystoreAddress(evmAddr.Hex())
 	if err != nil {
-		return nil, fmt.Errorf("failed to map operator signer to nil address: %w", err)
+		return nil, fmt.Errorf("failed to map operator signer to PolyStore address: %w", err)
 	}
 
 	pairing, pairingStatus, pairingErr := fetchProviderPairingFromLCD(ctx, localProviderAddr)

--- a/polystore_gateway/provider_admin_test.go
+++ b/polystore_gateway/provider_admin_test.go
@@ -34,7 +34,7 @@ func providerAdminTestKey(t *testing.T) *ecdsa.PrivateKey {
 	return key
 }
 
-func providerAdminOperatorNilAddress(t *testing.T) string {
+func providerAdminOperatorPolystoreAddress(t *testing.T) string {
 	t.Helper()
 	key := providerAdminTestKey(t)
 	addr, err := evmHexToPolystoreAddress(gethCrypto.PubkeyToAddress(key.PublicKey).Hex())
@@ -85,7 +85,7 @@ func setupProviderAdminStatusEnv(t *testing.T, providerAddress string, localURL 
 }
 
 func TestSpAdminStatus_AllowsPairedOperator(t *testing.T) {
-	operator := providerAdminOperatorNilAddress(t)
+	operator := providerAdminOperatorPolystoreAddress(t)
 	const provider = "nil1provideradminstatus"
 
 	localSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -166,7 +166,7 @@ func TestSpAdminStatus_AllowsPairedOperator(t *testing.T) {
 }
 
 func TestSpAdminDoctor_RejectsNonceReplay(t *testing.T) {
-	operator := providerAdminOperatorNilAddress(t)
+	operator := providerAdminOperatorPolystoreAddress(t)
 	const provider = "nil1provideradmindoctor"
 
 	localSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -229,7 +229,7 @@ func TestSpAdminDoctor_RejectsNonceReplay(t *testing.T) {
 }
 
 func TestSpAdminRotateEndpoint_UsesUpdateTransaction(t *testing.T) {
-	operator := providerAdminOperatorNilAddress(t)
+	operator := providerAdminOperatorPolystoreAddress(t)
 	const provider = "nil1provideradminrotate"
 	const endpoint = "/dns4/new.example.com/tcp/443/https"
 

--- a/polystore_gateway/provider_admin_test.go
+++ b/polystore_gateway/provider_admin_test.go
@@ -37,9 +37,9 @@ func providerAdminTestKey(t *testing.T) *ecdsa.PrivateKey {
 func providerAdminOperatorNilAddress(t *testing.T) string {
 	t.Helper()
 	key := providerAdminTestKey(t)
-	addr, err := evmHexToNilAddress(gethCrypto.PubkeyToAddress(key.PublicKey).Hex())
+	addr, err := evmHexToPolystoreAddress(gethCrypto.PubkeyToAddress(key.PublicKey).Hex())
 	if err != nil {
-		t.Fatalf("evmHexToNilAddress: %v", err)
+		t.Fatalf("evmHexToPolystoreAddress: %v", err)
 	}
 	return addr
 }

--- a/polystore_gateway_gui/src-tauri/src/sidecar.rs
+++ b/polystore_gateway_gui/src-tauri/src/sidecar.rs
@@ -181,7 +181,9 @@ impl SidecarManager {
         configure_sidecar_from_binary_layout(&mut cmd, &binary);
 
         if let Ok(resource_dir) = app.path().resource_dir() {
-            let polystore_cli_path = resource_dir.join("bin").join(binary_filename("polystore_cli"));
+            let polystore_cli_path = resource_dir
+                .join("bin")
+                .join(binary_filename("polystore_cli"));
             if is_resource_ready(&polystore_cli_path) {
                 cmd.env("POLYSTORE_CLI_BIN", &polystore_cli_path);
             }

--- a/polystore_gateway_gui/src-tauri/src/sp.rs
+++ b/polystore_gateway_gui/src-tauri/src/sp.rs
@@ -597,7 +597,8 @@ pub async fn health_snapshot(req: SpHealthSnapshotRequest) -> Result<SpHealthSna
     }
 
     if let Some(provider_addr) = req.provider_addr.clone() {
-        let provider_url = format!("{lcd_base}/polystorechain/polystorechain/v1/providers/{provider_addr}");
+        let provider_url =
+            format!("{lcd_base}/polystorechain/polystorechain/v1/providers/{provider_addr}");
         match client.get(&provider_url).send().await {
             Ok(resp) if resp.status().is_success() => checks.push(SpCheckResult {
                 name: "provider_registered".to_string(),
@@ -642,7 +643,8 @@ pub async fn health_snapshot(req: SpHealthSnapshotRequest) -> Result<SpHealthSna
             code: "auth_mismatch".to_string(),
             severity: "critical".to_string(),
             message: "shared auth token is missing".to_string(),
-            recommended_action: "Set POLYSTORE_GATEWAY_SP_AUTH to the hub-provided token.".to_string(),
+            recommended_action: "Set POLYSTORE_GATEWAY_SP_AUTH to the hub-provided token."
+                .to_string(),
         });
         checks.push(SpCheckResult {
             name: "shared_auth_present".to_string(),

--- a/polystore_gateway_gui/src/App.tsx
+++ b/polystore_gateway_gui/src/App.tsx
@@ -44,7 +44,7 @@ const RECOVERY_COOLDOWN_MS = 20_000;
 const RECENT_DEAL_LIMIT = 6;
 const RECENT_FILE_LIMIT = 8;
 const RECENT_ACTIVITY_LIMIT = 5;
-const TECHNOLOGY_MDU_PRIMER_URL = "https://nil.store/#/technology?section=mdu-primer";
+const TECHNOLOGY_MDU_PRIMER_URL = "https://polynomialstore.com/#/technology?section=mdu-primer";
 
 function errorMessage(err: unknown, fallback: string): string {
   if (err instanceof Error && err.message) return err.message;

--- a/polystore_gateway_gui/src/hooks/useWallet.ts
+++ b/polystore_gateway_gui/src/hooks/useWallet.ts
@@ -11,7 +11,7 @@ const PROJECT_ID =
 const metadata = {
   name: "PolyStore Gateway GUI",
   description: "PolyStore desktop gateway",
-  url: "https://nil.store",
+  url: "https://polynomialstore.com",
   icons: [],
 };
 

--- a/polystore_p2p/src/lib.rs
+++ b/polystore_p2p/src/lib.rs
@@ -109,8 +109,8 @@ impl PolyStoreNode {
         swarm
             .behaviour_mut()
             .gossipsub
-            .subscribe(&gossipsub::IdentTopic::new("nil-proxy"))
-            .map_err(|_| anyhow::anyhow!("Failed to subscribe to nil-proxy"))?;
+            .subscribe(&gossipsub::IdentTopic::new("polystore-proxy"))
+            .map_err(|_| anyhow::anyhow!("Failed to subscribe to polystore-proxy"))?;
 
         Ok(Self { swarm, command_rx })
     }

--- a/polystorechain/x/polystorechain/client/cli/tx_basic.go
+++ b/polystorechain/x/polystorechain/client/cli/tx_basic.go
@@ -227,7 +227,7 @@ func CmdCreateDeal() *cobra.Command {
 			return generateOrBroadcastTxCLIFn(clientCtx, cmd.Flags(), &msg)
 		},
 	}
-	cmd.Flags().String("service-hint", "General", "Service hint for placement (e.g. General[:owner=<polystoreAddress>][:rs=K+M]). replicas-only hints are deprecated; omit rs= to auto-select Mode 2.")
+	cmd.Flags().String("service-hint", "General", "Service hint for placement (e.g. General[:owner=<nil1... PolyStore address>][:rs=K+M]). replicas-only hints are deprecated; omit rs= to auto-select Mode 2.")
 	flags.AddTxFlagsToCmd(cmd)
 	return cmd
 }

--- a/polystorechain/x/polystorechain/client/cli/tx_basic.go
+++ b/polystorechain/x/polystorechain/client/cli/tx_basic.go
@@ -227,7 +227,7 @@ func CmdCreateDeal() *cobra.Command {
 			return generateOrBroadcastTxCLIFn(clientCtx, cmd.Flags(), &msg)
 		},
 	}
-	cmd.Flags().String("service-hint", "General", "Service hint for placement (e.g. General[:owner=<nilAddress>][:rs=K+M]). replicas-only hints are deprecated; omit rs= to auto-select Mode 2.")
+	cmd.Flags().String("service-hint", "General", "Service hint for placement (e.g. General[:owner=<polystoreAddress>][:rs=K+M]). replicas-only hints are deprecated; omit rs= to auto-select Mode 2.")
 	flags.AddTxFlagsToCmd(cmd)
 	return cmd
 }

--- a/polystorechain/x/polystorechain/keeper/msg_server.go
+++ b/polystorechain/x/polystorechain/keeper/msg_server.go
@@ -604,7 +604,7 @@ func (k msgServer) CreateDeal(goCtx context.Context, msg *types.MsgCreateDeal) (
 
 	// Decode any overrides embedded in the service hint.
 	// Format used by the web gateway:
-	//   "<Hint>[:owner=<nilAddress>][:rs=K+M]"
+	//   "<Hint>[:owner=<polystoreAddress>][:rs=K+M]"
 	// Note: Mode 1 (replicas-only) hints are deprecated; omit rs= to auto-select a balanced Mode 2 profile.
 	rawHint := strings.TrimSpace(msg.ServiceHint)
 	parsedHint, err := types.ParseServiceHint(rawHint)

--- a/polystorechain/x/polystorechain/keeper/msg_server.go
+++ b/polystorechain/x/polystorechain/keeper/msg_server.go
@@ -604,7 +604,7 @@ func (k msgServer) CreateDeal(goCtx context.Context, msg *types.MsgCreateDeal) (
 
 	// Decode any overrides embedded in the service hint.
 	// Format used by the web gateway:
-	//   "<Hint>[:owner=<polystoreAddress>][:rs=K+M]"
+	//   "<Hint>[:owner=<nil1... PolyStore address>][:rs=K+M]"
 	// Note: Mode 1 (replicas-only) hints are deprecated; omit rs= to auto-select a balanced Mode 2 profile.
 	rawHint := strings.TrimSpace(msg.ServiceHint)
 	parsedHint, err := types.ParseServiceHint(rawHint)

--- a/scripts/run_devnet_alpha_multi_sp.sh
+++ b/scripts/run_devnet_alpha_multi_sp.sh
@@ -179,13 +179,13 @@ ensure_polystore_core() {
     fi
 
     for sym in \
-      nil_compute_mdu_root_from_witness_flat \
-      nil_expand_mdu_rs \
-      nil_reconstruct_mdu_rs \
-      nil_mdu0_builder_new_with_commitments \
-      nil_mdu0_builder_load_with_commitments \
-      nil_encode_payload_to_mdu \
-      nil_decode_payload_from_mdu; do
+      polystore_compute_mdu_root_from_witness_flat \
+      polystore_expand_mdu_rs \
+      polystore_reconstruct_mdu_rs \
+      polystore_mdu0_builder_new_with_commitments \
+      polystore_mdu0_builder_load_with_commitments \
+      polystore_encode_payload_to_mdu \
+      polystore_decode_payload_from_mdu; do
       if [ "$nm_supports_dash_d" = "1" ]; then
         if ! nm -D "$file" 2>/dev/null | awk '{print $3}' | sed 's/@.*$//' | grep -Fxq "$sym"; then
           return 1

--- a/scripts/run_local_stack.sh
+++ b/scripts/run_local_stack.sh
@@ -205,13 +205,13 @@ ensure_polystore_core() {
     fi
 
     for sym in \
-      nil_compute_mdu_root_from_witness_flat \
-      nil_expand_mdu_rs \
-      nil_reconstruct_mdu_rs \
-      nil_mdu0_builder_new_with_commitments \
-      nil_mdu0_builder_load_with_commitments \
-      nil_encode_payload_to_mdu \
-      nil_decode_payload_from_mdu; do
+      polystore_compute_mdu_root_from_witness_flat \
+      polystore_expand_mdu_rs \
+      polystore_reconstruct_mdu_rs \
+      polystore_mdu0_builder_new_with_commitments \
+      polystore_mdu0_builder_load_with_commitments \
+      polystore_encode_payload_to_mdu \
+      polystore_decode_payload_from_mdu; do
       if [ "$nm_supports_dash_d" = "1" ]; then
         if ! nm -D "$file" 2>/dev/null | grep -Eq "(^|[[:space:]]|_)${sym}([[:space:]]|$)"; then
           return 1


### PR DESCRIPTION
## Summary
- rename internal `nilAddress` and `ethToNil` vocabulary to `polystoreAddress` and `ethToPolystoreAddress`
- update gateway address helper names and user-facing wording to refer to PolyStore addresses while keeping the current `nil1...` HRP
- rename website identity test ids and supporting docs/spec text to match the new PolyStore address terminology

## Testing
- `GOFLAGS=-mod=mod go test ./...` in `polystorechain`
- `go test ./...` in `polystore_gateway`
- `npm run test:unit` in `polystore-website`
- `npm run build` in `polystore-website`
- `git diff --check`

## Notes
- This PR intentionally does not change the live bech32 HRP. The current chain still encodes PolyStore addresses as `nil1...`; an HRP change would be a separate protocol-breaking migration.