### PR TITLE
Explain repair candidate exclusion in reports

### DIFF
--- a/docs/planning/POLICING_AND_FAILURE_SIMULATION_ROADMAP.md
+++ b/docs/planning/POLICING_AND_FAILURE_SIMULATION_ROADMAP.md
@@ -608,7 +608,7 @@ desired-state pieces include:
 2. Keeper/runtime repair attempt counters and cooldown windows. The simulator
    now models these with `repair_attempt_cap_per_slot`,
    `repair_backoff_epochs`, per-slot attempt state, cooldown backoff events,
-   and attempt-cap backoff events.
+   attempt-cap backoff events, and candidate-exclusion diagnostics.
 3. Full catch-up proofs for all data/generation ranges, beyond the current
    readiness marker.
 4. Per-slot health queries for UI and operator tooling.
@@ -1193,7 +1193,8 @@ Each simulator run should be able to emit:
    provider, and reward eligibility state.
 5. `evidence.csv`: hard faults, soft faults, threshold evidence, and source.
 6. `repairs.csv`: repair start, candidate selection, catch-up, promotion,
-   attempt-count, cooldown, attempt-cap, and backoff events.
+   attempt-count, cooldown, candidate-exclusion, attempt-cap, and backoff
+   events.
 7. `economy.csv`: storage charges, retrieval burns, payouts, reward mint/burn,
    audit budget, escrow runway, and elasticity spend.
 8. No `comparison.json` or other precomputed baseline-vs-candidate artifact in

--- a/docs/simulation-reports/policy-sim/audit-budget-exhaustion/report.md
+++ b/docs/simulation-reports/policy-sim/audit-budget-exhaustion/report.md
@@ -153,6 +153,10 @@ Repair summary:
 - Delinquent slot-epochs: `64`
 - Final active slots in last epoch: `432`
 
+Candidate exclusion summary:
+
+- No no-candidate repair backoffs were recorded.
+
 ### Repair Ledger Excerpt
 
 | Epoch | Event | Deal | Slot | Old Provider | New Provider | Reason | Attempt | Cooldown Until |
@@ -284,6 +288,6 @@ Shows whether started repairs are accumulating faster than they complete.
 - `providers.csv`: final provider-level economics and fault counters.
 - `slots.csv`: per-slot epoch ledger, including health state and reason.
 - `evidence.csv`: policy evidence events.
-- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, attempt-cap, and backoff events.
+- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, candidate-exclusion, attempt-cap, and backoff events.
 - `economy.csv`: per-epoch market and accounting ledger.
 - `signals.json`: derived availability, saturation, repair, capacity, economic, regional, and provider bottleneck signals.

--- a/docs/simulation-reports/policy-sim/coordinated-regional-outage/report.md
+++ b/docs/simulation-reports/policy-sim/coordinated-regional-outage/report.md
@@ -169,6 +169,10 @@ Repair summary:
 - Delinquent slot-epochs: `925`
 - Final active slots in last epoch: `960`
 
+Candidate exclusion summary:
+
+- No no-candidate repair backoffs were recorded.
+
 ### Repair Ledger Excerpt
 
 | Epoch | Event | Deal | Slot | Old Provider | New Provider | Reason | Attempt | Cooldown Until |
@@ -302,6 +306,6 @@ Shows whether started repairs are accumulating faster than they complete.
 - `providers.csv`: final provider-level economics and fault counters.
 - `slots.csv`: per-slot epoch ledger, including health state and reason.
 - `evidence.csv`: policy evidence events.
-- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, attempt-cap, and backoff events.
+- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, candidate-exclusion, attempt-cap, and backoff events.
 - `economy.csv`: per-epoch market and accounting ledger.
 - `signals.json`: derived availability, saturation, repair, capacity, economic, regional, and provider bottleneck signals.

--- a/docs/simulation-reports/policy-sim/corrupt-provider/report.md
+++ b/docs/simulation-reports/policy-sim/corrupt-provider/report.md
@@ -155,6 +155,10 @@ Repair summary:
 - Delinquent slot-epochs: `6`
 - Final active slots in last epoch: `288`
 
