### PR TITLE
Add devnet user ops helpers

### DIFF
--- a/ops/grant_devnet_user_ops.sh
+++ b/ops/grant_devnet_user_ops.sh
@@ -48,9 +48,9 @@ trap cleanup EXIT
 
 cat >"$tmp_sudoers" <<EOF
 Defaults:$DEVNET_USER !requiretty
-$DEVNET_USER ALL=(root) NOPASSWD: $SYSTEMCTL_BIN start polystorechaind.service, $SYSTEMCTL_BIN stop polystorechaind.service, $SYSTEMCTL_BIN restart polystorechaind.service, $SYSTEMCTL_BIN is-active polystorechaind.service
-$DEVNET_USER ALL=(root) NOPASSWD: $SYSTEMCTL_BIN start polystore-faucet.service, $SYSTEMCTL_BIN stop polystore-faucet.service, $SYSTEMCTL_BIN restart polystore-faucet.service, $SYSTEMCTL_BIN is-active polystore-faucet.service
-$DEVNET_USER ALL=(root) NOPASSWD: $SYSTEMCTL_BIN start polystore-gateway-router.service, $SYSTEMCTL_BIN stop polystore-gateway-router.service, $SYSTEMCTL_BIN restart polystore-gateway-router.service, $SYSTEMCTL_BIN is-active polystore-gateway-router.service
+$DEVNET_USER ALL=(root) NOPASSWD: $SYSTEMCTL_BIN start polystorechaind.service, $SYSTEMCTL_BIN stop polystorechaind.service, $SYSTEMCTL_BIN restart polystorechaind.service, $SYSTEMCTL_BIN is-active polystorechaind.service, $SYSTEMCTL_BIN status polystorechaind.service
+$DEVNET_USER ALL=(root) NOPASSWD: $SYSTEMCTL_BIN start polystore-faucet.service, $SYSTEMCTL_BIN stop polystore-faucet.service, $SYSTEMCTL_BIN restart polystore-faucet.service, $SYSTEMCTL_BIN is-active polystore-faucet.service, $SYSTEMCTL_BIN status polystore-faucet.service
+$DEVNET_USER ALL=(root) NOPASSWD: $SYSTEMCTL_BIN start polystore-gateway-router.service, $SYSTEMCTL_BIN stop polystore-gateway-router.service, $SYSTEMCTL_BIN restart polystore-gateway-router.service, $SYSTEMCTL_BIN is-active polystore-gateway-router.service, $SYSTEMCTL_BIN status polystore-gateway-router.service
 EOF
 
 echo "==> Installing narrow sudoers allowlist at $SUDOERS_FILE"
@@ -60,10 +60,13 @@ visudo -cf "$SUDOERS_FILE"
 echo "==> Verifying passwordless service control for $DEVNET_USER"
 runuser -u "$DEVNET_USER" -- sudo -n -l "$SYSTEMCTL_BIN" start polystorechaind.service >/dev/null
 runuser -u "$DEVNET_USER" -- sudo -n -l "$SYSTEMCTL_BIN" stop polystorechaind.service >/dev/null
+runuser -u "$DEVNET_USER" -- sudo -n -l "$SYSTEMCTL_BIN" status polystorechaind.service >/dev/null
 runuser -u "$DEVNET_USER" -- sudo -n -l "$SYSTEMCTL_BIN" start polystore-faucet.service >/dev/null
 runuser -u "$DEVNET_USER" -- sudo -n -l "$SYSTEMCTL_BIN" stop polystore-faucet.service >/dev/null
+runuser -u "$DEVNET_USER" -- sudo -n -l "$SYSTEMCTL_BIN" status polystore-faucet.service >/dev/null
 runuser -u "$DEVNET_USER" -- sudo -n -l "$SYSTEMCTL_BIN" start polystore-gateway-router.service >/dev/null
 runuser -u "$DEVNET_USER" -- sudo -n -l "$SYSTEMCTL_BIN" stop polystore-gateway-router.service >/dev/null
+runuser -u "$DEVNET_USER" -- sudo -n -l "$SYSTEMCTL_BIN" status polystore-gateway-router.service >/dev/null
 
 echo "DONE: $DEVNET_USER can update $TARGET_ROOT and $CHAIN_STATE_ROOT and restart PolyStore root services with sudo -n systemctl."
-echo "NOTE: systemctl status is intentionally not granted; update scripts read status without sudo."
+echo "NOTE: sudoers is intentionally limited to start/stop/restart/is-active/status for PolyStore root services."

