### PR TITLE
Share policy simulator parallel runner

### DIFF
--- a/tools/policy_sim/README.md
+++ b/tools/policy_sim/README.md
@@ -74,9 +74,10 @@ python3 tools/policy_sim/run_sweeps.py \
 ```
 
 `--jobs 0` auto-detects CPU count and caps parallel workers at 8. Directory
-sweeps share one bounded worker pool across all selected sweep cases, so small
-sweep specs still utilize available cores. Use `--jobs 1` for single-process
-debugging or exact profiler traces.
+fixture runs default to this auto-parallel mode, and directory sweeps share one
+bounded worker pool across all selected sweep cases, so small sweep specs still
+utilize available cores. Use `--jobs 1` for single-process debugging or exact
+profiler traces.
 
 If `--out-dir` is omitted, `report.py` writes to a dedicated subdirectory
 instead of polluting raw simulator outputs: `<run-dir>/report` for single-run

--- a/tools/policy_sim/generate_report_corpus.py
+++ b/tools/policy_sim/generate_report_corpus.py
@@ -11,18 +11,18 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import shutil
 import tempfile
-from concurrent.futures import ProcessPoolExecutor
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
 try:
+    from .parallel import map_parallel, resolve_jobs
     from .policing_sim import SimConfig, fixture_paths, load_scenario_spec, run_one, write_output_dir
     from .report import generate_run_report, stable_json_value
 except ImportError:  # Allows direct execution as a script.
+    from parallel import map_parallel, resolve_jobs
     from policing_sim import SimConfig, fixture_paths, load_scenario_spec, run_one, write_output_dir
     from report import generate_run_report, stable_json_value
 
@@ -199,11 +199,7 @@ def _generate(paths: list[Path], out_dir: Path, run_root: Path, jobs: int) -> in
     rows: list[dict[str, Any]] = []
     failures = 0
     tasks = [(path, out_dir, run_root) for path in paths]
-    if jobs == 1:
-        results = [_generate_one(task) for task in tasks]
-    else:
-        with ProcessPoolExecutor(max_workers=jobs) as executor:
-            results = list(executor.map(_generate_one, tasks))
+    results = map_parallel(_generate_one, tasks, jobs)
 
     for row, failed_count in sorted(results, key=lambda item: item[0]["scenario"]):
         rows.append(row)
@@ -258,15 +254,6 @@ def _generate_one(task: tuple[Path, Path, Path]) -> tuple[dict[str, Any], int]:
         encoding="utf-8",
     )
     return index_row(spec.name, result, failed), int(bool(failed))
-
-
-def resolve_jobs(requested: int, task_count: int) -> int:
-    if task_count <= 1:
-        return 1
-    if requested > 0:
-        return min(requested, task_count)
-    cpu_count = os.cpu_count() or 1
-    return max(1, min(task_count, cpu_count, 8))
 
 
 def index_row(name: str, result, failed: list[Any]) -> dict[str, Any]:

--- a/tools/policy_sim/parallel.py
+++ b/tools/policy_sim/parallel.py
@@ -1,0 +1,53 @@
+"""Shared bounded parallel execution helpers for policy-simulator tools."""
+
+from __future__ import annotations
+
+import math
+import os
+from collections.abc import Callable, Sequence
+from concurrent.futures import ProcessPoolExecutor
+from typing import TypeVar
+
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+AUTO_JOB_CAP = 8
+
+
+def resolve_jobs(requested: int, task_count: int) -> int:
+    """Resolve a requested worker count into a safe bounded worker count.
+
+    A requested value of 0 or less means "auto": use available CPUs, bounded by
+    AUTO_JOB_CAP and the number of tasks. Positive values are still capped by
+    task count so small suites do not create idle worker processes.
+    """
+
+    if task_count <= 1:
+        return 1
+    if requested > 0:
+        return min(requested, task_count)
+    cpu_count = os.cpu_count() or 1
+    return max(1, min(task_count, cpu_count, AUTO_JOB_CAP))
+
+
+def resolve_chunksize(task_count: int, jobs: int) -> int:
+    """Pick a conservative chunksize for ProcessPoolExecutor.map.
+
+    Scenario cases are usually heavier than the scheduling overhead, so this
+    keeps small suites balanced while avoiding per-task IPC overhead for large
+    sweep matrices.
+    """
+
+    if task_count <= 1 or jobs <= 1:
+        return 1
+    return max(1, min(32, math.ceil(task_count / (jobs * 4))))
+
+
+def map_parallel(function: Callable[[T], R], tasks: Sequence[T], requested_jobs: int) -> list[R]:
+    jobs = resolve_jobs(requested_jobs, len(tasks))
+    if jobs == 1:
+        return [function(task) for task in tasks]
+
+    with ProcessPoolExecutor(max_workers=jobs) as executor:
+        return list(executor.map(function, tasks, chunksize=resolve_chunksize(len(tasks), jobs)))

--- a/tools/policy_sim/policing_sim.py
+++ b/tools/policy_sim/policing_sim.py
@@ -14,13 +14,16 @@ import argparse
 import csv
 import hashlib
 import json
-import os
 import random
 import sys
-from concurrent.futures import ProcessPoolExecutor
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Iterable
+
+try:
+    from .parallel import map_parallel
+except ImportError:  # Allows direct execution as a script.
+    from parallel import map_parallel
 
 
 BLOB_SIZE_BYTES = 128 * 1024
@@ -2378,15 +2381,6 @@ def run_scenario_dir_task(task: tuple[SimConfig, list[str], dict[str, Any], floa
     return result
 
 
-def resolve_jobs(requested: int, task_count: int) -> int:
-    if task_count <= 1:
-        return 1
-    if requested > 0:
-        return min(requested, task_count)
-    cpu_count = os.cpu_count() or 1
-    return max(1, min(task_count, cpu_count, 8))
-
-
 def fixture_paths(directory: Path) -> list[Path]:
     return sorted([*directory.glob("*.yaml"), *directory.glob("*.json")])
 
@@ -2429,7 +2423,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--assert", dest="assertions", action="store_true")
     parser.add_argument("--min-success-rate", type=float)
-    parser.add_argument("--jobs", type=int, default=1, help="parallel workers for --scenario-dir; 0 auto-detects CPU count capped at 8")
+    parser.add_argument("--jobs", type=int, default=0, help="parallel workers for --scenario-dir; 0 auto-detects CPU count capped at 8")
     parser.add_argument("--json-out", type=Path)
     parser.add_argument("--csv-out", type=Path)
     parser.add_argument("--out-dir", type=Path)
@@ -2448,12 +2442,7 @@ def main(argv: list[str] | None = None) -> int:
             config, faults, assertion_specs = config_from_args(args, spec)
             out_dir = args.out_dir / spec.name if args.out_dir else None
             tasks.append((config, faults, assertion_specs, args.min_success_rate, args.assertions, out_dir))
-        jobs = resolve_jobs(args.jobs, len(tasks))
-        if jobs == 1:
-            results = [run_scenario_dir_task(task) for task in tasks]
-        else:
-            with ProcessPoolExecutor(max_workers=jobs) as executor:
-                results = list(executor.map(run_scenario_dir_task, tasks))
+        results = map_parallel(run_scenario_dir_task, tasks, args.jobs)
 
         failures = 0
         for result in results:

--- a/tools/policy_sim/run_sweeps.py
+++ b/tools/policy_sim/run_sweeps.py
@@ -6,17 +6,17 @@ from __future__ import annotations
 import argparse
 import itertools
 import json
-import os
 import shutil
-from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 try:
+    from .parallel import map_parallel, resolve_jobs
     from .policing_sim import SimConfig, load_scenario_spec, run_one, write_output_dir
     from .report import generate_sweep_report
 except ImportError:  # Allows direct execution as a script.
+    from parallel import map_parallel, resolve_jobs
     from policing_sim import SimConfig, load_scenario_spec, run_one, write_output_dir
     from report import generate_sweep_report
 
@@ -143,11 +143,7 @@ def run_sweep_specs(spec_paths: list[Path], run_root: Path, report_root: Path, c
         for index, case in enumerate(plan.spec.cases)
     ]
     jobs = resolve_jobs(jobs, len(tasks))
-    if jobs == 1:
-        results = [_run_sweep_case(task) for task in tasks]
-    else:
-        with ProcessPoolExecutor(max_workers=jobs) as executor:
-            results = list(executor.map(_run_sweep_case, tasks))
+    results = map_parallel(_run_sweep_case, tasks, jobs)
 
     grouped: dict[str, list[tuple[int, dict[str, Any], int]]] = {plan.spec.name: [] for plan in plans}
     for spec_name, case_index, row, failed_count in results:
@@ -216,15 +212,6 @@ def _run_sweep_case(task: tuple[str, int, SweepCase, Path]) -> tuple[str, int, d
         },
         int(bool(failed)),
     )
-
-
-def resolve_jobs(requested: int, task_count: int) -> int:
-    if task_count <= 1:
-        return 1
-    if requested > 0:
-        return min(requested, task_count)
-    cpu_count = os.cpu_count() or 1
-    return max(1, min(task_count, cpu_count, 8))
 
 
 def stable_repo_path(path: Path) -> str:

--- a/tools/policy_sim/test_policing_sim.py
+++ b/tools/policy_sim/test_policing_sim.py
@@ -4,9 +4,11 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 try:
+    from .parallel import map_parallel, resolve_chunksize, resolve_jobs
     from .policing_sim import (
         PolicySimulator,
         SimConfig,
+        build_parser as build_sim_parser,
         evaluate_assertions,
         load_scenario_spec,
         run_one,
@@ -16,9 +18,11 @@ try:
     from .generate_report_corpus import write_graduation_map
     from .run_sweeps import load_sweep_spec, run_sweep_spec, run_sweep_specs
 except ImportError:  # Allows `python3 -m unittest discover -s tools/policy_sim`.
+    from parallel import map_parallel, resolve_chunksize, resolve_jobs
     from policing_sim import (
         PolicySimulator,
         SimConfig,
+        build_parser as build_sim_parser,
         evaluate_assertions,
         load_scenario_spec,
         run_one,
@@ -27,6 +31,10 @@ except ImportError:  # Allows `python3 -m unittest discover -s tools/policy_sim`
     from report import generate_policy_delta, generate_run_report, generate_sweep_report, main as report_main
     from generate_report_corpus import write_graduation_map
     from run_sweeps import load_sweep_spec, run_sweep_spec, run_sweep_specs
+
+
+def square_for_parallel_test(value):
+    return value * value
 
 
 class PolicySimulatorTests(unittest.TestCase):
@@ -39,6 +47,20 @@ class PolicySimulatorTests(unittest.TestCase):
     def assert_assertions_pass(self, result):
         failed = [item for item in result.assertions if not item.passed]
         self.assertEqual([], failed)
+
+    def test_parallel_helpers_bound_jobs_and_preserve_order(self):
+        self.assertEqual(1, resolve_jobs(0, 1))
+        self.assertEqual(3, resolve_jobs(3, 10))
+        self.assertLessEqual(resolve_jobs(0, 100), 8)
+        self.assertEqual(1, resolve_chunksize(1, 8))
+        self.assertEqual(32, resolve_chunksize(1000, 8))
+
+        result = map_parallel(square_for_parallel_test, [0, 1, 2, 3, 4], requested_jobs=2)
+        self.assertEqual([0, 1, 4, 9, 16], result)
+
+    def test_scenario_dir_defaults_to_auto_parallel_jobs(self):
+        args = build_sim_parser().parse_args(["--scenario-dir", "tools/policy_sim/scenarios"])
+        self.assertEqual(0, args.jobs)
 
     def test_ideal_scenario_has_no_repairs_or_failures(self):
         result = self.run_scenario("ideal", providers=48, deals=24, users=80, epochs=8)


### PR DESCRIPTION
## Summary
- add a shared policy-simulator parallel helper for bounded process-pool execution and chunk sizing
- switch fixture-directory runs, report corpus generation, and sweep generation onto the shared helper
- make `policing_sim.py --scenario-dir` default to auto-parallel execution while keeping `--jobs 1` for deterministic profiling/debugging

## Validation
- python3 -m unittest tools.policy_sim.test_policing_sim.PolicySimulatorTests.test_parallel_helpers_bound_jobs_and_preserve_order tools.policy_sim.test_policing_sim.PolicySimulatorTests.test_scenario_dir_defaults_to_auto_parallel_jobs
- python3 tools/policy_sim/policing_sim.py --scenario-dir tools/policy_sim/scenarios --out-dir /tmp/polystore-policy-parallel-check --jobs 2
- python3 -m unittest discover -s tools/policy_sim
- python3 tools/policy_sim/generate_report_corpus.py --scenario-dir tools/policy_sim/scenarios --out-dir /tmp/polystore-policy-report-parallel-check --work-dir /tmp/polystore-policy-report-parallel-runs --jobs 2
- python3 tools/policy_sim/run_sweeps.py --sweep-dir tools/policy_sim/sweeps --run-dir /tmp/polystore-policy-sweep-parallel-runs --out-dir /tmp/polystore-policy-sweep-parallel-reports --jobs 2
- git diff --check