### PR TITLE
Require eligible pending providers for slot repair

### DIFF
--- a/polystorechain/x/polystorechain/keeper/mode2_repair.go
+++ b/polystorechain/x/polystorechain/keeper/mode2_repair.go
@@ -29,6 +29,23 @@ func providerMatchesServiceHint(provider types.Provider, serviceHint string) boo
 	}
 }
 
+func mode2ReplacementProviderIneligibility(provider types.Provider, serviceHint string) string {
+	if strings.TrimSpace(provider.Status) != "Active" {
+		return "status is not Active"
+	}
+	if provider.Draining {
+		return "provider is draining"
+	}
+	if !providerMatchesServiceHint(provider, serviceHint) {
+		return "provider does not match service hint"
+	}
+	return ""
+}
+
+func mode2ReplacementProviderEligible(provider types.Provider, serviceHint string) bool {
+	return mode2ReplacementProviderIneligibility(provider, serviceHint) == ""
+}
+
 func (k Keeper) selectMode2ReplacementProvider(ctx sdk.Context, deal types.Deal, slot uint32, epochID uint64) (string, error) {
 	if len(deal.Mode2Slots) == 0 {
 		return "", fmt.Errorf("mode2 slot map is empty")
@@ -56,13 +73,7 @@ func (k Keeper) selectMode2ReplacementProvider(ctx sdk.Context, deal types.Deal,
 
 	candidates := make([]string, 0, 8)
 	if err := k.Providers.Walk(ctx, nil, func(addr string, provider types.Provider) (stop bool, err error) {
-		if strings.TrimSpace(provider.Status) != "Active" {
-			return false, nil
-		}
-		if provider.Draining {
-			return false, nil
-		}
-		if !providerMatchesServiceHint(provider, deal.ServiceHint) {
+		if !mode2ReplacementProviderEligible(provider, deal.ServiceHint) {
 			return false, nil
 		}
 		if _, blocked := exclude[strings.TrimSpace(provider.Address)]; blocked {
@@ -80,13 +91,7 @@ func (k Keeper) selectMode2ReplacementProvider(ctx sdk.Context, deal types.Deal,
 	// one) so repairs remain possible without requiring extra providers.
 	if len(candidates) == 0 {
 		if err := k.Providers.Walk(ctx, nil, func(addr string, provider types.Provider) (stop bool, err error) {
-			if strings.TrimSpace(provider.Status) != "Active" {
-				return false, nil
-			}
-			if provider.Draining {
-				return false, nil
-			}
-			if !providerMatchesServiceHint(provider, deal.ServiceHint) {
+			if !mode2ReplacementProviderEligible(provider, deal.ServiceHint) {
 				return false, nil
 			}
 			cand := strings.TrimSpace(provider.Address)

--- a/polystorechain/x/polystorechain/keeper/msg_slot_repair.go
+++ b/polystorechain/x/polystorechain/keeper/msg_slot_repair.go
@@ -53,11 +53,15 @@ func (k msgServer) StartSlotRepair(goCtx context.Context, msg *types.MsgStartSlo
 	if strings.TrimSpace(slot.Provider) == pending {
 		return nil, sdkerrors.ErrInvalidRequest.Wrap("pending_provider must differ from current provider")
 	}
-	if _, err := k.Providers.Get(ctx, pending); err != nil {
+	provider, err := k.Providers.Get(ctx, pending)
+	if err != nil {
 		if errors.Is(err, collections.ErrNotFound) {
 			return nil, sdkerrors.ErrNotFound.Wrapf("pending provider %q not registered", pending)
 		}
 		return nil, fmt.Errorf("failed to load pending provider: %w", err)
+	}
+	if reason := mode2ReplacementProviderIneligibility(provider, deal.ServiceHint); reason != "" {
+		return nil, sdkerrors.ErrInvalidRequest.Wrapf("pending_provider is not eligible for slot repair: %s", reason)
 	}
 
 	slot.Status = types.SlotStatus_SLOT_STATUS_REPAIRING

--- a/polystorechain/x/polystorechain/keeper/msg_slot_repair_test.go
+++ b/polystorechain/x/polystorechain/keeper/msg_slot_repair_test.go
@@ -1,0 +1,139 @@
+package keeper_test
+
+import (
+	"fmt"
+	"testing"
+
+	"cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+
+	"polystorechain/x/polystorechain/keeper"
+	"polystorechain/x/polystorechain/types"
+)
+
+type manualSlotRepairSetup struct {
+	f         *fixture
+	msgServer types.MsgServer
+	ctx       sdk.Context
+	deal      types.Deal
+	owner     string
+	candidate string
+}
+
+func setupManualSlotRepair(t *testing.T, serviceHint string) manualSlotRepairSetup {
+	t.Helper()
+
+	f := initFixture(t)
+	msgServer := keeper.NewMsgServerImpl(f.keeper)
+	ctx := sdk.UnwrapSDKContext(f.ctx).WithBlockHeight(5)
+
+	for i := 0; i < 20; i++ {
+		addrBz := make([]byte, 20)
+		copy(addrBz, []byte(fmt.Sprintf("repair_elig_p_%02d", i)))
+		addr, _ := f.addressCodec.BytesToString(addrBz)
+		_, err := msgServer.RegisterProvider(ctx, &types.MsgRegisterProvider{
+			Creator:      addr,
+			Capabilities: "General",
+			TotalStorage: 100000000000,
+			Endpoints:    testProviderEndpoints,
+		})
+		require.NoError(t, err)
+	}
+
+	ownerBz := make([]byte, 20)
+	copy(ownerBz, []byte("repair_elig_owner"))
+	owner, _ := f.addressCodec.BytesToString(ownerBz)
+
+	res, err := msgServer.CreateDeal(ctx, &types.MsgCreateDeal{
+		Creator:             owner,
+		DurationBlocks:      1000,
+		ServiceHint:         serviceHint,
+		MaxMonthlySpend:     math.NewInt(500000),
+		InitialEscrowAmount: math.NewInt(1000000),
+	})
+	require.NoError(t, err)
+
+	deal, err := f.keeper.Deals.Get(ctx, res.DealId)
+	require.NoError(t, err)
+	require.Len(t, deal.Mode2Slots, int(types.DealBaseReplication))
+	require.NotEqual(t, deal.Mode2Slots[0].Provider, deal.Mode2Slots[1].Provider)
+
+	return manualSlotRepairSetup{
+		f:         f,
+		msgServer: msgServer,
+		ctx:       ctx,
+		deal:      deal,
+		owner:     owner,
+		candidate: deal.Mode2Slots[1].Provider,
+	}
+}
+
+func TestStartSlotRepairRejectsIneligiblePendingProvider(t *testing.T) {
+	tests := []struct {
+		name        string
+		serviceHint string
+		mutate      func(t *testing.T, setup manualSlotRepairSetup)
+		wantReason  string
+	}{
+		{
+			name:        "non active provider",
+			serviceHint: "General:rs=8+4",
+			mutate: func(t *testing.T, setup manualSlotRepairSetup) {
+				t.Helper()
+				provider, err := setup.f.keeper.Providers.Get(setup.ctx, setup.candidate)
+				require.NoError(t, err)
+				provider.Status = "Jailed"
+				require.NoError(t, setup.f.keeper.Providers.Set(setup.ctx, setup.candidate, provider))
+			},
+			wantReason: "status is not Active",
+		},
+		{
+			name:        "draining provider",
+			serviceHint: "General:rs=8+4",
+			mutate: func(t *testing.T, setup manualSlotRepairSetup) {
+				t.Helper()
+				_, err := setup.msgServer.SetProviderDraining(setup.ctx, &types.MsgSetProviderDraining{
+					Creator:  setup.candidate,
+					Draining: true,
+				})
+				require.NoError(t, err)
+			},
+			wantReason: "provider is draining",
+		},
+		{
+			name:        "service incompatible provider",
+			serviceHint: "Hot:rs=8+4",
+			mutate: func(t *testing.T, setup manualSlotRepairSetup) {
+				t.Helper()
+				provider, err := setup.f.keeper.Providers.Get(setup.ctx, setup.candidate)
+				require.NoError(t, err)
+				provider.Capabilities = "Archive"
+				require.NoError(t, setup.f.keeper.Providers.Set(setup.ctx, setup.candidate, provider))
+			},
+			wantReason: "provider does not match service hint",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			setup := setupManualSlotRepair(t, tc.serviceHint)
+			tc.mutate(t, setup)
+
+			_, err := setup.msgServer.StartSlotRepair(setup.ctx, &types.MsgStartSlotRepair{
+				Creator:         setup.owner,
+				DealId:          setup.deal.Id,
+				Slot:            0,
+				PendingProvider: setup.candidate,
+			})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "pending_provider is not eligible for slot repair")
+			require.Contains(t, err.Error(), tc.wantReason)
+
+			deal, getErr := setup.f.keeper.Deals.Get(setup.ctx, setup.deal.Id)
+			require.NoError(t, getErr)
+			require.Equal(t, types.SlotStatus_SLOT_STATUS_ACTIVE, deal.Mode2Slots[0].Status)
+			require.Empty(t, deal.Mode2Slots[0].PendingProvider)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- share Mode 2 replacement-provider eligibility between automatic selection and manual slot repair
- reject manual pending providers that are non-active, draining, or incompatible with the deal service hint
- add keeper tests proving rejected candidates leave the slot ACTIVE with no pending provider

## Tests
- LD_LIBRARY_PATH="$PWD/../polystore_core/target/release${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" go test ./x/polystorechain/keeper -run 'TestStartSlotRepair|TestMode2SlotRepairLifecycle|TestCheckMissedProofs'
- LD_LIBRARY_PATH="$PWD/../polystore_core/target/release${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" go test ./x/polystorechain/keeper