+Candidate exclusion summary:
+
+- No no-candidate repair backoffs were recorded.
+
 ### Repair Ledger Excerpt
 
 | Epoch | Event | Deal | Slot | Old Provider | New Provider | Reason | Attempt | Cooldown Until |
@@ -288,6 +292,6 @@ Shows whether started repairs are accumulating faster than they complete.
 - `providers.csv`: final provider-level economics and fault counters.
 - `slots.csv`: per-slot epoch ledger, including health state and reason.
 - `evidence.csv`: policy evidence events.
-- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, attempt-cap, and backoff events.
+- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, candidate-exclusion, attempt-cap, and backoff events.
 - `economy.csv`: per-epoch market and accounting ledger.
 - `signals.json`: derived availability, saturation, repair, capacity, economic, regional, and provider bottleneck signals.

--- a/docs/simulation-reports/policy-sim/elasticity-cap-hit/report.md
+++ b/docs/simulation-reports/policy-sim/elasticity-cap-hit/report.md
@@ -147,6 +147,10 @@ Repair summary:
 - Delinquent slot-epochs: `0`
 - Final active slots in last epoch: `288`
 
+Candidate exclusion summary:
+
+- No no-candidate repair backoffs were recorded.
+
 ### Repair Ledger Excerpt
 
 - No repair ledger events were recorded.
@@ -253,6 +257,6 @@ Shows whether started repairs are accumulating faster than they complete.
 - `providers.csv`: final provider-level economics and fault counters.
 - `slots.csv`: per-slot epoch ledger, including health state and reason.
 - `evidence.csv`: policy evidence events.
-- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, attempt-cap, and backoff events.
+- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, candidate-exclusion, attempt-cap, and backoff events.
 - `economy.csv`: per-epoch market and accounting ledger.
 - `signals.json`: derived availability, saturation, repair, capacity, economic, regional, and provider bottleneck signals.

--- a/docs/simulation-reports/policy-sim/flapping-provider/report.md
+++ b/docs/simulation-reports/policy-sim/flapping-provider/report.md
@@ -155,6 +155,10 @@ Repair summary:
 - Delinquent slot-epochs: `0`
 - Final active slots in last epoch: `288`
 
+Candidate exclusion summary:
+
+- No no-candidate repair backoffs were recorded.
+
 ### Repair Ledger Excerpt
 
 - No repair ledger events were recorded.
@@ -274,6 +278,6 @@ Shows whether started repairs are accumulating faster than they complete.
 - `providers.csv`: final provider-level economics and fault counters.
 - `slots.csv`: per-slot epoch ledger, including health state and reason.
 - `evidence.csv`: policy evidence events.
-- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, attempt-cap, and backoff events.
+- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, candidate-exclusion, attempt-cap, and backoff events.
 - `economy.csv`: per-epoch market and accounting ledger.
 - `signals.json`: derived availability, saturation, repair, capacity, economic, regional, and provider bottleneck signals.

--- a/docs/simulation-reports/policy-sim/ideal/report.md
+++ b/docs/simulation-reports/policy-sim/ideal/report.md
@@ -148,6 +148,10 @@ Repair summary:
 - Delinquent slot-epochs: `0`
 - Final active slots in last epoch: `288`
 
+Candidate exclusion summary:
+
+- No no-candidate repair backoffs were recorded.
+
 ### Repair Ledger Excerpt
 
 - No repair ledger events were recorded.
@@ -257,6 +261,6 @@ Shows whether started repairs are accumulating faster than they complete.
 - `providers.csv`: final provider-level economics and fault counters.
 - `slots.csv`: per-slot epoch ledger, including health state and reason.
 - `evidence.csv`: policy evidence events.
-- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, attempt-cap, and backoff events.
+- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, candidate-exclusion, attempt-cap, and backoff events.
 - `economy.csv`: per-epoch market and accounting ledger.
 - `signals.json`: derived availability, saturation, repair, capacity, economic, regional, and provider bottleneck signals.

