### PR TITLE
Add policy simulator graduation map

### DIFF
--- a/docs/planning/POLICING_AND_FAILURE_SIMULATION_ROADMAP.md
+++ b/docs/planning/POLICING_AND_FAILURE_SIMULATION_ROADMAP.md
@@ -1203,6 +1203,9 @@ Outputs:
 7. `sweep_summary.md` and `sweep_summary.json`: parameter-sweep or
    regression-suite summaries with run matrices, varied parameters,
    metric ranges, high-risk runs, and human review questions.
+8. `graduation_map.md` and `graduation_map.json`: corpus-level mapping from
+   scenario evidence to keeper tests, gateway/provider tests, e2e posture,
+   missing implementation surfaces, and further simulation review.
 
 The first report implementation must be stdlib-only and Markdown/CSV focused.
 Graph generation starts with SVG written directly by the report tool. Optional

--- a/docs/simulation-reports/policy-sim/README.md
+++ b/docs/simulation-reports/policy-sim/README.md
@@ -15,6 +15,8 @@ python3 tools/policy_sim/generate_report_corpus.py \
 
 ## Scenario Index
 
+The corpus-level [graduation map](graduation_map.md) translates these simulator results into the next keeper, gateway/provider, or policy-calibration artifacts.
+
 | Scenario | Verdict | Success | Unavailable Reads | Data Loss Events | Repairs | Backoffs | Saturated | Negative P&L | Report |
 |---|---|---:|---:|---:|---:|---:|---:|---:|---|
 | `audit-budget-exhaustion` | `PASS` | 1.0000 | 0 | 0 | 32/32 | 0 | 0 | 4 | [report](audit-budget-exhaustion/report.md) |

