### PR TITLE
Fix public smoke helper edge cases

### DIFF
--- a/polystore-website/scripts/testnet_burner_wallet.ts
+++ b/polystore-website/scripts/testnet_burner_wallet.ts
@@ -81,6 +81,7 @@ function exportKeystore() {
   const ciphertext = Buffer.concat([cipher.update(hexToBytes(privateKey)), cipher.final()])
   const mac = keccak256(concat([derivedKey.subarray(16, 32), ciphertext]) as Hex)
   const account = privateKeyToAccount(privateKey)
+  const polystoreAddress = ethToPolystoreAddress(account.address)
 
   const keystore = {
     version: 3,
@@ -109,8 +110,8 @@ function exportKeystore() {
   process.stdout.write(
     JSON.stringify({
       address: account.address,
-      nil_address: ethToPolystoreAddress(account.address),
-      polystore_address: ethToPolystoreAddress(account.address),
+      nil_address: polystoreAddress,
+      polystore_address: polystoreAddress,
       keystore_path: outPath,
     }),
   )

--- a/polystore-website/scripts/testnet_burner_wallet.ts
+++ b/polystore-website/scripts/testnet_burner_wallet.ts
@@ -41,6 +41,7 @@ function generateWallet() {
     JSON.stringify({
       private_key: privateKey,
       address: account.address,
+      nil_address: polystoreAddress,
       polystore_address: polystoreAddress,
     }),
   )
@@ -108,6 +109,7 @@ function exportKeystore() {
   process.stdout.write(
     JSON.stringify({
       address: account.address,
+      nil_address: ethToPolystoreAddress(account.address),
       polystore_address: ethToPolystoreAddress(account.address),
       keystore_path: outPath,
     }),

--- a/polystore_gateway/main.go
+++ b/polystore_gateway/main.go
@@ -364,14 +364,29 @@ var lcdHTTPClient = &http.Client{Timeout: 5 * time.Second}
 var chainModuleCLINameOnce sync.Once
 var chainModuleCLINameValue string
 
-// extractJSONBody attempts to locate the first JSON object in a mixed CLI output.
+// extractJSONBody attempts to locate the first JSON object or array in mixed CLI output.
 func extractJSONBody(b []byte) []byte {
-	start := bytes.IndexByte(b, '{')
-	end := bytes.LastIndexByte(b, '}')
-	if start == -1 || end == -1 || end <= start {
-		return nil
+	for start, c := range b {
+		var close byte
+		switch c {
+		case '{':
+			close = '}'
+		case '[':
+			close = ']'
+		default:
+			continue
+		}
+		for end := len(b) - 1; end > start; end-- {
+			if b[end] != close {
+				continue
+			}
+			candidate := b[start : end+1]
+			if json.Valid(candidate) {
+				return candidate
+			}
+		}
 	}
-	return b[start : end+1]
+	return nil
 }
 
 type PolyStoreCliOutput struct {

--- a/polystore_gateway/main_test.go
+++ b/polystore_gateway/main_test.go
@@ -80,6 +80,57 @@ func setupMockCombinedOutput(t *testing.T, mockFn func(ctx context.Context, name
 	t.Cleanup(func() { mockCombinedOutput = oldMock })
 }
 
+func TestExtractJSONBodyHandlesNoisyObjectAndArray(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "object",
+			in:   "Initializing KZG with path: trusted_setup.txt\n{\"txhash\":\"ABC\"}\n",
+			want: "{\"txhash\":\"ABC\"}",
+		},
+		{
+			name: "array",
+			in:   "Initializing KZG with path: trusted_setup.txt\n[{\"name\":\"provider1\"},{\"name\":\"provider2\"}]\n",
+			want: "[{\"name\":\"provider1\"},{\"name\":\"provider2\"}]",
+		},
+		{
+			name: "ignores bracketed log prefix",
+			in:   "[INFO] initializing\n{\"txhash\":\"ABC\"}\n",
+			want: "{\"txhash\":\"ABC\"}",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := string(extractJSONBody([]byte(tc.in)))
+			if got != tc.want {
+				t.Fatalf("extractJSONBody() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveKeyNameForAddressHandlesNoisyKeyringArray(t *testing.T) {
+	const provider = "nil182f6qy5taazj5fa722p2ut4d0v5j2gkap0dprj"
+	setupMockCombinedOutput(t, func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		if len(args) >= 2 && args[0] == "keys" && args[1] == "list" {
+			return []byte(`Initializing KZG with path: /opt/polystore/polystorechain/trusted_setup.txt
+[{"name":"provider3","type":"local","address":"` + provider + `"}]`), nil
+		}
+		return nil, fmt.Errorf("unexpected command: %s %s", name, strings.Join(args, " "))
+	})
+
+	got, err := resolveKeyNameForAddress(context.Background(), provider)
+	if err != nil {
+		t.Fatalf("resolveKeyNameForAddress failed: %v", err)
+	}
+	if got != "provider3" {
+		t.Fatalf("resolveKeyNameForAddress() = %q, want provider3", got)
+	}
+}
+
 func deterministicManifestRootHex(tag string) string {
 	sum := sha256.Sum256([]byte(tag))
 	scalar := new(big.Int).SetBytes(sum[:])

--- a/scripts/enterprise_upload_job.sh
+++ b/scripts/enterprise_upload_job.sh
@@ -16,6 +16,8 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck disable=SC1091
 source "$ROOT_DIR/scripts/load_testnet_public_env.sh"
+# shellcheck disable=SC1091
+source "$ROOT_DIR/scripts/chain_cli_helpers.sh"
 
 FILE_PATH="${1:-}"
 DEAL_ID="${2:-}"
@@ -52,6 +54,7 @@ POLYSTORE_TX_SENDER_MNEMONIC="${POLYSTORE_TX_SENDER_MNEMONIC:-${POLYSTORE_TESTNE
 CREATE_NONCE="${CREATE_NONCE:-1}"
 UPDATE_NONCE="${UPDATE_NONCE:-}"
 EVM_NONCE_RETRY_ATTEMPTS="${EVM_NONCE_RETRY_ATTEMPTS:-8}"
+CHAIN_MODULE_CLI_NAME="${POLYSTORE_CHAIN_MODULE_CLI_NAME:-}"
 
 if [[ -z "${EVM_PRIVKEY:-}" ]]; then
   echo "error: EVM_PRIVKEY env var required" >&2
@@ -104,6 +107,13 @@ ensure_tx_sender_key() {
     --home "$POLYSTORE_TX_SENDER_HOME" >/dev/null
 }
 
+chain_module_cli_name() {
+  if [[ -z "$CHAIN_MODULE_CLI_NAME" ]]; then
+    CHAIN_MODULE_CLI_NAME="$(detect_chain_module_cli_name "$POLYSTORECHAIND_BIN")"
+  fi
+  printf '%s\n' "$CHAIN_MODULE_CLI_NAME"
+}
+
 poll_tx_body() {
   local tx_hash="$1"
   local attempt
@@ -127,9 +137,10 @@ poll_tx_body() {
 
 direct_create_deal() {
   local payload_json payload_file create_out tx_json tx_hash tx_code tx_body deal_id list_out max_id
-  local current_nonce raw_log cmd_status attempt
+  local current_nonce raw_log cmd_status attempt module_cli
 
   ensure_tx_sender_key
+  module_cli="$(chain_module_cli_name)"
   current_nonce="$CREATE_NONCE"
 
   for attempt in $(seq 1 "$EVM_NONCE_RETRY_ATTEMPTS"); do
@@ -143,7 +154,7 @@ direct_create_deal() {
     printf '%s\n' "$payload_json" >"$payload_file"
 
     cmd_status=0
-    create_out="$("$POLYSTORECHAIND_BIN" tx polystorechain create-deal-from-evm "$payload_file" \
+    create_out="$("$POLYSTORECHAIND_BIN" tx "$module_cli" create-deal-from-evm "$payload_file" \
       --node "$POLYSTORE_NODE" \
       --chain-id "$CHAIN_ID" \
       --from "$POLYSTORE_TX_SENDER_KEY" \
@@ -220,7 +231,7 @@ direct_create_deal() {
     ' 2>/dev/null || true)"
 
     if [[ -z "$deal_id" ]]; then
-      list_out="$("$POLYSTORECHAIND_BIN" query polystorechain list-deals \
+      list_out="$("$POLYSTORECHAIND_BIN" query "$module_cli" list-deals \
         --node "$POLYSTORE_NODE" \
         --output json 2>/dev/null || true)"
       max_id="$(printf '%s' "$list_out" | jq -r '[.deals[]?.id | tonumber] | max // empty' 2>/dev/null || true)"
@@ -246,9 +257,10 @@ direct_create_deal() {
 
 direct_update_deal_content() {
   local update_json update_file update_out tx_json tx_hash tx_code tx_body
-  local current_nonce raw_log cmd_status attempt
+  local current_nonce raw_log cmd_status attempt module_cli
 
   ensure_tx_sender_key
+  module_cli="$(chain_module_cli_name)"
   current_nonce="${UPDATE_NONCE:-$CREATE_NONCE}"
 
   for attempt in $(seq 1 "$EVM_NONCE_RETRY_ATTEMPTS"); do
@@ -270,7 +282,7 @@ direct_update_deal_content() {
     printf '%s\n' "$update_json" >"$update_file"
 
     cmd_status=0
-    update_out="$("$POLYSTORECHAIND_BIN" tx polystorechain update-deal-content-from-evm "$update_file" \
+    update_out="$("$POLYSTORECHAIND_BIN" tx "$module_cli" update-deal-content-from-evm "$update_file" \
       --node "$POLYSTORE_NODE" \
       --chain-id "$CHAIN_ID" \
       --from "$POLYSTORE_TX_SENDER_KEY" \

--- a/scripts/testnet_burner_upload.sh
+++ b/scripts/testnet_burner_upload.sh
@@ -166,6 +166,7 @@ export POLYSTORE_GAS_PRICES="${POLYSTORE_GAS_PRICES:-${POLYSTORE_TESTNET_GAS_PRI
 export POLYSTORE_TX_SENDER_KEY="${POLYSTORE_TX_SENDER_KEY:-${POLYSTORE_TESTNET_TX_SENDER_KEY:-faucet}}"
 export POLYSTORE_TX_SENDER_MNEMONIC="${POLYSTORE_TX_SENDER_MNEMONIC:-${POLYSTORE_TESTNET_TX_SENDER_MNEMONIC:-}}"
 export POLYSTORE_TX_SUBMIT_MODE="${POLYSTORE_TX_SUBMIT_MODE:-direct}"
+export SERVICE_HINT="${SERVICE_HINT:-General}"
 
 if ! curl -fsS "${GATEWAY_BASE}/health" >/dev/null 2>&1; then
   echo "error: local gateway is not healthy at ${GATEWAY_BASE}. Start Nil Gateway GUI before running this helper." >&2
@@ -182,7 +183,7 @@ umask 077
 wallet_json="$(cd "$ROOT_DIR/polystore-website" && node_modules/.bin/tsx "$ROOT_DIR/polystore-website/scripts/testnet_burner_wallet.ts" generate)"
 PRIVATE_KEY="$(printf '%s' "$wallet_json" | jq -r '.private_key')"
 EVM_ADDRESS="$(printf '%s' "$wallet_json" | jq -r '.address')"
-POLYSTORE_ADDRESS="$(printf '%s' "$wallet_json" | jq -r '.nil_address')"
+POLYSTORE_ADDRESS="$(printf '%s' "$wallet_json" | jq -r '.nil_address // .polystore_address // empty')"
 
 if [[ -z "$PRIVATE_KEY" || -z "$EVM_ADDRESS" || -z "$POLYSTORE_ADDRESS" || "$PRIVATE_KEY" == "null" ]]; then
   echo "error: failed to generate burner wallet" >&2
@@ -257,6 +258,8 @@ if [[ -n "$DEAL_ID" && -n "$POLYFS_PATH" ]]; then
   "$ROOT_DIR/scripts/enterprise_upload_job.sh" "$FILE_PATH" "$DEAL_ID" "$POLYFS_PATH"
 elif [[ -n "$DEAL_ID" ]]; then
   "$ROOT_DIR/scripts/enterprise_upload_job.sh" "$FILE_PATH" "$DEAL_ID"
+elif [[ -n "$POLYFS_PATH" ]]; then
+  "$ROOT_DIR/scripts/enterprise_upload_job.sh" "$FILE_PATH" "" "$POLYFS_PATH"
 else
   "$ROOT_DIR/scripts/enterprise_upload_job.sh" "$FILE_PATH"
 fi


### PR DESCRIPTION
## Summary
- add a backward-compatible nil_address alias to burner wallet output and let the upload wrapper read either address field
- make direct public upload submission detect the chain module CLI namespace instead of assuming polystorechain
- make gateway CLI JSON extraction handle noisy JSON arrays, fixing keyring parsing when KZG init text precedes keys list output
- preserve SERVICE_HINT and PolyFS path overrides through the burner upload wrapper

## Validation
- LD_LIBRARY_PATH=/opt/polystore/polystore_core/target/release go test . -run 'TestExtractJSONBodyHandlesNoisyObjectAndArray|TestResolveKeyNameForAddressHandlesNoisyKeyringArray' (in polystore_gateway)
- shellcheck scripts/testnet_burner_upload.sh scripts/enterprise_upload_job.sh
- cd polystore-website && node_modules/.bin/tsx scripts/testnet_burner_wallet.ts generate | jq -e '.nil_address and .polystore_address and (.nil_address == .polystore_address)'
- source scripts/chain_cli_helpers.sh && LD_LIBRARY_PATH=/opt/polystore/polystore_core/target/release detect_chain_module_cli_name /opt/polystore/polystorechain/polystorechaind

## Notes
- A live helper rerun reached direct chain submission, but the public devnet currently rejects new placement because all three non-draining SPs are in DELINQUENT ProviderHealthState; this is operational chain state, not a helper regression.