### PR TITLE
Document branch and PR policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,16 +4,31 @@
 **CRITICAL:** When pushing changes to the repository, use the canonical `origin` remote.
 *   `git push origin <branch>`
 
+**CRITICAL:** Agents must not push implementation or planning work directly to
+`main`. Work must land through a topic branch and pull request with human
+approval before merge.
+
 ### Git Best Practices for Agents
 *   **Commit Regularly:** Always commit your work frequently, in small, logical chunks.
 *   **Prohibited Commands:** Agents are strictly forbidden from running aggressive Git commands like `git clean` or `git reset --hard` as these can lead to irreversible data loss of uncommitted work. If such commands are necessary, confirm with the user first.
 *   **Tests Before Push:** For every non-trivial change, run the most relevant unit/e2e tests before committing. Do not push code that you haven't at least smoke-tested locally.
 *   **Commit & Push Cadence:** Treat `AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md` as the canonical PR-by-PR TODO list for the Feb 2026 trusted devnet soft launch. Keep this file high-level and link out to repo-tracked TODOs/checklists instead of using this as a sprint tracker.
-*   **Default Autonomy:** Unless the user explicitly says “don’t commit/push yet,” agents should **automatically** commit completed work (after relevant tests pass) and push to `origin`. Keep commits small and descriptive, and avoid batching unrelated changes.
+*   **Default Autonomy:** Unless the user explicitly says “don’t commit/push yet,” agents should **automatically** commit completed work (after relevant tests pass) and push the topic branch to `origin`. Keep commits small and descriptive, and avoid batching unrelated changes.
 
-### Auto-commit contract (MANDATORY)
-*   If a task is implemented and the user did not explicitly say “don’t commit/push yet,” commit and push automatically.
-*   Do not ask for commit/push confirmation.
+### Branch / PR Contract (MANDATORY)
+*   If a task is implemented and the user did not explicitly say “don’t commit/push yet,” commit and push automatically to a non-`main` topic branch.
+*   Open or update a pull request when the branch is ready for review. Mark it draft if validation is incomplete or if the work is intentionally planning-only.
+*   Agents must not merge their own PRs.
+*   Human approval is required before merge.
+*   Direct pushes to `main` are prohibited except for a documented emergency hotfix explicitly authorized by the user.
+*   Prefer branch names that describe the workstream, for example:
+    *   `docs/<topic>`
+    *   `sim/<scenario-or-ledger>`
+    *   `chain/<keeper-policy>`
+    *   `gateway/<fault-or-routing>`
+    *   `website/<ux-surface>`
+    *   `e2e/<scenario>`
+*   Do not ask for commit/push confirmation when pushing the topic branch.
 *   Only ask if blocked by one of these:
     *   push/auth failure
     *   required tests failing with unclear remediation

--- a/docs/planning/POLICING_AND_FAILURE_SIMULATION_ROADMAP.md
+++ b/docs/planning/POLICING_AND_FAILURE_SIMULATION_ROADMAP.md
@@ -1423,7 +1423,86 @@ The financial market portion is not complete until:
    minting.
 7. Elasticity can absorb demand when funded and fails closed when unfunded.
 
