### PR TITLE
Add base reward compliance graduation tests

### DIFF
--- a/polystorechain/x/polystorechain/keeper/base_rewards_test.go
+++ b/polystorechain/x/polystorechain/keeper/base_rewards_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -13,15 +14,15 @@ import (
 	"polystorechain/x/polystorechain/types"
 )
 
-func TestBaseRewardPool_DistributesBySlotBytesWhenCompliant(t *testing.T) {
-	bank := newTrackingBankKeeper()
-	f := initFixtureWithBankKeeper(t, bank)
+func setupBaseRewardMode2Deal(t *testing.T, f *fixture, bank *trackingBankKeeper, label string) (sdk.Context, uint64, []string) {
+	t.Helper()
+
 	msgServer := keeper.NewMsgServerImpl(f.keeper)
 
 	// Register minimal providers for Mode 2 (rs=2+1).
 	for i := 0; i < 3; i++ {
 		addrBz := make([]byte, 20)
-		copy(addrBz, []byte(fmt.Sprintf("provider_reward_%02d", i)))
+		copy(addrBz, []byte(fmt.Sprintf("%s_prov_%02d", label, i)))
 		addr, _ := f.addressCodec.BytesToString(addrBz)
 		_, err := msgServer.RegisterProvider(f.ctx, &types.MsgRegisterProvider{
 			Creator:      addr,
@@ -43,7 +44,7 @@ func TestBaseRewardPool_DistributesBySlotBytesWhenCompliant(t *testing.T) {
 	require.NoError(t, f.keeper.Params.Set(ctx2, p))
 
 	userBz := make([]byte, 20)
-	copy(userBz, []byte("user_reward_test____"))
+	copy(userBz, []byte(label+"_user"))
 	user, _ := f.addressCodec.BytesToString(userBz)
 	userAddr, err := sdk.AccAddressFromBech32(user)
 	require.NoError(t, err)
@@ -68,27 +69,93 @@ func TestBaseRewardPool_DistributesBySlotBytesWhenCompliant(t *testing.T) {
 		WitnessMdus: 0,
 	})
 	require.NoError(t, err)
+	return ctx2, resDeal.DealId, resDeal.AssignedProviders
+}
+
+func setMode2BaseRewardCredits(t *testing.T, f *fixture, ctx sdk.Context, dealID uint64, epochID uint64, slots ...uint32) {
+	t.Helper()
+
+	for _, slot := range slots {
+		key := collections.Join(collections.Join(dealID, slot), epochID)
+		require.NoError(t, f.keeper.Mode2EpochCredits.Set(ctx, key, 100))
+	}
+}
+
+func requireProviderBalance(t *testing.T, bank *trackingBankKeeper, provider string, expected string) {
+	t.Helper()
+
+	addr, err := sdk.AccAddressFromBech32(provider)
+	require.NoError(t, err)
+	require.Equal(t, expected, bank.GetBalance(context.Background(), addr, sdk.DefaultBondDenom).String())
+}
+
+func TestBaseRewardPool_DistributesBySlotBytesWhenCompliant(t *testing.T) {
+	bank := newTrackingBankKeeper()
+	f := initFixtureWithBankKeeper(t, bank)
+	ctx2, dealID, assignedProviders := setupBaseRewardMode2Deal(t, f, bank, "rall")
 
 	// Make both providers quota-compliant for epoch 1.
 	epochID := uint64(1)
-	deal, err := f.keeper.Deals.Get(ctx2, resDeal.DealId)
+	deal, err := f.keeper.Deals.Get(ctx2, dealID)
 	require.NoError(t, err)
 	require.NotEmpty(t, deal.Mode2Slots)
 	for _, slot := range deal.Mode2Slots {
 		if slot == nil {
 			continue
 		}
-		key := collections.Join(collections.Join(resDeal.DealId, slot.Slot), epochID)
-		require.NoError(t, f.keeper.Mode2EpochCredits.Set(ctx2, key, 100))
+		setMode2BaseRewardCredits(t, f, ctx2, dealID, epochID, slot.Slot)
 	}
 
 	// Epoch 1 ends at height 10 when epoch_len_blocks == 10.
 	ctx10 := ctx2.WithBlockHeight(10)
 	require.NoError(t, f.keeper.CheckMissedProofs(ctx10))
 
-	for _, provider := range resDeal.AssignedProviders {
-		addr, err := sdk.AccAddressFromBech32(provider)
-		require.NoError(t, err)
-		require.Equal(t, "42stake", bank.accountBalances[addr.String()].String())
+	for _, provider := range assignedProviders {
+		requireProviderBalance(t, bank, provider, "42stake")
 	}
+}
+
+func TestBaseRewardPool_ExcludesQuotaShortfallSlot(t *testing.T) {
+	bank := newTrackingBankKeeper()
+	f := initFixtureWithBankKeeper(t, bank)
+	ctx2, dealID, _ := setupBaseRewardMode2Deal(t, f, bank, "rmiss")
+
+	deal, err := f.keeper.Deals.Get(ctx2, dealID)
+	require.NoError(t, err)
+	require.Len(t, deal.Mode2Slots, 3)
+
+	epochID := uint64(1)
+	setMode2BaseRewardCredits(t, f, ctx2, dealID, epochID, deal.Mode2Slots[0].Slot, deal.Mode2Slots[1].Slot)
+
+	ctx10 := ctx2.WithBlockHeight(10)
+	require.NoError(t, f.keeper.CheckMissedProofs(ctx10))
+
+	requireProviderBalance(t, bank, deal.Mode2Slots[0].Provider, "63stake")
+	requireProviderBalance(t, bank, deal.Mode2Slots[1].Provider, "63stake")
+	requireProviderBalance(t, bank, deal.Mode2Slots[2].Provider, "0stake")
+}
+
+func TestBaseRewardPool_ExcludesRepairingSlotResponsibility(t *testing.T) {
+	bank := newTrackingBankKeeper()
+	f := initFixtureWithBankKeeper(t, bank)
+	ctx2, dealID, _ := setupBaseRewardMode2Deal(t, f, bank, "rrep")
+
+	deal, err := f.keeper.Deals.Get(ctx2, dealID)
+	require.NoError(t, err)
+	require.Len(t, deal.Mode2Slots, 3)
+
+	repairingProvider := deal.Mode2Slots[2].Provider
+	deal.Mode2Slots[2].Status = types.SlotStatus_SLOT_STATUS_REPAIRING
+	deal.Mode2Slots[2].StatusSinceHeight = 9
+	require.NoError(t, f.keeper.Deals.Set(ctx2, dealID, deal))
+
+	epochID := uint64(1)
+	setMode2BaseRewardCredits(t, f, ctx2, dealID, epochID, deal.Mode2Slots[0].Slot, deal.Mode2Slots[1].Slot)
+
+	ctx10 := ctx2.WithBlockHeight(10)
+	require.NoError(t, f.keeper.CheckMissedProofs(ctx10))
+
+	requireProviderBalance(t, bank, deal.Mode2Slots[0].Provider, "42stake")
+	requireProviderBalance(t, bank, deal.Mode2Slots[1].Provider, "42stake")
+	requireProviderBalance(t, bank, repairingProvider, "0stake")
 }


### PR DESCRIPTION
## Summary
- Add keeper-level base-reward compliance tests for quota shortfall and repairing Mode2 slots.
- Prove quota-shortfall slots receive no base-reward weight and repairing slots are excluded from rewardable responsibility.
- Keep this stacked after the dynamic-pricing graduation PR.

## Validation
- From `polystorechain/`: `LD_LIBRARY_PATH="$PWD/../polystore_core/target/release${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" go test ./x/polystorechain/keeper -run "TestBaseRewardPool"`
- From `polystorechain/`: `LD_LIBRARY_PATH="$PWD/../polystore_core/target/release${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" go test ./x/polystorechain/keeper`
- `git diff --check`