### PR TITLE
Fix Tauri clippy sort lint

### DIFF
--- a/polystore_gateway_gui/src-tauri/src/sidecar.rs
+++ b/polystore_gateway_gui/src-tauri/src/sidecar.rs
@@ -654,7 +654,7 @@ pub fn local_storage_summary(app: &AppHandle) -> Result<GatewayStorageSummary, S
             .then_with(|| a.deal_id.cmp(&b.deal_id))
     });
 
-    recent_files.sort_by_key(|file| std::cmp::Reverse(file.modified_unix));
+    recent_files.sort_unstable_by_key(|file| std::cmp::Reverse(file.modified_unix));
     recent_files.truncate(12);
 
     Ok(GatewayStorageSummary {

--- a/polystore_gateway_gui/src-tauri/src/sidecar.rs
+++ b/polystore_gateway_gui/src-tauri/src/sidecar.rs
@@ -654,7 +654,7 @@ pub fn local_storage_summary(app: &AppHandle) -> Result<GatewayStorageSummary, S
             .then_with(|| a.deal_id.cmp(&b.deal_id))
     });
 
-    recent_files.sort_by(|a, b| b.modified_unix.cmp(&a.modified_unix));
+    recent_files.sort_by_key(|file| std::cmp::Reverse(file.modified_unix));
     recent_files.truncate(12);
 
     Ok(GatewayStorageSummary {


### PR DESCRIPTION
## Summary
- Replace newest-first recent file sorting with `sort_by_key` and `Reverse` to satisfy the current clippy `unnecessary_sort_by` lint.

## Test
- `cargo clippy --all-targets -- -D warnings` from `polystore_gateway_gui/src-tauri`