--- a/docs/simulation-reports/policy-sim/graduation_map.json
+++ b/docs/simulation-reports/policy-sim/graduation_map.json
@@ -1,0 +1,441 @@
+{
+  "scenarios": [
+    {
+      "blockers": [],
+      "e2e": "No process e2e until audit sessions are wired through provider-daemon.",
+      "metrics": {
+        "data_loss_events": 0,
+        "providers_negative_pnl": 4,
+        "repair_backoffs": 0,
+        "repairs_completed": 32,
+        "repairs_started": 32,
+        "saturated_responses": 0,
+        "success_rate": 1.0,
+        "unavailable_reads": 0,
+        "verdict": "PASS"
+      },
+      "missing_surfaces": [
+        "audit budget state",
+        "audit backlog query",
+        "evidence bounty accounting"
+      ],
+      "next_test": "Add audit-budget minted/spent/carryover tests proving audit demand is capped and backlog is explicit.",
+      "scenario": "audit-budget-exhaustion",
+      "status": "implementation planning",
+      "target": "audit budget keeper tests"
+    },
+    {
+      "blockers": [],
+      "e2e": "Manual or nightly multi-provider outage, not PR-blocking CI.",
+      "metrics": {
+        "data_loss_events": 0,
+        "providers_negative_pnl": 0,
+        "repair_backoffs": 1144,
+        "repairs_completed": 96,
+        "repairs_started": 96,
+        "saturated_responses": 0,
+        "success_rate": 1.0,
+        "unavailable_reads": 0,
+        "verdict": "PASS"
+      },
+      "missing_surfaces": [
+        "regional/provider-class placement metadata",
+        "operator concentration limits",
+        "nightly stress harness"
+      ],
+      "next_test": "Keep as simulator calibration until placement-diversity params exist, then add keeper candidate-selection tests.",
+      "scenario": "coordinated-regional-outage",
+      "status": "further simulation review",
+      "target": "placement diversity and nightly stress"
+    },
+    {
+      "blockers": [],
+      "e2e": "Provider returns corrupt bytes or invalid proof and user-gateway rejects the response.",
+      "metrics": {
+        "data_loss_events": 0,
+        "providers_negative_pnl": 1,
+        "repair_backoffs": 0,
+        "repairs_completed": 6,
+        "repairs_started": 6,
+        "saturated_responses": 0,
+        "success_rate": 1.0,
+        "unavailable_reads": 0,
+        "verdict": "PASS"
+      },
+      "missing_surfaces": [
+        "hard evidence submission",
+        "corrupt-byte reward exclusion",
+        "jail/slash params"
+      ],
+      "next_test": "Add invalid-proof or wrong-data keeper tests proving no corrupt payment, repair start, and slash/jail simulation gates.",
+      "scenario": "corrupt-provider",
+      "status": "implementation planning",
+      "target": "hard-fault keeper path"
+    },
+    {
+      "blockers": [],
+      "e2e": "Burst traffic e2e after overlay semantics are implemented.",
+      "metrics": {
+        "data_loss_events": 0,
+        "providers_negative_pnl": 0,
+        "repair_backoffs": 0,
+        "repairs_completed": 0,
+        "repairs_started": 0,
+        "saturated_responses": 0,
+        "success_rate": 1.0,
+        "unavailable_reads": 0,
+        "verdict": "PASS"
+      },
+      "missing_surfaces": [
+        "MsgSignalSaturation hardening",
+        "overlay accountability",
+        "deal spend window"
+      ],
+      "next_test": "Add spend-window tests for saturation signaling, fail-closed expansion, TTL, and cap-bound rejection.",
+      "scenario": "elasticity-cap-hit",
+      "status": "further simulation review",
+      "target": "elasticity spend-window tests"
+    },
+    {
+      "blockers": [],
+      "e2e": "Optional provider restart e2e; keeper coverage should be the first artifact.",
+      "metrics": {
+        "data_loss_events": 0,
+        "providers_negative_pnl": 0,
+        "repair_backoffs": 0,
+        "repairs_completed": 0,
+        "repairs_started": 0,
+        "saturated_responses": 0,
+        "success_rate": 1.0,
+        "unavailable_reads": 0,
+        "verdict": "PASS"
+      },
+      "missing_surfaces": [
+        "soft-fault decay",
+        "per-slot suspect state",
+        "operator health query"
+      ],
+      "next_test": "Add missed-epoch window tests proving intermittent failures create health evidence without triggering repair churn.",
+      "scenario": "flapping-provider",
+      "status": "implementation planning",
+      "target": "keeper soft-fault window"
+    },
+    {
+      "blockers": [],
+      "e2e": "Gateway happy-path smoke remains sufficient; do not add a slow failure e2e for the control case.",
+      "metrics": {
+        "data_loss_events": 0,
+        "providers_negative_pnl": 0,
+        "repair_backoffs": 0,
+        "repairs_completed": 0,
+        "repairs_started": 0,
+        "saturated_responses": 0,
+        "success_rate": 1.0,
+        "unavailable_reads": 0,
+        "verdict": "PASS"
+      },
+      "missing_surfaces": [
+        "keeper epoch hooks",
+        "reward eligibility queries"
+      ],
+      "next_test": "Add no-op epoch tests proving healthy providers do not accrue evidence, repair, reward exclusion, jail, or slash state.",
+      "scenario": "ideal",
+      "status": "implementation planning",
+      "target": "keeper control tests"
+    },
+    {
+      "blockers": [],
+      "e2e": "Do not mirror this as process e2e; keep it as simulator/CI artifact work.",
+      "metrics": {
+        "data_loss_events": 0,
+        "providers_negative_pnl": 4,
+        "repair_backoffs": 21150,
+        "repairs_completed": 3050,
+        "repairs_started": 3624,
+        "saturated_responses": 15482,
+        "success_rate": 0.9926041666666666,
+        "unavailable_reads": 1065,
+        "verdict": "PASS"
+      },
+      "missing_surfaces": [
+        "scale sweep corpus",
+        "placement diversity params",
+        "operator concentration analysis",
+        "CI artifact retention"
+      ],
+      "next_test": "Use sweep reports to tune repair throughput, placement headroom, retrieval pricing, and provider P&L before keeper defaults.",
+      "scenario": "large-scale-regional-stress",
+      "status": "further simulation review",
+      "target": "scale calibration and regression reporting"
+    },
+    {
+      "blockers": [],
+      "e2e": "Slow-path only after keeper reward accounting is stable.",
+      "metrics": {
+        "data_loss_events": 0,
+        "providers_negative_pnl": 1,
+        "repair_backoffs": 0,
+        "repairs_completed": 6,
+        "repairs_started": 6,
+        "saturated_responses": 0,
+        "success_rate": 1.0,
+        "unavailable_reads": 0,
+        "verdict": "PASS"
+      },
+      "missing_surfaces": [
+        "quota miss ledger",
+        "reward exclusion reason query",
+        "soft fault consequence ceiling"
+      ],
+      "next_test": "Add quota shortfall and synthetic-fill tests proving lazy responsibility is excluded from base rewards without soft-fault slashing.",
+      "scenario": "lazy-provider",
+      "status": "implementation planning",
+      "target": "reward eligibility keeper tests"
+    },
+    {
+      "blockers": [],
+      "e2e": "No process e2e; validate with keeper tests and simulator sweeps first.",
+      "metrics": {
+        "data_loss_events": 0,
+        "providers_negative_pnl": 0,
+        "repair_backoffs": 0,
+        "repairs_completed": 0,
+        "repairs_started": 0,
+        "saturated_responses": 0,
+        "success_rate": 1.0,
+        "unavailable_reads": 0,
+        "verdict": "PASS"
+      },
+      "missing_surfaces": [
+        "dynamic pricing params",
+        "storage utilization accumulator",
+        "retrieval demand accumulator"
+      ],
+      "next_test": "Add epoch pricing tests for floors, ceilings, utilization target, retrieval-demand target, and max step bps.",
+      "scenario": "price-controller-bounds",
+      "status": "implementation planning",
+      "target": "dynamic pricing keeper tests"
+    },
+    {
+      "blockers": [],
+      "e2e": "Small devnet with no spare provider capacity after keeper behavior is stable.",
+      "metrics": {
+        "data_loss_events": 0,
+        "providers_negative_pnl": 0,
+        "repair_backoffs": 72,
+        "repairs_completed": 0,
+        "repairs_started": 0,
+        "saturated_responses": 0,
+        "success_rate": 1.0,
+        "unavailable_reads": 0,
+        "verdict": "PASS"
+      },
+      "missing_surfaces": [
+        "candidate exclusion reasons",
+        "repair attempt caps",
+        "replacement capacity query"
+      ],
+      "next_test": "Add tests proving no eligible replacement emits backoff, preserves capacity constraints, and does not over-assign providers.",
+      "scenario": "repair-candidate-exhaustion",
+      "status": "implementation planning",
+      "target": "candidate selection and repair backoff keeper tests"
+    },
+    {
+      "blockers": [],
+      "e2e": "Create deal with one failing provider upload and verify replacement before first content commit.",
+      "metrics": {
+        "data_loss_events": 0,
+        "providers_negative_pnl": 1,
+        "repair_backoffs": 0,
+        "repairs_completed": 6,
+        "repairs_started": 6,
+        "saturated_responses": 0,
+        "success_rate": 1.0,
+        "unavailable_reads": 0,
+        "verdict": "PASS"
+      },
+      "missing_surfaces": [
+        "setup slot state",
+        "setup bump event",
+        "candidate exclusion reasons"
+      ],
+      "next_test": "Add setup-phase replacement tests proving failed initial upload selects a system provider and does not imply fraud.",
+      "scenario": "setup-failure",
+      "status": "implementation planning",
+      "target": "setup bump and deterministic replacement"
+    },
+    {
+      "blockers": [],
+      "e2e": "Kill one provider-daemon during retrieval and assert reads stay available while repair starts.",
+      "metrics": {
+        "data_loss_events": 0,
+        "providers_negative_pnl": 1,
+        "repair_backoffs": 0,
+        "repairs_completed": 6,
+        "repairs_started": 6,
+        "saturated_responses": 0,
+        "success_rate": 1.0,
+        "unavailable_reads": 0,
+        "verdict": "PASS"
+      },
+      "missing_surfaces": [
+        "slot health state",
+        "repair attempt ledger",
+        "promotion readiness proof",
+        "gateway repair-aware routing"
+      ],
+      "next_test": "Add a keeper test where a slot crosses missed-epoch threshold, enters repair, selects a deterministic pending provider, and later promotes.",
+      "scenario": "single-outage",
+      "status": "implementation planning",
+      "target": "keeper repair and gateway route-around"
+    },
+    {
+      "blockers": [],
+      "e2e": "No process e2e until keeper reward gating is complete.",
+      "metrics": {
+        "data_loss_events": 0,
+        "providers_negative_pnl": 6,
+        "repair_backoffs": 0,
+        "repairs_completed": 48,
+        "repairs_started": 48,
+        "saturated_responses": 0,
+        "success_rate": 1.0,
+        "unavailable_reads": 0,
+        "verdict": "PASS"
+      },
+      "missing_surfaces": [
+        "compliance-gated base rewards",
+        "subsidy leakage metrics",
+        "operator concentration checks"
+      ],
+      "next_test": "Add tests proving idle or non-compliant responsibility cannot farm base rewards profitably.",
+      "scenario": "subsidy-farming",
+      "status": "implementation planning",
+      "target": "base reward compliance tests"
+    },
+    {
+      "blockers": [],
+      "e2e": "Provider timeout/blackhole e2e after keeper state is deterministic.",
+      "metrics": {
+        "data_loss_events": 0,
+        "providers_negative_pnl": 1,
+        "repair_backoffs": 0,
+        "repairs_completed": 6,
+        "repairs_started": 6,
+        "saturated_responses": 0,
+        "success_rate": 1.0,
+        "unavailable_reads": 0,
+        "verdict": "PASS"
+      },
+      "missing_surfaces": [
+        "non-response accumulator",
+        "delinquency reason codes",
+        "reward exclusion event"
+      ],
+      "next_test": "Add per-slot delinquency tests for repeated non-response, reward exclusion, repair start, and replacement selection.",
+      "scenario": "sustained-non-response",
+      "status": "implementation planning",
+      "target": "keeper delinquency repair"
+    },
+    {
+      "blockers": [],
+      "e2e": "No process e2e yet; this is a parameter-calibration fixture.",
+      "metrics": {
+        "data_loss_events": 0,
+        "providers_negative_pnl": 48,
+        "repair_backoffs": 0,
+        "repairs_completed": 0,
+        "repairs_started": 0,
+        "saturated_responses": 0,
+        "success_rate": 1.0,
+        "unavailable_reads": 0,
+        "verdict": "PASS"
+      },
+      "missing_surfaces": [
+        "dynamic pricing state",
+        "provider cost assumptions",
+        "profitability dashboards"
+      ],
+      "next_test": "Compare storage floors, base rewards, and provider cost assumptions before encoding governance defaults.",
+      "scenario": "underpriced-storage",
+      "status": "further simulation review",
+      "target": "economic policy calibration"
+    },
+    {
+      "blockers": [],
+      "e2e": "Public retrieval spike against one deal with requester/sponsor funding.",
+      "metrics": {
+        "data_loss_events": 0,
+        "providers_negative_pnl": 0,
+        "repair_backoffs": 0,
+        "repairs_completed": 0,
+        "repairs_started": 0,
+        "saturated_responses": 0,
+        "success_rate": 1.0,
+        "unavailable_reads": 0,
+        "verdict": "PASS"
+      },
+      "missing_surfaces": [
+        "sponsored session funding",
+        "owner escrow isolation",
+        "hot route observability"
+      ],
+      "next_test": "Add sponsored-session tests proving public demand pays providers without draining owner escrow unexpectedly.",
+      "scenario": "viral-public-retrieval",
+      "status": "further simulation review",
+      "target": "sponsored retrieval accounting"
+    },
+    {
+      "blockers": [],
+      "e2e": "Synthetic wash traffic e2e only after keeper accounting exists.",
+      "metrics": {
+        "data_loss_events": 0,
+        "providers_negative_pnl": 0,
+        "repair_backoffs": 0,
+        "repairs_completed": 0,
+        "repairs_started": 0,
+        "saturated_responses": 0,
+        "success_rate": 1.0,
+        "unavailable_reads": 0,
+        "verdict": "PASS"
+      },
+      "missing_surfaces": [
+        "requester-paid session accounting",
+        "burn ledger",
+        "credit cap enforcement"
+      ],
+      "next_test": "Add retrieval fee, burn, credit-cap, and requester-paid session accounting tests.",
+      "scenario": "wash-retrieval",
+      "status": "further simulation review",
+      "target": "session fee and credit-cap keeper tests"
+    },
+    {
+      "blockers": [],
+      "e2e": "Provider refuses retrieval responses; gateway routes around and records attributable failure.",
+      "metrics": {
+        "data_loss_events": 0,
+        "providers_negative_pnl": 1,
+        "repair_backoffs": 0,
+        "repairs_completed": 6,
+        "repairs_started": 6,
+        "saturated_responses": 0,
+        "success_rate": 1.0,
+        "unavailable_reads": 0,
+        "verdict": "PASS"
+      },
+      "missing_surfaces": [
+        "threshold evidence case",
+        "deputy transcript accounting",
+        "gateway fallback telemetry"
+      ],
+      "next_test": "Add tests for threshold non-response evidence and deputy-served miss accounting before punitive policy.",
+      "scenario": "withholding",
+      "status": "implementation planning",
+      "target": "gateway fallback plus keeper evidence"
+    }
+  ],
+  "status_counts": {
+    "further simulation review": 6,
+    "implementation planning": 12
+  }
+}