--- a/docs/simulation-reports/policy-sim/large-scale-regional-stress/report.md
+++ b/docs/simulation-reports/policy-sim/large-scale-regional-stress/report.md
@@ -185,6 +185,10 @@ Repair summary:
 - Delinquent slot-epochs: `25634`
 - Final active slots in last epoch: `17426`
 
+Candidate exclusion summary:
+
+- No no-candidate repair backoffs were recorded.
+
 ### Repair Ledger Excerpt
 
 | Epoch | Event | Deal | Slot | Old Provider | New Provider | Reason | Attempt | Cooldown Until |
@@ -322,6 +326,6 @@ Shows whether started repairs are accumulating faster than they complete.
 - `providers.csv`: final provider-level economics and fault counters.
 - `slots.csv`: per-slot epoch ledger, including health state and reason.
 - `evidence.csv`: policy evidence events.
-- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, attempt-cap, and backoff events.
+- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, candidate-exclusion, attempt-cap, and backoff events.
 - `economy.csv`: per-epoch market and accounting ledger.
 - `signals.json`: derived availability, saturation, repair, capacity, economic, regional, and provider bottleneck signals.

--- a/docs/simulation-reports/policy-sim/lazy-provider/report.md
+++ b/docs/simulation-reports/policy-sim/lazy-provider/report.md
@@ -152,6 +152,10 @@ Repair summary:
 - Delinquent slot-epochs: `12`
 - Final active slots in last epoch: `288`
 
+Candidate exclusion summary:
+
+- No no-candidate repair backoffs were recorded.
+
 ### Repair Ledger Excerpt
 
 | Epoch | Event | Deal | Slot | Old Provider | New Provider | Reason | Attempt | Cooldown Until |
@@ -284,6 +288,6 @@ Shows whether started repairs are accumulating faster than they complete.
 - `providers.csv`: final provider-level economics and fault counters.
 - `slots.csv`: per-slot epoch ledger, including health state and reason.
 - `evidence.csv`: policy evidence events.
-- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, attempt-cap, and backoff events.
+- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, candidate-exclusion, attempt-cap, and backoff events.
 - `economy.csv`: per-epoch market and accounting ledger.
 - `signals.json`: derived availability, saturation, repair, capacity, economic, regional, and provider bottleneck signals.

--- a/docs/simulation-reports/policy-sim/price-controller-bounds/report.md
+++ b/docs/simulation-reports/policy-sim/price-controller-bounds/report.md
@@ -156,6 +156,10 @@ Repair summary:
 - Delinquent slot-epochs: `0`
 - Final active slots in last epoch: `1152`
 
+Candidate exclusion summary:
+
+- No no-candidate repair backoffs were recorded.
+
 ### Repair Ledger Excerpt
 
 - No repair ledger events were recorded.
@@ -263,6 +267,6 @@ Shows whether started repairs are accumulating faster than they complete.
 - `providers.csv`: final provider-level economics and fault counters.
 - `slots.csv`: per-slot epoch ledger, including health state and reason.
 - `evidence.csv`: policy evidence events.
-- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, attempt-cap, and backoff events.
+- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, candidate-exclusion, attempt-cap, and backoff events.
 - `economy.csv`: per-epoch market and accounting ledger.
 - `signals.json`: derived availability, saturation, repair, capacity, economic, regional, and provider bottleneck signals.

--- a/docs/simulation-reports/policy-sim/repair-candidate-exhaustion/report.md
+++ b/docs/simulation-reports/policy-sim/repair-candidate-exhaustion/report.md
@@ -155,6 +155,12 @@ Repair summary:
 - Delinquent slot-epochs: `40`
 - Final active slots in last epoch: `96`
 
+Candidate exclusion summary:
+
+| Candidate Mode | No-Candidate Events | Eligible | Current Deal | Current Provider | Draining | Jailed | Capacity-Bound |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| `fallback` | 8 | 0 | 0 | 8 | 0 | 0 | 88 |
+
 ### Repair Ledger Excerpt
 
 | Epoch | Event | Deal | Slot | Old Provider | New Provider | Reason | Attempt | Cooldown Until |
