### PR TITLE
Record health repair backoff evidence

### DIFF
--- a/polystorechain/x/polystorechain/keeper/health_eviction_test.go
+++ b/polystorechain/x/polystorechain/keeper/health_eviction_test.go
@@ -70,9 +70,9 @@ func TestProveLiveness_HealthFailures_StartMode2Repair(t *testing.T) {
 	// chain should start a Mode 2 repair by attaching a pending provider.
 	for i := 0; i < 3; i++ {
 		res, err := msgServer.ProveLiveness(sdkCtx, &types.MsgProveLiveness{
-			Creator:  providerA,
-			DealId:   dealID,
-			EpochId:  1,
+			Creator:   providerA,
+			DealId:    dealID,
+			EpochId:   1,
 			ProofType: &types.MsgProveLiveness_SystemProof{SystemProof: nil},
 		})
 		require.NoError(t, err)
@@ -100,3 +100,49 @@ func TestProveLiveness_HealthFailures_StartMode2Repair(t *testing.T) {
 	require.True(t, foundEvidence)
 }
 
+func TestProveLiveness_HealthFailures_RecordBackoffWhenNoReplacement(t *testing.T) {
+	f := initFixture(t)
+	msgServer := keeper.NewMsgServerImpl(f.keeper)
+
+	params := types.DefaultParams()
+	params.EpochLenBlocks = 5
+	require.NoError(t, f.keeper.Params.Set(f.ctx, params))
+
+	sdkCtx := sdk.UnwrapSDKContext(f.ctx).WithBlockHeight(1)
+
+	providerA := makePolicyTestAddr(t, f, 0xA1)
+	providerB := makePolicyTestAddr(t, f, 0xB2)
+	providerC := makePolicyTestAddr(t, f, 0xC3)
+	registerPolicyTestProviders(t, f, sdkCtx, providerA, providerB, providerC)
+
+	for _, addr := range []string{providerB, providerC} {
+		provider, err := f.keeper.Providers.Get(sdkCtx, addr)
+		require.NoError(t, err)
+		provider.Status = "Jailed"
+		require.NoError(t, f.keeper.Providers.Set(sdkCtx, addr, provider))
+	}
+
+	dealID := uint64(1)
+	deal := mode2PolicyTestDeal(dealID, makePolicyTestAddr(t, f, 0xEE), []string{providerA, providerB, providerC})
+	require.NoError(t, f.keeper.Deals.Set(sdkCtx, dealID, deal))
+
+	for i := 0; i < 3; i++ {
+		res, err := msgServer.ProveLiveness(sdkCtx, &types.MsgProveLiveness{
+			Creator:   providerA,
+			DealId:    dealID,
+			EpochId:   1,
+			ProofType: &types.MsgProveLiveness_SystemProof{SystemProof: nil},
+		})
+		require.NoError(t, err)
+		require.False(t, res.Success)
+	}
+
+	updated, err := f.keeper.Deals.Get(sdkCtx, dealID)
+	require.NoError(t, err)
+	slot0 := updated.Mode2Slots[0]
+	require.NotNil(t, slot0)
+	require.Equal(t, types.SlotStatus_SLOT_STATUS_ACTIVE, slot0.Status)
+	require.Empty(t, slot0.PendingProvider)
+	require.True(t, hasEvidenceSummary(t, f, sdkCtx, "repair_backoff_entered"))
+	require.False(t, hasEvidenceSummary(t, f, sdkCtx, "provider_degraded_repair_started"))
+}

--- a/polystorechain/x/polystorechain/keeper/msg_server.go
+++ b/polystorechain/x/polystorechain/keeper/msg_server.go
@@ -1849,6 +1849,9 @@ func (k msgServer) trackProviderHealth(ctx sdk.Context, dealID uint64, provider 
 		pending, err := k.selectMode2ReplacementProvider(ctx, deal, slot, epochID)
 		if err != nil {
 			ctx.Logger().Error("failed to select replacement provider for health eviction", "deal", dealID, "slot", slotIdxU64, "error", err)
+			if errEvidence := k.Keeper.recordRepairBackoff(ctx, dealID, provider, slot, epochID, err.Error()); errEvidence != nil {
+				ctx.Logger().Error("failed to record repair backoff evidence", "error", errEvidence)
+			}
 			return
 		}
 


### PR DESCRIPTION
## Summary
- record repair backoff evidence when repeated invalid proofs trigger health eviction but no replacement candidate exists
- keep the unhealthy slot ACTIVE with no pending provider when health repair cannot select a candidate
- add keeper coverage for invalid-proof health backoff without emitting a false repair-start event

## Tests
- LD_LIBRARY_PATH="$PWD/../polystore_core/target/release${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" go test ./x/polystorechain/keeper -run 'TestProveLiveness_HealthFailures'
- LD_LIBRARY_PATH="$PWD/../polystore_core/target/release${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" go test ./x/polystorechain/keeper
