### PR TITLE
Fix Mode 2 system liveness proofs

### DIFF
--- a/docs/planning/POLICING_AND_FAILURE_SIMULATION_ROADMAP.md
+++ b/docs/planning/POLICING_AND_FAILURE_SIMULATION_ROADMAP.md
@@ -1,6 +1,6 @@
 # PolyStore Policing and Failure Simulation Roadmap
 
-Last updated: 2026-04-27
+Last updated: 2026-05-27
 
 ## 1. Purpose
 
@@ -49,6 +49,7 @@ The current repo already contains several enforcement surfaces:
 | Structured evidence and slot health | Keeper-level `EvidenceCase` and `SlotHealthState` ledgers now classify quota misses, deputy misses, repair backoff, readiness, and promotion with indexed, paginated query surfaces. |
 | Provider health lifecycle | Keeper-level `ProviderHealthState` now aggregates provider lifecycle signals from structured evidence, registration state, and bond headroom; placement, setup bumping, repair replacement, base rewards, proof-time reward eligibility, soft-fault decay, hard-fault jail/reputation consequences, and underbonded exclusion consume it. |
 | Provider bond economics | Provider registration can lock an isolated self-bond, authorized provider/operator top-ups can restore bond headroom, hard/slashable evidence can burn a governance-parametrized bond share from active and queued provider-bond funds, provider records expose active/slashed bond, underbonded providers are excluded or repaired away when `min_provider_bond` / `assignment_collateral_per_slot` are enabled, `AssignmentCollateralLock` state makes live slot liabilities queryable, and `provider_bond_unbonding_blocks` can force excess-bond exits through a delayed slashable claim queue. |
+| Mode 2 system liveness | Provider-daemons now have regression coverage that generates proofs from the exact per-slot shard bytes they store. System KZG challenge points are reduced into BLS12-381 Fr before proof generation, and pending repair providers do not attempt proof responsibility until the challenged shard row is locally present. |
 | Fast simulation | `tools/policy_sim` now provides an initial deterministic logical simulator. |
 
 The remaining work is to organize these mechanisms into an explicit reliability
@@ -404,6 +405,10 @@ Current landed status:
    state: `EvidenceCase` records and `SlotHealthState` records are written by
    quota-miss, deputy-miss, repair-start, repair-backoff, repair-readiness, and
    repair-completion paths, and are exposed through keeper queries.
+5. Provider-health root cause and repair workflow phase are no longer conflated
+   for repair-severity events: `repair_backoff_entered` increments repair
+   accounting but does not replace the underlying delinquency reason such as
+   `provider_delinquent` or `quota_miss_repair_started`.
 
 ### Milestone 4: Gateway and Provider Enforcement
 
@@ -419,6 +424,19 @@ Exit criteria:
 1. Gateway/provider failures map to known taxonomy entries.
 2. Routing around unhealthy slots is observable.
 
+Current landed status:
+
+1. Mode 2 system-liveness proof generation is now covered by gateway tests that
+   build real Mode 2 artifacts, read the stored `mdu_<index>_slot_<slot>.bin`
+   shard row, generate a chained proof, and verify it against the manifest root.
+2. The previously observed provider-daemon failure class
+   `polystore_compute_blob_proof failed with code: -3` is covered as a
+   regression: deterministic system challenges must be valid BLS12-381 Fr
+   scalars before KZG proof generation.
+3. Pending repair assignments are treated as catch-up responsibility before
+   proof responsibility. A pending provider only attempts a system proof once
+   the challenged local slot shard row exists.
+
 ### Milestone 5: Process-Level Devnet Scenarios
 
 Deliverables:
@@ -431,6 +449,21 @@ Exit criteria:
 
 1. The most important simulation claims have at least one real-stack confirmation.
 2. Slow tests remain stable enough to run intentionally.
+
+Current reset/smoke gate for the next devnet update:
+
+1. Deploy the fixed chain and provider-daemon binaries.
+2. Reset chain and provider state so old quota-miss and delinquency evidence
+   from the invalid challenge-point bug does not contaminate the new baseline.
+3. Register fresh providers and endpoints.
+4. Create a fresh Mode 2 deal, upload through the public user-gateway path, and
+   commit the manifest root on chain.
+5. Wait through multiple system-liveness epochs and confirm provider health
+   remains `ACTIVE`, slot health remains `HEALTHY`, and system proofs are
+   submitted without `polystore_compute_blob_proof failed with code: -3`.
+6. Confirm a pending repair provider does not get penalized before repair
+   catch-up/readiness, then confirm it can prove after the target slot shard is
+   locally present.
 
 ### Milestone 6: Observability and Operator UX
 