--- a/docs/simulation-reports/policy-sim/graduation_map.md
+++ b/docs/simulation-reports/policy-sim/graduation_map.md
@@ -1,0 +1,108 @@
+# Policy Simulation Graduation Map
+
+This report converts the committed simulator corpus into implementation planning targets. It is intentionally higher-level than per-scenario `graduation.md` files: this is the artifact to use when choosing the next keeper, gateway/provider, or e2e test slice.
+
+## Readiness Summary
+
+| Status | Count | Meaning |
+|---|---:|---|
+| `implementation planning` | 12 | The fixture passed and maps to a concrete keeper, gateway/provider, or e2e artifact. |
+| `further simulation review` | 6 | The fixture passed but should inform parameter or product policy before implementation work. |
+| `blocked` | 0 | The fixture failed assertions or durability safety and should not graduate. |
+
+## Scenario-to-Implementation Map
+
+| Scenario | Status | Target | Next Test Slice | Missing Surfaces | E2E Posture |
+|---|---|---|---|---|---|
+| [`audit-budget-exhaustion`](audit-budget-exhaustion/report.md) | `implementation planning` | audit budget keeper tests | Add audit-budget minted/spent/carryover tests proving audit demand is capped and backlog is explicit. | `audit budget state`, `audit backlog query`, `evidence bounty accounting` | No process e2e until audit sessions are wired through provider-daemon. |
+| [`coordinated-regional-outage`](coordinated-regional-outage/report.md) | `further simulation review` | placement diversity and nightly stress | Keep as simulator calibration until placement-diversity params exist, then add keeper candidate-selection tests. | `regional/provider-class placement metadata`, `operator concentration limits`, `nightly stress harness` | Manual or nightly multi-provider outage, not PR-blocking CI. |
+| [`corrupt-provider`](corrupt-provider/report.md) | `implementation planning` | hard-fault keeper path | Add invalid-proof or wrong-data keeper tests proving no corrupt payment, repair start, and slash/jail simulation gates. | `hard evidence submission`, `corrupt-byte reward exclusion`, `jail/slash params` | Provider returns corrupt bytes or invalid proof and user-gateway rejects the response. |
+| [`elasticity-cap-hit`](elasticity-cap-hit/report.md) | `further simulation review` | elasticity spend-window tests | Add spend-window tests for saturation signaling, fail-closed expansion, TTL, and cap-bound rejection. | `MsgSignalSaturation hardening`, `overlay accountability`, `deal spend window` | Burst traffic e2e after overlay semantics are implemented. |
+| [`flapping-provider`](flapping-provider/report.md) | `implementation planning` | keeper soft-fault window | Add missed-epoch window tests proving intermittent failures create health evidence without triggering repair churn. | `soft-fault decay`, `per-slot suspect state`, `operator health query` | Optional provider restart e2e; keeper coverage should be the first artifact. |
+| [`ideal`](ideal/report.md) | `implementation planning` | keeper control tests | Add no-op epoch tests proving healthy providers do not accrue evidence, repair, reward exclusion, jail, or slash state. | `keeper epoch hooks`, `reward eligibility queries` | Gateway happy-path smoke remains sufficient; do not add a slow failure e2e for the control case. |
+| [`large-scale-regional-stress`](large-scale-regional-stress/report.md) | `further simulation review` | scale calibration and regression reporting | Use sweep reports to tune repair throughput, placement headroom, retrieval pricing, and provider P&L before keeper defaults. | `scale sweep corpus`, `placement diversity params`, `operator concentration analysis`, `CI artifact retention` | Do not mirror this as process e2e; keep it as simulator/CI artifact work. |
+| [`lazy-provider`](lazy-provider/report.md) | `implementation planning` | reward eligibility keeper tests | Add quota shortfall and synthetic-fill tests proving lazy responsibility is excluded from base rewards without soft-fault slashing. | `quota miss ledger`, `reward exclusion reason query`, `soft fault consequence ceiling` | Slow-path only after keeper reward accounting is stable. |
+| [`price-controller-bounds`](price-controller-bounds/report.md) | `implementation planning` | dynamic pricing keeper tests | Add epoch pricing tests for floors, ceilings, utilization target, retrieval-demand target, and max step bps. | `dynamic pricing params`, `storage utilization accumulator`, `retrieval demand accumulator` | No process e2e; validate with keeper tests and simulator sweeps first. |
+| [`repair-candidate-exhaustion`](repair-candidate-exhaustion/report.md) | `implementation planning` | candidate selection and repair backoff keeper tests | Add tests proving no eligible replacement emits backoff, preserves capacity constraints, and does not over-assign providers. | `candidate exclusion reasons`, `repair attempt caps`, `replacement capacity query` | Small devnet with no spare provider capacity after keeper behavior is stable. |
+| [`setup-failure`](setup-failure/report.md) | `implementation planning` | setup bump and deterministic replacement | Add setup-phase replacement tests proving failed initial upload selects a system provider and does not imply fraud. | `setup slot state`, `setup bump event`, `candidate exclusion reasons` | Create deal with one failing provider upload and verify replacement before first content commit. |
+| [`single-outage`](single-outage/report.md) | `implementation planning` | keeper repair and gateway route-around | Add a keeper test where a slot crosses missed-epoch threshold, enters repair, selects a deterministic pending provider, and later promotes. | `slot health state`, `repair attempt ledger`, `promotion readiness proof`, `gateway repair-aware routing` | Kill one provider-daemon during retrieval and assert reads stay available while repair starts. |
+| [`subsidy-farming`](subsidy-farming/report.md) | `implementation planning` | base reward compliance tests | Add tests proving idle or non-compliant responsibility cannot farm base rewards profitably. | `compliance-gated base rewards`, `subsidy leakage metrics`, `operator concentration checks` | No process e2e until keeper reward gating is complete. |
+| [`sustained-non-response`](sustained-non-response/report.md) | `implementation planning` | keeper delinquency repair | Add per-slot delinquency tests for repeated non-response, reward exclusion, repair start, and replacement selection. | `non-response accumulator`, `delinquency reason codes`, `reward exclusion event` | Provider timeout/blackhole e2e after keeper state is deterministic. |
+| [`underpriced-storage`](underpriced-storage/report.md) | `further simulation review` | economic policy calibration | Compare storage floors, base rewards, and provider cost assumptions before encoding governance defaults. | `dynamic pricing state`, `provider cost assumptions`, `profitability dashboards` | No process e2e yet; this is a parameter-calibration fixture. |
+| [`viral-public-retrieval`](viral-public-retrieval/report.md) | `further simulation review` | sponsored retrieval accounting | Add sponsored-session tests proving public demand pays providers without draining owner escrow unexpectedly. | `sponsored session funding`, `owner escrow isolation`, `hot route observability` | Public retrieval spike against one deal with requester/sponsor funding. |
+| [`wash-retrieval`](wash-retrieval/report.md) | `further simulation review` | session fee and credit-cap keeper tests | Add retrieval fee, burn, credit-cap, and requester-paid session accounting tests. | `requester-paid session accounting`, `burn ledger`, `credit cap enforcement` | Synthetic wash traffic e2e only after keeper accounting exists. |
+| [`withholding`](withholding/report.md) | `implementation planning` | gateway fallback plus keeper evidence | Add tests for threshold non-response evidence and deputy-served miss accounting before punitive policy. | `threshold evidence case`, `deputy transcript accounting`, `gateway fallback telemetry` | Provider refuses retrieval responses; gateway routes around and records attributable failure. |
+
+## Recommended Near-Term Keeper/E2E Slices
+
+- `ideal`: Add no-op epoch tests proving healthy providers do not accrue evidence, repair, reward exclusion, jail, or slash state.
+- `single-outage`: Add a keeper test where a slot crosses missed-epoch threshold, enters repair, selects a deterministic pending provider, and later promotes.
+- `sustained-non-response`: Add per-slot delinquency tests for repeated non-response, reward exclusion, repair start, and replacement selection.
+- `corrupt-provider`: Add invalid-proof or wrong-data keeper tests proving no corrupt payment, repair start, and slash/jail simulation gates.
+- `lazy-provider`: Add quota shortfall and synthetic-fill tests proving lazy responsibility is excluded from base rewards without soft-fault slashing.
+- `setup-failure`: Add setup-phase replacement tests proving failed initial upload selects a system provider and does not imply fraud.
+- `repair-candidate-exhaustion`: Add tests proving no eligible replacement emits backoff, preserves capacity constraints, and does not over-assign providers.
+- `price-controller-bounds`: Add epoch pricing tests for floors, ceilings, utilization target, retrieval-demand target, and max step bps.
+
+## Missing Surfaces By Component
+
+| Surface | Scenario Count |
+|---|---:|
+| `candidate exclusion reasons` | 2 |
+| `CI artifact retention` | 1 |
+| `MsgSignalSaturation hardening` | 1 |
+| `audit backlog query` | 1 |
+| `audit budget state` | 1 |
+| `burn ledger` | 1 |
+| `compliance-gated base rewards` | 1 |
+| `corrupt-byte reward exclusion` | 1 |
+| `credit cap enforcement` | 1 |
+| `deal spend window` | 1 |
+| `delinquency reason codes` | 1 |
+| `deputy transcript accounting` | 1 |
+| `dynamic pricing params` | 1 |
+| `dynamic pricing state` | 1 |
+| `evidence bounty accounting` | 1 |
+| `gateway fallback telemetry` | 1 |
+| `gateway repair-aware routing` | 1 |
+| `hard evidence submission` | 1 |
+| `hot route observability` | 1 |
+| `jail/slash params` | 1 |
+| `keeper epoch hooks` | 1 |
+| `nightly stress harness` | 1 |
+| `non-response accumulator` | 1 |
+| `operator concentration analysis` | 1 |
+| `operator concentration checks` | 1 |
+| `operator concentration limits` | 1 |
+| `operator health query` | 1 |
+| `overlay accountability` | 1 |
+| `owner escrow isolation` | 1 |
+| `per-slot suspect state` | 1 |
+| `placement diversity params` | 1 |
+| `profitability dashboards` | 1 |
+| `promotion readiness proof` | 1 |
+| `provider cost assumptions` | 1 |
+| `quota miss ledger` | 1 |
+| `regional/provider-class placement metadata` | 1 |
+| `repair attempt caps` | 1 |
+| `repair attempt ledger` | 1 |
+| `replacement capacity query` | 1 |
+| `requester-paid session accounting` | 1 |
+| `retrieval demand accumulator` | 1 |
+| `reward eligibility queries` | 1 |
+| `reward exclusion event` | 1 |
+| `reward exclusion reason query` | 1 |
+| `scale sweep corpus` | 1 |
+| `setup bump event` | 1 |
+| `setup slot state` | 1 |
+| `slot health state` | 1 |
+| `soft fault consequence ceiling` | 1 |
+| `soft-fault decay` | 1 |
+| `sponsored session funding` | 1 |
+| `storage utilization accumulator` | 1 |
+| `subsidy leakage metrics` | 1 |
+| `threshold evidence case` | 1 |
+
+## Review Rule
+
+Use this map to choose implementation work only after the linked scenario report, risk register, and assertion contract have been reviewed. A passing simulator fixture is evidence for planning, not permission to enable live punitive enforcement.

