### PR TITLE
Parallelize policy sweep directories across specs

### DIFF
--- a/tools/policy_sim/README.md
+++ b/tools/policy_sim/README.md
@@ -73,8 +73,10 @@ python3 tools/policy_sim/run_sweeps.py \
   --jobs 0
 ```
 
-`--jobs 0` auto-detects CPU count and caps parallel workers at 8. Use
-`--jobs 1` for single-process debugging or exact profiler traces.
+`--jobs 0` auto-detects CPU count and caps parallel workers at 8. Directory
+sweeps share one bounded worker pool across all selected sweep cases, so small
+sweep specs still utilize available cores. Use `--jobs 1` for single-process
+debugging or exact profiler traces.
 
 If `--out-dir` is omitted, `report.py` writes to a dedicated subdirectory
 instead of polluting raw simulator outputs: `<run-dir>/report` for single-run

--- a/tools/policy_sim/run_sweeps.py
+++ b/tools/policy_sim/run_sweeps.py
@@ -37,6 +37,13 @@ class SweepSpec:
     cases: list[SweepCase]
 
 
+@dataclass
+class SweepRunPlan:
+    spec: SweepSpec
+    run_dir: Path
+    report_dir: Path
+
+
 def load_sweep_spec(path: Path) -> SweepSpec:
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
@@ -125,8 +132,37 @@ def build_case(
 
 
 def run_sweep_spec(spec_path: Path, run_root: Path, report_root: Path, clean: bool = True, jobs: int = 1) -> dict[str, Any]:
-    spec = load_sweep_spec(spec_path)
-    jobs = resolve_jobs(jobs, len(spec.cases))
+    return run_sweep_specs([spec_path], run_root, report_root, clean=clean, jobs=jobs)[0]
+
+
+def run_sweep_specs(spec_paths: list[Path], run_root: Path, report_root: Path, clean: bool = True, jobs: int = 1) -> list[dict[str, Any]]:
+    plans = [prepare_sweep_run(load_sweep_spec(path), run_root, report_root, clean=clean) for path in spec_paths]
+    tasks = [
+        (plan.spec.name, index, case, plan.run_dir)
+        for plan in plans
+        for index, case in enumerate(plan.spec.cases)
+    ]
+    jobs = resolve_jobs(jobs, len(tasks))
+    if jobs == 1:
+        results = [_run_sweep_case(task) for task in tasks]
+    else:
+        with ProcessPoolExecutor(max_workers=jobs) as executor:
+            results = list(executor.map(_run_sweep_case, tasks))
+
+    grouped: dict[str, list[tuple[int, dict[str, Any], int]]] = {plan.spec.name: [] for plan in plans}
+    for spec_name, case_index, row, failed_count in results:
+        grouped[spec_name].append((case_index, row, failed_count))
+
+    manifests = []
+    for plan in plans:
+        case_results = sorted(grouped[plan.spec.name], key=lambda item: item[0])
+        case_rows = [row for _case_index, row, _failed_count in case_results]
+        failures = sum(failed_count for _case_index, _row, failed_count in case_results)
+        manifests.append(write_sweep_manifest(plan, case_rows, failures))
+    return manifests
+
+
+def prepare_sweep_run(spec: SweepSpec, run_root: Path, report_root: Path, clean: bool) -> SweepRunPlan:
     sweep_run_dir = run_root / spec.name
     sweep_report_dir = report_root / spec.name
     if clean:
@@ -135,18 +171,12 @@ def run_sweep_spec(spec_path: Path, run_root: Path, report_root: Path, clean: bo
                 shutil.rmtree(path)
     sweep_run_dir.mkdir(parents=True, exist_ok=True)
     sweep_report_dir.mkdir(parents=True, exist_ok=True)
+    return SweepRunPlan(spec=spec, run_dir=sweep_run_dir, report_dir=sweep_report_dir)
 
-    tasks = [(case, sweep_run_dir) for case in spec.cases]
-    if jobs == 1:
-        results = [_run_sweep_case(task) for task in tasks]
-    else:
-        with ProcessPoolExecutor(max_workers=jobs) as executor:
-            results = list(executor.map(_run_sweep_case, tasks))
 
-    case_rows = [row for row, _failed_count in results]
-    failures = sum(failed_count for _row, failed_count in results)
-
-    generate_sweep_report(sweep_run_dir, sweep_report_dir)
+def write_sweep_manifest(plan: SweepRunPlan, case_rows: list[dict[str, Any]], failures: int) -> dict[str, Any]:
+    spec = plan.spec
+    generate_sweep_report(plan.run_dir, plan.report_dir)
     manifest = {
         "name": spec.name,
         "description": spec.description,
@@ -159,20 +189,22 @@ def run_sweep_spec(spec_path: Path, run_root: Path, report_root: Path, clean: bo
         "omission_reason": "Sweep raw ledgers are generated locally or uploaded as CI artifacts to keep committed reports reviewable.",
         "cases": case_rows,
     }
-    sweep_report_dir.joinpath("manifest.json").write_text(
+    plan.report_dir.joinpath("manifest.json").write_text(
         json.dumps(manifest, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
     return manifest
 
 
-def _run_sweep_case(task: tuple[SweepCase, Path]) -> tuple[dict[str, Any], int]:
-    case, sweep_run_dir = task
+def _run_sweep_case(task: tuple[str, int, SweepCase, Path]) -> tuple[str, int, dict[str, Any], int]:
+    spec_name, case_index, case, sweep_run_dir = task
     result = run_one(SimConfig(**case.config), case.faults, case.assertions, None)
     failed = [item for item in result.assertions if not item.passed]
     run_dir = sweep_run_dir / case.name
     write_output_dir(run_dir, result)
     return (
+        spec_name,
+        case_index,
         {
             "case": case.name,
             "scenario": result.config.get("scenario"),
@@ -294,7 +326,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.sweep_dir:
         paths.extend(sweep_paths(args.sweep_dir))
 
-    manifests = [run_sweep_spec(path, args.run_dir, args.out_dir, clean=not args.no_clean, jobs=args.jobs) for path in paths]
+    manifests = run_sweep_specs(paths, args.run_dir, args.out_dir, clean=not args.no_clean, jobs=args.jobs)
     write_sweep_index(args.out_dir, manifests)
     failures = sum(int(manifest["assertion_failures"]) for manifest in manifests)
     return 1 if args.fail_on_assertion and failures else 0

--- a/tools/policy_sim/test_policing_sim.py
+++ b/tools/policy_sim/test_policing_sim.py
@@ -14,7 +14,7 @@ try:
     )
     from .report import generate_policy_delta, generate_run_report, generate_sweep_report, main as report_main
     from .generate_report_corpus import write_graduation_map
-    from .run_sweeps import load_sweep_spec, run_sweep_spec
+    from .run_sweeps import load_sweep_spec, run_sweep_spec, run_sweep_specs
 except ImportError:  # Allows `python3 -m unittest discover -s tools/policy_sim`.
     from policing_sim import (
         PolicySimulator,
@@ -26,7 +26,7 @@ except ImportError:  # Allows `python3 -m unittest discover -s tools/policy_sim`
     )
     from report import generate_policy_delta, generate_run_report, generate_sweep_report, main as report_main
     from generate_report_corpus import write_graduation_map
-    from run_sweeps import load_sweep_spec, run_sweep_spec
+    from run_sweeps import load_sweep_spec, run_sweep_spec, run_sweep_specs
 
 
 class PolicySimulatorTests(unittest.TestCase):
@@ -604,6 +604,71 @@ class PolicySimulatorTests(unittest.TestCase):
             self.assertTrue((root / "reports" / "test-sweep" / "sweep_summary.md").exists())
             self.assertTrue((root / "reports" / "test-sweep" / "sweep_summary.json").exists())
             self.assertTrue((root / "reports" / "test-sweep" / "manifest.json").exists())
+
+    def test_sweep_directory_runner_uses_one_pool_across_specs(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            scenario = root / "base.yaml"
+            scenario.write_text(
+                """
+{
+  "name": "ideal",
+  "config": {
+    "scenario": "ideal",
+    "seed": 7,
+    "providers": 24,
+    "users": 8,
+    "deals": 4,
+    "epochs": 3
+  },
+  "assertions": {
+    "min_success_rate": 1.0,
+    "max_repairs_started": 0
+  }
+}
+""".strip()
+                + "\n",
+                encoding="utf-8",
+            )
+            sweep_a = root / "sweep-a.yaml"
+            sweep_a.write_text(
+                """
+{
+  "name": "sweep-a",
+  "description": "Small unit-test sweep A.",
+  "base_scenario": "base.yaml",
+  "matrix": {
+    "seed": [7, 8]
+  }
+}
+""".strip()
+                + "\n",
+                encoding="utf-8",
+            )
+            sweep_b = root / "sweep-b.yaml"
+            sweep_b.write_text(
+                """
+{
+  "name": "sweep-b",
+  "description": "Small unit-test sweep B.",
+  "base_scenario": "base.yaml",
+  "matrix": {
+    "seed": [9, 10]
+  }
+}
+""".strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            manifests = run_sweep_specs([sweep_a, sweep_b], root / "runs", root / "reports", jobs=2)
+
+            self.assertEqual(["sweep-a", "sweep-b"], [manifest["name"] for manifest in manifests])
+            self.assertEqual([2, 2], [manifest["case_count"] for manifest in manifests])
+            self.assertTrue((root / "reports" / "sweep-a" / "manifest.json").exists())
+            self.assertTrue((root / "reports" / "sweep-b" / "manifest.json").exists())
+            self.assertTrue((root / "runs" / "sweep-a" / "seed-7" / "summary.json").exists())
+            self.assertTrue((root / "runs" / "sweep-b" / "seed-10" / "summary.json").exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- schedule all selected policy sweep cases through one bounded process pool
- keep per-sweep report generation deterministic after case execution
- document directory sweep worker behavior and add regression coverage

## Validation
- python3 -m unittest discover -s tools/policy_sim
- python3 tools/policy_sim/run_sweeps.py --sweep-dir tools/policy_sim/sweeps --run-dir _artifacts/policy_sim/sweeps --out-dir docs/simulation-reports/policy-sim/sweeps --jobs 0
- git diff --exit-code docs/simulation-reports/policy-sim/sweeps
- git diff --check