--- a/polystore-website/src/lib/storage/OpfsAdapter.test.ts
+++ b/polystore-website/src/lib/storage/OpfsAdapter.test.ts
@@ -8,6 +8,8 @@ import * as OpfsAdapter from './OpfsAdapter';
 // and stores content in a simple in-memory map.
 
 class MockFileSystemFileHandle {
+    static failReadCounts = new Map<string, number>();
+
     name: string;
     readonly kind = 'file' as const;
     private content: Uint8Array | null = null;
@@ -20,7 +22,16 @@ class MockFileSystemFileHandle {
     async getFile() {
         return {
             name: this.name,
-            arrayBuffer: async () => this.content?.buffer || new ArrayBuffer(0),
+            arrayBuffer: async () => {
+                const remainingFailures = MockFileSystemFileHandle.failReadCounts.get(this.name) || 0
+                if (remainingFailures > 0) {
+                    MockFileSystemFileHandle.failReadCounts.set(this.name, remainingFailures - 1)
+                    const err = new Error('File cannot be read')
+                    err.name = 'NotReadableError'
+                    throw err
+                }
+                return this.content?.buffer || new ArrayBuffer(0)
+            },
             size: this.content?.length || 0,
             type: 'application/octet-stream',
             lastModified: Date.now(),
@@ -132,8 +143,16 @@ Object.defineProperty(global, 'navigator', {
 // Reset mock before each test
 test.beforeEach(() => {
     mockRootDirectoryHandle.entries.clear();
+    MockFileSystemFileHandle.failReadCounts.clear();
     MockFileSystemDirectoryHandle.failRemoveNames.clear();
 });
+
+async function writeMockFile(dir: MockFileSystemDirectoryHandle, name: string, data: string | Uint8Array): Promise<void> {
+    const handle = await dir.getFileHandle(name, { create: true })
+    const writable = await handle.createWritable()
+    await writable.write(typeof data === 'string' ? new TextEncoder().encode(data) : data)
+    await writable.close()
+}
 
 function makeMetadata(opts: {
     dealId: string
@@ -468,6 +487,39 @@ test('OpfsAdapter: atomic slab generation swap survives stale cleanup failure af
     assert.deepStrictEqual(await OpfsAdapter.readMdu(dealId, 1), new Uint8Array([61]))
     assert.strictEqual(await OpfsAdapter.readManifestRoot(dealId), rootB)
     assert.strictEqual((await OpfsAdapter.readSlabMetadata(dealId))?.manifest_root, rootB)
+})
+
+test('OpfsAdapter: active generation reads retry transient OPFS NotReadableError', async () => {
+    const dealId = 'test-deal-transient-not-readable'
+    const root = '0x' + '56'.repeat(48)
+
+    await OpfsAdapter.writeSlabGenerationAtomically(dealId, {
+        manifestRoot: root,
+        manifestBlob: new Uint8Array([1]),
+        mdus: [
+            { index: 0, data: new Uint8Array([70]) },
+            { index: 1, data: new Uint8Array([71]) },
+        ],
+        metadata: makeMetadata({
+            dealId,
+            manifestRoot: root,
+            generationId: root.slice(2),
+        }),
+    })
+
+    MockFileSystemFileHandle.failReadCounts.set('mdu_0.bin', 1)
+    assert.deepStrictEqual(await OpfsAdapter.readMdu(dealId, 0), new Uint8Array([70]))
+})
+
+test('OpfsAdapter: stale active generation pointer cleanup failure does not break reads', async () => {
+    const dealId = 'test-deal-stale-pointer-cleanup-failure'
+    const dealDir = await mockRootDirectoryHandle.getDirectoryHandle(`deal-${dealId}`, { create: true })
+    const generationsDir = await dealDir.getDirectoryHandle('generations', { create: true })
+    await generationsDir.getDirectoryHandle('gen-incomplete', { create: true })
+    await writeMockFile(dealDir, 'active_generation.txt', 'gen-incomplete\n')
+    MockFileSystemDirectoryHandle.failRemoveNames.add('active_generation.txt')
+
+    assert.strictEqual(await OpfsAdapter.readMdu(dealId, 0), null)
 })
 
 test('OpfsAdapter: atomic slab generation swap rehydrates sparse artifacts on read', async () => {

--- a/polystore-website/src/lib/storage/OpfsAdapter.test.ts
+++ b/polystore-website/src/lib/storage/OpfsAdapter.test.ts
@@ -40,6 +40,8 @@ class MockFileSystemFileHandle {
 }
 
 class MockFileSystemDirectoryHandle {
+    static failRemoveNames = new Set<string>();
+
     name: string;
     readonly kind = 'directory' as const;
     entries: Map<string, MockFileSystemDirectoryHandle | MockFileSystemFileHandle>;
@@ -94,6 +96,11 @@ class MockFileSystemDirectoryHandle {
     }
 
     async removeEntry(name: string, options?: { recursive?: boolean }): Promise<void> {
+        if (MockFileSystemDirectoryHandle.failRemoveNames.has(name)) {
+            const err = new Error('Object cannot be modified');
+            err.name = 'NoModificationAllowedError';
+            throw err;
+        }
         if (!this.entries.has(name)) {
             const err = new Error('Entry not found');
             err.name = 'NotFoundError';
@@ -125,6 +132,7 @@ Object.defineProperty(global, 'navigator', {
 // Reset mock before each test
 test.beforeEach(() => {
     mockRootDirectoryHandle.entries.clear();
+    MockFileSystemDirectoryHandle.failRemoveNames.clear();
 });
 
 function makeMetadata(opts: {
@@ -412,6 +420,54 @@ test('OpfsAdapter: atomic slab generation swap serves new generation and cleans 
     assert.ok(files.includes('mdu_0.bin'))
     assert.ok(files.includes('mdu_1.bin'))
     assert.ok(files.includes('manifest.bin'))
+})
+
+test('OpfsAdapter: atomic slab generation swap survives stale cleanup failure after activation', async () => {
+    const dealId = 'test-deal-atomic-swap-cleanup-failure'
+    const rootA = '0x' + '12'.repeat(48)
+    const rootB = '0x' + '34'.repeat(48)
+
+    await OpfsAdapter.writeSlabGenerationAtomically(dealId, {
+        manifestRoot: rootA,
+        manifestBlob: new Uint8Array([1]),
+        mdus: [
+            { index: 0, data: new Uint8Array([50]) },
+            { index: 1, data: new Uint8Array([51]) },
+        ],
+        metadata: makeMetadata({
+            dealId,
+            manifestRoot: rootA,
+            generationId: rootA.slice(2),
+        }),
+    })
+
+    const dealDir = await mockRootDirectoryHandle.getDirectoryHandle(`deal-${dealId}`)
+    const generationsDir = await dealDir.getDirectoryHandle('generations')
+    const staleGenerationNames: string[] = []
+    for await (const entry of generationsDir.values()) {
+        if (entry.kind === 'directory') staleGenerationNames.push(entry.name)
+    }
+    assert.strictEqual(staleGenerationNames.length, 1)
+    MockFileSystemDirectoryHandle.failRemoveNames.add(staleGenerationNames[0])
+
+    await OpfsAdapter.writeSlabGenerationAtomically(dealId, {
+        manifestRoot: rootB,
+        manifestBlob: new Uint8Array([2]),
+        mdus: [
+            { index: 0, data: new Uint8Array([60]) },
+            { index: 1, data: new Uint8Array([61]) },
+        ],
+        metadata: makeMetadata({
+            dealId,
+            manifestRoot: rootB,
+            generationId: rootB.slice(2),
+        }),
+    })
+
+    assert.deepStrictEqual(await OpfsAdapter.readMdu(dealId, 0), new Uint8Array([60]))
+    assert.deepStrictEqual(await OpfsAdapter.readMdu(dealId, 1), new Uint8Array([61]))
+    assert.strictEqual(await OpfsAdapter.readManifestRoot(dealId), rootB)
+    assert.strictEqual((await OpfsAdapter.readSlabMetadata(dealId))?.manifest_root, rootB)
 })
 
 test('OpfsAdapter: atomic slab generation swap rehydrates sparse artifacts on read', async () => {

--- a/polystore-website/src/lib/storage/OpfsAdapter.ts
+++ b/polystore-website/src/lib/storage/OpfsAdapter.ts
@@ -95,23 +95,54 @@ async function writeBlobToDirectory(
     await writable.close()
 }
 
+function isDomErrorName(e: unknown, name: string): boolean {
+    return e instanceof Error && e.name === name
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
 async function readBlobFromDirectory(dir: FileSystemDirectoryHandle, name: string): Promise<Uint8Array | null> {
-    try {
-        const fileHandle = await dir.getFileHandle(name)
-        const file = await fileHandle.getFile()
-        const buffer = await file.arrayBuffer()
-        return new Uint8Array(buffer)
-    } catch (e: unknown) {
-        if (e instanceof Error && e.name === 'NotFoundError') return null
-        throw e
+    let lastRetryableError: unknown = null
+    const retryDelaysMs = [0, 25, 100, 250]
+    for (const delayMs of retryDelaysMs) {
+        if (delayMs > 0) await sleep(delayMs)
+        try {
+            const fileHandle = await dir.getFileHandle(name)
+            const file = await fileHandle.getFile()
+            const buffer = await file.arrayBuffer()
+            return new Uint8Array(buffer)
+        } catch (e: unknown) {
+            if (isDomErrorName(e, 'NotFoundError')) return null
+            if (isDomErrorName(e, 'NotReadableError')) {
+                lastRetryableError = e
+                continue
+            }
+            throw e
+        }
     }
+    throw lastRetryableError
 }
 
 async function removeEntryIfExists(dir: FileSystemDirectoryHandle, name: string, recursive = false): Promise<void> {
     try {
         await dir.removeEntry(name, recursive ? { recursive: true } : undefined)
     } catch (e: unknown) {
-        if (e instanceof Error && e.name === 'NotFoundError') return
+        if (isDomErrorName(e, 'NotFoundError')) return
+        throw e
+    }
+}
+
+async function bestEffortRemoveEntryIfExists(
+    dir: FileSystemDirectoryHandle,
+    name: string,
+    recursive = false,
+): Promise<void> {
+    try {
+        await removeEntryIfExists(dir, name, recursive)
+    } catch (e: unknown) {
+        if (isDomErrorName(e, 'NoModificationAllowedError')) return
         throw e
     }
 }
@@ -154,22 +185,6 @@ async function generationLooksComplete(dir: FileSystemDirectoryHandle): Promise<
     return !!meta && !!mdu0 && !!manifest
 }
 
-async function removeIncompleteGenerationIfAny(
-    generationsDir: FileSystemDirectoryHandle,
-    generationName: string,
-): Promise<void> {
-    try {
-        const handle = await generationsDir.getDirectoryHandle(generationName)
-        const complete = await generationLooksComplete(handle)
-        if (!complete) {
-            await removeEntryIfExists(generationsDir, generationName, true)
-        }
-    } catch (e: unknown) {
-        if (e instanceof Error && e.name === 'NotFoundError') return
-        throw e
-    }
-}
-
 async function cleanupInactiveGenerations(
     dealDir: FileSystemDirectoryHandle,
     activeGenerationName: string,
@@ -193,22 +208,20 @@ async function resolveActiveStorageDirectory(dealId: string, create: boolean): P
 
     const generationsDir = await getGenerationsDirectory(dealDir, false)
     if (!generationsDir) {
-        await removeEntryIfExists(dealDir, ACTIVE_GENERATION_POINTER_FILE)
+        await bestEffortRemoveEntryIfExists(dealDir, ACTIVE_GENERATION_POINTER_FILE)
         return dealDir
     }
 
-    await removeIncompleteGenerationIfAny(generationsDir, activeGenerationName)
     try {
         const activeDir = await generationsDir.getDirectoryHandle(activeGenerationName)
         if (!(await generationLooksComplete(activeDir))) {
-            await removeEntryIfExists(generationsDir, activeGenerationName, true)
-            await removeEntryIfExists(dealDir, ACTIVE_GENERATION_POINTER_FILE)
+            await bestEffortRemoveEntryIfExists(dealDir, ACTIVE_GENERATION_POINTER_FILE)
             return dealDir
         }
         return activeDir
     } catch (e: unknown) {
-        if (e instanceof Error && e.name === 'NotFoundError') {
-            await removeEntryIfExists(dealDir, ACTIVE_GENERATION_POINTER_FILE)
+        if (isDomErrorName(e, 'NotFoundError')) {
+            await bestEffortRemoveEntryIfExists(dealDir, ACTIVE_GENERATION_POINTER_FILE)
             return dealDir
         }
         throw e

--- a/polystore-website/src/lib/storage/OpfsAdapter.ts
+++ b/polystore-website/src/lib/storage/OpfsAdapter.ts
@@ -454,7 +454,11 @@ export async function writeSlabGenerationAtomically(
         await writeBlobToDirectory(generationDir, GENERATION_COMPLETE_MARKER_FILE, new TextEncoder().encode('ok\n'))
 
         await writeActiveGenerationName(dealDir, generationName)
-        await cleanupInactiveGenerations(dealDir, generationName)
+        try {
+            await cleanupInactiveGenerations(dealDir, generationName)
+        } catch (cleanupError) {
+            console.warn('Failed to clean inactive OPFS slab generations', cleanupError)
+        }
     } catch (e) {
         await removeEntryIfExists(generationsDir, generationName, true)
         throw e

--- a/polystore_gateway/system_liveness.go
+++ b/polystore_gateway/system_liveness.go
@@ -225,6 +225,10 @@ func classifySystemLivenessError(err error) (systemLivenessFailureReason, time.D
 	}
 }
 
+func pendingRepairShardNotReadyError(dealID uint64, slot uint32, ordinal, mduIndex, row uint64) error {
+	return fmt.Errorf("%w: pending repair shard not ready deal=%d slot=%d ord=%d mdu=%d row=%d", os.ErrNotExist, dealID, slot, ordinal, mduIndex, row)
+}
+
 func (s *systemLivenessState) recordFailure(key systemLivenessKey, now time.Time, err error) (systemLivenessFailureReason, time.Duration, uint32, bool) {
 	reason, base, expected := classifySystemLivenessError(err)
 
@@ -431,8 +435,10 @@ dealLoop:
 				mduIndex, blobIndex := deriveMode2ChallengeLocal(epochSeed, deal.dealID, deal.currentGen, uint64(slotU), ordinal, metaMdus, userMdus, stripe.rows)
 				row := uint64(blobIndex) % stripe.rows
 				if localRole == systemLivenessRolePendingRepair && !mode2ShardBlobReadyForSystemProof(dealDir, mduIndex, slotU, row) {
+					err := pendingRepairShardNotReadyError(deal.dealID, slotU, ordinal, mduIndex, row)
+					reason, retryIn, attempt, _ := systemProverState.recordFailure(key, now, err)
 					snapshot.MissingDataSkips++
-					log.Printf("system liveness: pending repair shard not ready deal=%d slot=%d ord=%d mdu=%d row=%d", deal.dealID, slotU, ordinal, mduIndex, row)
+					log.Printf("system liveness: expected skip deal=%d slot=%d ord=%d reason=%s attempt=%d retry_in=%s: %v", deal.dealID, slotU, ordinal, reason, attempt, retryIn.Round(time.Second), err)
 					continue
 				}
 				proof, err := generateSystemChainedProof(ctx, epochSeed, deal.dealID, dealDir, manifestPath, stripe, mduIndex, blobIndex)

--- a/polystore_gateway/system_liveness.go
+++ b/polystore_gateway/system_liveness.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math/big"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -29,6 +30,7 @@ var (
 	epochSeedTagBytes     = []byte("polystore/epoch/v1")
 	challengeSeedTagBytes = []byte("polystore/chal/v1")
 	kzgZSeedTagBytes      = []byte("polystore/kzgz/v1")
+	bls12381FrModulus     = mustParseBigIntHex("73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001")
 )
 
 type systemLivenessParams struct {
@@ -60,6 +62,14 @@ type systemLivenessKey struct {
 	slot    uint32
 	ordinal uint64
 }
+
+type systemLivenessLocalRole uint8
+
+const (
+	systemLivenessRoleNone systemLivenessLocalRole = iota
+	systemLivenessRoleAssigned
+	systemLivenessRolePendingRepair
+)
 
 type systemLivenessFailureReason string
 
@@ -394,14 +404,8 @@ dealLoop:
 				continue
 			}
 
-			local := false
-			if strings.TrimSpace(slot.Provider) == providerAddr {
-				local = true
-			}
-			if !local && strings.TrimSpace(slot.PendingProvider) == providerAddr {
-				local = true
-			}
-			if !local {
+			localRole := classifySystemLivenessLocalRole(providerAddr, slot)
+			if localRole == systemLivenessRoleNone {
 				continue
 			}
 
@@ -425,6 +429,12 @@ dealLoop:
 				}
 
 				mduIndex, blobIndex := deriveMode2ChallengeLocal(epochSeed, deal.dealID, deal.currentGen, uint64(slotU), ordinal, metaMdus, userMdus, stripe.rows)
+				row := uint64(blobIndex) % stripe.rows
+				if localRole == systemLivenessRolePendingRepair && !mode2ShardBlobReadyForSystemProof(dealDir, mduIndex, slotU, row) {
+					snapshot.MissingDataSkips++
+					log.Printf("system liveness: pending repair shard not ready deal=%d slot=%d ord=%d mdu=%d row=%d", deal.dealID, slotU, ordinal, mduIndex, row)
+					continue
+				}
 				proof, err := generateSystemChainedProof(ctx, epochSeed, deal.dealID, dealDir, manifestPath, stripe, mduIndex, blobIndex)
 				if err != nil {
 					reason, retryIn, attempt, expected := systemProverState.recordFailure(key, now, err)
@@ -872,6 +882,30 @@ func deriveMode2ChallengeLocal(seed [32]byte, dealID uint64, currentGen uint64, 
 	return mduIndex, uint32(leafIndex)
 }
 
+func classifySystemLivenessLocalRole(providerAddr string, slot mode2SlotAssignment) systemLivenessLocalRole {
+	providerAddr = strings.TrimSpace(providerAddr)
+	if providerAddr == "" {
+		return systemLivenessRoleNone
+	}
+	if strings.TrimSpace(slot.Provider) == providerAddr {
+		return systemLivenessRoleAssigned
+	}
+	if strings.TrimSpace(slot.PendingProvider) == providerAddr {
+		return systemLivenessRolePendingRepair
+	}
+	return systemLivenessRoleNone
+}
+
+func mode2ShardBlobReadyForSystemProof(dealDir string, mduIndex uint64, slot uint32, row uint64) bool {
+	path := filepath.Join(dealDir, fmt.Sprintf("mdu_%d_slot_%d.bin", mduIndex, slot))
+	info, err := os.Stat(path)
+	if err != nil || !info.Mode().IsRegular() {
+		return false
+	}
+	minSize := int64(row+1) * int64(types.BLOB_SIZE)
+	return info.Size() >= minSize
+}
+
 func deriveKzgZ(seed [32]byte, dealID uint64, mduIndex uint64, blobIndex uint32) []byte {
 	buf := make([]byte, 0, len(kzgZSeedTagBytes)+32+8+8+4)
 	buf = append(buf, kzgZSeedTagBytes...)
@@ -881,8 +915,21 @@ func deriveKzgZ(seed [32]byte, dealID uint64, mduIndex uint64, blobIndex uint32)
 	buf = binary.BigEndian.AppendUint32(buf, blobIndex)
 	sum := sha256.Sum256(buf)
 	out := make([]byte, 32)
-	copy(out, sum[:])
+	// KZG opening points are BLS12-381 Fr elements. Raw SHA-256 output is not
+	// guaranteed to be canonical, so reduce it before passing it into the FFI.
+	z := new(big.Int).SetBytes(sum[:])
+	z.Mod(z, bls12381FrModulus)
+	zBytes := z.Bytes()
+	copy(out[32-len(zBytes):], zBytes)
 	return out
+}
+
+func mustParseBigIntHex(raw string) *big.Int {
+	n, ok := new(big.Int).SetString(raw, 16)
+	if !ok {
+		panic("invalid big.Int hex constant")
+	}
+	return n
 }
 
 func generateSystemChainedProof(ctx context.Context, epochSeed [32]byte, dealID uint64, dealDir string, manifestPath string, stripe stripeParams, mduIndex uint64, blobIndex uint32) (*types.ChainedProof, error) {

--- a/polystore_gateway/system_liveness.go
+++ b/polystore_gateway/system_liveness.go
@@ -164,6 +164,12 @@ func (s *systemLivenessState) markDone(key systemLivenessKey) {
 	delete(s.failures, key)
 }
 
+func (s *systemLivenessState) clearFailure(key systemLivenessKey) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.failures, key)
+}
+
 func (s *systemLivenessState) shouldBackoff(key systemLivenessKey, now time.Time) (bool, time.Duration, systemLivenessFailureReason) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -424,16 +430,22 @@ dealLoop:
 					snapshot.ProofsAlreadyDone++
 					continue
 				}
-				if blocked, _, reason := systemProverState.shouldBackoff(key, now); blocked {
-					snapshot.ProofsBackoffSkipped++
-					if reason == systemLivenessFailureMissingLocalData {
-						snapshot.MissingDataSkips++
-					}
-					continue
-				}
-
 				mduIndex, blobIndex := deriveMode2ChallengeLocal(epochSeed, deal.dealID, deal.currentGen, uint64(slotU), ordinal, metaMdus, userMdus, stripe.rows)
 				row := uint64(blobIndex) % stripe.rows
+				if blocked, _, reason := systemProverState.shouldBackoff(key, now); blocked {
+					if reason == systemLivenessFailureMissingLocalData &&
+						localRole == systemLivenessRolePendingRepair &&
+						mode2ShardBlobReadyForSystemProof(dealDir, mduIndex, slotU, row) {
+						systemProverState.clearFailure(key)
+					} else {
+						snapshot.ProofsBackoffSkipped++
+						if reason == systemLivenessFailureMissingLocalData {
+							snapshot.MissingDataSkips++
+						}
+						continue
+					}
+				}
+
 				if localRole == systemLivenessRolePendingRepair && !mode2ShardBlobReadyForSystemProof(dealDir, mduIndex, slotU, row) {
 					err := pendingRepairShardNotReadyError(deal.dealID, slotU, ordinal, mduIndex, row)
 					reason, retryIn, attempt, _ := systemProverState.recordFailure(key, now, err)

--- a/polystore_gateway/system_liveness_mode2_test.go
+++ b/polystore_gateway/system_liveness_mode2_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"polystorechain/x/crypto_ffi"
+	"polystorechain/x/polystorechain/types"
+)
+
+func TestSystemLivenessKzgChallengeIsProofable(t *testing.T) {
+	if err := crypto_ffi.Init(trustedSetup); err != nil {
+		t.Fatalf("crypto_ffi.Init failed: %v", err)
+	}
+
+	var seed [32]byte
+	z := deriveKzgZ(seed, 1, 2, 0)
+	if _, _, err := crypto_ffi.ComputeBlobProof(make([]byte, types.BLOB_SIZE), z); err != nil {
+		t.Fatalf("system liveness KZG challenge must be a proofable scalar: %v", err)
+	}
+}
+
+func TestSystemLivenessGeneratesProofFromMode2SlotShard(t *testing.T) {
+	useTempUploadDir(t)
+	if err := crypto_ffi.Init(trustedSetup); err != nil {
+		t.Fatalf("crypto_ffi.Init failed: %v", err)
+	}
+
+	payloadPath := filepath.Join(t.TempDir(), "payload.txt")
+	if err := os.WriteFile(payloadPath, []byte("mode2 system liveness proof fixture"), 0o644); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+
+	const dealID = uint64(1)
+	const serviceHint = "General:rs=8+4"
+	result, _, err := mode2BuildArtifacts(context.Background(), payloadPath, dealID, serviceHint, "payload.txt", 0)
+	if err != nil {
+		t.Fatalf("mode2BuildArtifacts failed: %v", err)
+	}
+
+	stripe, err := stripeParamsFromHint(serviceHint)
+	if err != nil {
+		t.Fatalf("stripeParamsFromHint failed: %v", err)
+	}
+	mduIndex := uint64(1) + result.witnessMdus
+	blobIndex := uint32(0) // slot 0, row 0 in Mode 2 slot-major witness layout.
+	dealDir := dealScopedDir(dealID, result.manifestRoot)
+	manifestPath := filepath.Join(dealDir, "manifest.bin")
+
+	var seed [32]byte
+	proof, err := generateSystemChainedProof(context.Background(), seed, dealID, dealDir, manifestPath, stripe, mduIndex, blobIndex)
+	if err != nil {
+		t.Fatalf("generateSystemChainedProof failed: %v", err)
+	}
+
+	flatMerklePath := make([]byte, 0, len(proof.MerklePath)*32)
+	for _, node := range proof.MerklePath {
+		flatMerklePath = append(flatMerklePath, node...)
+	}
+	ok, err := crypto_ffi.VerifyChainedProof(
+		result.manifestRoot.Bytes[:],
+		proof.MduIndex,
+		proof.ManifestOpening,
+		proof.MduRootFr,
+		proof.BlobCommitment,
+		uint64(proof.BlobIndex),
+		stripe.leafCount,
+		flatMerklePath,
+		proof.ZValue,
+		proof.YValue,
+		proof.KzgOpeningProof,
+	)
+	if err != nil {
+		t.Fatalf("VerifyChainedProof failed: %v", err)
+	}
+	if !ok {
+		t.Fatalf("generated system liveness proof did not verify")
+	}
+}
+
+func TestSystemLivenessPendingRepairRequiresLocalShardReadiness(t *testing.T) {
+	slot := mode2SlotAssignment{
+		Provider:        "nil1assigned",
+		PendingProvider: "nil1pending",
+		Status:          1,
+	}
+	if got := classifySystemLivenessLocalRole("nil1assigned", slot); got != systemLivenessRoleAssigned {
+		t.Fatalf("assigned provider role mismatch: got %d", got)
+	}
+	if got := classifySystemLivenessLocalRole("nil1pending", slot); got != systemLivenessRolePendingRepair {
+		t.Fatalf("pending provider role mismatch: got %d", got)
+	}
+
+	dealDir := t.TempDir()
+	if mode2ShardBlobReadyForSystemProof(dealDir, 2, 0, 0) {
+		t.Fatalf("pending repair shard must not be ready before local catch-up data exists")
+	}
+	if err := os.WriteFile(filepath.Join(dealDir, "mdu_2_slot_1.bin"), make([]byte, types.BLOB_SIZE), 0o644); err != nil {
+		t.Fatalf("write wrong slot shard: %v", err)
+	}
+	if mode2ShardBlobReadyForSystemProof(dealDir, 2, 0, 0) {
+		t.Fatalf("pending repair shard readiness must be slot-specific")
+	}
+	if err := os.WriteFile(filepath.Join(dealDir, "mdu_2_slot_0.bin"), make([]byte, types.BLOB_SIZE), 0o644); err != nil {
+		t.Fatalf("write pending slot shard: %v", err)
+	}
+	if !mode2ShardBlobReadyForSystemProof(dealDir, 2, 0, 0) {
+		t.Fatalf("pending repair shard should be ready after the target slot blob exists")
+	}
+	if mode2ShardBlobReadyForSystemProof(dealDir, 2, 0, 1) {
+		t.Fatalf("pending repair shard row readiness must require the challenged row")
+	}
+}

--- a/polystore_gateway/system_liveness_test.go
+++ b/polystore_gateway/system_liveness_test.go
@@ -24,6 +24,22 @@ func TestClassifySystemLivenessError_MissingLocalData(t *testing.T) {
 	}
 }
 
+func TestClassifySystemLivenessError_PendingRepairShardNotReady(t *testing.T) {
+	t.Parallel()
+
+	err := pendingRepairShardNotReadyError(22, 3, 4, 5, 6)
+	reason, backoff, expected := classifySystemLivenessError(err)
+	if reason != systemLivenessFailureMissingLocalData {
+		t.Fatalf("expected reason=%q, got %q", systemLivenessFailureMissingLocalData, reason)
+	}
+	if backoff != systemLivenessMissingDataBackoff {
+		t.Fatalf("expected backoff=%s, got %s", systemLivenessMissingDataBackoff, backoff)
+	}
+	if !expected {
+		t.Fatalf("expected expected=true")
+	}
+}
+
 func TestClassifySystemLivenessError_DealExpired(t *testing.T) {
 	t.Parallel()
 

--- a/polystore_gateway/system_liveness_test.go
+++ b/polystore_gateway/system_liveness_test.go
@@ -84,12 +84,28 @@ func TestSystemLivenessState_BackoffProgression(t *testing.T) {
 		t.Fatalf("expected blocked reason=%q, got %q", systemLivenessFailureMissingLocalData, blockedReason)
 	}
 
-	_, delay2, attempt2, _ := st.recordFailure(key, now.Add(delay1+time.Second), errors.New("no such file or directory"))
-	if attempt2 != 2 {
-		t.Fatalf("expected second attempt=2, got %d", attempt2)
+	st.clearFailure(key)
+	blocked, _, _ = st.shouldBackoff(key, now.Add(2*time.Second))
+	if blocked {
+		t.Fatalf("expected no backoff after clearFailure")
 	}
-	if delay2 <= delay1 {
-		t.Fatalf("expected delay2 > delay1, got delay1=%s delay2=%s", delay1, delay2)
+
+	_, delay2, attempt2, _ := st.recordFailure(key, now.Add(delay1+time.Second), errors.New("no such file or directory"))
+	if attempt2 != 1 {
+		t.Fatalf("expected retry after clearFailure to restart at attempt=1, got %d", attempt2)
+	}
+	if delay2 != delay1 {
+		t.Fatalf("expected delay2 to restart at %s, got %s", delay1, delay2)
+	}
+
+	key2 := systemLivenessKey{dealID: 13, slot: 1, ordinal: 0}
+	_, baseDelay, _, _ := st.recordFailure(key2, now, errors.New("no such file or directory"))
+	_, escalatedDelay, escalatedAttempt, _ := st.recordFailure(key2, now.Add(baseDelay+time.Second), errors.New("no such file or directory"))
+	if escalatedAttempt != 2 {
+		t.Fatalf("expected second attempt=2, got %d", escalatedAttempt)
+	}
+	if escalatedDelay <= baseDelay {
+		t.Fatalf("expected escalated delay > base delay, got base=%s escalated=%s", baseDelay, escalatedDelay)
 	}
 
 	st.markDone(key)

--- a/polystorechain/x/polystorechain/keeper/provider_health.go
+++ b/polystorechain/x/polystorechain/keeper/provider_health.go
@@ -127,6 +127,10 @@ func providerLifecycleFromEvidence(ev types.EvidenceCase, current types.Provider
 	}
 }
 
+func isProviderHealthRepairPhaseOnly(ev types.EvidenceCase) bool {
+	return ev.Severity == types.EvidenceSeverity_EVIDENCE_SEVERITY_REPAIR
+}
+
 func (k Keeper) deriveProviderHealthState(ctx sdk.Context, providerAddr string) (types.ProviderHealthState, error) {
 	counts, err := k.providerMode2AssignmentCountSnapshot(ctx)
 	if err != nil {
@@ -274,16 +278,20 @@ func (k Keeper) updateProviderHealthFromEvidence(ctx sdk.Context, ev types.Evide
 
 	health := current
 	health.Provider = providerAddr
-	health.LifecycleStatus = providerLifecycleFromEvidence(ev, current)
-	health.Reason = strings.TrimSpace(ev.Reason)
-	health.EvidenceClass = ev.EvidenceClass
-	health.Severity = ev.Severity
-	health.LastEvidenceCaseId = ev.Id
-	health.LastDealId = ev.DealId
-	health.LastSlot = ev.Slot
-	health.LastEpochId = ev.EpochId
+	if !isProviderHealthRepairPhaseOnly(ev) {
+		health.LifecycleStatus = providerLifecycleFromEvidence(ev, current)
+		health.Reason = strings.TrimSpace(ev.Reason)
+		health.EvidenceClass = ev.EvidenceClass
+		health.Severity = ev.Severity
+		health.LastEvidenceCaseId = ev.Id
+		health.LastDealId = ev.DealId
+		health.LastSlot = ev.Slot
+		health.LastEpochId = ev.EpochId
+		health.ConsequenceCeiling = strings.TrimSpace(ev.ConsequenceCeiling)
+	} else if health.LifecycleStatus == types.ProviderLifecycleStatus_PROVIDER_LIFECYCLE_STATUS_UNSPECIFIED {
+		health.LifecycleStatus = providerLifecycleFromEvidence(ev, current)
+	}
 	health.UpdatedHeight = ctx.BlockHeight()
-	health.ConsequenceCeiling = strings.TrimSpace(ev.ConsequenceCeiling)
 
 	switch {
 	case ev.Severity == types.EvidenceSeverity_EVIDENCE_SEVERITY_HARD || ev.Slashable:

--- a/polystorechain/x/polystorechain/keeper/slashing_repair_test.go
+++ b/polystorechain/x/polystorechain/keeper/slashing_repair_test.go
@@ -517,6 +517,11 @@ func TestCheckMissedProofs_Mode2RepairBackoffWhenNoCandidate(t *testing.T) {
 	require.Equal(t, "repair_backoff_entered", attempt.LastReason)
 	require.Equal(t, providerA, attempt.Provider)
 	require.Empty(t, attempt.PendingProvider)
+	providerHealth, err := f.keeper.ProviderHealthStates.Get(sdkCtx, providerA)
+	require.NoError(t, err)
+	require.Equal(t, types.ProviderLifecycleStatus_PROVIDER_LIFECYCLE_STATUS_DELINQUENT, providerHealth.LifecycleStatus)
+	require.Equal(t, "provider_delinquent", providerHealth.Reason)
+	require.Positive(t, providerHealth.RepairEventCount)
 
 	sdkCtx = sdkCtx.WithBlockHeight(10)
 	setMode2EpochCredits(t, f, sdkCtx, dealID, 2, 1, 2)

--- a/scripts/e2e_deputy_ghost_repair_multi_sp.sh
+++ b/scripts/e2e_deputy_ghost_repair_multi_sp.sh
@@ -104,6 +104,32 @@ wait_for_height() {
   return 1
 }
 
+wait_for_epoch_window() {
+  local min_remaining="${1:-8}"
+  local attempts="${2:-180}"
+  local delay="${3:-1}"
+  for _ in $(seq 1 "$attempts"); do
+    local h mod remaining
+    h="$(rpc_height)"
+    if [ "$h" -le 0 ]; then
+      sleep "$delay"
+      continue
+    fi
+    mod="$((h % EPOCH_LEN))"
+    if [ "$mod" -eq 0 ]; then
+      remaining="$EPOCH_LEN"
+    else
+      remaining="$((EPOCH_LEN - mod))"
+    fi
+    if [ "$remaining" -ge "$min_remaining" ]; then
+      echo "    epoch window ready at height=$h remaining_blocks=$remaining"
+      return 0
+    fi
+    sleep "$delay"
+  done
+  return 1
+}
+
 json_get() {
   local key="$1"
   python3 -c '
@@ -126,6 +152,24 @@ elif isinstance(cur, (dict, list)):
 else:
   print(cur)
 ' "$key"
+}
+
+slot_json_by_index() {
+  local slot_index="$1"
+  python3 -c '
+import json, sys
+slot_index = str(sys.argv[1])
+data = json.load(sys.stdin)
+deal = data.get("deal") or {}
+slots = deal.get("mode2_slots") or []
+for s in slots:
+  if not s:
+    continue
+  if str(s.get("slot","")) == slot_index:
+    print(json.dumps(s))
+    sys.exit(0)
+print("")
+' "$slot_index"
 }
 
 extract_last_json() {
@@ -397,6 +441,7 @@ export PROVIDER_COUNT
 export START_WEB="${START_WEB:-0}"
 export POLYSTORE_EPOCH_LEN_BLOCKS="${POLYSTORE_EPOCH_LEN_BLOCKS:-20}"
 export POLYSTORE_EVICT_AFTER_MISSED_EPOCHS="${POLYSTORE_EVICT_AFTER_MISSED_EPOCHS:-1}"
+EPOCH_LEN="$POLYSTORE_EPOCH_LEN_BLOCKS"
 
 echo "==> Starting devnet alpha multi-SP stack (providers=$PROVIDER_COUNT)..."
 "$STACK_SCRIPT" start
@@ -520,18 +565,35 @@ if [ "${CHAIN_ROOT_HEX:-}" != "$MANIFEST_ROOT" ]; then
   exit 1
 fi
 
+echo "==> Aligning ghost scenario inside an epoch window..."
+MIN_GHOST_REPAIR_REMAINING_BLOCKS="${MIN_GHOST_REPAIR_REMAINING_BLOCKS:-8}"
+wait_for_epoch_window "$MIN_GHOST_REPAIR_REMAINING_BLOCKS" 180 1 || {
+  echo "ERROR: timed out waiting for an epoch window with >=$MIN_GHOST_REPAIR_REMAINING_BLOCKS blocks remaining" >&2
+  exit 1
+}
+
 echo "==> Planning retrieval session for first blob..."
 PLAN_RESP="$(timeout 10s curl -sS "$GATEWAY_BASE/gateway/plan-retrieval-session/$MANIFEST_ROOT?deal_id=$DEAL_ID&owner=$FAUCET_ADDR&file_path=$(urlencode "$FILENAME")&range_start=0&range_len=$RAW_BLOB_PAYLOAD_BYTES")"
 PLAN_PROVIDER="$(echo "$PLAN_RESP" | python3 -c 'import sys, json; print(json.load(sys.stdin).get("provider",""))' 2>/dev/null || true)"
+PLAN_PROVIDER_SOURCE="$(echo "$PLAN_RESP" | python3 -c 'import sys, json; print(json.load(sys.stdin).get("provider_source",""))' 2>/dev/null || true)"
+PLAN_MODE2_SLOT="$(echo "$PLAN_RESP" | python3 -c 'import sys, json; v=json.load(sys.stdin).get("mode2_slot",""); print("" if v is None else v)' 2>/dev/null || true)"
+PLAN_MODE2_SLOT_STATUS="$(echo "$PLAN_RESP" | python3 -c 'import sys, json; v=json.load(sys.stdin).get("mode2_slot_status",""); print("" if v is None else v)' 2>/dev/null || true)"
+PLAN_MODE2_ACTIVE_PROVIDER="$(echo "$PLAN_RESP" | python3 -c 'import sys, json; print(json.load(sys.stdin).get("mode2_active_provider",""))' 2>/dev/null || true)"
+PLAN_MODE2_PENDING_PROVIDER="$(echo "$PLAN_RESP" | python3 -c 'import sys, json; print(json.load(sys.stdin).get("mode2_pending_provider",""))' 2>/dev/null || true)"
 PLAN_START_MDU="$(echo "$PLAN_RESP" | python3 -c 'import sys, json; print(json.load(sys.stdin).get("start_mdu_index",""))' 2>/dev/null || true)"
 PLAN_START_BLOB="$(echo "$PLAN_RESP" | python3 -c 'import sys, json; print(json.load(sys.stdin).get("start_blob_index",""))' 2>/dev/null || true)"
 PLAN_BLOB_COUNT="$(echo "$PLAN_RESP" | python3 -c 'import sys, json; print(json.load(sys.stdin).get("blob_count",""))' 2>/dev/null || true)"
-if [ -z "$PLAN_PROVIDER" ] || [ -z "$PLAN_START_MDU" ] || [ -z "$PLAN_START_BLOB" ] || [ -z "$PLAN_BLOB_COUNT" ]; then
+if [ -z "$PLAN_PROVIDER" ] || [ -z "$PLAN_MODE2_SLOT" ] || [ -z "$PLAN_START_MDU" ] || [ -z "$PLAN_START_BLOB" ] || [ -z "$PLAN_BLOB_COUNT" ]; then
   echo "ERROR: plan response missing required fields" >&2
   echo "$PLAN_RESP" >&2
   exit 1
 fi
-echo "    planned slot provider=$PLAN_PROVIDER start_mdu=$PLAN_START_MDU start_blob=$PLAN_START_BLOB blob_count=$PLAN_BLOB_COUNT"
+if [ "$PLAN_MODE2_SLOT_STATUS" != "1" ]; then
+  echo "ERROR: planned slot is not ACTIVE before ghosting (status=$PLAN_MODE2_SLOT_STATUS)" >&2
+  echo "$PLAN_RESP" >&2
+  exit 1
+fi
+echo "    planned slot=$PLAN_MODE2_SLOT status=$PLAN_MODE2_SLOT_STATUS provider=$PLAN_PROVIDER source=$PLAN_PROVIDER_SOURCE active=$PLAN_MODE2_ACTIVE_PROVIDER pending=$PLAN_MODE2_PENDING_PROVIDER start_mdu=$PLAN_START_MDU start_blob=$PLAN_START_BLOB blob_count=$PLAN_BLOB_COUNT"
 
 echo "==> Resolving planned provider endpoint..."
 PROVIDER_JSON="$(timeout 10s curl -sS "$LCD_BASE/polystorechain/polystorechain/v1/providers/$PLAN_PROVIDER")"
@@ -610,34 +672,20 @@ fi
 
 submit_session_proof "$SESSION_HEX" "$DEPUTY_PROVIDER"
 
-echo "==> Waiting for epoch end to trigger deputy-miss repair..."
-EPOCH_LEN="$POLYSTORE_EPOCH_LEN_BLOCKS"
-CUR_H="$(rpc_height)"
-NEXT_EPOCH_END="$(( ( (CUR_H + EPOCH_LEN - 1) / EPOCH_LEN ) * EPOCH_LEN ))"
-if [ "$NEXT_EPOCH_END" -le "$CUR_H" ]; then
-  NEXT_EPOCH_END="$((CUR_H + EPOCH_LEN))"
-fi
-wait_for_height "$NEXT_EPOCH_END" 180 1 || { echo "ERROR: timed out waiting for epoch end" >&2; exit 1; }
-sleep 2
-
-DEAL_JSON="$(timeout 10s curl -sS "$LCD_BASE/polystorechain/polystorechain/v1/deals/$DEAL_ID")"
-REPAIR_SLOT_JSON="$(echo "$DEAL_JSON" | PLANNED_PROVIDER="$PLAN_PROVIDER" python3 -c '
-import json, os, sys
-planned = (os.environ.get("PLANNED_PROVIDER","") or "").strip()
-data = json.load(sys.stdin)
-deal = data.get("deal") or {}
-slots = deal.get("mode2_slots") or []
-for s in slots:
-  if not s:
-    continue
-  if (s.get("provider") or "").strip() != planned:
-    continue
-  print(json.dumps(s))
-  sys.exit(0)
-print("")
-')"
+echo "==> Waiting for deputy-miss repair to start..."
+REPAIR_SLOT_JSON=""
+for _ in $(seq 1 180); do
+  DEAL_JSON="$(timeout 10s curl -sS "$LCD_BASE/polystorechain/polystorechain/v1/deals/$DEAL_ID")"
+  REPAIR_SLOT_JSON="$(echo "$DEAL_JSON" | slot_json_by_index "$PLAN_MODE2_SLOT")"
+  SLOT_STATUS="$(echo "$REPAIR_SLOT_JSON" | python3 -c 'import sys, json; print((json.load(sys.stdin).get("status") or ""))' 2>/dev/null || true)"
+  PENDING_PROVIDER="$(echo "$REPAIR_SLOT_JSON" | python3 -c 'import sys, json; print((json.load(sys.stdin).get("pending_provider") or ""))' 2>/dev/null || true)"
+  if { [ "$SLOT_STATUS" = "SLOT_STATUS_REPAIRING" ] || [ "$SLOT_STATUS" = "2" ]; } && [ -n "$PENDING_PROVIDER" ]; then
+    break
+  fi
+  sleep 1
+done
 if [ -z "$REPAIR_SLOT_JSON" ]; then
-  echo "ERROR: failed to find slot for planned provider in deal state" >&2
+  echo "ERROR: failed to find planned slot $PLAN_MODE2_SLOT in deal state" >&2
   echo "$DEAL_JSON" >&2
   exit 1
 fi

--- a/scripts/run_devnet_alpha_multi_sp.sh
+++ b/scripts/run_devnet_alpha_multi_sp.sh
@@ -4,7 +4,7 @@
 # - polystorechaind (CometBFT + LCD + JSON-RPC)
 # - polystore_faucet
 # - N provider daemons (polystore_gateway, provider mode) on ports 8091+
-# - 1 gateway router (polystore_gateway, router mode) on :8080
+# - 1 gateway router (polystore_gateway, router mode) on :8080 by default
 # - polystore-website (optional, default on)
 #
 # Usage:
@@ -37,6 +37,7 @@ EVM_WS_PORT="${EVM_WS_PORT:-8546}"
 LCD_PORT="${LCD_PORT:-1317}"
 FAUCET_PORT="${FAUCET_PORT:-8081}"
 WEB_PORT="${WEB_PORT:-5173}"
+GATEWAY_PORT="${GATEWAY_PORT:-8080}"
 GAS_PRICE="${POLYSTORE_GAS_PRICES:-0.001aatom}"
 DENOM="${POLYSTORE_DENOM:-stake}"
 POLYSTORE_BIND_ALL="${POLYSTORE_BIND_ALL:-0}" # set to 1 to bind LCD/EVM JSON-RPC to 0.0.0.0
@@ -805,6 +806,7 @@ start_router() {
       POLYSTORE_HOME="$CHAIN_HOME" \
       POLYSTORE_NODE="$RPC_ADDR" \
       POLYSTORE_LCD_BASE="http://127.0.0.1:${LCD_PORT}" \
+      POLYSTORE_LISTEN_ADDR="${POLYSTORE_LISTEN_ADDR:-:$GATEWAY_PORT}" \
       POLYSTORE_UPLOAD_DIR="$LOG_DIR/router_tmp" \
       POLYSTORECHAIND_BIN="$POLYSTORECHAIND_BIN" \
       POLYSTORE_GATEWAY_SP_AUTH="$POLYSTORE_GATEWAY_SP_AUTH" \
@@ -813,6 +815,22 @@ start_router() {
     echo $! >"$PID_DIR/router.pid"
   )
   echo "router pid $(cat "$PID_DIR/router.pid"), logs: $LOG_DIR/router.log"
+}
+
+ensure_service_running() {
+  local svc="$1"
+  local pid_file="$PID_DIR/$svc.pid"
+  if [ ! -f "$pid_file" ]; then
+    echo "ERROR: $svc pid file missing: $pid_file" >&2
+    return 1
+  fi
+  local pid
+  pid="$(cat "$pid_file")"
+  if ! kill -0 "$pid" 2>/dev/null; then
+    echo "ERROR: $svc process exited; check $LOG_DIR/$svc.log" >&2
+    tail -80 "$LOG_DIR/$svc.log" >&2 || true
+    return 1
+  fi
 }
 
 start_web() {
@@ -825,7 +843,7 @@ start_web() {
     VITE_LCD_BASE="${VITE_LCD_BASE:-http://localhost:${LCD_PORT}}" \
     VITE_EVM_RPC="${VITE_EVM_RPC:-http://localhost:$EVM_RPC_PORT}" \
     VITE_SP_BASE="${VITE_SP_BASE:-http://localhost:${PROVIDER_PORT_BASE}}" \
-    VITE_GATEWAY_BASE="${VITE_GATEWAY_BASE:-http://localhost:8080}" \
+    VITE_GATEWAY_BASE="${VITE_GATEWAY_BASE:-http://localhost:${GATEWAY_PORT}}" \
     VITE_COSMOS_CHAIN_ID="$CHAIN_ID" \
     VITE_CHAIN_ID="$EVM_CHAIN_ID" \
     VITE_POLYSTORE_PRECOMPILE="${VITE_POLYSTORE_PRECOMPILE:-0x0000000000000000000000000000000000000900}" \
@@ -855,7 +873,7 @@ stop_all() {
   done
 
   # Best-effort kill by port in case go run spawned children.
-  local ports=("${RPC_ADDR##*:}" "${P2P_ADDR##*:}" "$LCD_PORT" "$EVM_RPC_PORT" "$EVM_WS_PORT" 8080 "$FAUCET_PORT" "$WEB_PORT" "$P2P_PORT_BASE")
+  local ports=("${RPC_ADDR##*:}" "${P2P_ADDR##*:}" "$LCD_PORT" "$EVM_RPC_PORT" "$EVM_WS_PORT" "$GATEWAY_PORT" "$FAUCET_PORT" "$WEB_PORT" "$P2P_PORT_BASE")
   if [ "$PROVIDER_COUNT" -gt 0 ]; then
     for i in $(seq 1 "$PROVIDER_COUNT"); do
       ports+=("$((PROVIDER_PORT_BASE + i - 1))")
@@ -913,7 +931,9 @@ start_all() {
   fi
 
   start_router
-  wait_for_http "router" "http://localhost:8080/health" "200" 60 1
+  ensure_service_running "router"
+  wait_for_http "router" "http://localhost:${GATEWAY_PORT}/health" "200" 60 1
+  ensure_service_running "router"
 
   if [ "$START_WEB" = "1" ]; then
     start_web
@@ -926,7 +946,7 @@ RPC:         http://localhost:${RPC_ADDR##*:}
 REST/LCD:    http://localhost:${LCD_PORT}
 EVM RPC:     http://localhost:$EVM_RPC_PORT  (Cosmos Chain ID $CHAIN_ID / EVM Chain ID $EVM_CHAIN_ID)
 Faucet:      http://localhost:${FAUCET_PORT}/faucet
-Gateway:     http://localhost:8080/gateway/upload
+Gateway:     http://localhost:${GATEWAY_PORT}/gateway/upload
 Web UI:      http://localhost:${WEB_PORT}/#/dashboard
 Providers:   $PROVIDER_COUNT (ports starting at $PROVIDER_PORT_BASE)
 Home:        $CHAIN_HOME


### PR DESCRIPTION
## Summary
- Reduce system-liveness KZG challenge points into BLS12-381 Fr before proof generation so deterministic challenges are accepted by the KZG FFI.
- Add Mode 2 gateway regressions that build real artifacts, read the stored `mdu_<index>_slot_<slot>.bin` shard bytes, generate a chained proof, and verify it against the manifest root.
- Gate pending repair providers so they do not attempt system-proof responsibility until the challenged shard row exists locally; route missing-shard skips through the backoff infrastructure to throttle log noise and redundant `os.Stat` calls, and clear the backoff immediately when the shard arrives mid-window.
- Preserve provider-health root cause when repair-backoff evidence is recorded, while still incrementing repair accounting.
- Harden OPFS generation handling for CI/browser stability: activation survives stale cleanup failure, transient `NotReadableError` reads retry, and stale pointer cleanup is best-effort.
- Stabilize the ghost-repair E2E script: align scenario start to an epoch window, poll for `SLOT_STATUS_REPAIRING`, and look up the repair slot by index rather than provider address.
- Update the policing/failure simulation roadmap with the landed status and the next devnet reset/smoke gate.

## Root Cause
System liveness derived KZG opening points directly from raw SHA-256 output. Random SHA-256 digests are often not canonical BLS12-381 Fr elements, which made the provider-daemon fail proof generation with `polystore_compute_blob_proof failed with code: -3` even when Mode 2 shard bytes were present.

## Validation
Local:
- `cd polystore_gateway && LD_LIBRARY_PATH=/home/mikers/dev/polynomialstore/polystore/polystore_core/target/release go test . -count=1`
- `cd polystorechain && LD_LIBRARY_PATH=/home/mikers/dev/polynomialstore/polystore/polystore_core/target/release go test ./x/polystorechain/keeper -count=1`
- `bash -n scripts/run_devnet_alpha_multi_sp.sh`
- `bash -n scripts/e2e_deputy_ghost_repair_multi_sp.sh`
- local isolated `scripts/e2e_deputy_ghost_repair_multi_sp.sh` smoke passed
- `cd polystore-website && npx tsx --test src/lib/storage/OpfsAdapter.test.ts`
- `cd polystore-website && npm run test:unit`
- `cd polystore-website && npm run build:app`
- local isolated `scripts/e2e_browser_smoke_no_gateway.sh` smoke passed
- `git diff --check`

GitHub latest-head CI on `07962aefce4760f2879ee90d04a4009a7cec3139`:
- `PolyStore CI`: all checks passed, including `Go Test (polystore_gateway)`, `Go Test (polystorechain)`, `Website Build & Lint`, `Policy Simulator Suite`, `Browser Sparse Upload Proof`, `Native/WASM Parity`, all e2e smoke jobs, `Playwright (Gateway Absent)`, `E2E Mode2 Stripe (Fast 3 SPs)`, `E2E Gateway Retrieval (Multi-SP)`, and `Website Node Integration`.
- `E2E Playwright Tests`: passed.
- `Repro Bug E2E`: passed.
- `Workers Builds: polystore`: passed.

## Review Status
- Copilot inline review thread `PRRT_kwDOR8nFT86FOHa2` is resolved/outdated.
- Latest Copilot reviews found no blocking issues through commit `07962aef`.
- Codex GitHub review is unavailable in this repo context; the connector replies that a Codex account must be connected.
- No unresolved review threads remain.

## Notes
- This PR does not reset the live devnet. The reset/smoke sequence is staged in the roadmap and should run after merge/deploy.
- The pre-existing untracked `polystore_faucet/polystore_faucet` binary is intentionally not included.