@@ -290,6 +296,6 @@ Shows whether started repairs are accumulating faster than they complete.
 - `providers.csv`: final provider-level economics and fault counters.
 - `slots.csv`: per-slot epoch ledger, including health state and reason.
 - `evidence.csv`: policy evidence events.
-- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, attempt-cap, and backoff events.
+- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, candidate-exclusion, attempt-cap, and backoff events.
 - `economy.csv`: per-epoch market and accounting ledger.
 - `signals.json`: derived availability, saturation, repair, capacity, economic, regional, and provider bottleneck signals.

--- a/docs/simulation-reports/policy-sim/setup-failure/report.md
+++ b/docs/simulation-reports/policy-sim/setup-failure/report.md
@@ -153,6 +153,10 @@ Repair summary:
 - Delinquent slot-epochs: `12`
 - Final active slots in last epoch: `288`
 
+Candidate exclusion summary:
+
+- No no-candidate repair backoffs were recorded.
+
 ### Repair Ledger Excerpt
 
 | Epoch | Event | Deal | Slot | Old Provider | New Provider | Reason | Attempt | Cooldown Until |
@@ -284,6 +288,6 @@ Shows whether started repairs are accumulating faster than they complete.
 - `providers.csv`: final provider-level economics and fault counters.
 - `slots.csv`: per-slot epoch ledger, including health state and reason.
 - `evidence.csv`: policy evidence events.
-- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, attempt-cap, and backoff events.
+- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, candidate-exclusion, attempt-cap, and backoff events.
 - `economy.csv`: per-epoch market and accounting ledger.
 - `signals.json`: derived availability, saturation, repair, capacity, economic, regional, and provider bottleneck signals.

--- a/docs/simulation-reports/policy-sim/single-outage/report.md
+++ b/docs/simulation-reports/policy-sim/single-outage/report.md
@@ -155,6 +155,10 @@ Repair summary:
 - Delinquent slot-epochs: `12`
 - Final active slots in last epoch: `288`
 
+Candidate exclusion summary:
+
+- No no-candidate repair backoffs were recorded.
+
 ### Repair Ledger Excerpt
 
 | Epoch | Event | Deal | Slot | Old Provider | New Provider | Reason | Attempt | Cooldown Until |
@@ -289,6 +293,6 @@ Shows whether started repairs are accumulating faster than they complete.
 - `providers.csv`: final provider-level economics and fault counters.
 - `slots.csv`: per-slot epoch ledger, including health state and reason.
 - `evidence.csv`: policy evidence events.
-- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, attempt-cap, and backoff events.
+- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, candidate-exclusion, attempt-cap, and backoff events.
 - `economy.csv`: per-epoch market and accounting ledger.
 - `signals.json`: derived availability, saturation, repair, capacity, economic, regional, and provider bottleneck signals.

--- a/docs/simulation-reports/policy-sim/subsidy-farming/report.md
+++ b/docs/simulation-reports/policy-sim/subsidy-farming/report.md
@@ -157,6 +157,10 @@ Repair summary:
 - Delinquent slot-epochs: `96`
 - Final active slots in last epoch: `576`
 
+Candidate exclusion summary:
+
+- No no-candidate repair backoffs were recorded.
+
 ### Repair Ledger Excerpt
 
 | Epoch | Event | Deal | Slot | Old Provider | New Provider | Reason | Attempt | Cooldown Until |
@@ -288,6 +292,6 @@ Shows whether started repairs are accumulating faster than they complete.
 - `providers.csv`: final provider-level economics and fault counters.
 - `slots.csv`: per-slot epoch ledger, including health state and reason.
 - `evidence.csv`: policy evidence events.
-- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, attempt-cap, and backoff events.
+- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, candidate-exclusion, attempt-cap, and backoff events.
 - `economy.csv`: per-epoch market and accounting ledger.
 - `signals.json`: derived availability, saturation, repair, capacity, economic, regional, and provider bottleneck signals.