--- a/ops/grant_devnet_user_ops.sh
+++ b/ops/grant_devnet_user_ops.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEVNET_USER="${POLYSTORE_DEVNET_USER:-${SUDO_USER:-mikers}}"
+TARGET_ROOT="${TARGET_ROOT:-/opt/polystore}"
+CHAIN_STATE_ROOT="${CHAIN_STATE_ROOT:-/var/lib/nilstore}"
+SUDOERS_FILE="${SUDOERS_FILE:-/etc/sudoers.d/polystore-devnet-systemctl}"
+SYSTEMCTL_BIN="${SYSTEMCTL_BIN:-$(command -v systemctl)}"
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "ERROR: run this script with sudo/root." >&2
+  echo "       Example: sudo $0" >&2
+  exit 1
+fi
+
+if ! id "$DEVNET_USER" >/dev/null 2>&1; then
+  echo "ERROR: devnet user does not exist: $DEVNET_USER" >&2
+  exit 1
+fi
+
+if [ -z "$SYSTEMCTL_BIN" ] || [ ! -x "$SYSTEMCTL_BIN" ]; then
+  echo "ERROR: systemctl not found or not executable." >&2
+  exit 1
+fi
+
+if ! command -v visudo >/dev/null 2>&1; then
+  echo "ERROR: visudo is required to validate sudoers changes." >&2
+  exit 1
+fi
+
+echo "==> Granting $DEVNET_USER ownership of devnet install/state paths"
+install -d -o "$DEVNET_USER" -g "$DEVNET_USER" "$TARGET_ROOT" "$TARGET_ROOT/backups" "$CHAIN_STATE_ROOT"
+chown -R "$DEVNET_USER:$DEVNET_USER" "$TARGET_ROOT" "$CHAIN_STATE_ROOT"
+chmod -R u+rwX,go+rX "$TARGET_ROOT"
+chmod -R u+rwX,go-rwx "$CHAIN_STATE_ROOT"
+
+tmp_sudoers="$(mktemp)"
+cleanup() {
+  rm -f "$tmp_sudoers"
+}
+trap cleanup EXIT
+
+cat >"$tmp_sudoers" <<EOF
+Defaults:$DEVNET_USER !requiretty
+$DEVNET_USER ALL=(root) NOPASSWD: $SYSTEMCTL_BIN start polystorechaind.service, $SYSTEMCTL_BIN stop polystorechaind.service, $SYSTEMCTL_BIN restart polystorechaind.service, $SYSTEMCTL_BIN is-active polystorechaind.service
+$DEVNET_USER ALL=(root) NOPASSWD: $SYSTEMCTL_BIN start polystore-faucet.service, $SYSTEMCTL_BIN stop polystore-faucet.service, $SYSTEMCTL_BIN restart polystore-faucet.service, $SYSTEMCTL_BIN is-active polystore-faucet.service
+$DEVNET_USER ALL=(root) NOPASSWD: $SYSTEMCTL_BIN start polystore-gateway-router.service, $SYSTEMCTL_BIN stop polystore-gateway-router.service, $SYSTEMCTL_BIN restart polystore-gateway-router.service, $SYSTEMCTL_BIN is-active polystore-gateway-router.service
+EOF
+
+echo "==> Installing narrow sudoers allowlist at $SUDOERS_FILE"
+install -m 0440 "$tmp_sudoers" "$SUDOERS_FILE"
+visudo -cf "$SUDOERS_FILE"
+
+echo "==> Verifying passwordless service control for $DEVNET_USER"
+runuser -u "$DEVNET_USER" -- sudo -n -l "$SYSTEMCTL_BIN" start polystorechaind.service >/dev/null
+runuser -u "$DEVNET_USER" -- sudo -n -l "$SYSTEMCTL_BIN" stop polystorechaind.service >/dev/null
+runuser -u "$DEVNET_USER" -- sudo -n -l "$SYSTEMCTL_BIN" start polystore-faucet.service >/dev/null
+runuser -u "$DEVNET_USER" -- sudo -n -l "$SYSTEMCTL_BIN" stop polystore-faucet.service >/dev/null
+runuser -u "$DEVNET_USER" -- sudo -n -l "$SYSTEMCTL_BIN" start polystore-gateway-router.service >/dev/null
+runuser -u "$DEVNET_USER" -- sudo -n -l "$SYSTEMCTL_BIN" stop polystore-gateway-router.service >/dev/null
+
+echo "DONE: $DEVNET_USER can update $TARGET_ROOT/$CHAIN_STATE_ROOT and restart PolyStore root services with sudo -n systemctl."

--- a/ops/grant_devnet_user_ops.sh
+++ b/ops/grant_devnet_user_ops.sh
@@ -1,15 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DEVNET_USER="${POLYSTORE_DEVNET_USER:-${SUDO_USER:-mikers}}"
+DEVNET_USER="${POLYSTORE_DEVNET_USER:-${SUDO_USER:-}}"
 TARGET_ROOT="${TARGET_ROOT:-/opt/polystore}"
-CHAIN_STATE_ROOT="${CHAIN_STATE_ROOT:-/var/lib/nilstore}"
+CHAIN_STATE_ROOT="${CHAIN_STATE_ROOT:-/var/lib/polystore}"
 SUDOERS_FILE="${SUDOERS_FILE:-/etc/sudoers.d/polystore-devnet-systemctl}"
 SYSTEMCTL_BIN="${SYSTEMCTL_BIN:-$(command -v systemctl)}"
 
 if [ "$(id -u)" -ne 0 ]; then
   echo "ERROR: run this script with sudo/root." >&2
   echo "       Example: sudo $0" >&2
