### PR TITLE
Require repair readiness before slot promotion

### DIFF
--- a/docs/planning/POLICING_AND_FAILURE_SIMULATION_ROADMAP.md
+++ b/docs/planning/POLICING_AND_FAILURE_SIMULATION_ROADMAP.md
@@ -377,6 +377,18 @@ Exit criteria:
 1. Chain behavior matches simulator assumptions for the covered policy surfaces.
 2. No punitive policy is enabled without deterministic tests.
 
+Current landed status:
+
+1. Dynamic pricing bounds, base reward compliance, audit budget caps, protocol
+   repair-session authorization, repair candidate eligibility, and repair
+   backoff evidence have keeper coverage.
+2. Repair start and replacement selection now have deterministic tests across
+   quota misses, deputy-served misses, provider health failures, draining, and
+   routine rotation.
+3. The active graduation slice is repair-readiness and promotion correctness:
+   a pending provider must produce deterministic readiness evidence before
+   manual or automatic slot promotion can replace the active provider.
+
 ### Milestone 4: Gateway and Provider Enforcement
 
 Deliverables:
@@ -582,11 +594,15 @@ delinquency.
 | `EXPIRED` | Deal expired; slot no longer serves. | No | No | Deal expiry / GC. |
 
 Current implementation already has `ACTIVE`, `REPAIRING`, `pending_provider`,
-and `repair_target_gen`. Missing desired-state pieces include:
+`repair_target_gen`, and a first-generation `Mode2RepairReadiness` keeper
+ledger. The readiness ledger is set by valid pending-provider proof activity
+while a slot is repairing, and promotion checks that readiness before swapping
+the active provider. Missing desired-state pieces include:
 
 1. Explicit `SUSPECT` / `DELINQUENT` reason codes.
 2. Repair attempt counters and cooldown windows.
-3. Readiness proof or catch-up proof before promotion.
+3. Full catch-up proofs for all data/generation ranges, beyond the current
+   readiness marker.
 4. Per-slot health queries for UI and operator tooling.
 5. A unified treatment of setup-phase bumping and post-commit repair.
 
@@ -641,6 +657,14 @@ Implementation surfaces:
 | Website | Show degraded/repairing slot state and current provider/pending provider. |
 | Simulator | Model delinquency thresholds, candidate exhaustion, repair duration, false positives, and promotion success. |
 | E2E | Kill/withhold/corrupt provider, verify repair starts, pending provider catches up, promotion occurs, reads remain available. |
+
+Current implementation note:
+
+The current keeper-level readiness marker is a promotion guardrail, not a full
+data-plane catch-up proof. It prevents immediate promotion without pending
+provider proof activity, but the next data-plane step is to prove that the
+pending provider reconstructed every required shard for `repair_target_gen`
+and any generations committed while repair was in progress.
 
 ## 20. New SP Onboarding and Higher-Bandwidth Promotion
 

