### PR TITLE
Expose repair-aware retrieval planning context

### DIFF
--- a/polystore_gateway/main.go
+++ b/polystore_gateway/main.go
@@ -4199,30 +4199,49 @@ func GatewayPlanRetrievalSession(w http.ResponseWriter, r *http.Request) {
 	}
 
 	type response struct {
-		DealID         uint64 `json:"deal_id"`
-		Owner          string `json:"owner"`
-		Provider       string `json:"provider"`
-		ManifestRoot   string `json:"manifest_root"`
-		FilePath       string `json:"file_path"`
-		RangeStart     uint64 `json:"range_start"`
-		RangeLen       uint64 `json:"range_len"`
-		StartMduIndex  uint64 `json:"start_mdu_index"`
-		StartBlobIndex uint32 `json:"start_blob_index"`
-		BlobCount      uint64 `json:"blob_count"`
+		DealID               uint64  `json:"deal_id"`
+		Owner                string  `json:"owner"`
+		Provider             string  `json:"provider"`
+		ProviderSource       string  `json:"provider_source"`
+		Mode2Slot            *uint64 `json:"mode2_slot,omitempty"`
+		Mode2SlotStatus      *int    `json:"mode2_slot_status,omitempty"`
+		Mode2ActiveProvider  string  `json:"mode2_active_provider,omitempty"`
+		Mode2PendingProvider string  `json:"mode2_pending_provider,omitempty"`
+		ManifestRoot         string  `json:"manifest_root"`
+		FilePath             string  `json:"file_path"`
+		RangeStart           uint64  `json:"range_start"`
+		RangeLen             uint64  `json:"range_len"`
+		StartMduIndex        uint64  `json:"start_mdu_index"`
+		StartBlobIndex       uint32  `json:"start_blob_index"`
+		BlobCount            uint64  `json:"blob_count"`
+	}
+
+	var mode2SlotPtr *uint64
+	var mode2SlotStatusPtr *int
+	if stripe.mode == 2 {
+		slot := providerResolution.Mode2Slot
+		status := providerResolution.SlotStatus
+		mode2SlotPtr = &slot
+		mode2SlotStatusPtr = &status
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(response{
-		DealID:         dealID,
-		Owner:          owner,
-		Provider:       providerAddr,
-		ManifestRoot:   dealRoot.Canonical,
-		FilePath:       filePath,
-		RangeStart:     rangeStart,
-		RangeLen:       rangeLen,
-		StartMduIndex:  startMdu,
-		StartBlobIndex: startBlob,
-		BlobCount:      blobCount,
+		DealID:               dealID,
+		Owner:                owner,
+		Provider:             providerAddr,
+		ProviderSource:       providerResolution.Source,
+		Mode2Slot:            mode2SlotPtr,
+		Mode2SlotStatus:      mode2SlotStatusPtr,
+		Mode2ActiveProvider:  providerResolution.ActiveProvider,
+		Mode2PendingProvider: providerResolution.PendingProvider,
+		ManifestRoot:         dealRoot.Canonical,
+		FilePath:             filePath,
+		RangeStart:           rangeStart,
+		RangeLen:             rangeLen,
+		StartMduIndex:        startMdu,
+		StartBlobIndex:       startBlob,
+		BlobCount:            blobCount,
 	})
 }
 

--- a/polystore_gateway/main_test.go
+++ b/polystore_gateway/main_test.go
@@ -1429,13 +1429,17 @@ func TestGatewayPlanRetrievalSession_UsesMetadataProviderWithoutLocalProvider(t 
 	}
 
 	var resp struct {
-		Provider string `json:"provider"`
+		Provider       string `json:"provider"`
+		ProviderSource string `json:"provider_source"`
 	}
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
 	if resp.Provider != metadataProvider {
 		t.Fatalf("expected metadata provider %q, got %q", metadataProvider, resp.Provider)
+	}
+	if resp.ProviderSource != "deal_metadata_provider" {
+		t.Fatalf("expected provider source deal_metadata_provider, got %q", resp.ProviderSource)
 	}
 }
 