+  exit 1
+fi
+
+if [ -z "$DEVNET_USER" ]; then
+  echo "ERROR: devnet user is required." >&2
+  echo "       Run via sudo as the target user or set POLYSTORE_DEVNET_USER=<user>." >&2
   exit 1
 fi
 
@@ -59,4 +65,5 @@ runuser -u "$DEVNET_USER" -- sudo -n -l "$SYSTEMCTL_BIN" stop polystore-faucet.s
 runuser -u "$DEVNET_USER" -- sudo -n -l "$SYSTEMCTL_BIN" start polystore-gateway-router.service >/dev/null
 runuser -u "$DEVNET_USER" -- sudo -n -l "$SYSTEMCTL_BIN" stop polystore-gateway-router.service >/dev/null
 
-echo "DONE: $DEVNET_USER can update $TARGET_ROOT/$CHAIN_STATE_ROOT and restart PolyStore root services with sudo -n systemctl."
+echo "DONE: $DEVNET_USER can update $TARGET_ROOT and $CHAIN_STATE_ROOT and restart PolyStore root services with sudo -n systemctl."
+echo "NOTE: systemctl status is intentionally not granted; update scripts read status without sudo."

--- a/ops/systemd/README.md
+++ b/ops/systemd/README.md
@@ -111,8 +111,8 @@ Minimum required edits in `polystore-gateway-provider.env`:
   `PROVIDER_UNITS=...` and `PROVIDER_HEALTH_URLS=...` for that layout, or leave
   provider units absent to update only the hub services.
 - The sudoers allowlist installed by `ops/grant_devnet_user_ops.sh` covers only
-  `start`, `stop`, `restart`, and `is-active` for the three root services.
-  `systemctl status` is intentionally read without sudo by the update helper.
+  `start`, `stop`, `restart`, `is-active`, and `status` for the three root
+  services.
 - Unit `ExecStart` commands intentionally use a shell wrapper so EnvironmentFile
   variables (for example `POLYSTORECHAIND_BIN`) are expanded correctly by systemd.
 - The env templates include `LD_LIBRARY_PATH=/opt/polystore/polystore_core/target/release`

--- a/ops/systemd/README.md
+++ b/ops/systemd/README.md
@@ -95,6 +95,24 @@ Minimum required edits in `polystore-gateway-provider.env`:
 ## Notes
 
 - These templates assume you checked the repo out at `/opt/polystore`. Adjust as needed.
+- `ops/grant_devnet_user_ops.sh` grants ownership of `/opt/polystore` and
+  `/var/lib/polystore` by default. If a legacy/local devnet uses another chain
+  state root, run it with `CHAIN_STATE_ROOT=/path/to/state`.
+- `ops/update_devnet_stack_from_main.sh` derives `SOURCE_ROOT` from its own
+  checkout by default. Override `SOURCE_ROOT` only when intentionally deploying
+  artifacts from a different repo path.
+- The update helper reads the router port from
+  `/etc/polystore/polystore-gateway-router.env` when present, otherwise it uses
+  `http://127.0.0.1:8080`. Override with `ROUTER_GATEWAY_URL=...` for custom
+  local deployments.
+- The polynomialstore.com hub currently uses user-level provider units named
+  `polystore-provider1.service` through `polystore-provider3.service`. Fresh
+  hosts may instead use the checked-in system-level provider template; set
+  `PROVIDER_UNITS=...` and `PROVIDER_HEALTH_URLS=...` for that layout, or leave
+  provider units absent to update only the hub services.
+- The sudoers allowlist installed by `ops/grant_devnet_user_ops.sh` covers only
+  `start`, `stop`, `restart`, and `is-active` for the three root services.
+  `systemctl status` is intentionally read without sudo by the update helper.
 - Unit `ExecStart` commands intentionally use a shell wrapper so EnvironmentFile
   variables (for example `POLYSTORECHAIND_BIN`) are expanded correctly by systemd.
 - The env templates include `LD_LIBRARY_PATH=/opt/polystore/polystore_core/target/release`

