### PR TITLE
chain: graduate soft-fault repair reward keeper tests

### DIFF
--- a/polystorechain/x/polystorechain/keeper/base_rewards_test.go
+++ b/polystorechain/x/polystorechain/keeper/base_rewards_test.go
@@ -133,6 +133,12 @@ func TestBaseRewardPool_ExcludesQuotaShortfallSlot(t *testing.T) {
 	requireProviderBalance(t, bank, deal.Mode2Slots[0].Provider, "63stake")
 	requireProviderBalance(t, bank, deal.Mode2Slots[1].Provider, "63stake")
 	requireProviderBalance(t, bank, deal.Mode2Slots[2].Provider, "0stake")
+
+	excludedProvider, err := f.keeper.Providers.Get(ctx10, deal.Mode2Slots[2].Provider)
+	require.NoError(t, err)
+	require.Equal(t, "Active", excludedProvider.Status)
+	require.True(t, hasEvidenceSummary(t, f, ctx10, "quota_miss_recorded"))
+	require.False(t, hasEvidenceSummary(t, f, ctx10, "quota_miss_repair_started"))
 }
 
 func TestBaseRewardPool_ExcludesRepairingSlotResponsibility(t *testing.T) {

--- a/polystorechain/x/polystorechain/keeper/slashing.go
+++ b/polystorechain/x/polystorechain/keeper/slashing.go
@@ -210,6 +210,16 @@ func (k Keeper) CheckMissedProofs(ctx context.Context) error {
 					if err := k.Mode2DeputyMissedEpochs.Set(ctx, missedKey, nextMissed); err != nil {
 						return false, err
 					}
+					if err := k.recordMode2SoftFaultEvidence(sdkCtx, deal, dealID, slot, epochID, "deputy_served_zero_direct", nextMissed); err != nil {
+						return false, err
+					}
+					healthKind := "provider_degraded"
+					if params.EvictAfterMissedEpochs > 0 && nextMissed >= params.EvictAfterMissedEpochs {
+						healthKind = "provider_delinquent"
+					}
+					if err := k.recordMode2SoftFaultEvidence(sdkCtx, deal, dealID, slot, epochID, healthKind, nextMissed); err != nil {
+						return false, err
+					}
 
 					sdkCtx.Logger().Info(
 						"deputy-served slot had zero retrieval service",
@@ -289,6 +299,16 @@ func (k Keeper) CheckMissedProofs(ctx context.Context) error {
 					}
 					nextMissed := prev + 1
 					if err := k.Mode2MissedEpochs.Set(ctx, missedKey, nextMissed); err != nil {
+						return false, err
+					}
+					if err := k.recordMode2SoftFaultEvidence(sdkCtx, deal, dealID, slot, epochID, "quota_miss_recorded", nextMissed); err != nil {
+						return false, err
+					}
+					healthKind := "provider_degraded"
+					if params.EvictAfterMissedEpochs > 0 && nextMissed >= params.EvictAfterMissedEpochs {
+						healthKind = "provider_delinquent"
+					}
+					if err := k.recordMode2SoftFaultEvidence(sdkCtx, deal, dealID, slot, epochID, healthKind, nextMissed); err != nil {
 						return false, err
 					}
 					sdkCtx.Logger().Info(
@@ -393,4 +413,33 @@ func (k Keeper) recordRepairBackoff(ctx sdk.Context, dealID uint64, provider str
 	extra = append(extra, []byte(reason)...)
 	eid := deriveEvidenceID("repair_backoff_entered", dealID, epochID, extra)
 	return k.recordEvidenceSummary(ctx, dealID, provider, "repair_backoff_entered", eid[:], "chain:"+reason, false)
+}
+
+func (k Keeper) recordMode2SoftFaultEvidence(
+	ctx sdk.Context,
+	deal types.Deal,
+	dealID uint64,
+	slot uint32,
+	epochID uint64,
+	kind string,
+	missedEpochs uint64,
+) error {
+	if int(slot) >= len(deal.Mode2Slots) {
+		return nil
+	}
+	entry := deal.Mode2Slots[slot]
+	if entry == nil {
+		return nil
+	}
+	provider := strings.TrimSpace(entry.Provider)
+	if provider == "" {
+		return nil
+	}
+
+	extra := make([]byte, 0, 4+8)
+	extra = binary.BigEndian.AppendUint32(extra, slot)
+	extra = binary.BigEndian.AppendUint64(extra, missedEpochs)
+	eid := deriveEvidenceID(kind, dealID, epochID, extra)
+	reporter := fmt.Sprintf("chain:slot=%d:missed_epochs=%d", slot, missedEpochs)
+	return k.recordEvidenceSummary(ctx, dealID, provider, kind, eid[:], reporter, false)
 }

--- a/polystorechain/x/polystorechain/keeper/slashing_repair_test.go
+++ b/polystorechain/x/polystorechain/keeper/slashing_repair_test.go
@@ -187,6 +187,9 @@ func TestCheckMissedProofs_Mode2QuotaMissWaitsForThreshold(t *testing.T) {
 	missed, err := f.keeper.Mode2MissedEpochs.Get(sdkCtx, missedKey)
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), missed)
+	require.True(t, hasEvidenceSummary(t, f, sdkCtx, "quota_miss_recorded"))
+	require.True(t, hasEvidenceSummary(t, f, sdkCtx, "provider_degraded"))
+	require.False(t, hasEvidenceSummary(t, f, sdkCtx, "provider_delinquent"))
 	require.False(t, hasEvidenceSummary(t, f, sdkCtx, "quota_miss_repair_started"))
 
 	sdkCtx = sdkCtx.WithBlockHeight(10)
@@ -207,6 +210,7 @@ func TestCheckMissedProofs_Mode2QuotaMissWaitsForThreshold(t *testing.T) {
 
 	_, err = f.keeper.Mode2MissedEpochs.Get(sdkCtx, missedKey)
 	require.ErrorIs(t, err, collections.ErrNotFound)
+	require.True(t, hasEvidenceSummary(t, f, sdkCtx, "provider_delinquent"))
 	require.True(t, hasEvidenceSummary(t, f, sdkCtx, "quota_miss_repair_started"))
 
 	// Soft quota-miss repair is make-before-break: the outgoing provider remains
@@ -215,6 +219,45 @@ func TestCheckMissedProofs_Mode2QuotaMissWaitsForThreshold(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "Active", registeredProvider.Status)
 	require.False(t, registeredProvider.Draining)
+}
+
+func TestCheckMissedProofs_Mode2QuotaMissMeasureOnlyRecordsEvidenceWithoutRepair(t *testing.T) {
+	f := initFixture(t)
+
+	sdkCtx := sdk.UnwrapSDKContext(f.ctx).WithBlockHeight(5)
+
+	params := types.DefaultParams()
+	params.EpochLenBlocks = 5
+	params.EvictAfterMissedEpochs = 0
+	require.NoError(t, f.keeper.Params.Set(sdkCtx, params))
+
+	providerA := makePolicyTestAddr(t, f, 0xA1)
+	providerB := makePolicyTestAddr(t, f, 0xB2)
+	providerC := makePolicyTestAddr(t, f, 0xC3)
+	providerD := makePolicyTestAddr(t, f, 0xD4)
+	registerPolicyTestProviders(t, f, sdkCtx, providerA, providerB, providerC, providerD)
+
+	dealID := uint64(1)
+	deal := mode2PolicyTestDeal(dealID, makePolicyTestAddr(t, f, 0xEE), []string{providerA, providerB, providerC})
+	require.NoError(t, f.keeper.Deals.Set(sdkCtx, dealID, deal))
+
+	epochID := uint64(1)
+	setMode2EpochCredits(t, f, sdkCtx, dealID, epochID, 1, 2)
+
+	require.NoError(t, f.keeper.CheckMissedProofs(sdkCtx))
+
+	updated, err := f.keeper.Deals.Get(sdkCtx, dealID)
+	require.NoError(t, err)
+	require.Equal(t, types.SlotStatus_SLOT_STATUS_ACTIVE, updated.Mode2Slots[0].Status)
+	require.Empty(t, updated.Mode2Slots[0].PendingProvider)
+
+	missed, err := f.keeper.Mode2MissedEpochs.Get(sdkCtx, collections.Join(dealID, uint32(0)))
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), missed)
+	require.True(t, hasEvidenceSummary(t, f, sdkCtx, "quota_miss_recorded"))
+	require.True(t, hasEvidenceSummary(t, f, sdkCtx, "provider_degraded"))
+	require.False(t, hasEvidenceSummary(t, f, sdkCtx, "provider_delinquent"))
+	require.False(t, hasEvidenceSummary(t, f, sdkCtx, "quota_miss_repair_started"))
 }
 
 func TestCheckMissedProofs_StartsMode2SlotRepair(t *testing.T) {
@@ -680,4 +723,46 @@ func TestCheckMissedProofs_DeputyServedTriggersRepairEvenIfQuotaMet(t *testing.T
 	activity, err := f.keeper.DealActivityStates.Get(sdkCtx, dealID)
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, activity.FailedChallengesTotal, uint64(1))
+}
+
+func TestCheckMissedProofs_DeputyServedRecordsSoftEvidenceBeforeThreshold(t *testing.T) {
+	f := initFixture(t)
+
+	sdkCtx := sdk.UnwrapSDKContext(f.ctx).WithBlockHeight(5)
+
+	params := types.DefaultParams()
+	params.EpochLenBlocks = 5
+	params.EvictAfterMissedEpochs = 2
+	require.NoError(t, f.keeper.Params.Set(sdkCtx, params))
+
+	providerA := makePolicyTestAddr(t, f, 0xA1)
+	providerB := makePolicyTestAddr(t, f, 0xB2)
+	providerC := makePolicyTestAddr(t, f, 0xC3)
+	providerD := makePolicyTestAddr(t, f, 0xD4)
+	registerPolicyTestProviders(t, f, sdkCtx, providerA, providerB, providerC, providerD)
+
+	dealID := uint64(1)
+	deal := mode2PolicyTestDeal(dealID, makePolicyTestAddr(t, f, 0xEE), []string{providerA, providerB, providerC})
+	require.NoError(t, f.keeper.Deals.Set(sdkCtx, dealID, deal))
+
+	epochID := uint64(1)
+	key := collections.Join(collections.Join(dealID, uint32(0)), epochID)
+	require.NoError(t, f.keeper.Mode2EpochCredits.Set(sdkCtx, key, 10))
+	require.NoError(t, f.keeper.Mode2EpochSynthetic.Set(sdkCtx, key, 10))
+	require.NoError(t, f.keeper.Mode2EpochDeputyServed.Set(sdkCtx, key, 1))
+
+	require.NoError(t, f.keeper.CheckMissedProofs(sdkCtx))
+
+	updated, err := f.keeper.Deals.Get(sdkCtx, dealID)
+	require.NoError(t, err)
+	require.Equal(t, types.SlotStatus_SLOT_STATUS_ACTIVE, updated.Mode2Slots[0].Status)
+	require.Empty(t, updated.Mode2Slots[0].PendingProvider)
+
+	missed, err := f.keeper.Mode2DeputyMissedEpochs.Get(sdkCtx, collections.Join(dealID, uint32(0)))
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), missed)
+	require.True(t, hasEvidenceSummary(t, f, sdkCtx, "deputy_served_zero_direct"))
+	require.True(t, hasEvidenceSummary(t, f, sdkCtx, "provider_degraded"))
+	require.False(t, hasEvidenceSummary(t, f, sdkCtx, "provider_delinquent"))
+	require.False(t, hasEvidenceSummary(t, f, sdkCtx, "deputy_miss_repair_started"))
 }


### PR DESCRIPTION
## Summary\n- records queryable soft-fault evidence for Mode 2 quota misses and deputy-served zero-direct cases before repair starts\n- distinguishes degraded vs delinquent soft-fault posture from threshold state without enabling slash/jail\n- adds keeper coverage for T0-T3 graduation surfaces: healthy control, measure-only soft evidence, thresholded repair, readiness-backed repair flow, and reward exclusion without punitive provider status changes\n\n## Validation\n- LD_LIBRARY_PATH=/home/mikers/dev/polynomialstore/polystore/polystore_core/target/release go test ./x/polystorechain/keeper\n- git diff --check\n\nStacked on #113.\n