### PR TITLE
Add dynamic pricing keeper graduation tests

### DIFF
--- a/polystorechain/x/polystorechain/keeper/dynamic_pricing_test.go
+++ b/polystorechain/x/polystorechain/keeper/dynamic_pricing_test.go
@@ -12,6 +12,24 @@ import (
 	"polystorechain/x/polystorechain/types"
 )
 
+func registerDynamicPricingProvider(t *testing.T, f *fixture, ctx sdk.Context, label string, totalStorage uint64) string {
+	t.Helper()
+
+	msgServer := keeper.NewMsgServerImpl(f.keeper)
+	addrBz := make([]byte, 20)
+	copy(addrBz, []byte(label))
+	addr, err := f.addressCodec.BytesToString(addrBz)
+	require.NoError(t, err)
+	_, err = msgServer.RegisterProvider(ctx, &types.MsgRegisterProvider{
+		Creator:      addr,
+		Capabilities: "General",
+		TotalStorage: totalStorage,
+		Endpoints:    testProviderEndpoints,
+	})
+	require.NoError(t, err)
+	return addr
+}
+
 func TestDynamicPricing_EpochStart_ClampsMaxStep(t *testing.T) {
 	f := initFixture(t)
 	msgServer := keeper.NewMsgServerImpl(f.keeper)
@@ -184,4 +202,72 @@ func TestDynamicPricing_EpochStart_NoStepClamp_JumpsToTarget(t *testing.T) {
 	after := f.keeper.GetParams(epoch2Ctx)
 	require.True(t, after.StoragePrice.Equal(math.LegacyMustNewDecFromStr("200")))
 	require.Equal(t, math.NewInt(200), after.RetrievalPricePerBlob.Amount)
+}
+
+func TestDynamicPricing_EpochStart_FallsToFloorsWithoutDemand(t *testing.T) {
+	f := initFixture(t)
+
+	p := types.DefaultParams()
+	p.DynamicPricingEnabled = true
+	p.DynamicPricingMaxStepBps = 0 // no clamp, so the controller can reach the floor in one epoch
+
+	p.StoragePrice = math.LegacyMustNewDecFromStr("200")
+	p.StoragePriceMin = math.LegacyMustNewDecFromStr("100")
+	p.StoragePriceMax = math.LegacyMustNewDecFromStr("200")
+	p.StorageTargetUtilizationBps = 5000
+
+	p.BaseRetrievalFee = sdk.NewInt64Coin(sdk.DefaultBondDenom, 0)
+	p.RetrievalPricePerBlob = sdk.NewInt64Coin(sdk.DefaultBondDenom, 200)
+	p.RetrievalPricePerBlobMin = sdk.NewInt64Coin(sdk.DefaultBondDenom, 100)
+	p.RetrievalPricePerBlobMax = sdk.NewInt64Coin(sdk.DefaultBondDenom, 200)
+	p.RetrievalTargetBlobsPerEpoch = 100
+
+	require.NoError(t, f.keeper.Params.Set(f.ctx, p))
+
+	ctx1 := sdk.UnwrapSDKContext(f.ctx).WithBlockHeight(1)
+	registerDynamicPricingProvider(t, f, ctx1, "dyn_floor_provider", 1_000_000)
+
+	epoch2Ctx := ctx1.WithBlockHeight(101)
+	require.NoError(t, f.keeper.BeginBlock(epoch2Ctx))
+
+	after := f.keeper.GetParams(epoch2Ctx)
+	require.True(t, after.StoragePrice.Equal(math.LegacyMustNewDecFromStr("100")))
+	require.Equal(t, math.NewInt(100), after.RetrievalPricePerBlob.Amount)
+}
+
+func TestDynamicPricing_EpochStart_IdempotentWithinEpoch(t *testing.T) {
+	f := initFixture(t)
+
+	p := types.DefaultParams()
+	p.DynamicPricingEnabled = true
+	p.DynamicPricingMaxStepBps = 500 // 5% per epoch
+
+	p.StoragePrice = math.LegacyMustNewDecFromStr("200")
+	p.StoragePriceMin = math.LegacyMustNewDecFromStr("100")
+	p.StoragePriceMax = math.LegacyMustNewDecFromStr("200")
+	p.StorageTargetUtilizationBps = 5000
+
+	p.BaseRetrievalFee = sdk.NewInt64Coin(sdk.DefaultBondDenom, 0)
+	p.RetrievalPricePerBlob = sdk.NewInt64Coin(sdk.DefaultBondDenom, 200)
+	p.RetrievalPricePerBlobMin = sdk.NewInt64Coin(sdk.DefaultBondDenom, 100)
+	p.RetrievalPricePerBlobMax = sdk.NewInt64Coin(sdk.DefaultBondDenom, 200)
+	p.RetrievalTargetBlobsPerEpoch = 100
+
+	require.NoError(t, f.keeper.Params.Set(f.ctx, p))
+
+	ctx1 := sdk.UnwrapSDKContext(f.ctx).WithBlockHeight(1)
+	registerDynamicPricingProvider(t, f, ctx1, "dyn_idempotent_p", 1_000_000)
+
+	epoch2Ctx := ctx1.WithBlockHeight(101)
+	require.NoError(t, f.keeper.BeginBlock(epoch2Ctx))
+
+	afterFirst := f.keeper.GetParams(epoch2Ctx)
+	require.True(t, afterFirst.StoragePrice.Equal(math.LegacyMustNewDecFromStr("190")))
+	require.Equal(t, math.NewInt(190), afterFirst.RetrievalPricePerBlob.Amount)
+
+	require.NoError(t, f.keeper.BeginBlock(epoch2Ctx))
+
+	afterSecond := f.keeper.GetParams(epoch2Ctx)
+	require.True(t, afterSecond.StoragePrice.Equal(afterFirst.StoragePrice))
+	require.Equal(t, afterFirst.RetrievalPricePerBlob.Amount, afterSecond.RetrievalPricePerBlob.Amount)
 }


### PR DESCRIPTION
## Summary
- Add keeper-level dynamic-pricing graduation tests for downward movement to configured storage/retrieval floors.
- Add an idempotence test proving one epoch cannot apply multiple price-controller steps.
- Keep this stacked after the policy-repair keeper graduation PR.

## Validation
- From `polystorechain/`: `LD_LIBRARY_PATH="$PWD/../polystore_core/target/release${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" go test ./x/polystorechain/keeper -run "TestDynamicPricing"`
- From `polystorechain/`: `LD_LIBRARY_PATH="$PWD/../polystore_core/target/release${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" go test ./x/polystorechain/keeper`
- `git diff --check`