### PR TITLE
Add keeper graduation tests for policy repair

### DIFF
--- a/polystorechain/x/polystorechain/keeper/slashing_repair_test.go
+++ b/polystorechain/x/polystorechain/keeper/slashing_repair_test.go
@@ -12,6 +12,200 @@ import (
 	"polystorechain/x/polystorechain/types"
 )
 
+func makePolicyTestAddr(t *testing.T, f *fixture, tag byte) string {
+	t.Helper()
+
+	addr := make([]byte, 20)
+	addr[19] = tag
+	out, err := f.addressCodec.BytesToString(addr)
+	require.NoError(t, err)
+	return out
+}
+
+func registerPolicyTestProviders(t *testing.T, f *fixture, ctx sdk.Context, addrs ...string) {
+	t.Helper()
+
+	msgServer := keeper.NewMsgServerImpl(f.keeper)
+	for _, addr := range addrs {
+		_, err := msgServer.RegisterProvider(ctx, &types.MsgRegisterProvider{
+			Creator:      addr,
+			Capabilities: "General",
+			TotalStorage: 1_000_000_000,
+			Endpoints:    testProviderEndpoints,
+		})
+		require.NoError(t, err)
+	}
+}
+
+func mode2PolicyTestDeal(dealID uint64, owner string, providers []string) types.Deal {
+	slots := make([]*types.DealSlot, 0, len(providers))
+	for i, provider := range providers {
+		slots = append(slots, &types.DealSlot{
+			Slot:     uint32(i),
+			Provider: provider,
+			Status:   types.SlotStatus_SLOT_STATUS_ACTIVE,
+		})
+	}
+
+	return types.Deal{
+		Id:             dealID,
+		Owner:          owner,
+		StartBlock:     1,
+		EndBlock:       10_000,
+		RedundancyMode: 2,
+		Mode2Profile:   &types.StripeReplicaProfile{K: 2, M: 1},
+		Providers:      providers,
+		Mode2Slots:     slots,
+		TotalMdus:      3,
+		WitnessMdus:    1,
+		CurrentGen:     1,
+		ServiceHint:    "General",
+	}
+}
+
+func setMode2EpochCredits(t *testing.T, f *fixture, ctx sdk.Context, dealID uint64, epochID uint64, slots ...uint32) {
+	t.Helper()
+
+	for _, slot := range slots {
+		require.NoError(t, f.keeper.Mode2EpochCredits.Set(
+			ctx,
+			collections.Join(collections.Join(dealID, slot), epochID),
+			1,
+		))
+	}
+}
+
+func hasEvidenceSummary(t *testing.T, f *fixture, ctx sdk.Context, kind string) bool {
+	t.Helper()
+
+	var found bool
+	require.NoError(t, f.keeper.Proofs.Walk(ctx, nil, func(_ uint64, proof types.Proof) (bool, error) {
+		if strings.Contains(proof.Commitment, "evidence:"+kind) {
+			found = true
+		}
+		return false, nil
+	}))
+	return found
+}
+
+func requireNoPolicyRepairEvidence(t *testing.T, f *fixture, ctx sdk.Context) {
+	t.Helper()
+
+	for _, kind := range []string{
+		"quota_miss_repair_started",
+		"deputy_miss_repair_started",
+		"slot_repair_completed",
+	} {
+		require.False(t, hasEvidenceSummary(t, f, ctx, kind), "unexpected evidence summary: %s", kind)
+	}
+}
+
+func TestCheckMissedProofs_Mode2HealthySlotsDoNotRepairOrEmitEvidence(t *testing.T) {
+	f := initFixture(t)
+
+	sdkCtx := sdk.UnwrapSDKContext(f.ctx).WithBlockHeight(5)
+
+	params := types.DefaultParams()
+	params.EpochLenBlocks = 5
+	params.EvictAfterMissedEpochs = 1
+	require.NoError(t, f.keeper.Params.Set(sdkCtx, params))
+
+	providerA := makePolicyTestAddr(t, f, 0xA1)
+	providerB := makePolicyTestAddr(t, f, 0xB2)
+	providerC := makePolicyTestAddr(t, f, 0xC3)
+	providerD := makePolicyTestAddr(t, f, 0xD4)
+	registerPolicyTestProviders(t, f, sdkCtx, providerA, providerB, providerC, providerD)
+
+	dealID := uint64(1)
+	deal := mode2PolicyTestDeal(dealID, makePolicyTestAddr(t, f, 0xEE), []string{providerA, providerB, providerC})
+	require.NoError(t, f.keeper.Deals.Set(sdkCtx, dealID, deal))
+
+	epochID := uint64(1)
+	setMode2EpochCredits(t, f, sdkCtx, dealID, epochID, 0, 1, 2)
+
+	require.NoError(t, f.keeper.CheckMissedProofs(sdkCtx))
+
+	updated, err := f.keeper.Deals.Get(sdkCtx, dealID)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), updated.CurrentGen)
+	require.Len(t, updated.Mode2Slots, 3)
+	for idx, slot := range updated.Mode2Slots {
+		require.NotNil(t, slot)
+		require.Equal(t, types.SlotStatus_SLOT_STATUS_ACTIVE, slot.Status, "slot %d", idx)
+		require.Empty(t, slot.PendingProvider, "slot %d", idx)
+
+		missedKey := collections.Join(dealID, uint32(idx))
+		_, err = f.keeper.Mode2MissedEpochs.Get(sdkCtx, missedKey)
+		require.ErrorIs(t, err, collections.ErrNotFound)
+		_, err = f.keeper.Mode2DeputyMissedEpochs.Get(sdkCtx, missedKey)
+		require.ErrorIs(t, err, collections.ErrNotFound)
+	}
+	require.Equal(t, []string{providerA, providerB, providerC}, updated.Providers)
+	requireNoPolicyRepairEvidence(t, f, sdkCtx)
+}
+
+func TestCheckMissedProofs_Mode2QuotaMissWaitsForThreshold(t *testing.T) {
+	f := initFixture(t)
+
+	sdkCtx := sdk.UnwrapSDKContext(f.ctx).WithBlockHeight(5)
+
+	params := types.DefaultParams()
+	params.EpochLenBlocks = 5
+	params.EvictAfterMissedEpochs = 2
+	require.NoError(t, f.keeper.Params.Set(sdkCtx, params))
+
+	providerA := makePolicyTestAddr(t, f, 0xA1)
+	providerB := makePolicyTestAddr(t, f, 0xB2)
+	providerC := makePolicyTestAddr(t, f, 0xC3)
+	providerD := makePolicyTestAddr(t, f, 0xD4)
+	registerPolicyTestProviders(t, f, sdkCtx, providerA, providerB, providerC, providerD)
+
+	dealID := uint64(1)
+	deal := mode2PolicyTestDeal(dealID, makePolicyTestAddr(t, f, 0xEE), []string{providerA, providerB, providerC})
+	require.NoError(t, f.keeper.Deals.Set(sdkCtx, dealID, deal))
+
+	missedKey := collections.Join(dealID, uint32(0))
+
+	setMode2EpochCredits(t, f, sdkCtx, dealID, 1, 1, 2)
+	require.NoError(t, f.keeper.CheckMissedProofs(sdkCtx))
+
+	afterFirst, err := f.keeper.Deals.Get(sdkCtx, dealID)
+	require.NoError(t, err)
+	require.Equal(t, types.SlotStatus_SLOT_STATUS_ACTIVE, afterFirst.Mode2Slots[0].Status)
+	require.Empty(t, afterFirst.Mode2Slots[0].PendingProvider)
+	missed, err := f.keeper.Mode2MissedEpochs.Get(sdkCtx, missedKey)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), missed)
+	require.False(t, hasEvidenceSummary(t, f, sdkCtx, "quota_miss_repair_started"))
+
+	sdkCtx = sdkCtx.WithBlockHeight(10)
+	setMode2EpochCredits(t, f, sdkCtx, dealID, 2, 1, 2)
+	require.NoError(t, f.keeper.CheckMissedProofs(sdkCtx))
+
+	updated, err := f.keeper.Deals.Get(sdkCtx, dealID)
+	require.NoError(t, err)
+
+	require.Len(t, updated.Mode2Slots, 3)
+	slot0 := updated.Mode2Slots[0]
+	require.NotNil(t, slot0)
+	require.Equal(t, types.SlotStatus_SLOT_STATUS_REPAIRING, slot0.Status)
+	require.Equal(t, providerA, slot0.Provider)
+	require.Equal(t, providerD, slot0.PendingProvider)
+	require.Equal(t, int64(10), slot0.StatusSinceHeight)
+	require.Equal(t, uint64(1), slot0.RepairTargetGen)
+
+	_, err = f.keeper.Mode2MissedEpochs.Get(sdkCtx, missedKey)
+	require.ErrorIs(t, err, collections.ErrNotFound)
+	require.True(t, hasEvidenceSummary(t, f, sdkCtx, "quota_miss_repair_started"))
+
+	// Soft quota-miss repair is make-before-break: the outgoing provider remains
+	// registered and active until a separate hard-fault path changes provider status.
+	registeredProvider, err := f.keeper.Providers.Get(sdkCtx, providerA)
+	require.NoError(t, err)
+	require.Equal(t, "Active", registeredProvider.Status)
+	require.False(t, registeredProvider.Draining)
+}
+
 func TestCheckMissedProofs_StartsMode2SlotRepair(t *testing.T) {
 	f := initFixture(t)
 	msgServer := keeper.NewMsgServerImpl(f.keeper)


### PR DESCRIPTION
## Summary
- Add keeper-level graduation tests for healthy Mode2 no-op epochs and missed-quota repair thresholds.
- Assert soft quota-miss repair keeps the outgoing provider registered and active until separate hard-fault policy changes provider status.
- Keep s9 stacked on the sweep corpus branch so simulator findings can graduate into keeper behavior without blocking #39 review.

## Validation
- `python3 -m unittest discover -s tools/policy_sim`
- `python3 tools/policy_sim/generate_report_corpus.py --scenario-dir tools/policy_sim/scenarios --out-dir docs/simulation-reports/policy-sim --work-dir _artifacts/policy_sim/runs && python3 tools/policy_sim/run_sweeps.py --sweep-dir tools/policy_sim/sweeps --run-dir _artifacts/policy_sim/sweeps --out-dir docs/simulation-reports/policy-sim/sweeps`
- From `polystorechain/`: `LD_LIBRARY_PATH="$PWD/../polystore_core/target/release${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" go test ./x/polystorechain/keeper`
- `git diff --check`