--- a/docs/simulation-reports/policy-sim/sustained-non-response/report.md
+++ b/docs/simulation-reports/policy-sim/sustained-non-response/report.md
@@ -155,6 +155,10 @@ Repair summary:
 - Delinquent slot-epochs: `12`
 - Final active slots in last epoch: `288`
 
+Candidate exclusion summary:
+
+- No no-candidate repair backoffs were recorded.
+
 ### Repair Ledger Excerpt
 
 | Epoch | Event | Deal | Slot | Old Provider | New Provider | Reason | Attempt | Cooldown Until |
@@ -288,6 +292,6 @@ Shows whether started repairs are accumulating faster than they complete.
 - `providers.csv`: final provider-level economics and fault counters.
 - `slots.csv`: per-slot epoch ledger, including health state and reason.
 - `evidence.csv`: policy evidence events.
-- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, attempt-cap, and backoff events.
+- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, candidate-exclusion, attempt-cap, and backoff events.
 - `economy.csv`: per-epoch market and accounting ledger.
 - `signals.json`: derived availability, saturation, repair, capacity, economic, regional, and provider bottleneck signals.

--- a/docs/simulation-reports/policy-sim/underpriced-storage/report.md
+++ b/docs/simulation-reports/policy-sim/underpriced-storage/report.md
@@ -148,6 +148,10 @@ Repair summary:
 - Delinquent slot-epochs: `0`
 - Final active slots in last epoch: `288`
 
+Candidate exclusion summary:
+
+- No no-candidate repair backoffs were recorded.
+
 ### Repair Ledger Excerpt
 
 - No repair ledger events were recorded.
@@ -251,6 +255,6 @@ Shows whether started repairs are accumulating faster than they complete.
 - `providers.csv`: final provider-level economics and fault counters.
 - `slots.csv`: per-slot epoch ledger, including health state and reason.
 - `evidence.csv`: policy evidence events.
-- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, attempt-cap, and backoff events.
+- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, candidate-exclusion, attempt-cap, and backoff events.
 - `economy.csv`: per-epoch market and accounting ledger.
 - `signals.json`: derived availability, saturation, repair, capacity, economic, regional, and provider bottleneck signals.

--- a/docs/simulation-reports/policy-sim/viral-public-retrieval/report.md
+++ b/docs/simulation-reports/policy-sim/viral-public-retrieval/report.md
@@ -146,6 +146,10 @@ Repair summary:
 - Delinquent slot-epochs: `0`
 - Final active slots in last epoch: `576`
 
+Candidate exclusion summary:
+
+- No no-candidate repair backoffs were recorded.
+
 ### Repair Ledger Excerpt
 
 - No repair ledger events were recorded.
@@ -250,6 +254,6 @@ Shows whether started repairs are accumulating faster than they complete.
 - `providers.csv`: final provider-level economics and fault counters.
 - `slots.csv`: per-slot epoch ledger, including health state and reason.
 - `evidence.csv`: policy evidence events.
-- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, attempt-cap, and backoff events.
+- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, candidate-exclusion, attempt-cap, and backoff events.
 - `economy.csv`: per-epoch market and accounting ledger.
 - `signals.json`: derived availability, saturation, repair, capacity, economic, regional, and provider bottleneck signals.

--- a/docs/simulation-reports/policy-sim/wash-retrieval/report.md
+++ b/docs/simulation-reports/policy-sim/wash-retrieval/report.md
@@ -146,6 +146,10 @@ Repair summary:
 - Delinquent slot-epochs: `0`
 - Final active slots in last epoch: `288`
 
+Candidate exclusion summary:
+
+- No no-candidate repair backoffs were recorded.
+
 ### Repair Ledger Excerpt
 
 - No repair ledger events were recorded.
@@ -250,6 +254,6 @@ Shows whether started repairs are accumulating faster than they complete.
 - `providers.csv`: final provider-level economics and fault counters.
 - `slots.csv`: per-slot epoch ledger, including health state and reason.
 - `evidence.csv`: policy evidence events.
-- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, attempt-cap, and backoff events.
+- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, candidate-exclusion, attempt-cap, and backoff events.
 - `economy.csv`: per-epoch market and accounting ledger.
 - `signals.json`: derived availability, saturation, repair, capacity, economic, regional, and provider bottleneck signals.