--- a/ops/update_devnet_stack_from_main.sh
+++ b/ops/update_devnet_stack_from_main.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE_ROOT="${SOURCE_ROOT:-/home/mikers/dev/polynomialstore/polystore}"
+TARGET_ROOT="${TARGET_ROOT:-/opt/polystore}"
+RUN_USER="${POLYSTORE_RUN_USER:-${SUDO_USER:-$(id -un)}}"
+RUN_UID="$(id -u "$RUN_USER")"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+BACKUP_DIR="$TARGET_ROOT/backups/update-$STAMP"
+IS_ROOT=0
+if [ "$(id -u)" -eq 0 ]; then
+  IS_ROOT=1
+fi
+
+if [ "$IS_ROOT" -ne 1 ] && [ "$(id -un)" != "$RUN_USER" ]; then
+  echo "ERROR: non-root update must run as POLYSTORE_RUN_USER=$RUN_USER." >&2
+  exit 1
+fi
+
+if [ ! -w "$TARGET_ROOT" ]; then
+  echo "ERROR: $TARGET_ROOT is not writable by $(id -un)." >&2
+  echo "       Run: sudo $SOURCE_ROOT/ops/grant_devnet_user_ops.sh" >&2
+  exit 1
+fi
+
+install_with_backup() {
+  local src="$1"
+  local dst="$2"
+  local mode="$3"
+
+  if [ ! -f "$src" ]; then
+    echo "ERROR: source artifact missing: $src" >&2
+    exit 1
+  fi
+
+  mkdir -p "$BACKUP_DIR/$(dirname "${dst#"$TARGET_ROOT"/}")" "$(dirname "$dst")"
+  if [ -e "$dst" ]; then
+    cp -p "$dst" "$BACKUP_DIR/${dst#"$TARGET_ROOT"/}"
+  fi
+  install -m "$mode" "$src" "$dst"
+  sha256sum "$src" "$dst"
+}
+
+user_systemctl() {
+  if [ "$IS_ROOT" -eq 1 ]; then
+    runuser -u "$RUN_USER" -- env XDG_RUNTIME_DIR="/run/user/$RUN_UID" systemctl --user "$@"
+    return
+  fi
+
+  env XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$RUN_UID}" systemctl --user "$@"
+}
+
+root_systemctl() {
+  if [ "$IS_ROOT" -eq 1 ]; then
+    systemctl "$@"
+    return
+  fi
+
+  sudo -n systemctl "$@"
+}
+
+root_service_action() {
+  local action="$1"
+  shift
+
+  local service
+  for service in "$@"; do
+    root_systemctl "$action" "$service"
+  done
+}
+
+wait_http() {
+  local name="$1"
+  local url="$2"
+  local attempts="${3:-60}"
+
+  echo "==> Waiting for $name: $url"
+  for _ in $(seq 1 "$attempts"); do
+    if curl -fsS --max-time 5 "$url" >/dev/null; then
+      echo "    OK: $name"
+      return 0
+    fi
+    sleep 2
+  done
+
+  echo "ERROR: $name did not become healthy at $url" >&2
+  return 1
+}
+
+echo "==> Updating PolyStore devnet stack from $SOURCE_ROOT"
+echo "    backup dir: $BACKUP_DIR"
+
+echo "==> Stopping provider user services"
+user_systemctl stop polystore-provider1.service polystore-provider2.service polystore-provider3.service || true
+
+echo "==> Stopping hub system services"
+root_service_action stop polystore-gateway-router.service polystore-faucet.service polystorechaind.service
+
+echo "==> Installing binaries and runtime library"
+install_with_backup "$SOURCE_ROOT/polystore_core/target/release/libpolystore_core.so" "$TARGET_ROOT/polystore_core/target/release/libpolystore_core.so" 755
+install_with_backup "$SOURCE_ROOT/polystorechain/polystorechaind" "$TARGET_ROOT/polystorechain/polystorechaind" 755
+install_with_backup "$SOURCE_ROOT/polystore_gateway/polystore_gateway" "$TARGET_ROOT/polystore_gateway/polystore_gateway" 755
+install_with_backup "$SOURCE_ROOT/polystore_faucet/polystore_faucet" "$TARGET_ROOT/polystore_faucet/polystore_faucet" 755
+install_with_backup "$SOURCE_ROOT/polystore_cli/target/release/polystore_cli" "$TARGET_ROOT/polystore_cli/target/release/polystore_cli" 755
+install_with_backup "$SOURCE_ROOT/polystorechain/trusted_setup.txt" "$TARGET_ROOT/polystorechain/trusted_setup.txt" 644
+
+echo "==> Starting chain"
+root_service_action start polystorechaind.service
+wait_http "LCD node_info" "http://127.0.0.1:1317/cosmos/base/tendermint/v1beta1/node_info" 90
+
+echo "==> Starting faucet and router"
+root_service_action start polystore-faucet.service polystore-gateway-router.service
+wait_http "faucet" "http://127.0.0.1:8081/health" 45
+wait_http "router gateway" "http://127.0.0.1:18080/health" 45
+
+echo "==> Starting provider user services"
+user_systemctl start polystore-provider1.service polystore-provider2.service polystore-provider3.service
+wait_http "provider1" "http://127.0.0.1:8091/health" 45
+wait_http "provider2" "http://127.0.0.1:8092/health" 45
+wait_http "provider3" "http://127.0.0.1:8093/health" 45
+
+echo "==> Running hub healthcheck"
+cd "$SOURCE_ROOT"
+scripts/devnet_healthcheck.sh hub --gateway http://127.0.0.1:18080 --faucet http://127.0.0.1:8081
+
+echo "==> Service status"
+systemctl --no-pager --full status polystorechaind.service polystore-faucet.service polystore-gateway-router.service | sed -n '1,120p'
+user_systemctl --no-pager --full status polystore-provider1.service polystore-provider2.service polystore-provider3.service | sed -n '1,120p'
+
+echo "DONE: PolyStore devnet stack updated. Backups are in $BACKUP_DIR"

