### PR TITLE
Record repair backoff evidence on candidate exhaustion

### DIFF
--- a/polystorechain/x/polystorechain/keeper/slashing.go
+++ b/polystorechain/x/polystorechain/keeper/slashing.go
@@ -230,6 +230,9 @@ func (k Keeper) CheckMissedProofs(ctx context.Context) error {
 								"slot", slotIdx,
 								"error", err,
 							)
+							if errEvidence := k.recordRepairBackoff(sdkCtx, dealID, entry.Provider, slot, epochID, err.Error()); errEvidence != nil {
+								sdkCtx.Logger().Error("failed to record repair backoff evidence", "error", errEvidence)
+							}
 							continue
 						}
 
@@ -305,6 +308,9 @@ func (k Keeper) CheckMissedProofs(ctx context.Context) error {
 								"slot", slotIdx,
 								"error", err,
 							)
+							if errEvidence := k.recordRepairBackoff(sdkCtx, dealID, entry.Provider, slot, epochID, err.Error()); errEvidence != nil {
+								sdkCtx.Logger().Error("failed to record repair backoff evidence", "error", errEvidence)
+							}
 							continue
 						}
 
@@ -362,4 +368,12 @@ func (k Keeper) CheckMissedProofs(ctx context.Context) error {
 		return err
 	}
 	return k.scheduleRoutineRotations(sdkCtx, epochID)
+}
+
+func (k Keeper) recordRepairBackoff(ctx sdk.Context, dealID uint64, provider string, slot uint32, epochID uint64, reason string) error {
+	extra := make([]byte, 0, 4+len(reason))
+	extra = binary.BigEndian.AppendUint32(extra, slot)
+	extra = append(extra, []byte(reason)...)
+	eid := deriveEvidenceID("repair_backoff_entered", dealID, epochID, extra)
+	return k.recordEvidenceSummary(ctx, dealID, provider, "repair_backoff_entered", eid[:], "chain:"+reason, false)
 }

--- a/polystorechain/x/polystorechain/keeper/slashing_repair_test.go
+++ b/polystorechain/x/polystorechain/keeper/slashing_repair_test.go
@@ -94,6 +94,7 @@ func requireNoPolicyRepairEvidence(t *testing.T, f *fixture, ctx sdk.Context) {
 	for _, kind := range []string{
 		"quota_miss_repair_started",
 		"deputy_miss_repair_started",
+		"repair_backoff_entered",
 		"slot_repair_completed",
 	} {
 		require.False(t, hasEvidenceSummary(t, f, ctx, kind), "unexpected evidence summary: %s", kind)
@@ -387,6 +388,51 @@ func TestCheckMissedProofs_Mode2RepairFallbackReusesProvider(t *testing.T) {
 	require.NotEmpty(t, slot0.PendingProvider)
 	require.NotEqual(t, providerA, slot0.PendingProvider)
 	require.Contains(t, []string{providerB, providerC}, slot0.PendingProvider)
+}
+
+func TestCheckMissedProofs_Mode2RepairBackoffWhenNoCandidate(t *testing.T) {
+	f := initFixture(t)
+
+	sdkCtx := sdk.UnwrapSDKContext(f.ctx).WithBlockHeight(5)
+
+	params := types.DefaultParams()
+	params.EpochLenBlocks = 5
+	params.EvictAfterMissedEpochs = 1
+	require.NoError(t, f.keeper.Params.Set(sdkCtx, params))
+
+	providerA := makePolicyTestAddr(t, f, 0xA1)
+	providerB := makePolicyTestAddr(t, f, 0xB2)
+	providerC := makePolicyTestAddr(t, f, 0xC3)
+	registerPolicyTestProviders(t, f, sdkCtx, providerA, providerB, providerC)
+
+	for _, addr := range []string{providerB, providerC} {
+		provider, err := f.keeper.Providers.Get(sdkCtx, addr)
+		require.NoError(t, err)
+		provider.Status = "Jailed"
+		require.NoError(t, f.keeper.Providers.Set(sdkCtx, addr, provider))
+	}
+
+	dealID := uint64(1)
+	deal := mode2PolicyTestDeal(dealID, makePolicyTestAddr(t, f, 0xEE), []string{providerA, providerB, providerC})
+	require.NoError(t, f.keeper.Deals.Set(sdkCtx, dealID, deal))
+
+	epochID := uint64(1)
+	setMode2EpochCredits(t, f, sdkCtx, dealID, epochID, 1, 2)
+
+	require.NoError(t, f.keeper.CheckMissedProofs(sdkCtx))
+
+	updated, err := f.keeper.Deals.Get(sdkCtx, dealID)
+	require.NoError(t, err)
+	slot0 := updated.Mode2Slots[0]
+	require.NotNil(t, slot0)
+	require.Equal(t, types.SlotStatus_SLOT_STATUS_ACTIVE, slot0.Status)
+	require.Empty(t, slot0.PendingProvider)
+
+	missed, err := f.keeper.Mode2MissedEpochs.Get(sdkCtx, collections.Join(dealID, uint32(0)))
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), missed)
+	require.True(t, hasEvidenceSummary(t, f, sdkCtx, "repair_backoff_entered"))
+	require.False(t, hasEvidenceSummary(t, f, sdkCtx, "quota_miss_repair_started"))
 }
 
 func TestCheckMissedProofs_CompletesMode2SlotRepairWhenQuotaMet(t *testing.T) {


### PR DESCRIPTION
## Summary
- record `repair_backoff_entered` evidence when quota/deputy repair reaches threshold but no replacement candidate is available
- keep exhausted slots ACTIVE with missed-epoch state intact rather than silently promoting or over-assigning
- add keeper coverage for candidate exhaustion with all non-outgoing providers ineligible

## Tests
- LD_LIBRARY_PATH="$PWD/../polystore_core/target/release${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" go test ./x/polystorechain/keeper -run 'TestCheckMissedProofs_Mode2RepairBackoffWhenNoCandidate|TestCheckMissedProofs_Mode2RepairFallbackReusesProvider|TestCheckMissedProofs_Mode2QuotaMissWaitsForThreshold'
- LD_LIBRARY_PATH="$PWD/../polystore_core/target/release${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" go test ./x/polystorechain/keeper