--- a/polystorechain/x/polystorechain/keeper/draining.go
+++ b/polystorechain/x/polystorechain/keeper/draining.go
@@ -143,6 +143,9 @@ func (k Keeper) scheduleDrainingRepairs(ctx sdk.Context, epochID uint64) error {
 				entry.PendingProvider = strings.TrimSpace(pending)
 				entry.StatusSinceHeight = ctx.BlockHeight()
 				entry.RepairTargetGen = deal.CurrentGen
+				if err := k.clearMode2RepairReadiness(ctx, dealID, slot); err != nil {
+					return true, err
+				}
 				deal.Mode2Slots[i] = entry
 				dealChanged = true
 

--- a/polystorechain/x/polystorechain/keeper/keeper.go
+++ b/polystorechain/x/polystorechain/keeper/keeper.go
@@ -67,6 +67,7 @@ type Keeper struct {
 	Mode2EpochSynthetic     collections.Map[collections.Pair[collections.Pair[uint64, uint32], uint64], uint64]
 	Mode2EpochSlotServed    collections.Map[collections.Pair[collections.Pair[uint64, uint32], uint64], uint64]
 	Mode2EpochDeputyServed  collections.Map[collections.Pair[collections.Pair[uint64, uint32], uint64], uint64]
+	Mode2RepairReadiness    collections.Map[collections.Pair[uint64, uint32], uint64]
 	Mode2MissedEpochs       collections.Map[collections.Pair[uint64, uint32], uint64]
 	Mode2DeputyMissedEpochs collections.Map[collections.Pair[uint64, uint32], uint64]
 	CreditSeen              collections.Map[[]byte, bool]
@@ -210,6 +211,13 @@ func NewKeeper(
 			types.Mode2EpochDeputyServedKey,
 			"mode2_epoch_deputy_served",
 			collections.PairKeyCodec(collections.PairKeyCodec(collections.Uint64Key, collections.Uint32Key), collections.Uint64Key),
+			collections.Uint64Value,
+		),
+		Mode2RepairReadiness: collections.NewMap(
+			sb,
+			types.Mode2RepairReadinessKey,
+			"mode2_repair_readiness",
+			collections.PairKeyCodec(collections.Uint64Key, collections.Uint32Key),
 			collections.Uint64Value,
 		),
 		Mode2MissedEpochs: collections.NewMap(

--- a/polystorechain/x/polystorechain/keeper/msg_server.go
+++ b/polystorechain/x/polystorechain/keeper/msg_server.go
@@ -1859,6 +1859,10 @@ func (k msgServer) trackProviderHealth(ctx sdk.Context, dealID uint64, provider 
 		entry.PendingProvider = strings.TrimSpace(pending)
 		entry.StatusSinceHeight = ctx.BlockHeight()
 		entry.RepairTargetGen = deal.CurrentGen
+		if err := k.clearMode2RepairReadiness(ctx, dealID, slot); err != nil {
+			ctx.Logger().Error("failed to clear stale repair readiness", "deal", dealID, "slot", slot, "error", err)
+			return
+		}
 		deal.Mode2Slots[slot] = entry
 
 		if err := k.Deals.Set(ctx, dealID, deal); err != nil {

--- a/polystorechain/x/polystorechain/keeper/msg_server_test.go
+++ b/polystorechain/x/polystorechain/keeper/msg_server_test.go
@@ -334,6 +334,16 @@ func TestMode2SlotRepairLifecycle(t *testing.T) {
 		DealId:  res.DealId,
 		Slot:    0,
 	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "slot repair is not ready")
+
+	markMode2RepairReadyForTest(t, f, sdk.UnwrapSDKContext(f.ctx), res.DealId, 0, dealAfterStart.Mode2Slots[0].RepairTargetGen)
+
+	_, err = msgServer.CompleteSlotRepair(f.ctx, &types.MsgCompleteSlotRepair{
+		Creator: candidate,
+		DealId:  res.DealId,
+		Slot:    0,
+	})
 	require.NoError(t, err)
 
 	dealAfterComplete, err := f.keeper.Deals.Get(f.ctx, res.DealId)

--- a/polystorechain/x/polystorechain/keeper/msg_slot_repair.go
+++ b/polystorechain/x/polystorechain/keeper/msg_slot_repair.go
@@ -70,6 +70,9 @@ func (k msgServer) StartSlotRepair(goCtx context.Context, msg *types.MsgStartSlo
 	slot.RepairTargetGen = deal.CurrentGen
 	deal.Mode2Slots[slotIdx] = slot
 
+	if err := k.clearMode2RepairReadiness(ctx, deal.Id, msg.Slot); err != nil {
+		return nil, fmt.Errorf("failed to clear stale repair readiness: %w", err)
+	}
 	if err := k.Deals.Set(ctx, deal.Id, deal); err != nil {
 		return nil, fmt.Errorf("failed to update deal: %w", err)
 	}
@@ -126,6 +129,14 @@ func (k msgServer) CompleteSlotRepair(goCtx context.Context, msg *types.MsgCompl
 		return nil, sdkerrors.ErrUnauthorized.Wrap("only deal owner or pending provider can complete slot repair")
 	}
 
+	ready, err := k.mode2RepairReady(ctx, deal.Id, msg.Slot, slot.RepairTargetGen)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check repair readiness: %w", err)
+	}
+	if !ready {
+		return nil, sdkerrors.ErrInvalidRequest.Wrap("slot repair is not ready; pending provider must submit repair readiness proof before promotion")
+	}
+
 	oldProvider := slot.Provider
 	slot.Provider = slot.PendingProvider
 	slot.PendingProvider = ""
@@ -143,6 +154,9 @@ func (k msgServer) CompleteSlotRepair(goCtx context.Context, msg *types.MsgCompl
 	// cannot keep replaying historical proofs.
 	deal.CurrentGen++
 
+	if err := k.clearMode2RepairReadiness(ctx, deal.Id, msg.Slot); err != nil {
+		return nil, fmt.Errorf("failed to clear consumed repair readiness: %w", err)
+	}
 	if err := k.Deals.Set(ctx, deal.Id, deal); err != nil {
 		return nil, fmt.Errorf("failed to update deal: %w", err)
 	}

--- a/polystorechain/x/polystorechain/keeper/repair_readiness.go
+++ b/polystorechain/x/polystorechain/keeper/repair_readiness.go
@@ -1,0 +1,83 @@
+package keeper
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"strings"
+
+	"cosmossdk.io/collections"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"polystorechain/x/polystorechain/types"
+)
+
+func mode2RepairReadinessValue(repairTargetGen uint64) (uint64, error) {
+	if repairTargetGen == ^uint64(0) {
+		return 0, fmt.Errorf("repair target generation overflow")
+	}
+	return repairTargetGen + 1, nil
+}
+
+func (k Keeper) clearMode2RepairReadiness(ctx sdk.Context, dealID uint64, slot uint32) error {
+	key := collections.Join(dealID, slot)
+	err := k.Mode2RepairReadiness.Remove(ctx, key)
+	if err != nil && !errors.Is(err, collections.ErrNotFound) {
+		return err
+	}
+	return nil
+}
+
+func (k Keeper) mode2RepairReady(ctx sdk.Context, dealID uint64, slot uint32, repairTargetGen uint64) (bool, error) {
+	expected, err := mode2RepairReadinessValue(repairTargetGen)
+	if err != nil {
+		return false, err
+	}
+
+	actual, err := k.Mode2RepairReadiness.Get(ctx, collections.Join(dealID, slot))
+	if errors.Is(err, collections.ErrNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return actual == expected, nil
+}
+
+func (k Keeper) markMode2RepairReady(ctx sdk.Context, deal types.Deal, slot uint32, pendingProvider string, epochID uint64) error {
+	if deal.RedundancyMode != 2 || deal.Mode2Profile == nil || int(slot) >= len(deal.Mode2Slots) {
+		return nil
+	}
+
+	entry := deal.Mode2Slots[slot]
+	if entry == nil || entry.Status != types.SlotStatus_SLOT_STATUS_REPAIRING {
+		return nil
+	}
+	pending := strings.TrimSpace(pendingProvider)
+	if pending == "" || pending != strings.TrimSpace(entry.PendingProvider) {
+		return nil
+	}
+
+	value, err := mode2RepairReadinessValue(entry.RepairTargetGen)
+	if err != nil {
+		return err
+	}
+
+	key := collections.Join(deal.Id, slot)
+	current, err := k.Mode2RepairReadiness.Get(ctx, key)
+	if err == nil && current == value {
+		return nil
+	}
+	if err != nil && !errors.Is(err, collections.ErrNotFound) {
+		return err
+	}
+	if err := k.Mode2RepairReadiness.Set(ctx, key, value); err != nil {
+		return err
+	}
+
+	extra := make([]byte, 0, 4+8)
+	extra = binary.BigEndian.AppendUint32(extra, slot)
+	extra = binary.BigEndian.AppendUint64(extra, entry.RepairTargetGen)
+	eid := deriveEvidenceID("slot_repair_ready", deal.Id, epochID, extra)
+	return k.recordEvidenceSummary(ctx, deal.Id, pending, "slot_repair_ready", eid[:], "chain", true)
+}

--- a/polystorechain/x/polystorechain/keeper/rotation.go
+++ b/polystorechain/x/polystorechain/keeper/rotation.go
@@ -132,6 +132,9 @@ func (k Keeper) scheduleRoutineRotations(ctx sdk.Context, epochID uint64) error 
 			entry.PendingProvider = strings.TrimSpace(pending)
 			entry.StatusSinceHeight = ctx.BlockHeight()
 			entry.RepairTargetGen = deal.CurrentGen
+			if err := k.clearMode2RepairReadiness(ctx, dealID, slot); err != nil {
+				return true, err
+			}
 			deal.Mode2Slots[i] = entry
 			dealChanged = true
 

--- a/polystorechain/x/polystorechain/keeper/slashing.go
+++ b/polystorechain/x/polystorechain/keeper/slashing.go
@@ -139,6 +139,14 @@ func (k Keeper) CheckMissedProofs(ctx context.Context) error {
 					entry := deal.Mode2Slots[slot]
 					if entry != nil && entry.Status == types.SlotStatus_SLOT_STATUS_REPAIRING && strings.TrimSpace(entry.PendingProvider) != "" {
 						if total >= quota {
+							ready, err := k.mode2RepairReady(sdkCtx, dealID, slot, entry.RepairTargetGen)
+							if err != nil {
+								return false, err
+							}
+							if !ready {
+								continue
+							}
+
 							oldProvider := entry.Provider
 							newProvider := strings.TrimSpace(entry.PendingProvider)
 
@@ -156,6 +164,9 @@ func (k Keeper) CheckMissedProofs(ctx context.Context) error {
 
 							deal.CurrentGen++
 							dealChanged = true
+							if err := k.clearMode2RepairReadiness(sdkCtx, dealID, slot); err != nil {
+								return false, err
+							}
 							_ = k.Mode2MissedEpochs.Remove(ctx, missedKey)
 							_ = k.Mode2DeputyMissedEpochs.Remove(ctx, missedKey)
 
@@ -240,6 +251,9 @@ func (k Keeper) CheckMissedProofs(ctx context.Context) error {
 						entry.PendingProvider = strings.TrimSpace(pending)
 						entry.StatusSinceHeight = sdkCtx.BlockHeight()
 						entry.RepairTargetGen = deal.CurrentGen
+						if err := k.clearMode2RepairReadiness(sdkCtx, dealID, slot); err != nil {
+							return false, err
+						}
 						deal.Mode2Slots[slot] = entry
 						dealChanged = true
 						_ = k.Mode2DeputyMissedEpochs.Remove(ctx, missedKey)
@@ -318,6 +332,9 @@ func (k Keeper) CheckMissedProofs(ctx context.Context) error {
 						entry.PendingProvider = strings.TrimSpace(pending)
 						entry.StatusSinceHeight = sdkCtx.BlockHeight()
 						entry.RepairTargetGen = deal.CurrentGen
+						if err := k.clearMode2RepairReadiness(sdkCtx, dealID, slot); err != nil {
+							return false, err
+						}
 						deal.Mode2Slots[slot] = entry
 						dealChanged = true
 						_ = k.Mode2MissedEpochs.Remove(ctx, missedKey)

--- a/polystorechain/x/polystorechain/keeper/slashing_repair_test.go
+++ b/polystorechain/x/polystorechain/keeper/slashing_repair_test.go
@@ -75,6 +75,16 @@ func setMode2EpochCredits(t *testing.T, f *fixture, ctx sdk.Context, dealID uint
 	}
 }
 
+func markMode2RepairReadyForTest(t *testing.T, f *fixture, ctx sdk.Context, dealID uint64, slot uint32, repairTargetGen uint64) {
+	t.Helper()
+
+	require.NoError(t, f.keeper.Mode2RepairReadiness.Set(
+		ctx,
+		collections.Join(dealID, slot),
+		repairTargetGen+1,
+	))
+}
+
 func hasEvidenceSummary(t *testing.T, f *fixture, ctx sdk.Context, kind string) bool {
 	t.Helper()
 
@@ -498,6 +508,7 @@ func TestCheckMissedProofs_CompletesMode2SlotRepairWhenQuotaMet(t *testing.T) {
 		collections.Join(collections.Join(dealID, uint32(0)), epochID),
 		1,
 	))
+	markMode2RepairReadyForTest(t, f, sdkCtx, dealID, 0, 1)
 
 	require.NoError(t, f.keeper.CheckMissedProofs(sdkCtx))
 
@@ -523,6 +534,49 @@ func TestCheckMissedProofs_CompletesMode2SlotRepairWhenQuotaMet(t *testing.T) {
 		return false, nil
 	}))
 	require.True(t, foundEvidence)
+}
+
+func TestCheckMissedProofs_Mode2RepairWaitsForReadinessWhenQuotaMet(t *testing.T) {
+	f := initFixture(t)
+
+	sdkCtx := sdk.UnwrapSDKContext(f.ctx).WithBlockHeight(5)
+
+	params := types.DefaultParams()
+	params.EpochLenBlocks = 5
+	require.NoError(t, f.keeper.Params.Set(sdkCtx, params))
+
+	providerA := makePolicyTestAddr(t, f, 0xA1)
+	providerB := makePolicyTestAddr(t, f, 0xB2)
+	providerC := makePolicyTestAddr(t, f, 0xC3)
+	providerD := makePolicyTestAddr(t, f, 0xD4)
+	registerPolicyTestProviders(t, f, sdkCtx, providerA, providerB, providerC, providerD)
+
+	dealID := uint64(1)
+	deal := mode2PolicyTestDeal(dealID, makePolicyTestAddr(t, f, 0xEE), []string{providerA, providerB, providerC})
+	deal.Mode2Slots[0].Status = types.SlotStatus_SLOT_STATUS_REPAIRING
+	deal.Mode2Slots[0].PendingProvider = providerD
+	deal.Mode2Slots[0].StatusSinceHeight = 4
+	deal.Mode2Slots[0].RepairTargetGen = deal.CurrentGen
+	require.NoError(t, f.keeper.Deals.Set(sdkCtx, dealID, deal))
+
+	epochID := uint64(1)
+	require.NoError(t, f.keeper.Mode2EpochSynthetic.Set(
+		sdkCtx,
+		collections.Join(collections.Join(dealID, uint32(0)), epochID),
+		1,
+	))
+
+	require.NoError(t, f.keeper.CheckMissedProofs(sdkCtx))
+
+	updated, err := f.keeper.Deals.Get(sdkCtx, dealID)
+	require.NoError(t, err)
+	slot0 := updated.Mode2Slots[0]
+	require.NotNil(t, slot0)
+	require.Equal(t, types.SlotStatus_SLOT_STATUS_REPAIRING, slot0.Status)
+	require.Equal(t, providerA, slot0.Provider)
+	require.Equal(t, providerD, slot0.PendingProvider)
+	require.Equal(t, uint64(1), updated.CurrentGen)
+	require.False(t, hasEvidenceSummary(t, f, sdkCtx, "slot_repair_completed"))
 }
 
 func TestCheckMissedProofs_DeputyServedTriggersRepairEvenIfQuotaMet(t *testing.T) {

--- a/polystorechain/x/polystorechain/keeper/unified_liveness.go
+++ b/polystorechain/x/polystorechain/keeper/unified_liveness.go
@@ -335,27 +335,27 @@ func (k Keeper) recordCredit(ctx sdk.Context, epochID uint64, dealID uint64, ass
 	return k.Mode1EpochCredits.Set(ctx, key, current+1)
 }
 
-func (k Keeper) recordCreditMode2(ctx sdk.Context, epochID uint64, dealID uint64, slot uint32, key collections.Pair[collections.Pair[uint64, uint32], uint64], mduIndex uint64, blobIndex uint64) error {
+func (k Keeper) recordCreditMode2(ctx sdk.Context, epochID uint64, dealID uint64, slot uint32, key collections.Pair[collections.Pair[uint64, uint32], uint64], mduIndex uint64, blobIndex uint64) (bool, error) {
 	if epochID == 0 {
-		return nil
+		return false, nil
 	}
 	assignment := assignmentBytesMode2(slot)
 	seenKey := creditSeenKey(epochID, dealID, assignment, mduIndex, blobIndex)
 	_, err := k.CreditSeen.Get(ctx, seenKey)
 	if err == nil {
-		return nil
+		return false, nil
 	}
 	if !errors.Is(err, collections.ErrNotFound) {
-		return err
+		return false, err
 	}
 	if err := k.CreditSeen.Set(ctx, seenKey, true); err != nil {
-		return err
+		return false, err
 	}
 	current, err := k.Mode2EpochCredits.Get(ctx, key)
 	if err != nil && !errors.Is(err, collections.ErrNotFound) {
-		return err
+		return false, err
 	}
-	return k.Mode2EpochCredits.Set(ctx, key, current+1)
+	return true, k.Mode2EpochCredits.Set(ctx, key, current+1)
 }
 
 func (k Keeper) recordSynthetic(ctx sdk.Context, epochID uint64, dealID uint64, assignment []byte, key collections.Pair[collections.Pair[uint64, string], uint64], mduIndex uint64, blobIndex uint64) (bool, error) {
@@ -498,7 +498,14 @@ func (k Keeper) recordCreditForProof(ctx sdk.Context, epochID uint64, deal types
 		}
 
 		key := collections.Join(collections.Join(deal.Id, slotU), epochID)
-		return k.recordCreditMode2(ctx, epochID, deal.Id, slotU, key, mduIndex, uint64(blobIndex))
+		counted, err := k.recordCreditMode2(ctx, epochID, deal.Id, slotU, key, mduIndex, uint64(blobIndex))
+		if err != nil {
+			return err
+		}
+		if counted && pending != "" && creator == pending {
+			return k.markMode2RepairReady(ctx, deal, slotU, creator, epochID)
+		}
+		return nil
 	}
 
 	assignment, err := assignmentBytesMode1(provider)
@@ -595,6 +602,9 @@ func (k Keeper) validateAndRecordSystemProof(ctx sdk.Context, epochID uint64, se
 		}
 		if !counted {
 			return sdkerrors.ErrInvalidRequest.Wrap("duplicate synthetic challenge proof")
+		}
+		if pending != "" && creator == pending {
+			return k.markMode2RepairReady(ctx, deal, slotU, creator, epochID)
 		}
 		return nil
 	}

--- a/polystorechain/x/polystorechain/types/keys.go
+++ b/polystorechain/x/polystorechain/types/keys.go
@@ -63,6 +63,7 @@ var (
 	Mode2EpochSyntheticKey     = collections.NewPrefix("Mode2EpochSynthetic/value/")
 	Mode2EpochSlotServedKey    = collections.NewPrefix("Mode2EpochSlotServed/value/")
 	Mode2EpochDeputyServedKey  = collections.NewPrefix("Mode2EpochDeputyServed/value/")
+	Mode2RepairReadinessKey    = collections.NewPrefix("Mode2RepairReadiness/value/")
 	Mode2MissedEpochsKey       = collections.NewPrefix("Mode2MissedEpochs/value/")
 	Mode2DeputyMissedEpochsKey = collections.NewPrefix("Mode2DeputyMissedEpochs/value/")
 	CreditSeenKey              = collections.NewPrefix("CreditSeen/value/")


### PR DESCRIPTION
## Summary
- add a Mode2 repair readiness ledger keyed by deal/slot and repair target generation
- require readiness before manual or automatic slot repair promotion
- mark readiness from valid pending-provider proof activity and clear stale/consumed readiness markers
- update the policing roadmap with current keeper-graduation status and the remaining full catch-up proof gap

## Validation
- LD_LIBRARY_PATH="/home/mikers/dev/polynomialstore/polystore/../polystore_core/target/release${LD_LIBRARY_PATH:+:/opt/nilstore/nil_core/target/release:/home/mikers/.gvm/pkgsets/go1.25/global/overlay/lib:/home/mikers/.gvm/pkgsets/go1.25/global/overlay/lib:/opt/nilstore/nil_core/target/release:/home/mikers/.gvm/pkgsets/go1.25/global/overlay/lib:/home/mikers/.gvm/pkgsets/go1.25/global/overlay/lib:/home/mikers/.gvm/pkgsets/go1.25/global/overlay/lib}" go test -count=1 ./x/polystorechain/keeper
- LD_LIBRARY_PATH="/home/mikers/dev/polynomialstore/polystore/../polystore_core/target/release${LD_LIBRARY_PATH:+:/opt/nilstore/nil_core/target/release:/home/mikers/.gvm/pkgsets/go1.25/global/overlay/lib:/home/mikers/.gvm/pkgsets/go1.25/global/overlay/lib:/opt/nilstore/nil_core/target/release:/home/mikers/.gvm/pkgsets/go1.25/global/overlay/lib:/home/mikers/.gvm/pkgsets/go1.25/global/overlay/lib:/home/mikers/.gvm/pkgsets/go1.25/global/overlay/lib}" go test -count=1 ./x/polystorechain/...
- git diff --check