--- a/tools/policy_sim/README.md
+++ b/tools/policy_sim/README.md
@@ -162,6 +162,10 @@ set under `docs/simulation-reports/policy-sim`. The corpus includes Markdown,
 graphs, `signals.json`, `summary.json`, and `assertions.json`; full CSV ledgers
 are generated as local/CI artifacts instead of being committed.
 
+The corpus also includes `graduation_map.md` and `graduation_map.json`, which
+aggregate all scenario outcomes into keeper, gateway/provider, process-level
+e2e, and further-simulation targets.
+
 The Markdown reports are intended to be human review artifacts, not just metric
 dumps. A run report explains scenario intent, expected behavior, what happened
 over the timeline, enforcement interpretation, economic interpretation, the

--- a/tools/policy_sim/generate_report_corpus.py
+++ b/tools/policy_sim/generate_report_corpus.py
@@ -25,6 +25,118 @@ except ImportError:  # Allows direct execution as a script.
     from report import generate_run_report
 
 
+GRADUATION_TARGETS = {
+    "ideal": {
+        "target": "keeper control tests",
+        "next_test": "Add no-op epoch tests proving healthy providers do not accrue evidence, repair, reward exclusion, jail, or slash state.",
+        "missing_surfaces": ["keeper epoch hooks", "reward eligibility queries"],
+        "e2e": "Gateway happy-path smoke remains sufficient; do not add a slow failure e2e for the control case.",
+    },
+    "single-outage": {
+        "target": "keeper repair and gateway route-around",
+        "next_test": "Add a keeper test where a slot crosses missed-epoch threshold, enters repair, selects a deterministic pending provider, and later promotes.",
+        "missing_surfaces": ["slot health state", "repair attempt ledger", "promotion readiness proof", "gateway repair-aware routing"],
+        "e2e": "Kill one provider-daemon during retrieval and assert reads stay available while repair starts.",
+    },
+    "flapping-provider": {
+        "target": "keeper soft-fault window",
+        "next_test": "Add missed-epoch window tests proving intermittent failures create health evidence without triggering repair churn.",
+        "missing_surfaces": ["soft-fault decay", "per-slot suspect state", "operator health query"],
+        "e2e": "Optional provider restart e2e; keeper coverage should be the first artifact.",
+    },
+    "sustained-non-response": {
+        "target": "keeper delinquency repair",
+        "next_test": "Add per-slot delinquency tests for repeated non-response, reward exclusion, repair start, and replacement selection.",
+        "missing_surfaces": ["non-response accumulator", "delinquency reason codes", "reward exclusion event"],
+        "e2e": "Provider timeout/blackhole e2e after keeper state is deterministic.",
+    },
+    "withholding": {
+        "target": "gateway fallback plus keeper evidence",
+        "next_test": "Add tests for threshold non-response evidence and deputy-served miss accounting before punitive policy.",
+        "missing_surfaces": ["threshold evidence case", "deputy transcript accounting", "gateway fallback telemetry"],
+        "e2e": "Provider refuses retrieval responses; gateway routes around and records attributable failure.",
+    },
+    "corrupt-provider": {
+        "target": "hard-fault keeper path",
+        "next_test": "Add invalid-proof or wrong-data keeper tests proving no corrupt payment, repair start, and slash/jail simulation gates.",
+        "missing_surfaces": ["hard evidence submission", "corrupt-byte reward exclusion", "jail/slash params"],
+        "e2e": "Provider returns corrupt bytes or invalid proof and user-gateway rejects the response.",
+    },
+    "lazy-provider": {
+        "target": "reward eligibility keeper tests",
+        "next_test": "Add quota shortfall and synthetic-fill tests proving lazy responsibility is excluded from base rewards without soft-fault slashing.",
+        "missing_surfaces": ["quota miss ledger", "reward exclusion reason query", "soft fault consequence ceiling"],
+        "e2e": "Slow-path only after keeper reward accounting is stable.",
+    },
+    "setup-failure": {
+        "target": "setup bump and deterministic replacement",
+        "next_test": "Add setup-phase replacement tests proving failed initial upload selects a system provider and does not imply fraud.",
+        "missing_surfaces": ["setup slot state", "setup bump event", "candidate exclusion reasons"],
+        "e2e": "Create deal with one failing provider upload and verify replacement before first content commit.",
+    },
+    "underpriced-storage": {
+        "target": "economic policy calibration",
+        "next_test": "Compare storage floors, base rewards, and provider cost assumptions before encoding governance defaults.",
+        "missing_surfaces": ["dynamic pricing state", "provider cost assumptions", "profitability dashboards"],
+        "e2e": "No process e2e yet; this is a parameter-calibration fixture.",
+    },
+    "wash-retrieval": {
+        "target": "session fee and credit-cap keeper tests",
+        "next_test": "Add retrieval fee, burn, credit-cap, and requester-paid session accounting tests.",
+        "missing_surfaces": ["requester-paid session accounting", "burn ledger", "credit cap enforcement"],
+        "e2e": "Synthetic wash traffic e2e only after keeper accounting exists.",
+    },
+    "viral-public-retrieval": {
+        "target": "sponsored retrieval accounting",
+        "next_test": "Add sponsored-session tests proving public demand pays providers without draining owner escrow unexpectedly.",
+        "missing_surfaces": ["sponsored session funding", "owner escrow isolation", "hot route observability"],
+        "e2e": "Public retrieval spike against one deal with requester/sponsor funding.",
+    },
+    "elasticity-cap-hit": {
+        "target": "elasticity spend-window tests",
+        "next_test": "Add spend-window tests for saturation signaling, fail-closed expansion, TTL, and cap-bound rejection.",
+        "missing_surfaces": ["MsgSignalSaturation hardening", "overlay accountability", "deal spend window"],
+        "e2e": "Burst traffic e2e after overlay semantics are implemented.",
+    },
+    "audit-budget-exhaustion": {
+        "target": "audit budget keeper tests",
+        "next_test": "Add audit-budget minted/spent/carryover tests proving audit demand is capped and backlog is explicit.",
+        "missing_surfaces": ["audit budget state", "audit backlog query", "evidence bounty accounting"],
+        "e2e": "No process e2e until audit sessions are wired through provider-daemon.",
+    },
+    "price-controller-bounds": {
+        "target": "dynamic pricing keeper tests",
+        "next_test": "Add epoch pricing tests for floors, ceilings, utilization target, retrieval-demand target, and max step bps.",
+        "missing_surfaces": ["dynamic pricing params", "storage utilization accumulator", "retrieval demand accumulator"],
+        "e2e": "No process e2e; validate with keeper tests and simulator sweeps first.",
+    },
+    "subsidy-farming": {
+        "target": "base reward compliance tests",
+        "next_test": "Add tests proving idle or non-compliant responsibility cannot farm base rewards profitably.",
+        "missing_surfaces": ["compliance-gated base rewards", "subsidy leakage metrics", "operator concentration checks"],
+        "e2e": "No process e2e until keeper reward gating is complete.",
+    },
+    "coordinated-regional-outage": {
+        "target": "placement diversity and nightly stress",
+        "next_test": "Keep as simulator calibration until placement-diversity params exist, then add keeper candidate-selection tests.",
+        "missing_surfaces": ["regional/provider-class placement metadata", "operator concentration limits", "nightly stress harness"],
+        "e2e": "Manual or nightly multi-provider outage, not PR-blocking CI.",
+    },
+    "repair-candidate-exhaustion": {
+        "target": "candidate selection and repair backoff keeper tests",
+        "next_test": "Add tests proving no eligible replacement emits backoff, preserves capacity constraints, and does not over-assign providers.",
+        "missing_surfaces": ["candidate exclusion reasons", "repair attempt caps", "replacement capacity query"],
+        "e2e": "Small devnet with no spare provider capacity after keeper behavior is stable.",
+    },
+    "large-scale-regional-stress": {
+        "target": "scale calibration and regression reporting",
+        "next_test": "Use sweep reports to tune repair throughput, placement headroom, retrieval pricing, and provider P&L before keeper defaults.",
+        "missing_surfaces": ["scale sweep corpus", "placement diversity params", "operator concentration analysis", "CI artifact retention"],
+        "e2e": "Do not mirror this as process e2e; keep it as simulator/CI artifact work.",
+    },
+}
+
+
 def generate_corpus(scenario_dir: Path, out_dir: Path, work_dir: Path | None, clean: bool) -> int:
     paths = fixture_paths(scenario_dir)
     if not paths:
@@ -93,6 +205,7 @@ def _generate(paths: list[Path], out_dir: Path, run_root: Path) -> int:
         rows.append(index_row(spec.name, result, failed))
 
     write_index(out_dir, rows)
+    write_graduation_map(out_dir, rows)
     return 1 if failures else 0
 
 
@@ -132,6 +245,8 @@ def write_index(out_dir: Path, rows: list[dict[str, Any]]) -> None:
         "",
         "## Scenario Index",
         "",
+        "The corpus-level [graduation map](graduation_map.md) translates these simulator results into the next keeper, gateway/provider, or policy-calibration artifacts.",
+        "",
         "| Scenario | Verdict | Success | Unavailable Reads | Data Loss Events | Repairs | Backoffs | Saturated | Negative P&L | Report |",
         "|---|---|---:|---:|---:|---:|---:|---:|---:|---|",
     ]
@@ -153,6 +268,165 @@ def write_index(out_dir: Path, rows: list[dict[str, Any]]) -> None:
         ]
     )
     out_dir.joinpath("README.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_graduation_map(out_dir: Path, rows: list[dict[str, Any]]) -> None:
+    mapped = [graduation_map_row(row) for row in sorted(rows, key=lambda item: item["scenario"])]
+    status_counts: dict[str, int] = {}
+    for row in mapped:
+        status_counts[row["status"]] = status_counts.get(row["status"], 0) + 1
+
+    (out_dir / "graduation_map.json").write_text(
+        json.dumps({"status_counts": status_counts, "scenarios": mapped}, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    lines = [
+        "# Policy Simulation Graduation Map",
+        "",
+        "This report converts the committed simulator corpus into implementation planning targets. It is intentionally higher-level than per-scenario `graduation.md` files: this is the artifact to use when choosing the next keeper, gateway/provider, or e2e test slice.",
+        "",
+        "## Readiness Summary",
+        "",
+        "| Status | Count | Meaning |",
+        "|---|---:|---|",
+    ]
+    for status in ["implementation planning", "further simulation review", "blocked"]:
+        lines.append(f"| `{status}` | {status_counts.get(status, 0)} | {graduation_status_meaning(status)} |")
+    lines.extend(
+        [
+            "",
+            "## Scenario-to-Implementation Map",
+            "",
+            "| Scenario | Status | Target | Next Test Slice | Missing Surfaces | E2E Posture |",
+            "|---|---|---|---|---|---|",
+        ]
+    )
+    for row in mapped:
+        lines.append(
+            f"| [`{row['scenario']}`]({row['scenario']}/report.md) | `{row['status']}` | {row['target']} | "
+            f"{row['next_test']} | {', '.join(f'`{item}`' for item in row['missing_surfaces'])} | {row['e2e']} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Recommended Near-Term Keeper/E2E Slices",
+            "",
+            *recommended_graduation_lines(mapped),
+            "",
+            "## Missing Surfaces By Component",
+            "",
+            *missing_surface_lines(mapped),
+            "",
+            "## Review Rule",
+            "",
+            "Use this map to choose implementation work only after the linked scenario report, risk register, and assertion contract have been reviewed. A passing simulator fixture is evidence for planning, not permission to enable live punitive enforcement.",
+        ]
+    )
+    (out_dir / "graduation_map.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def graduation_map_row(row: dict[str, Any]) -> dict[str, Any]:
+    scenario = row["scenario"]
+    target = GRADUATION_TARGETS.get(
+        scenario,
+        {
+            "target": "case-by-case policy review",
+            "next_test": "Define the implementation target before adding keeper or e2e coverage.",
+            "missing_surfaces": ["explicit graduation target"],
+            "e2e": "Undecided.",
+        },
+    )
+    status, blockers = graduation_status(row)
+    return {
+        "scenario": scenario,
+        "status": status,
+        "blockers": blockers,
+        "target": target["target"],
+        "next_test": target["next_test"],
+        "missing_surfaces": target["missing_surfaces"],
+        "e2e": target["e2e"],
+        "metrics": {
+            "verdict": row["verdict"],
+            "success_rate": row["success_rate"],
+            "unavailable_reads": row["unavailable_reads"],
+            "data_loss_events": row["data_loss_events"],
+            "repairs_started": row["repairs_started"],
+            "repairs_completed": row["repairs_completed"],
+            "repair_backoffs": row["repair_backoffs"],
+            "providers_negative_pnl": row["providers_negative_pnl"],
+            "saturated_responses": row["saturated_responses"],
+        },
+    }
+
+
+def graduation_status(row: dict[str, Any]) -> tuple[str, list[str]]:
+    blockers = []
+    if row["verdict"] != "PASS":
+        blockers.append("assertion contract failed")
+    if row["data_loss_events"]:
+        blockers.append("modeled data loss occurred")
+    if blockers:
+        return "blocked", blockers
+    scenario = row["scenario"]
+    implementation_ready = {
+        "ideal",
+        "single-outage",
+        "flapping-provider",
+        "sustained-non-response",
+        "withholding",
+        "corrupt-provider",
+        "lazy-provider",
+        "setup-failure",
+        "audit-budget-exhaustion",
+        "price-controller-bounds",
+        "subsidy-farming",
+        "repair-candidate-exhaustion",
+    }
+    if scenario in implementation_ready:
+        return "implementation planning", []
+    return "further simulation review", []
+
+
+def graduation_status_meaning(status: str) -> str:
+    meanings = {
+        "implementation planning": "The fixture passed and maps to a concrete keeper, gateway/provider, or e2e artifact.",
+        "further simulation review": "The fixture passed but should inform parameter or product policy before implementation work.",
+        "blocked": "The fixture failed assertions or durability safety and should not graduate.",
+    }
+    return meanings[status]
+
+
+def recommended_graduation_lines(rows: list[dict[str, Any]]) -> list[str]:
+    ready = [row for row in rows if row["status"] == "implementation planning"]
+    priority = [
+        "ideal",
+        "single-outage",
+        "sustained-non-response",
+        "corrupt-provider",
+        "lazy-provider",
+        "setup-failure",
+        "repair-candidate-exhaustion",
+        "price-controller-bounds",
+    ]
+    ready.sort(key=lambda row: (priority.index(row["scenario"]) if row["scenario"] in priority else 99, row["scenario"]))
+    if not ready:
+        return ["- No scenario is ready for implementation planning from this corpus."]
+    lines = []
+    for row in ready[:8]:
+        lines.append(f"- `{row['scenario']}`: {row['next_test']}")
+    return lines
+
+
+def missing_surface_lines(rows: list[dict[str, Any]]) -> list[str]:
+    counts: dict[str, int] = {}
+    for row in rows:
+        for surface in row["missing_surfaces"]:
+            counts[surface] = counts.get(surface, 0) + 1
+    lines = ["| Surface | Scenario Count |", "|---|---:|"]
+    for surface, count in sorted(counts.items(), key=lambda item: (-item[1], item[0])):
+        lines.append(f"| `{surface}` | {count} |")
+    return lines
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/tools/policy_sim/test_policing_sim.py
+++ b/tools/policy_sim/test_policing_sim.py
@@ -12,6 +12,7 @@ try:
         write_output_dir,
     )
     from .report import generate_policy_delta, generate_run_report, generate_sweep_report, main as report_main
+    from .generate_report_corpus import write_graduation_map
 except ImportError:  # Allows `python3 -m unittest discover -s tools/policy_sim`.
     from policing_sim import (
         PolicySimulator,
@@ -22,6 +23,7 @@ except ImportError:  # Allows `python3 -m unittest discover -s tools/policy_sim`
         write_output_dir,
     )
     from report import generate_policy_delta, generate_run_report, generate_sweep_report, main as report_main
+    from generate_report_corpus import write_graduation_map
 
 
 class PolicySimulatorTests(unittest.TestCase):
@@ -275,6 +277,48 @@ class PolicySimulatorTests(unittest.TestCase):
             payload = (report_dir / "sweep_summary.json").read_text(encoding="utf-8")
             self.assertIn('"metric_ranges"', payload)
             self.assertIn('"high_risk_runs"', payload)
+
+    def test_graduation_map_links_scenarios_to_implementation_targets(self):
+        rows = [
+            {
+                "scenario": "ideal",
+                "verdict": "PASS",
+                "success_rate": 1.0,
+                "unavailable_reads": 0,
+                "data_loss_events": 0,
+                "repairs_started": 0,
+                "repairs_completed": 0,
+                "repair_backoffs": 0,
+                "providers_negative_pnl": 0,
+                "saturated_responses": 0,
+                "assertions": [],
+            },
+            {
+                "scenario": "corrupt-provider",
+                "verdict": "PASS",
+                "success_rate": 1.0,
+                "unavailable_reads": 0,
+                "data_loss_events": 0,
+                "repairs_started": 1,
+                "repairs_completed": 1,
+                "repair_backoffs": 0,
+                "providers_negative_pnl": 0,
+                "saturated_responses": 0,
+                "assertions": [],
+            },
+        ]
+        with TemporaryDirectory() as tmp:
+            out_dir = Path(tmp)
+            write_graduation_map(out_dir, rows)
+
+            self.assertTrue((out_dir / "graduation_map.md").exists())
+            self.assertTrue((out_dir / "graduation_map.json").exists())
+            text = (out_dir / "graduation_map.md").read_text(encoding="utf-8")
+            self.assertIn("## Scenario-to-Implementation Map", text)
+            self.assertIn("hard-fault keeper path", text)
+            self.assertIn("Provider returns corrupt bytes or invalid proof", text)
+            payload = (out_dir / "graduation_map.json").read_text(encoding="utf-8")
+            self.assertIn('"implementation planning"', payload)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add corpus-level graduation_map.md/json mapping simulator scenarios to keeper, gateway/provider, e2e, or further-simulation targets
- wire the graduation map into generate_report_corpus.py and the committed policy-sim report corpus
- document the graduation map in the simulator README and roadmap output contract

## Tests
- python3 -m unittest discover -s tools/policy_sim
- python3 tools/policy_sim/generate_report_corpus.py --scenario-dir tools/policy_sim/scenarios --out-dir docs/simulation-reports/policy-sim --work-dir /tmp/polystore-policy-s7-runs
- git diff --check