--- a/docs/simulation-reports/policy-sim/withholding/report.md
+++ b/docs/simulation-reports/policy-sim/withholding/report.md
@@ -155,6 +155,10 @@ Repair summary:
 - Delinquent slot-epochs: `12`
 - Final active slots in last epoch: `288`
 
+Candidate exclusion summary:
+
+- No no-candidate repair backoffs were recorded.
+
 ### Repair Ledger Excerpt
 
 | Epoch | Event | Deal | Slot | Old Provider | New Provider | Reason | Attempt | Cooldown Until |
@@ -287,6 +291,6 @@ Shows whether started repairs are accumulating faster than they complete.
 - `providers.csv`: final provider-level economics and fault counters.
 - `slots.csv`: per-slot epoch ledger, including health state and reason.
 - `evidence.csv`: policy evidence events.
-- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, attempt-cap, and backoff events.
+- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, candidate-exclusion, attempt-cap, and backoff events.
 - `economy.csv`: per-epoch market and accounting ledger.
 - `signals.json`: derived availability, saturation, repair, capacity, economic, regional, and provider bottleneck signals.

--- a/tools/policy_sim/README.md
+++ b/tools/policy_sim/README.md
@@ -167,7 +167,7 @@ When `--out-dir` is supplied, the simulator emits:
 
 `slots.csv` includes per-slot health reason, repair attempt, and cooldown state.
 `repairs.csv` includes start, pending-provider readiness, completion,
-attempt-count, cooldown, attempt-cap, and backoff events.
+attempt-count, cooldown, candidate-exclusion, attempt-cap, and backoff events.
 
 `report.py` consumes those raw files and can emit:
 

--- a/tools/policy_sim/policing_sim.py
+++ b/tools/policy_sim/policing_sim.py
@@ -913,9 +913,9 @@ class PolicySimulator:
         ):
             self._record_repair_backoff(epoch, deal, slot, "repair_coordination_limit", metrics)
             return
-        pending = self._select_replacement(epoch, deal, slot)
+        pending, candidate_diagnostics = self._select_replacement(epoch, deal, slot)
         if not pending:
-            self._record_repair_backoff(epoch, deal, slot, "no_candidate", metrics)
+            self._record_repair_backoff(epoch, deal, slot, "no_candidate", metrics, candidate_diagnostics)
             return
         old_provider = slot.provider_id
         slot.status = SLOT_REPAIRING
@@ -938,6 +938,7 @@ class PolicySimulator:
                 "generation": slot.current_gen,
                 "attempt": slot.repair_attempts,
                 "cooldown_until_epoch": slot.repair_backoff_until_epoch,
+                **candidate_diagnostics,
             }
         )
 
@@ -948,6 +949,7 @@ class PolicySimulator:
         slot: SlotState,
         reason: str,
         metrics: EpochMetrics,
+        candidate_diagnostics: dict[str, Any] | None = None,
     ) -> None:
         metrics.repair_backoffs += 1
         if reason == "repair_cooldown":
@@ -972,40 +974,65 @@ class PolicySimulator:
                 "generation": slot.current_gen,
                 "attempt": slot.repair_attempts,
                 "cooldown_until_epoch": slot.repair_backoff_until_epoch,
+                **(candidate_diagnostics or empty_candidate_diagnostics()),
             }
         )
 
-    def _select_replacement(self, epoch: int, deal: DealState, slot: SlotState) -> str | None:
+    def _select_replacement(self, epoch: int, deal: DealState, slot: SlotState) -> tuple[str | None, dict[str, Any]]:
         excluded = {s.provider_id for s in deal.slots}
         excluded.update(s.pending_provider_id for s in deal.slots if s.pending_provider_id)
         assigned_counts = self._assigned_counts(include_pending=True)
