### PR TITLE
gateway: add dev fault injection hooks

### DIFF
--- a/polystore_gateway/main.go
+++ b/polystore_gateway/main.go
@@ -2963,6 +2963,9 @@ func GatewayFetch(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
+	if maybeApplyHTTPTestFault(w, "sp_fetch_fail", http.StatusServiceUnavailable) {
+		return
+	}
 
 	startTotal := time.Now()
 
@@ -3715,6 +3718,10 @@ func GatewayFetch(w http.ResponseWriter, r *http.Request) {
 	}
 	if proofPayload != nil {
 		w.Header().Set("X-PolyStore-Proof-JSON", base64.StdEncoding.EncodeToString(proofPayload))
+	}
+	if testFaultEnabled("sp_fetch_corrupt") {
+		w.Header().Set("X-PolyStore-Test-Fault", "sp_fetch_corrupt")
+		content = &corruptOnceReadCloser{ReadCloser: content}
 	}
 
 	// Serve as attachment so browsers will download instead of inline JSON.
@@ -6398,6 +6405,11 @@ func SpUploadMdu(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
+	if maybeApplyHTTPTestFault(w, "sp_upload_fail", http.StatusServiceUnavailable) {
+		statusCode = http.StatusServiceUnavailable
+		outcome = "test_fault_sp_upload_fail"
+		return
+	}
 
 	// Default limit 10MB (MDU is 8MB). We also drain the body on early returns to avoid
 	// clients seeing "connection broken" errors when the handler rejects a request before
@@ -6631,6 +6643,11 @@ func SpUploadShard(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodOptions {
 		statusCode = http.StatusNoContent
 		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if maybeApplyHTTPTestFault(w, "sp_upload_fail", http.StatusServiceUnavailable) {
+		statusCode = http.StatusServiceUnavailable
+		outcome = "test_fault_sp_upload_fail"
 		return
 	}
 
@@ -6943,6 +6960,11 @@ func SpUploadManifest(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodOptions {
 		statusCode = http.StatusNoContent
 		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if maybeApplyHTTPTestFault(w, "sp_upload_fail", http.StatusServiceUnavailable) {
+		statusCode = http.StatusServiceUnavailable
+		outcome = "test_fault_sp_upload_fail"
 		return
 	}
 

--- a/polystore_gateway/sp_upload_bundle.go
+++ b/polystore_gateway/sp_upload_bundle.go
@@ -234,6 +234,11 @@ func SpUploadBundle(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
+	if maybeApplyHTTPTestFault(w, "sp_upload_fail", http.StatusServiceUnavailable) {
+		statusCode = http.StatusServiceUnavailable
+		outcome = "test_fault_sp_upload_fail"
+		return
+	}
 
 	binaryBundle := strings.HasPrefix(strings.TrimSpace(r.Header.Get("Content-Type")), spUploadBundleV2MediaType)
 	var (

--- a/polystore_gateway/test_faults.go
+++ b/polystore_gateway/test_faults.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"strings"
+)
+
+const testFaultsEnv = "POLYSTORE_TEST_FAULTS"
+
+func testFaultEnabled(name string) bool {
+	name = strings.TrimSpace(strings.ToLower(name))
+	if name == "" {
+		return false
+	}
+	raw := strings.TrimSpace(os.Getenv(testFaultsEnv))
+	if raw == "" {
+		return false
+	}
+	for _, token := range strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == ';' || r == ' ' || r == '\t' || r == '\n'
+	}) {
+		token = strings.TrimSpace(strings.ToLower(token))
+		if token == name || token == "all" {
+			return true
+		}
+	}
+	return false
+}
+
+func maybeApplyHTTPTestFault(w http.ResponseWriter, fault string, status int) bool {
+	if !testFaultEnabled(fault) {
+		return false
+	}
+	w.Header().Set("X-PolyStore-Test-Fault", fault)
+	writeJSONError(w, status, "test fault injected", fault)
+	return true
+}
+
+type corruptOnceReadCloser struct {
+	io.ReadCloser
+	corrupted bool
+}
+
+func (r *corruptOnceReadCloser) Read(p []byte) (int, error) {
+	n, err := r.ReadCloser.Read(p)
+	if n > 0 && !r.corrupted {
+		p[0] ^= 0xff
+		r.corrupted = true
+	}
+	return n, err
+}

--- a/polystore_gateway/test_faults_test.go
+++ b/polystore_gateway/test_faults_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestTestFaultEnabledIsDisabledByDefault(t *testing.T) {
+	t.Setenv(testFaultsEnv, "")
+
+	if testFaultEnabled("sp_upload_fail") {
+		t.Fatal("expected test faults to be disabled by default")
+	}
+}
+
+func TestTestFaultEnabledParsesList(t *testing.T) {
+	t.Setenv(testFaultsEnv, "sp_upload_fail, sp_fetch_corrupt")
+
+	if !testFaultEnabled("sp_upload_fail") {
+		t.Fatal("expected upload fault to be enabled")
+	}
+	if !testFaultEnabled("sp_fetch_corrupt") {
+		t.Fatal("expected corrupt fetch fault to be enabled")
+	}
+	if testFaultEnabled("sp_fetch_fail") {
+		t.Fatal("did not expect fetch-fail fault to be enabled")
+	}
+}
+
+func TestSpUploadMduTestFaultReturnsUnavailable(t *testing.T) {
+	t.Setenv(testFaultsEnv, "sp_upload_fail")
+
+	req := httptest.NewRequest(http.MethodPost, "/sp/upload_mdu", bytes.NewReader([]byte("ignored")))
+	w := httptest.NewRecorder()
+
+	SpUploadMdu(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d body=%s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("X-PolyStore-Test-Fault"); got != "sp_upload_fail" {
+		t.Fatalf("expected test fault header, got %q", got)
+	}
+}
+
+func TestGatewayFetchTestFaultReturnsUnavailable(t *testing.T) {
+	t.Setenv(testFaultsEnv, "sp_fetch_fail")
+
+	req := httptest.NewRequest(http.MethodGet, "/gateway/fetch/test", nil)
+	w := httptest.NewRecorder()
+
+	GatewayFetch(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d body=%s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("X-PolyStore-Test-Fault"); got != "sp_fetch_fail" {
+		t.Fatalf("expected test fault header, got %q", got)
+	}
+}
+
+func TestCorruptOnceReadCloserFlipsOnlyFirstByte(t *testing.T) {
+	reader := &corruptOnceReadCloser{ReadCloser: io.NopCloser(bytes.NewReader([]byte{0x00, 0x11, 0x22}))}
+
+	out, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read corrupt reader: %v", err)
+	}
+	if !bytes.Equal(out, []byte{0xff, 0x11, 0x22}) {
+		t.Fatalf("unexpected corrupt output: %x", out)
+	}
+}


### PR DESCRIPTION
## Summary
- add opt-in `POLYSTORE_TEST_FAULTS` dev/test fault hooks for gateway/provider failure simulation
- support `sp_upload_fail`, `sp_fetch_fail`, and `sp_fetch_corrupt`
- cover disabled-by-default behavior, list parsing, upload/fetch 503 injection, and corrupt-byte reader behavior

## Validation
- `LD_LIBRARY_PATH=/home/mikers/dev/polynomialstore/polystore/polystore_core/target/release go test ./...` from `polystore_gateway`
- `git diff --check`