-## 34. Open Questions
+## 34. Branching and PR Strategy
+
+The simulator and policing work should move through reviewable branches and
+pull requests. The historical direct-to-`main` workflow was acceptable during
+rapid planning, but it is not appropriate for the simulator, keeper, gateway,
+or enforcement workstreams.
+
+### 34.1 Branch Policy
+
+1. Agents should branch from a fresh `origin/main` before starting non-trivial
+   work.
+2. Agents must not push implementation or planning changes directly to `main`.
+3. Work should land on topic branches and be reviewed through PRs.
+4. Human approval is required before merge.
+5. Agents may push branches and open or update PRs, but must not merge their
+   own PRs.
+6. Direct `main` pushes are reserved for documented emergency hotfixes
+   explicitly authorized by the user.
+
+Recommended branch prefixes:
+
+| Prefix | Use |
+|---|---|
+| `docs/` | Roadmaps, RFCs, runbooks, AGENTS.md policy, planning updates. |
+| `sim/` | `tools/policy_sim` scenarios, ledgers, output schemas, assertions. |
+| `chain/` | Keeper state, params, messages, epoch hooks, consensus tests. |
+| `gateway/` | user-gateway or provider-daemon behavior, routing, fault hooks. |
+| `website/` | UX surfaces, dashboards, operator/user visibility. |
+| `e2e/` | process-level scripts, fixtures, and devnet orchestration. |
+
+### 34.2 PR Sizing
+
+PRs should be small enough to review as one policy or implementation unit.
+Recommended slicing:
+
+1. One PR for S0 simulator planning contract.
+2. One PR for fixture loading and built-in scenario migration.
+3. One PR for reliability ledgers.
+4. One PR for economic ledgers.
+5. One PR for simulated enforcement modes.
+6. One PR per keeper policy graduation.
+7. One PR per process-level e2e scenario or tightly related scenario group.
+
+Avoid combining docs, simulator behavior, keeper state, gateway behavior, and
+website UX in one PR unless the change is a deliberate end-to-end slice.
+
+### 34.3 PR Review Requirements
+
+Every PR should state:
+
+1. Which roadmap stage or simulator milestone it advances.
+2. Which scenario fixtures or policy surfaces it changes.
+3. Which tests or smoke checks were run.
+4. Which output schemas changed, if any.
+5. Whether the PR is planning-only, simulator-only, keeper-level,
+   runtime/e2e, or live-enforcement related.
+
+For simulator PRs, include example output paths or summarized assertion results.
+For keeper or runtime PRs, identify the simulator scenario that justified
+graduation.
+
+### 34.4 Merge Gates
+
+Minimum merge gates:
+
+1. Human review and approval.
+2. Relevant tests pass, or failures are documented and accepted by a human.
+3. No direct `main` push by agents.
+4. No destructive git operations or history rewrites without explicit approval.
+5. For schema changes, fixtures and regression tests are updated in the same
+   PR.
+
+### 34.5 Agent Instruction Source
+
+The root `AGENTS.md` must encode this branch/PR policy so future agents follow
+it by default. If nested `AGENTS.md` files add local guidance, they should not
+weaken the repo-wide requirement that agent work uses branches, PRs, and human
+approval before merge.
+
+## 35. Open Questions
 
 1. Should hot and cold deals use separate missed-epoch thresholds from the start?
 2. What false-positive repair rate is acceptable during trusted devnet?

--- a/polystore_gateway_gui/src-tauri/src/sidecar.rs
+++ b/polystore_gateway_gui/src-tauri/src/sidecar.rs
@@ -654,7 +654,7 @@ pub fn local_storage_summary(app: &AppHandle) -> Result<GatewayStorageSummary, S
             .then_with(|| a.deal_id.cmp(&b.deal_id))
     });
 
-    recent_files.sort_by_key(|file| std::cmp::Reverse(file.modified_unix));
+    recent_files.sort_unstable_by_key(|file| std::cmp::Reverse(file.modified_unix));
     recent_files.truncate(12);
 
     Ok(GatewayStorageSummary {

--- a/polystore_gateway_gui/src-tauri/src/sidecar.rs
+++ b/polystore_gateway_gui/src-tauri/src/sidecar.rs
@@ -654,7 +654,7 @@ pub fn local_storage_summary(app: &AppHandle) -> Result<GatewayStorageSummary, S
             .then_with(|| a.deal_id.cmp(&b.deal_id))
     });
 
-    recent_files.sort_by(|a, b| b.modified_unix.cmp(&a.modified_unix));
+    recent_files.sort_by_key(|file| std::cmp::Reverse(file.modified_unix));
     recent_files.truncate(12);
 
     Ok(GatewayStorageSummary {


### PR DESCRIPTION
## Summary
- Add repo-wide branch/PR policy to root AGENTS.md.
- Add Branching and PR Strategy section to the policing/simulator roadmap.
- Require topic branches, PRs, and human approval before merge; prohibit direct agent pushes to main except explicitly authorized emergency hotfixes.

## Validation
- git diff --check

## Notes
- This PR intentionally establishes the workflow requested for future agent work.
- Existing untracked local file `polystore_faucet/polystore_faucet` was not touched.