-        candidates = [
-            pid
-            for pid, p in self.providers.items()
-            if (
-                pid not in excluded
-                and not p.behavior.draining
-                and not self._is_jailed(p, epoch)
-                and assigned_counts.get(pid, 0) < p.capacity_slots
+        candidates, diagnostics = self._replacement_candidates(
+            epoch,
+            assigned_counts,
+            excluded,
+            slot.provider_id,
+            allow_same_deal=False,
+        )
+        if not candidates:
+            candidates, diagnostics = self._replacement_candidates(
+                epoch,
+                assigned_counts,
+                excluded,
+                slot.provider_id,
+                allow_same_deal=True,
             )
-        ]
-
         if not candidates:
-            candidates = [
-                pid
-                for pid, p in self.providers.items()
-                if (
-                    pid != slot.provider_id
-                    and not p.behavior.draining
-                    and not self._is_jailed(p, epoch)
-                    and assigned_counts.get(pid, 0) < p.capacity_slots
-                )
-            ]
-        if not candidates:
-            return None
+            return None, diagnostics
 
         seed = f"{self.config.seed}:{epoch}:{deal.deal_id}:{slot.slot}:{slot.current_gen}"
-        return min(candidates, key=lambda pid: stable_digest(seed, pid))
+        return min(candidates, key=lambda pid: stable_digest(seed, pid)), diagnostics
+
+    def _replacement_candidates(
+        self,
+        epoch: int,
+        assigned_counts: dict[str, int],
+        current_deal_providers: set[str | None],
+        current_provider_id: str,
+        allow_same_deal: bool,
+    ) -> tuple[list[str], dict[str, Any]]:
+        candidates = []
+        diagnostics = empty_candidate_diagnostics()
+        diagnostics["candidate_mode"] = "fallback" if allow_same_deal else "primary"
+        for pid, provider in self.providers.items():
+            if pid == current_provider_id:
+                diagnostics["excluded_current_provider"] += 1
+                continue
+            if not allow_same_deal and pid in current_deal_providers:
+                diagnostics["excluded_current_deal"] += 1
+                continue
+            if provider.behavior.draining:
+                diagnostics["excluded_draining"] += 1
+                continue
+            if self._is_jailed(provider, epoch):
+                diagnostics["excluded_jailed"] += 1
+                continue
+            if assigned_counts.get(pid, 0) >= provider.capacity_slots:
+                diagnostics["excluded_capacity"] += 1
+                continue
+            candidates.append(pid)
+        diagnostics["eligible_candidates"] = len(candidates)
+        return candidates, diagnostics
 
     @staticmethod
     def _is_jailed(provider: Provider, epoch: int) -> bool:
@@ -1478,6 +1505,18 @@ def bounded_step(current: float, direction: int, step_bps: int, min_value: float
     factor = step_bps / 10_000
     next_value = current * (1 + factor if direction > 0 else 1 - factor)
     return max(min_value, min(max_value, next_value))
+
+
+def empty_candidate_diagnostics() -> dict[str, Any]:
+    return {
+        "candidate_mode": "",
+        "eligible_candidates": 0,
+        "excluded_current_deal": 0,
+        "excluded_current_provider": 0,
+        "excluded_draining": 0,
+        "excluded_jailed": 0,
+        "excluded_capacity": 0,
+    }
 
 
 def jitter_multiplier(rng: random.Random, jitter_bps: int) -> float:

--- a/tools/policy_sim/report.py
+++ b/tools/policy_sim/report.py
@@ -675,6 +675,10 @@ def write_report_md(
             f"- Delinquent slot-epochs: `{fmt_num(totals.get('delinquent_slots'))}`",
             f"- Final active slots in last epoch: `{len(active_end_slots)}`",
             "",
+            "Candidate exclusion summary:",
+            "",
+            *candidate_exclusion_lines(repairs),
+            "",
             "### Repair Ledger Excerpt",
             "",
             *repair_excerpt_lines(repairs),
@@ -764,7 +768,7 @@ def write_report_md(
             "- `providers.csv`: final provider-level economics and fault counters.",
             "- `slots.csv`: per-slot epoch ledger, including health state and reason.",
             "- `evidence.csv`: policy evidence events.",
-            "- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, attempt-cap, and backoff events.",
+            "- `repairs.csv`: repair start, pending-provider readiness, completion, attempt-count, cooldown, candidate-exclusion, attempt-cap, and backoff events.",
             "- `economy.csv`: per-epoch market and accounting ledger.",
             "- `signals.json`: derived availability, saturation, repair, capacity, economic, regional, and provider bottleneck signals.",
         ]
@@ -1006,6 +1010,34 @@ def counter_lines(counter: Counter[str]) -> list[str]:
     if not counter:
         return ["- None recorded."]
     return [f"- `{key}`: `{value}`" for key, value in counter.most_common(8)]
+
+
+def candidate_exclusion_lines(repairs: list[dict[str, str]]) -> list[str]:
+    rows = [row for row in repairs if row.get("reason") == "no_candidate"]
+    if not rows:
+        return ["- No no-candidate repair backoffs were recorded."]
+    fields = [
+        ("eligible_candidates", "Eligible candidates"),
+        ("excluded_current_deal", "Excluded current deal providers"),
+        ("excluded_current_provider", "Excluded current provider"),
+        ("excluded_draining", "Excluded draining providers"),
+        ("excluded_jailed", "Excluded jailed providers"),
+        ("excluded_capacity", "Excluded capacity-bound providers"),
+    ]
+    lines = [
+        "| Candidate Mode | No-Candidate Events | Eligible | Current Deal | Current Provider | Draining | Jailed | Capacity-Bound |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for mode in sorted({row.get("candidate_mode", "") or "unknown" for row in rows}):
+        mode_rows = [row for row in rows if (row.get("candidate_mode", "") or "unknown") == mode]
+        sums = {key: sum(fnum(row.get(key)) for row in mode_rows) for key, _ in fields}
+        lines.append(
+            f"| `{mode}` | {len(mode_rows)} | {fmt_num(sums['eligible_candidates'])} | "
+            f"{fmt_num(sums['excluded_current_deal'])} | {fmt_num(sums['excluded_current_provider'])} | "
+            f"{fmt_num(sums['excluded_draining'])} | {fmt_num(sums['excluded_jailed'])} | "
+            f"{fmt_num(sums['excluded_capacity'])} |"
+        )
+    return lines
 
 
 def repair_excerpt_lines(repairs: list[dict[str, str]]) -> list[str]:

--- a/tools/policy_sim/test_policing_sim.py
+++ b/tools/policy_sim/test_policing_sim.py
@@ -178,6 +178,11 @@ class PolicySimulatorTests(unittest.TestCase):
             max(int(row["attempt"]) for row in result.repairs if row.get("attempt") != ""),
             1,
         )
+        no_candidate_rows = [row for row in result.repairs if row["reason"] == "no_candidate"]
+        self.assertTrue(no_candidate_rows)
+        self.assertTrue(all(row["candidate_mode"] == "fallback" for row in no_candidate_rows))
+        self.assertTrue(all(row["eligible_candidates"] == 0 for row in no_candidate_rows))
+        self.assertTrue(any(row["excluded_capacity"] > 0 for row in no_candidate_rows))
 
     def test_flapping_provider_marks_suspect_without_delinquent_repair_churn(self):
         config = SimConfig(


### PR DESCRIPTION
## Summary
- add candidate-mode and exclusion diagnostics to repair selection/backoff ledger rows
- show no-candidate exclusion summaries in generated scenario reports
- document candidate-exclusion diagnostics in the simulator README and policing roadmap

## Stack
- Based on #54 (`sim/s23-slot-health-reasons`) and should be retargeted after #54 merges.

## Validation
- python3 -m unittest discover -s tools/policy_sim
- python3 tools/policy_sim/generate_report_corpus.py --scenario-dir tools/policy_sim/scenarios --out-dir docs/simulation-reports/policy-sim --work-dir _artifacts/policy_sim/runs
- python3 tools/policy_sim/run_sweeps.py --sweep-dir tools/policy_sim/sweeps --run-dir _artifacts/policy_sim/sweeps --out-dir docs/simulation-reports/policy-sim/sweeps
- git diff --check