--- a/ops/update_devnet_stack_from_main.sh
+++ b/ops/update_devnet_stack_from_main.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SOURCE_ROOT="${SOURCE_ROOT:-/home/mikers/dev/polynomialstore/polystore}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_ROOT="${SOURCE_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 TARGET_ROOT="${TARGET_ROOT:-/opt/polystore}"
 RUN_USER="${POLYSTORE_RUN_USER:-${SUDO_USER:-$(id -un)}}"
 RUN_UID="$(id -u "$RUN_USER")"
 STAMP="$(date +%Y%m%d-%H%M%S)"
 BACKUP_DIR="$TARGET_ROOT/backups/update-$STAMP"
+ROUTER_ENV_FILE="${ROUTER_ENV_FILE:-/etc/polystore/polystore-gateway-router.env}"
+ROUTER_PORT="${ROUTER_PORT:-8080}"
+FAUCET_URL="${FAUCET_URL:-http://127.0.0.1:8081}"
+PROVIDER_UNITS="${PROVIDER_UNITS:-polystore-provider1.service polystore-provider2.service polystore-provider3.service}"
+PROVIDER_HEALTH_URLS="${PROVIDER_HEALTH_URLS:-http://127.0.0.1:8091/health http://127.0.0.1:8092/health http://127.0.0.1:8093/health}"
 IS_ROOT=0
 if [ "$(id -u)" -eq 0 ]; then
   IS_ROOT=1
@@ -69,6 +75,63 @@ root_service_action() {
   done
 }
 
+env_listen_addr() {
+  local env_file="$1"
+
+  if [ ! -r "$env_file" ]; then
+    return 1
+  fi
+
+  sed -n 's/^[[:space:]]*POLYSTORE_LISTEN_ADDR[[:space:]]*=[[:space:]]*//p' "$env_file" \
+    | tail -n 1 \
+    | sed -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'$//"
+}
+
+http_url_from_listen_addr() {
+  local listen_addr="$1"
+
+  if [[ "$listen_addr" == http://* || "$listen_addr" == https://* ]]; then
+    printf '%s\n' "$listen_addr"
+    return
+  fi
+
+  if [[ "$listen_addr" == :* ]]; then
+    printf 'http://127.0.0.1%s\n' "$listen_addr"
+    return
+  fi
+
+  printf 'http://%s\n' "$listen_addr"
+}
+
+resolve_router_gateway_url() {
+  local listen_addr
+
+  if [ -n "${ROUTER_GATEWAY_URL:-}" ]; then
+    printf '%s\n' "$ROUTER_GATEWAY_URL"
+    return
+  fi
+
+  listen_addr="${POLYSTORE_LISTEN_ADDR:-}"
+  if [ -z "$listen_addr" ]; then
+    listen_addr="$(env_listen_addr "$ROUTER_ENV_FILE" || true)"
+  fi
+  if [ -z "$listen_addr" ]; then
+    listen_addr="127.0.0.1:$ROUTER_PORT"
+  fi
+
+  http_url_from_listen_addr "$listen_addr"
+}
+
+user_unit_exists() {
+  local unit="$1"
+
+  if user_systemctl list-unit-files "$unit" --no-legend 2>/dev/null | awk 'NF { found = 1 } END { exit found ? 0 : 1 }'; then
+    return 0
+  fi
+
+  user_systemctl status "$unit" >/dev/null 2>&1
+}
+
 wait_http() {
   local name="$1"
   local url="$2"
@@ -90,8 +153,24 @@ wait_http() {
 echo "==> Updating PolyStore devnet stack from $SOURCE_ROOT"
 echo "    backup dir: $BACKUP_DIR"
 
+router_gateway_url="$(resolve_router_gateway_url)"
+read -r -a provider_units <<<"$PROVIDER_UNITS"
+read -r -a provider_health_urls <<<"$PROVIDER_HEALTH_URLS"
+active_provider_units=()
+for unit in "${provider_units[@]}"; do
+  if user_unit_exists "$unit"; then
+    active_provider_units+=("$unit")
+  else
+    echo "WARN: provider user service not installed, skipping: $unit" >&2
+  fi
+done
+
 echo "==> Stopping provider user services"
-user_systemctl stop polystore-provider1.service polystore-provider2.service polystore-provider3.service || true
+if [ "${#active_provider_units[@]}" -gt 0 ]; then
+  user_systemctl stop "${active_provider_units[@]}" || true
+else
+  echo "    No provider user services configured on this host"
+fi
 
 echo "==> Stopping hub system services"
 root_service_action stop polystore-gateway-router.service polystore-faucet.service polystorechaind.service
@@ -110,21 +189,27 @@ wait_http "LCD node_info" "http://127.0.0.1:1317/cosmos/base/tendermint/v1beta1/
 
 echo "==> Starting faucet and router"
 root_service_action start polystore-faucet.service polystore-gateway-router.service
-wait_http "faucet" "http://127.0.0.1:8081/health" 45
-wait_http "router gateway" "http://127.0.0.1:18080/health" 45
+wait_http "faucet" "$FAUCET_URL/health" 45
+wait_http "router gateway" "$router_gateway_url/health" 45
 
 echo "==> Starting provider user services"
-user_systemctl start polystore-provider1.service polystore-provider2.service polystore-provider3.service
-wait_http "provider1" "http://127.0.0.1:8091/health" 45
-wait_http "provider2" "http://127.0.0.1:8092/health" 45
-wait_http "provider3" "http://127.0.0.1:8093/health" 45
+if [ "${#active_provider_units[@]}" -gt 0 ]; then
+  user_systemctl start "${active_provider_units[@]}"
+  for i in "${!provider_health_urls[@]}"; do
+    wait_http "provider$((i + 1))" "${provider_health_urls[$i]}" 45
+  done
+else
+  echo "    Skipping provider start/health waits; no provider user services are installed"
+fi
 
 echo "==> Running hub healthcheck"
 cd "$SOURCE_ROOT"
-scripts/devnet_healthcheck.sh hub --gateway http://127.0.0.1:18080 --faucet http://127.0.0.1:8081
+scripts/devnet_healthcheck.sh hub --gateway "$router_gateway_url" --faucet "$FAUCET_URL"
 
 echo "==> Service status"
 systemctl --no-pager --full status polystorechaind.service polystore-faucet.service polystore-gateway-router.service | sed -n '1,120p'
-user_systemctl --no-pager --full status polystore-provider1.service polystore-provider2.service polystore-provider3.service | sed -n '1,120p'
+if [ "${#active_provider_units[@]}" -gt 0 ]; then
+  user_systemctl --no-pager --full status "${active_provider_units[@]}" | sed -n '1,120p'
+fi
 
 echo "DONE: PolyStore devnet stack updated. Backups are in $BACKUP_DIR"

--- a/polystore-website/src/lib/providerScriptFlow.test.ts
+++ b/polystore-website/src/lib/providerScriptFlow.test.ts
@@ -67,8 +67,8 @@ case "$cmd" in
     esac
     ;;
   tx)
-    if [ "$#" -ge 2 ] && [ "$1" = "polystorechain" ] && [ "$2" = "request-provider-link" ]; then
-      printf 'tx polystorechain request-provider-link %s\\n' "$3" >>"\${POLYSTORE_TEST_TX_LOG:?}"
+    if [ "$#" -ge 2 ] && [ "$1" = "nilchain" ] && [ "$2" = "request-provider-link" ]; then
+      printf 'tx nilchain request-provider-link %s\\n' "$3" >>"\${POLYSTORE_TEST_TX_LOG:?}"
       exit 0
     fi
     echo "polystorechaind stub: unsupported tx invocation: $*" >&2
@@ -221,7 +221,7 @@ test('run_devnet_provider link auto-funds from faucet then submits provider-link
   assert.match(result.combinedOutput, /Faucet funding request accepted/i)
   assert.match(result.combinedOutput, /Provider account funded/i)
   assert.match(result.combinedOutput, /Requesting provider link on-chain/i)
-  assert.match(result.txLogContent, /tx polystorechain request-provider-link nil1operatorstub/)
+  assert.match(result.txLogContent, /tx nilchain request-provider-link nil1operatorstub/)
 })
 
 test('run_devnet_provider pair creates a missing key, auto-funds it, and submits provider-link tx', () => {
@@ -239,5 +239,5 @@ test('run_devnet_provider pair creates a missing key, auto-funds it, and submits
   assert.match(result.combinedOutput, /Faucet funding request accepted/i)
   assert.match(result.combinedOutput, /Provider account funded/i)
   assert.match(result.combinedOutput, /Requesting provider link on-chain/i)
-  assert.match(result.txLogContent, /tx polystorechain request-provider-link nil1operatorstub/)
+  assert.match(result.txLogContent, /tx nilchain request-provider-link nil1operatorstub/)
 })

--- a/scripts/enterprise_upload_job.sh
+++ b/scripts/enterprise_upload_job.sh
@@ -45,6 +45,7 @@ UPLOAD_STATUS_TIMEOUT_SECS="${UPLOAD_STATUS_TIMEOUT_SECS:-300}"
 UPLOAD_STATUS_POLL_INTERVAL_SECS="${UPLOAD_STATUS_POLL_INTERVAL_SECS:-2}"
 TX_SUBMIT_MODE="${POLYSTORE_TX_SUBMIT_MODE:-gateway}"
 POLYSTORECHAIND_BIN="${POLYSTORECHAIND_BIN:-polystorechaind}"
+POLYSTORE_CHAIN_TX_MODULE="${POLYSTORE_CHAIN_TX_MODULE:-nilchain}"
 POLYSTORE_GAS_PRICES="${POLYSTORE_GAS_PRICES:-${POLYSTORE_TESTNET_GAS_PRICES:-0.001aatom}}"
 POLYSTORE_TX_SENDER_KEY="${POLYSTORE_TX_SENDER_KEY:-${POLYSTORE_TESTNET_TX_SENDER_KEY:-faucet}}"
 POLYSTORE_TX_SENDER_HOME="${POLYSTORE_TX_SENDER_HOME:-$ROOT_DIR/_artifacts/testnet_tx_sender_home}"
@@ -143,7 +144,7 @@ direct_create_deal() {
     printf '%s\n' "$payload_json" >"$payload_file"
 
     cmd_status=0
-    create_out="$("$POLYSTORECHAIND_BIN" tx polystorechain create-deal-from-evm "$payload_file" \
+    create_out="$("$POLYSTORECHAIND_BIN" tx "$POLYSTORE_CHAIN_TX_MODULE" create-deal-from-evm "$payload_file" \
       --node "$POLYSTORE_NODE" \
       --chain-id "$CHAIN_ID" \
       --from "$POLYSTORE_TX_SENDER_KEY" \
@@ -220,7 +221,7 @@ direct_create_deal() {
     ' 2>/dev/null || true)"
 
     if [[ -z "$deal_id" ]]; then
-      list_out="$("$POLYSTORECHAIND_BIN" query polystorechain list-deals \
+      list_out="$("$POLYSTORECHAIND_BIN" query "$POLYSTORE_CHAIN_TX_MODULE" list-deals \
         --node "$POLYSTORE_NODE" \
         --output json 2>/dev/null || true)"
       max_id="$(printf '%s' "$list_out" | jq -r '[.deals[]?.id | tonumber] | max // empty' 2>/dev/null || true)"
@@ -270,7 +271,7 @@ direct_update_deal_content() {
     printf '%s\n' "$update_json" >"$update_file"
 
     cmd_status=0
-    update_out="$("$POLYSTORECHAIND_BIN" tx polystorechain update-deal-content-from-evm "$update_file" \
+    update_out="$("$POLYSTORECHAIND_BIN" tx "$POLYSTORE_CHAIN_TX_MODULE" update-deal-content-from-evm "$update_file" \
       --node "$POLYSTORE_NODE" \
       --chain-id "$CHAIN_ID" \
       --from "$POLYSTORE_TX_SENDER_KEY" \

--- a/scripts/run_devnet_provider.sh
+++ b/scripts/run_devnet_provider.sh
@@ -80,6 +80,7 @@ PROVIDER_FUNDING_POLL_SECS="${POLYSTORE_PROVIDER_FUNDING_POLL_SECS:-2}"
 POLYSTORECHAIND_BIN="${POLYSTORECHAIND_BIN:-$ROOT_DIR/polystorechain/polystorechaind}"
 POLYSTORE_CLI_BIN="${POLYSTORE_CLI_BIN:-$ROOT_DIR/polystore_cli/target/release/polystore_cli}"
 TRUSTED_SETUP="${POLYSTORE_TRUSTED_SETUP:-$ROOT_DIR/polystorechain/trusted_setup.txt}"
+CHAIN_TX_MODULE="${POLYSTORE_CHAIN_TX_MODULE:-nilchain}"
 
 PROVIDER_LISTEN="${PROVIDER_LISTEN:-${POLYSTORE_LISTEN_ADDR:-:8091}}"
 PROVIDER_CAPABILITIES="${PROVIDER_CAPABILITIES:-General}"
@@ -1205,7 +1206,7 @@ register_provider() {
 
   if provider_registered; then
     echo "==> Updating provider endpoints on-chain..."
-    "$POLYSTORECHAIND_BIN" tx polystorechain update-provider-endpoints \
+    "$POLYSTORECHAIND_BIN" tx "$CHAIN_TX_MODULE" update-provider-endpoints \
       "${endpoint_args[@]}" \
       --from "$PROVIDER_KEY" \
       --chain-id "$CHAIN_ID" \
@@ -1223,7 +1224,7 @@ register_provider() {
       bond_args=(--bond "$PROVIDER_REGISTRATION_BOND")
     fi
     echo "==> Registering provider on-chain..."
-    "$POLYSTORECHAIND_BIN" tx polystorechain register-provider "$PROVIDER_CAPABILITIES" "$PROVIDER_TOTAL_STORAGE" \
+    "$POLYSTORECHAIND_BIN" tx "$CHAIN_TX_MODULE" register-provider "$PROVIDER_CAPABILITIES" "$PROVIDER_TOTAL_STORAGE" \
       "${endpoint_args[@]}" \
       "${bond_args[@]}" \
       --from "$PROVIDER_KEY" \
@@ -1287,7 +1288,7 @@ request_provider_link() {
   ensure_provider_account_funded "$addr"
 
   echo "==> Requesting provider link on-chain..."
-  "$POLYSTORECHAIND_BIN" tx polystorechain request-provider-link "$operator" \
+  "$POLYSTORECHAIND_BIN" tx "$CHAIN_TX_MODULE" request-provider-link "$operator" \
     --from "$PROVIDER_KEY" \
     --chain-id "$CHAIN_ID" \
     --node "$NODE_ADDR" \

--- a/scripts/testnet_burner_upload.sh
+++ b/scripts/testnet_burner_upload.sh
@@ -47,6 +47,13 @@ require_cmd() {
   fi
 }
 
+abs_path() {
+  case "$1" in
+    /*) printf '%s' "$1" ;;
+    *) printf '%s/%s' "$(pwd -P)" "$1" ;;
+  esac
+}
+
 EXPORT_KEYSTORE="./burner-keystore.json"
 KEYSTORE_PASSWORD_ENV="POLYSTORE_BURNER_KEYSTORE_PASSWORD"
 ALLOW_RAW_KEY_EXPORT=0
@@ -143,6 +150,10 @@ if [[ "$ALLOW_RAW_KEY_EXPORT" != "1" && -n "$RAW_KEY_OUT" ]]; then
   echo "error: --raw-key-out requires --allow-raw-key-export" >&2
   exit 1
 fi
+EXPORT_KEYSTORE="$(abs_path "$EXPORT_KEYSTORE")"
+if [[ -n "$RAW_KEY_OUT" ]]; then
+  RAW_KEY_OUT="$(abs_path "$RAW_KEY_OUT")"
+fi
 
 require_cmd jq
 require_cmd curl
@@ -182,7 +193,7 @@ umask 077
 wallet_json="$(cd "$ROOT_DIR/polystore-website" && node_modules/.bin/tsx "$ROOT_DIR/polystore-website/scripts/testnet_burner_wallet.ts" generate)"
 PRIVATE_KEY="$(printf '%s' "$wallet_json" | jq -r '.private_key')"
 EVM_ADDRESS="$(printf '%s' "$wallet_json" | jq -r '.address')"
-POLYSTORE_ADDRESS="$(printf '%s' "$wallet_json" | jq -r '.nil_address')"
+POLYSTORE_ADDRESS="$(printf '%s' "$wallet_json" | jq -r '.polystore_address // .nil_address // ""')"
 
 if [[ -z "$PRIVATE_KEY" || -z "$EVM_ADDRESS" || -z "$POLYSTORE_ADDRESS" || "$PRIVATE_KEY" == "null" ]]; then
   echo "error: failed to generate burner wallet" >&2


### PR DESCRIPTION
## Summary

Adds tracked ops helpers for live devnet maintenance:

- `ops/grant_devnet_user_ops.sh` is a one-time sudo/root setup script that grants the devnet user ownership of `/opt/polystore` and the configured chain state root, defaulting to the repo-standard `/var/lib/polystore`.
- The grant script installs a narrow sudoers allowlist for only `start`, `stop`, `restart`, `is-active`, and `status` on the three root PolyStore services.
- `ops/update_devnet_stack_from_main.sh` can run as the devnet user after the grant, installing rebuilt artifacts and restarting root/user services without requiring a full root shell.
- The update helper now derives `SOURCE_ROOT` from its checkout, reads the router listen port from the systemd env file, allows explicit provider unit/health URL overrides, and tolerates absent user-level provider units on fresh hosts.
- Fixes devnet/testnet helper drift so provider registration and direct upload jobs use the current `nilchain` CLI namespace instead of the retired `polystorechain` tx/query namespace.
- Fixes burner upload helper compatibility with the current wallet generator (`polystore_address`) and resolves keystore/raw-key output paths before child scripts `cd polystore-website`.

## Validation

- `bash -n ops/grant_devnet_user_ops.sh ops/update_devnet_stack_from_main.sh scripts/run_devnet_provider.sh scripts/enterprise_upload_job.sh scripts/testnet_burner_upload.sh`
- `shellcheck ops/grant_devnet_user_ops.sh ops/update_devnet_stack_from_main.sh`
- `git diff --check`
- `npm -C polystore-website run test:unit -- --test-name-pattern 'run_devnet_provider'`
- `npm -C polystore-website run build`
- Verified `ops/grant_devnet_user_ops.sh` fails safely when run without sudo/root.
- Ran `ops/update_devnet_stack_from_main.sh` as the devnet user after sudoers grant; local hub healthcheck passed.
- Ran public healthcheck through Cloudflare-routed endpoints: RPC, LCD, EVM CORS, gateway, and faucet passed.
- Reset and re-registered the 3 public SPs; `sp1`, `sp2`, and `sp3` report `PROVIDER_LIFECYCLE_STATUS_ACTIVE` and `can_accept_new_slot=true`.
- Ran public funding/create/upload/commit/retrieval smoke via `https://gateway.polynomialstore.com`, `https://faucet.polynomialstore.com`, `https://lcd.polynomialstore.com`, `https://rpc.polynomialstore.com`, and `https://evm.polynomialstore.com`.
- Smoke evidence: deal `1`, manifest `0xac65815dedfab823d1f33a4e356a0205c3b0b0e6376ac18baf6739a9277597fa04d0a0de94bde9c696cd922e1f4e3130`, retrieval session `0x2aa64676788bfdbd4dfbe0f163cf5bf2858fea68f9d96036332fe2f30121b452`, fetched bytes matched input, and `/gateway/session-proof` returned `status=success` with tx `736FD26F19C00FB37A72A7A7DFF694582C846E04EA111FE9368DDDEC9A71EDAB`.
- GitHub CI is green on head `01a9683956fa5c71df5618325c4e5da69f538e1a`.

## Notes

The grant script intentionally does not add passwordless sudo for repo-writable scripts. It only allows specific `systemctl` service actions for the three root PolyStore services.