@@ -1510,6 +1514,97 @@ func setPlanResolverForTest(t *testing.T, resolver func(context.Context, uint64,
 	prev := resolveProviderForRetrievalPlanFn
 	resolveProviderForRetrievalPlanFn = resolver
 	t.Cleanup(func() { resolveProviderForRetrievalPlanFn = prev })
+}
+
+func TestGatewayPlanRetrievalSession_ExposesRepairAwareProviderContext(t *testing.T) {
+	useTempUploadDir(t)
+	resetProviderAddressCacheForTest(t)
+	t.Setenv("POLYSTORE_PROVIDER_ADDRESS", "")
+
+	dealID := uint64(14)
+	owner := testDealOwner(t)
+	manifestRoot := mustTestManifestRoot(t, "plan-repair-context")
+	preparePlanRetrievalTestSlab(t, dealID, manifestRoot, "plan.txt", 512)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/polystorechain/polystorechain/v1/deals/14" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"deal": map[string]any{
+				"id":           "14",
+				"owner":        owner,
+				"cid":          manifestRoot.Canonical,
+				"service_hint": "General:rs=2+1",
+				"providers":    []string{"nil1activeprovider"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	oldLCD := lcdBase
+	lcdBase = srv.URL
+	defer func() { lcdBase = oldLCD }()
+
+	setPlanResolverForTest(t, func(_ context.Context, gotDealID uint64, stripe stripeParams, mode2Slot uint64) (retrievalProviderResolution, error) {
+		if gotDealID != dealID {
+			t.Fatalf("resolver got deal_id=%d", gotDealID)
+		}
+		if stripe.mode != 2 {
+			t.Fatalf("expected Mode2 stripe, got mode=%d", stripe.mode)
+		}
+		if mode2Slot != 0 {
+			t.Fatalf("expected slot 0, got %d", mode2Slot)
+		}
+		return retrievalProviderResolution{
+			Provider:        "nil1pendingprovider",
+			Source:          "mode2_slot_pending_provider",
+			Mode2Slot:       0,
+			SlotStatus:      2,
+			ActiveProvider:  "nil1activeprovider",
+			PendingProvider: "nil1pendingprovider",
+		}, nil
+	})
+
+	r := testRouter()
+	q := url.Values{}
+	q.Set("deal_id", "14")
+	q.Set("owner", owner)
+	q.Set("file_path", "plan.txt")
+
+	req := httptest.NewRequest(http.MethodGet, "/gateway/plan-retrieval-session/"+manifestRoot.Canonical+"?"+q.Encode(), nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GatewayPlanRetrievalSession failed: %d, body: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Provider             string  `json:"provider"`
+		ProviderSource       string  `json:"provider_source"`
+		Mode2Slot            *uint64 `json:"mode2_slot"`
+		Mode2SlotStatus      *int    `json:"mode2_slot_status"`
+		Mode2ActiveProvider  string  `json:"mode2_active_provider"`
+		Mode2PendingProvider string  `json:"mode2_pending_provider"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Provider != "nil1pendingprovider" || resp.ProviderSource != "mode2_slot_pending_provider" {
+		t.Fatalf("unexpected provider context: provider=%q source=%q", resp.Provider, resp.ProviderSource)
+	}
+	if resp.Mode2Slot == nil || *resp.Mode2Slot != 0 {
+		t.Fatalf("expected mode2_slot=0, got %#v", resp.Mode2Slot)
+	}
+	if resp.Mode2SlotStatus == nil || *resp.Mode2SlotStatus != 2 {
+		t.Fatalf("expected mode2_slot_status=2, got %#v", resp.Mode2SlotStatus)
+	}
+	if resp.Mode2ActiveProvider != "nil1activeprovider" || resp.Mode2PendingProvider != "nil1pendingprovider" {
+		t.Fatalf("unexpected repair providers: active=%q pending=%q", resp.Mode2ActiveProvider, resp.Mode2PendingProvider)
+	}
 }
 
 func TestGatewayPlanRetrievalSession_ProviderResolutionStatusMapping(t *testing.T) {

--- a/polystore_gateway/provider_discovery.go
+++ b/polystore_gateway/provider_discovery.go
@@ -78,6 +78,10 @@ type retrievalProviderResolution struct {
 	Provider          string
 	Source            string
 	UsedLocalFallback bool
+	Mode2Slot         uint64
+	SlotStatus        int
+	ActiveProvider    string
+	PendingProvider   string
 }
 
 func providerHTTPBaseOverrides() map[string]string {
@@ -307,10 +311,12 @@ func resolveProviderForRetrievalPlan(ctx context.Context, dealID uint64, stripe 
 
 		assign := slots[mode2Slot]
 		provider := strings.TrimSpace(assign.Provider)
+		activeProvider := provider
+		pendingProvider := strings.TrimSpace(assign.PendingProvider)
 		source := "mode2_slot_provider"
 		if assign.Status == 2 {
-			if pending := strings.TrimSpace(assign.PendingProvider); pending != "" {
-				provider = pending
+			if pendingProvider != "" {
+				provider = pendingProvider
 				source = "mode2_slot_pending_provider"
 			}
 		}
@@ -329,8 +335,12 @@ func resolveProviderForRetrievalPlan(ctx context.Context, dealID uint64, stripe 
 			expires:  time.Now().Add(dealProviderTTL),
 		})
 		return retrievalProviderResolution{
-			Provider: provider,
-			Source:   source,
+			Provider:        provider,
+			Source:          source,
+			Mode2Slot:       mode2Slot,
+			SlotStatus:      assign.Status,
+			ActiveProvider:  activeProvider,
+			PendingProvider: pendingProvider,
 		}, nil
 	}
 

--- a/polystore_gateway/provider_discovery_test.go
+++ b/polystore_gateway/provider_discovery_test.go
@@ -254,6 +254,12 @@ func TestResolveProviderForRetrievalPlan_Mode2UsesPendingProvider(t *testing.T) 
 	if res.Source != "mode2_slot_pending_provider" {
 		t.Fatalf("unexpected source: %q", res.Source)
 	}
+	if res.Mode2Slot != 0 || res.SlotStatus != 2 {
+		t.Fatalf("unexpected mode2 context: slot=%d status=%d", res.Mode2Slot, res.SlotStatus)
+	}
+	if res.ActiveProvider != "providerA" || res.PendingProvider != "providerPending" {
+		t.Fatalf("unexpected repair context: active=%q pending=%q", res.ActiveProvider, res.PendingProvider)
+	}
 }
 
 func TestResolveProviderForRetrievalPlan_FallsBackToLocalWhenMetadataUnavailable(t *testing.T) {


### PR DESCRIPTION
## Summary
- include provider_source in retrieval plan responses
- include Mode 2 slot status, active provider, and pending provider context when planning against Mode 2 slots
- keep existing repair-aware routing behavior while making pending-provider routing visible to clients/operators

## Validation
- LD_LIBRARY_PATH="/home/mikers/dev/polynomialstore/polystore/../polystore_core/target/release${LD_LIBRARY_PATH:+:/opt/nilstore/nil_core/target/release:/home/mikers/.gvm/pkgsets/go1.25/global/overlay/lib:/home/mikers/.gvm/pkgsets/go1.25/global/overlay/lib:/opt/nilstore/nil_core/target/release:/home/mikers/.gvm/pkgsets/go1.25/global/overlay/lib:/home/mikers/.gvm/pkgsets/go1.25/global/overlay/lib:/home/mikers/.gvm/pkgsets/go1.25/global/overlay/lib}" go test -count=1 . -run 'TestResolveProviderForRetrievalPlan|TestFetchDealProvidersFromLCD|TestResolveDealMode2Slots|TestGatewayPlanRetrievalSession'
- LD_LIBRARY_PATH="/home/mikers/dev/polynomialstore/polystore/../polystore_core/target/release${LD_LIBRARY_PATH:+:/opt/nilstore/nil_core/target/release:/home/mikers/.gvm/pkgsets/go1.25/global/overlay/lib:/home/mikers/.gvm/pkgsets/go1.25/global/overlay/lib:/opt/nilstore/nil_core/target/release:/home/mikers/.gvm/pkgsets/go1.25/global/overlay/lib:/home/mikers/.gvm/pkgsets/go1.25/global/overlay/lib:/home/mikers/.gvm/pkgsets/go1.25/global/overlay/lib}" go test -count=1 .
- git diff --check