### PR TITLE
ci: require policy sweep coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,9 @@ jobs:
       - name: Run policy simulator unit tests
         run: python3 -m unittest discover -s tools/policy_sim
 
+      - name: Verify policy sweep coverage
+        run: python3 tools/policy_sim/check_sweep_coverage.py
+
       - name: Run full policy fixture suite and regenerate reports
         run: |
           python3 tools/policy_sim/generate_report_corpus.py \

--- a/tools/policy_sim/README.md
+++ b/tools/policy_sim/README.md
@@ -185,6 +185,17 @@ steps, high-bandwidth capability thresholds, elasticity overlay controls,
 sponsored retrieval funding, storage escrow close/refund accounting, and
 storage escrow noncompliance enforcement modes.
 
+CI enforces direct sweep coverage for every scenario fixture:
+
+```bash
+python3 tools/policy_sim/check_sweep_coverage.py
+```
+
+This check ensures each `tools/policy_sim/scenarios/*.yaml` file has at least
+one sweep whose `base_scenario` points directly at that fixture. Scenario
+fixtures may still share broader population-scale sweeps, but a new fixture
+should not land without its own reviewable parameter sweep.
+
 ## Model Scope
 
 The simulator mirrors current protocol concepts:

--- a/tools/policy_sim/check_sweep_coverage.py
+++ b/tools/policy_sim/check_sweep_coverage.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Verify every policy simulator scenario has direct sweep coverage."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def scenario_stems(scenario_dir: Path) -> set[str]:
+    return {path.stem for path in scenario_dir.glob("*.yaml")}
+
+
+def sweep_base_stems(sweep_dir: Path) -> dict[str, list[str]]:
+    covered: dict[str, list[str]] = {}
+    for path in sorted(sweep_dir.glob("*.yaml")):
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"invalid sweep JSON {path}: {exc}") from exc
+        base = raw.get("base_scenario")
+        if not isinstance(base, str) or not base:
+            raise SystemExit(f"sweep missing base_scenario: {path}")
+        covered.setdefault(Path(base).stem, []).append(path.name)
+    return covered
+
+
+def check_coverage(scenario_dir: Path, sweep_dir: Path) -> int:
+    scenarios = scenario_stems(scenario_dir)
+    covered = sweep_base_stems(sweep_dir)
+    missing = sorted(scenarios - set(covered))
+    unknown = sorted(set(covered) - scenarios)
+
+    if unknown:
+        print("sweeps reference missing scenario fixtures:")
+        for stem in unknown:
+            print(f"  - {stem}: {', '.join(covered[stem])}")
+        return 1
+
+    if missing:
+        print("scenario fixtures without direct sweep coverage:")
+        for stem in missing:
+            print(f"  - {stem}")
+        return 1
+
+    print(
+        "policy simulator sweep coverage ok: "
+        f"{len(scenarios)} scenarios, {len(covered)} covered bases, "
+        f"{sum(len(paths) for paths in covered.values())} sweep specs"
+    )
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scenario-dir", type=Path, default=Path("tools/policy_sim/scenarios"))
+    parser.add_argument("--sweep-dir", type=Path, default=Path("tools/policy_sim/sweeps"))
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return check_coverage(args.scenario_dir, args.sweep_dir)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary\n- add a stdlib policy simulator coverage check that requires every scenario fixture to have a direct sweep base\n- run the check in the Policy Simulator Suite before regenerating the expensive report corpus\n- document the command in the policy simulator README\n\n## Validation\n- python3 tools/policy_sim/check_sweep_coverage.py\n- python3 -m py_compile tools/policy_sim/check_sweep_coverage.py tools/policy_sim/policing_sim.py tools/policy_sim/report.py tools/policy_sim/run_sweeps.py tools/policy_sim/generate_report_corpus.py\n- python3 -m unittest discover -s tools/policy_sim\n- git diff --check\n