### PR TITLE
Add browser KZG commitment backend seam

### DIFF
--- a/polystore-website/package.json
+++ b/polystore-website/package.json
@@ -27,6 +27,7 @@
     "perf:user-stage-concurrency": "tsx scripts/benchmark_user_stage_concurrency.ts",
     "perf:msm-windows": "tsx scripts/benchmark_pippenger_windows.ts",
     "perf:kzg-compare": "tsx scripts/benchmark_kzg_commit_compare.ts",
+    "perf:kzg-browser": "tsx scripts/benchmark_browser_kzg_commit.ts",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },

--- a/polystore-website/scripts/benchmark_browser_kzg_commit.ts
+++ b/polystore-website/scripts/benchmark_browser_kzg_commit.ts
@@ -25,10 +25,14 @@ function parsePositiveInt(name: string, fallback: number): number {
 
 function parseBlobMatrix(): number[] {
   const raw = process.env.KZG_BENCH_BLOBS || '1,4,16,64,256'
-  const values = raw
-    .split(',')
-    .map((part) => Number(part.trim()))
-    .filter((value) => Number.isFinite(value))
+  const values = raw.split(',').map((part) => {
+    const token = part.trim()
+    const value = Number(token)
+    if (token.length === 0 || !Number.isFinite(value) || !Number.isInteger(value) || value <= 0) {
+      throw new Error('KZG_BENCH_BLOBS must be a comma-separated list of positive integers')
+    }
+    return value
+  })
   if (values.length === 0 || values.some((value) => !Number.isInteger(value) || value <= 0)) {
     throw new Error('KZG_BENCH_BLOBS must be a comma-separated list of positive integers')
   }
@@ -95,9 +99,10 @@ const config = {
 }
 
 const server = await startStaticServer()
-const browser = await chromium.launch({ headless: process.env.HEADLESS !== '0' })
+let browser: Awaited<ReturnType<typeof chromium.launch>> | null = null
 
 try {
+  browser = await chromium.launch({ headless: process.env.HEADLESS !== '0' })
   const page = await browser.newPage()
   await page.goto(`${server.origin}/benchmark.html`)
   await page.addScriptTag({
@@ -252,6 +257,6 @@ try {
     ),
   )
 } finally {
-  await browser.close()
+  await browser?.close()
   await server.close()
 }

--- a/polystore-website/scripts/benchmark_browser_kzg_commit.ts
+++ b/polystore-website/scripts/benchmark_browser_kzg_commit.ts
@@ -1,0 +1,257 @@
+import fs from 'node:fs/promises'
+import http from 'node:http'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { chromium } from '@playwright/test'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const websiteRoot = path.resolve(__dirname, '..')
+const publicRoot = path.resolve(websiteRoot, 'public')
+
+const BLOB_SIZE = 128 * 1024
+
+function parsePositiveInt(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (!raw) return fallback
+  const parsed = Number(raw)
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`)
+  }
+  return parsed
+}
+
+function parseBlobMatrix(): number[] {
+  const raw = process.env.KZG_BENCH_BLOBS || '1,4,16,64,256'
+  const values = raw
+    .split(',')
+    .map((part) => Number(part.trim()))
+    .filter((value) => Number.isFinite(value))
+  if (values.length === 0 || values.some((value) => !Number.isInteger(value) || value <= 0)) {
+    throw new Error('KZG_BENCH_BLOBS must be a comma-separated list of positive integers')
+  }
+  return values
+}
+
+function contentType(filePath: string): string {
+  if (filePath.endsWith('.html')) return 'text/html; charset=utf-8'
+  if (filePath.endsWith('.js')) return 'text/javascript; charset=utf-8'
+  if (filePath.endsWith('.wasm')) return 'application/wasm'
+  if (filePath.endsWith('.txt')) return 'text/plain; charset=utf-8'
+  return 'application/octet-stream'
+}
+
+async function startStaticServer(): Promise<{ origin: string; close: () => Promise<void> }> {
+  const server = http.createServer(async (req, res) => {
+    try {
+      const url = new URL(req.url || '/', 'http://127.0.0.1')
+      const pathname = url.pathname === '/' ? '/benchmark.html' : url.pathname
+      if (pathname === '/benchmark.html') {
+        res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
+        res.end('<!doctype html><meta charset="utf-8"><title>PolyStore KZG Browser Benchmark</title>')
+        return
+      }
+
+      const normalized = path.normalize(pathname).replace(/^(\.\.[/\\])+/, '')
+      const filePath = path.join(publicRoot, normalized)
+      if (!filePath.startsWith(publicRoot)) {
+        res.writeHead(403)
+        res.end('forbidden')
+        return
+      }
+      const bytes = await fs.readFile(filePath)
+      res.writeHead(200, { 'content-type': contentType(filePath) })
+      res.end(bytes)
+    } catch (error) {
+      res.writeHead(404)
+      res.end(error instanceof Error ? error.message : 'not found')
+    }
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => resolve())
+  })
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    throw new Error('failed to allocate benchmark server port')
+  }
+
+  return {
+    origin: `http://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()))
+      }),
+  }
+}
+
+const config = {
+  blobCounts: parseBlobMatrix(),
+  warmupRuns: parsePositiveInt('KZG_BENCH_WARMUP_RUNS', 1),
+  measureRuns: parsePositiveInt('KZG_BENCH_MEASURE_RUNS', 3),
+}
+
+const server = await startStaticServer()
+const browser = await chromium.launch({ headless: process.env.HEADLESS !== '0' })
+
+try {
+  const page = await browser.newPage()
+  await page.goto(`${server.origin}/benchmark.html`)
+  await page.addScriptTag({
+    content: `
+      window.__runPolyStoreKzgBenchmark = async function(config) {
+        const { blobCounts, warmupRuns, measureRuns, blobSize } = config;
+
+        function makeValidBlob(seed) {
+          const blob = new Uint8Array(blobSize);
+          const chunks = blobSize / 32;
+          for (let i = 0; i < chunks; i += 1) {
+            const offset = i * 32;
+            blob[offset] = 0;
+            for (let j = 1; j < 32; j += 1) {
+              blob[offset + j] = (seed + i * 17 + j * 29) & 0xff;
+            }
+          }
+          return blob;
+        }
+
+        function makeBatch(blobCount) {
+          const batch = new Uint8Array(blobSize * blobCount);
+          for (let i = 0; i < blobCount; i += 1) {
+            batch.set(makeValidBlob(11 + i), i * blobSize);
+          }
+          return batch;
+        }
+
+        function summarize(values) {
+          const sorted = [...values].sort((a, b) => a - b);
+          const middle = Math.floor(sorted.length / 2);
+          const median = sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle];
+          const mean = sorted.reduce((sum, value) => sum + value, 0) / sorted.length;
+          return { min: sorted[0], median, mean, max: sorted[sorted.length - 1] };
+        }
+
+        const mod = await import('/wasm/polystore_core.js');
+        const wasmBytes = await fetch('/wasm/polystore_core_bg.wasm').then((response) => response.arrayBuffer());
+        const initStart = performance.now();
+        await mod.default({ module_or_path: wasmBytes });
+        const trustedSetupBytes = new Uint8Array(
+          await fetch('/trusted_setup.txt').then((response) => response.arrayBuffer()),
+        );
+        const setupStart = performance.now();
+        const polyStoreWasm = new mod.PolyStoreWasm(trustedSetupBytes);
+        const setupMs = performance.now() - setupStart;
+        const initMs = performance.now() - initStart;
+
+        const batches = [];
+        for (const blobCount of blobCounts) {
+          const data = makeBatch(blobCount);
+          for (let i = 0; i < warmupRuns; i += 1) {
+            polyStoreWasm.commit_blobs_profiled(data);
+          }
+
+          const runs = [];
+          for (let i = 0; i < measureRuns; i += 1) {
+            const start = performance.now();
+            const raw = polyStoreWasm.commit_blobs_profiled(data);
+            const wallMs = performance.now() - start;
+            const witnessBytes =
+              raw.witness_flat instanceof Uint8Array
+                ? raw.witness_flat.byteLength
+                : new Uint8Array(raw.witness_flat).byteLength;
+            runs.push({
+              wall_ms: wallMs,
+              rust_total_ms: Number(raw.perf?.total_ms ?? 0),
+              rust_msm_ms: Number(raw.perf?.msm_ms ?? 0),
+              rust_decode_ms: Number(raw.perf?.decode_ms ?? 0),
+              rust_compress_ms: Number(raw.perf?.compress_ms ?? 0),
+              witness_bytes: witnessBytes,
+            });
+          }
+
+          const wallMs = runs.map((run) => run.wall_ms);
+          const perBlobMs = wallMs.map((ms) => ms / blobCount);
+          const perMduMs = perBlobMs.map((ms) => ms * 64);
+          const throughputMibSec = wallMs.map((ms) => ((blobCount * blobSize) / (1024 * 1024)) / (ms / 1000));
+          batches.push({
+            blob_count: blobCount,
+            input_mib: (blobCount * blobSize) / (1024 * 1024),
+            wall_ms: summarize(wallMs),
+            per_blob_ms: summarize(perBlobMs),
+            per_mdu_ms: summarize(perMduMs),
+            throughput_mib_sec: summarize(throughputMibSec),
+            rust_total_ms: summarize(runs.map((run) => run.rust_total_ms)),
+            rust_msm_ms: summarize(runs.map((run) => run.rust_msm_ms)),
+            rust_decode_ms: summarize(runs.map((run) => run.rust_decode_ms)),
+            rust_compress_ms: summarize(runs.map((run) => run.rust_compress_ms)),
+            runs,
+          });
+        }
+
+        return {
+          backend: 'wasm-blst',
+          scheduling_mode: 'direct-browser-wasm-profiled',
+          worker_count: 0,
+          browser: {
+            user_agent: navigator.userAgent,
+            hardware_concurrency: navigator.hardwareConcurrency ?? null,
+            device_memory_gib: 'deviceMemory' in navigator ? navigator.deviceMemory ?? null : null,
+            cross_origin_isolated: crossOriginIsolated,
+          },
+          wasm: {
+            init_ms: initMs,
+            setup_ms: setupMs,
+          },
+          batches,
+        };
+      };
+    `,
+  })
+  const result = await page.evaluate(`window.__runPolyStoreKzgBenchmark(${JSON.stringify({
+    blobCounts: config.blobCounts,
+    warmupRuns: config.warmupRuns,
+    measureRuns: config.measureRuns,
+    blobSize: BLOB_SIZE,
+  })})`) as {
+    batches: Array<{
+      blob_count: number
+      wall_ms: { median: number }
+      per_blob_ms: { median: number }
+      per_mdu_ms: { median: number }
+      throughput_mib_sec: { median: number }
+    }>
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        benchmark: 'browser-kzg-commit-baseline',
+        timestamp: new Date().toISOString(),
+        config,
+        host: {
+          platform: os.platform(),
+          release: os.release(),
+          arch: os.arch(),
+          cpus: os.cpus().length,
+          total_memory_gib: os.totalmem() / 1024 / 1024 / 1024,
+        },
+        result,
+        summary: result.batches.map((batch) => ({
+          blob_count: batch.blob_count,
+          wall_ms_median: batch.wall_ms.median,
+          per_blob_ms_median: batch.per_blob_ms.median,
+          per_mdu_ms_median: batch.per_mdu_ms.median,
+          throughput_mib_sec_median: batch.throughput_mib_sec.median,
+        })),
+      },
+      null,
+      2,
+    ),
+  )
+} finally {
+  await browser.close()
+  await server.close()
+}

--- a/polystore-website/src/lib/kzgCommitBackend.test.ts
+++ b/polystore-website/src/lib/kzgCommitBackend.test.ts
@@ -1,0 +1,158 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+import {
+  KZG_BLOB_SIZE,
+  KZG_COMMITMENT_SIZE,
+  WasmBlstKzgCommitBackend,
+  createWasmBlstKzgCommitBackend,
+  parseKzgCommitProfiledResult,
+} from './kzgCommitBackend'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+type PolyStoreWasmLike = {
+  commit_blobs: (blobBytes: Uint8Array) => Uint8Array
+  commit_blobs_profiled: (blobBytes: Uint8Array) => unknown
+}
+
+async function loadPolyStoreCoreWasm(): Promise<null | {
+  init: (args: unknown) => Promise<unknown>
+  PolyStoreWasm: new (trustedSetupBytes: Uint8Array) => PolyStoreWasmLike
+  wasmPath: string
+}> {
+  const jsPath = path.resolve(__dirname, '../../public/wasm/polystore_core.js')
+  const wasmPath = path.resolve(__dirname, '../../public/wasm/polystore_core_bg.wasm')
+  try {
+    await fs.access(jsPath)
+    await fs.access(wasmPath)
+  } catch {
+    return null
+  }
+  const mod = (await import(pathToFileURL(jsPath).href)) as {
+    default: (args: unknown) => Promise<unknown>
+    PolyStoreWasm: new (trustedSetupBytes: Uint8Array) => PolyStoreWasmLike
+  }
+  return { init: mod.default, PolyStoreWasm: mod.PolyStoreWasm, wasmPath }
+}
+
+function blobBatch(blobs: number): Uint8Array {
+  return new Uint8Array(KZG_BLOB_SIZE * blobs)
+}
+
+function validBlob(seed: number): Uint8Array {
+  const blob = new Uint8Array(KZG_BLOB_SIZE)
+  for (let i = 0; i < KZG_BLOB_SIZE / 32; i += 1) {
+    const offset = i * 32
+    blob[offset] = 0
+    for (let j = 1; j < 32; j += 1) {
+      blob[offset + j] = (seed + i * 17 + j * 29) & 0xff
+    }
+  }
+  return blob
+}
+
+function commitments(blobs: number, seed = 1): Uint8Array {
+  const out = new Uint8Array(KZG_COMMITMENT_SIZE * blobs)
+  for (let i = 0; i < out.length; i += 1) {
+    out[i] = (seed + i) & 0xff
+  }
+  return out
+}
+
+test('wasm blst backend reports default status', () => {
+  const backend = new WasmBlstKzgCommitBackend({
+    commit_blobs: () => commitments(1),
+    commit_blobs_profiled: () => ({ witness_flat: commitments(1), perf: { blobs: 1 } }),
+  })
+
+  assert.deepEqual(backend.getStatus(), {
+    kind: 'wasm-blst',
+    initialized: true,
+    label: 'WASM blst',
+  })
+})
+
+test('wasm blst backend wraps direct commit_blobs output unchanged', () => {
+  const expected = commitments(2, 17)
+  const backend = new WasmBlstKzgCommitBackend({
+    commit_blobs: (input) => {
+      assert.equal(input.byteLength, KZG_BLOB_SIZE * 2)
+      return expected
+    },
+    commit_blobs_profiled: () => ({ witness_flat: expected, perf: { blobs: 2 } }),
+  })
+
+  assert.strictEqual(backend.commitBlobs(blobBatch(2)), expected)
+})
+
+test('wasm blst backend rejects invalid batch shape and invalid output length', () => {
+  const backend = new WasmBlstKzgCommitBackend({
+    commit_blobs: () => new Uint8Array(1),
+    commit_blobs_profiled: () => ({ witness_flat: new Uint8Array(1), perf: { blobs: 1 } }),
+  })
+
+  assert.throws(() => backend.commitBlobs(new Uint8Array()), /non-zero multiple/)
+  assert.throws(() => backend.commitBlobs(new Uint8Array(KZG_BLOB_SIZE + 1)), /non-zero multiple/)
+  assert.throws(() => backend.commitBlobs(blobBatch(1)), /commit_blobs returned 1 bytes/)
+})
+
+test('profiled parser normalizes wasm field names', () => {
+  const witnessFlat = commitments(3)
+  const parsed = parseKzgCommitProfiledResult(
+    {
+      witness_flat: witnessFlat.buffer,
+      perf: {
+        decode_ms: 1,
+        transform_ms: 2,
+        msm_scalar_prep_ms: 3,
+        msm_bucket_fill_ms: 4,
+        msm_reduce_ms: 5,
+        msm_double_ms: 6,
+        msm_ms: 7,
+        compress_ms: 8,
+        total_ms: 9,
+        blobs: 3,
+      },
+    },
+    3,
+  )
+
+  assert.equal(parsed.witnessFlat.byteLength, KZG_COMMITMENT_SIZE * 3)
+  assert.equal(parsed.perf.decodeMs, 1)
+  assert.equal(parsed.perf.transformMs, 2)
+  assert.equal(parsed.perf.msmScalarPrepMs, 3)
+  assert.equal(parsed.perf.msmBucketFillMs, 4)
+  assert.equal(parsed.perf.msmReduceMs, 5)
+  assert.equal(parsed.perf.msmDoubleMs, 6)
+  assert.equal(parsed.perf.msmMs, 7)
+  assert.equal(parsed.perf.compressMs, 8)
+  assert.equal(parsed.perf.totalMs, 9)
+  assert.equal(parsed.perf.blobs, 3)
+})
+
+test('createWasmBlstKzgCommitBackend fails closed before wasm init', () => {
+  assert.throws(() => createWasmBlstKzgCommitBackend(null), /PolyStoreWasm not initialized/)
+})
+
+test('wasm blst backend output matches direct PolyStoreWasm commit_blobs', async (t) => {
+  const wasm = await loadPolyStoreCoreWasm()
+  if (!wasm) {
+    t.skip('WASM artifacts not present (polystore-website/public/wasm).')
+    return
+  }
+
+  const wasmBuffer = await fs.readFile(wasm.wasmPath)
+  await wasm.init({ module_or_path: wasmBuffer })
+  const trustedSetupPath = path.resolve(__dirname, '../../public/trusted_setup.txt')
+  const trustedSetupBytes = new Uint8Array(await fs.readFile(trustedSetupPath))
+  const polyStoreWasm = new wasm.PolyStoreWasm(trustedSetupBytes)
+  const backend = createWasmBlstKzgCommitBackend(polyStoreWasm)
+  const input = validBlob(23)
+
+  assert.deepEqual(backend.commitBlobs(input), polyStoreWasm.commit_blobs(input))
+})

--- a/polystore-website/src/lib/kzgCommitBackend.test.ts
+++ b/polystore-website/src/lib/kzgCommitBackend.test.ts
@@ -90,14 +90,41 @@ test('wasm blst backend wraps direct commit_blobs output unchanged', () => {
   assert.strictEqual(backend.commitBlobs(blobBatch(2)), expected)
 })
 
+test('wasm blst backend preserves empty commit_blobs batches', () => {
+  const expected = new Uint8Array()
+  const backend = new WasmBlstKzgCommitBackend({
+    commit_blobs: (input) => {
+      assert.equal(input.byteLength, 0)
+      return expected
+    },
+    commit_blobs_profiled: () => ({ witness_flat: expected, perf: { blobs: 0 } }),
+  })
+
+  assert.strictEqual(backend.commitBlobs(new Uint8Array()), expected)
+  assert.deepEqual(backend.commitBlobsProfiled(new Uint8Array()), {
+    witnessFlat: expected,
+    perf: {
+      decodeMs: 0,
+      transformMs: 0,
+      msmScalarPrepMs: 0,
+      msmBucketFillMs: 0,
+      msmReduceMs: 0,
+      msmDoubleMs: 0,
+      msmMs: 0,
+      compressMs: 0,
+      totalMs: 0,
+      blobs: 0,
+    },
+  })
+})
+
 test('wasm blst backend rejects invalid batch shape and invalid output length', () => {
   const backend = new WasmBlstKzgCommitBackend({
     commit_blobs: () => new Uint8Array(1),
     commit_blobs_profiled: () => ({ witness_flat: new Uint8Array(1), perf: { blobs: 1 } }),
   })
 
-  assert.throws(() => backend.commitBlobs(new Uint8Array()), /non-zero multiple/)
-  assert.throws(() => backend.commitBlobs(new Uint8Array(KZG_BLOB_SIZE + 1)), /non-zero multiple/)
+  assert.throws(() => backend.commitBlobs(new Uint8Array(KZG_BLOB_SIZE + 1)), /multiple/)
   assert.throws(() => backend.commitBlobs(blobBatch(1)), /commit_blobs returned 1 bytes/)
 })
 

--- a/polystore-website/src/lib/kzgCommitBackend.ts
+++ b/polystore-website/src/lib/kzgCommitBackend.ts
@@ -47,8 +47,8 @@ function assertBlobBatch(blobsFlat: Uint8Array): number {
   if (!(blobsFlat instanceof Uint8Array)) {
     throw new Error('blobsFlat must be a Uint8Array')
   }
-  if (blobsFlat.byteLength === 0 || blobsFlat.byteLength % KZG_BLOB_SIZE !== 0) {
-    throw new Error('blobsFlat length must be a non-zero multiple of 128 KiB')
+  if (blobsFlat.byteLength % KZG_BLOB_SIZE !== 0) {
+    throw new Error('blobsFlat length must be a multiple of 128 KiB')
   }
   return blobsFlat.byteLength / KZG_BLOB_SIZE
 }

--- a/polystore-website/src/lib/kzgCommitBackend.ts
+++ b/polystore-website/src/lib/kzgCommitBackend.ts
@@ -1,0 +1,141 @@
+export const KZG_BLOB_SIZE = 128 * 1024
+export const KZG_COMMITMENT_SIZE = 48
+
+export type KzgCommitBackendKind = 'wasm-blst'
+
+export type PolyStoreCommitApi = {
+  commit_blobs(blobBytes: Uint8Array): Uint8Array | ArrayBufferLike
+  commit_blobs_profiled(blobBytes: Uint8Array): unknown
+}
+
+export type KzgCommitPerf = {
+  decodeMs: number
+  transformMs: number
+  msmScalarPrepMs: number
+  msmBucketFillMs: number
+  msmReduceMs: number
+  msmDoubleMs: number
+  msmMs: number
+  compressMs: number
+  totalMs: number
+  blobs: number
+}
+
+export type KzgCommitProfiledResult = {
+  witnessFlat: Uint8Array
+  perf: KzgCommitPerf
+}
+
+export type KzgCommitBackendStatus = {
+  kind: KzgCommitBackendKind
+  initialized: boolean
+  label: string
+}
+
+export type KzgCommitBackend = {
+  readonly kind: KzgCommitBackendKind
+  getStatus(): KzgCommitBackendStatus
+  commitBlobs(blobsFlat: Uint8Array): Uint8Array
+  commitBlobsProfiled(blobsFlat: Uint8Array): KzgCommitProfiledResult
+}
+
+export function toUint8Array(value: Uint8Array | ArrayBufferLike): Uint8Array {
+  return value instanceof Uint8Array ? value : new Uint8Array(value)
+}
+
+function assertBlobBatch(blobsFlat: Uint8Array): number {
+  if (!(blobsFlat instanceof Uint8Array)) {
+    throw new Error('blobsFlat must be a Uint8Array')
+  }
+  if (blobsFlat.byteLength === 0 || blobsFlat.byteLength % KZG_BLOB_SIZE !== 0) {
+    throw new Error('blobsFlat length must be a non-zero multiple of 128 KiB')
+  }
+  return blobsFlat.byteLength / KZG_BLOB_SIZE
+}
+
+function numberField(value: unknown): number {
+  return Number(value ?? 0)
+}
+
+export function parseKzgCommitProfiledResult(raw: unknown, expectedBlobs: number): KzgCommitProfiledResult {
+  const obj = raw as {
+    witness_flat?: Uint8Array | ArrayBufferLike
+    perf?: {
+      decode_ms?: unknown
+      transform_ms?: unknown
+      msm_scalar_prep_ms?: unknown
+      msm_bucket_fill_ms?: unknown
+      msm_reduce_ms?: unknown
+      msm_double_ms?: unknown
+      msm_ms?: unknown
+      compress_ms?: unknown
+      total_ms?: unknown
+      blobs?: unknown
+    }
+  }
+
+  if (!obj?.witness_flat) {
+    throw new Error('commit_blobs_profiled returned no witness bytes')
+  }
+
+  const witnessFlat = toUint8Array(obj.witness_flat)
+  const expectedWitnessBytes = expectedBlobs * KZG_COMMITMENT_SIZE
+  if (witnessFlat.byteLength !== expectedWitnessBytes) {
+    throw new Error(
+      `commit_blobs_profiled returned ${witnessFlat.byteLength} witness bytes, expected ${expectedWitnessBytes}`,
+    )
+  }
+
+  const perf = obj.perf
+  return {
+    witnessFlat,
+    perf: {
+      decodeMs: numberField(perf?.decode_ms),
+      transformMs: numberField(perf?.transform_ms),
+      msmScalarPrepMs: numberField(perf?.msm_scalar_prep_ms),
+      msmBucketFillMs: numberField(perf?.msm_bucket_fill_ms),
+      msmReduceMs: numberField(perf?.msm_reduce_ms),
+      msmDoubleMs: numberField(perf?.msm_double_ms),
+      msmMs: numberField(perf?.msm_ms),
+      compressMs: numberField(perf?.compress_ms),
+      totalMs: numberField(perf?.total_ms),
+      blobs: Number(perf?.blobs ?? expectedBlobs),
+    },
+  }
+}
+
+export class WasmBlstKzgCommitBackend implements KzgCommitBackend {
+  readonly kind = 'wasm-blst' as const
+
+  constructor(private readonly wasm: PolyStoreCommitApi) {}
+
+  getStatus(): KzgCommitBackendStatus {
+    return {
+      kind: this.kind,
+      initialized: Boolean(this.wasm),
+      label: 'WASM blst',
+    }
+  }
+
+  commitBlobs(blobsFlat: Uint8Array): Uint8Array {
+    const expectedBlobs = assertBlobBatch(blobsFlat)
+    const commitments = toUint8Array(this.wasm.commit_blobs(blobsFlat))
+    const expectedBytes = expectedBlobs * KZG_COMMITMENT_SIZE
+    if (commitments.byteLength !== expectedBytes) {
+      throw new Error(`commit_blobs returned ${commitments.byteLength} bytes, expected ${expectedBytes}`)
+    }
+    return commitments
+  }
+
+  commitBlobsProfiled(blobsFlat: Uint8Array): KzgCommitProfiledResult {
+    const expectedBlobs = assertBlobBatch(blobsFlat)
+    return parseKzgCommitProfiledResult(this.wasm.commit_blobs_profiled(blobsFlat), expectedBlobs)
+  }
+}
+
+export function createWasmBlstKzgCommitBackend(wasm: PolyStoreCommitApi | null | undefined): KzgCommitBackend {
+  if (!wasm) {
+    throw new Error('PolyStoreWasm not initialized')
+  }
+  return new WasmBlstKzgCommitBackend(wasm)
+}

--- a/polystore-website/src/workers/commit.worker.ts
+++ b/polystore-website/src/workers/commit.worker.ts
@@ -4,12 +4,14 @@
 // across multiple single-threaded WASM instances (no SharedArrayBuffer required).
 
 import init, { PolyStoreWasm } from '../lib/polystoreCoreRuntime.js'
+import { createWasmBlstKzgCommitBackend, type KzgCommitBackend } from '../lib/kzgCommitBackend'
 
 let wasmInitialized = false
 let wasmInitPromise: Promise<void> | null = null
 let wasmInitError: unknown = null
 
 let polyStoreWasmInstance: PolyStoreWasm | null = null
+let kzgCommitBackend: KzgCommitBackend | null = null
 
 function initializeWasm(): Promise<void> {
   if (wasmInitialized) return Promise.resolve()
@@ -46,14 +48,15 @@ self.onmessage = async (event) => {
         const { trustedSetupBytes } = payload as { trustedSetupBytes: Uint8Array }
         if (!trustedSetupBytes) throw new Error('Trusted setup bytes required')
         polyStoreWasmInstance = new PolyStoreWasm(trustedSetupBytes)
+        kzgCommitBackend = createWasmBlstKzgCommitBackend(polyStoreWasmInstance)
         ;(self as unknown as Worker).postMessage({ id, type: 'result', payload: 'ok' })
         return
       }
       case 'commitBlobs': {
-        if (!polyStoreWasmInstance) throw new Error('PolyStoreWasm not initialized')
+        if (!kzgCommitBackend) throw new Error('PolyStoreWasm not initialized')
         const { data } = payload as { data: Uint8Array }
         if (!(data instanceof Uint8Array)) throw new Error('data must be Uint8Array')
-        const commitments = polyStoreWasmInstance.commit_blobs(data)
+        const commitments = kzgCommitBackend.commitBlobs(data)
         ;(self as unknown as Worker).postMessage({ id, type: 'result', payload: commitments }, [commitments.buffer])
         return
       }

--- a/polystore-website/src/workers/expand.worker.ts
+++ b/polystore-website/src/workers/expand.worker.ts
@@ -1,9 +1,11 @@
 import init, { PolyStoreWasm } from '../lib/polystoreCoreRuntime.js'
+import { createWasmBlstKzgCommitBackend, type KzgCommitBackend } from '../lib/kzgCommitBackend'
 
 let wasmInitialized = false
 let wasmInitPromise: Promise<void> | null = null
 let wasmInitError: unknown = null
 let polyStoreWasmInstance: PolyStoreWasm | null = null
+let kzgCommitBackend: KzgCommitBackend | null = null
 
 function initializeWasm(): Promise<void> {
   if (wasmInitialized) return Promise.resolve()
@@ -39,11 +41,12 @@ self.onmessage = async (event) => {
         const { trustedSetupBytes } = payload as { trustedSetupBytes: Uint8Array }
         if (!trustedSetupBytes) throw new Error('Trusted setup bytes required')
         polyStoreWasmInstance = new PolyStoreWasm(trustedSetupBytes)
+        kzgCommitBackend = createWasmBlstKzgCommitBackend(polyStoreWasmInstance)
         ;(self as unknown as Worker).postMessage({ id, type: 'result', payload: 'ok' })
         return
       }
       case 'expandMduRs': {
-        if (!polyStoreWasmInstance) throw new Error('PolyStoreWasm not initialized')
+        if (!polyStoreWasmInstance || !kzgCommitBackend) throw new Error('PolyStoreWasm not initialized')
         const { data, k, m, profile = true } = payload as { data: Uint8Array; k: number; m: number; profile?: boolean }
         if (!(data instanceof Uint8Array)) throw new Error('data must be Uint8Array')
         const opStart = performance.now()
@@ -211,7 +214,7 @@ self.onmessage = async (event) => {
         return
       }
       case 'commitMduProfiled': {
-        if (!polyStoreWasmInstance) throw new Error('PolyStoreWasm not initialized')
+        if (!polyStoreWasmInstance || !kzgCommitBackend) throw new Error('PolyStoreWasm not initialized')
         const { data } = payload as { data: Uint8Array }
         const BLOBS_PER_MDU = 64
         if (!(data instanceof Uint8Array)) throw new Error('data must be Uint8Array')
@@ -219,29 +222,10 @@ self.onmessage = async (event) => {
 
         const opStart = performance.now()
         const commitStart = performance.now()
-        const committedRaw = polyStoreWasmInstance.commit_blobs_profiled(data) as {
-          witness_flat?: Uint8Array | ArrayBufferLike
-          perf?: {
-            decode_ms?: unknown
-            transform_ms?: unknown
-            msm_scalar_prep_ms?: unknown
-            msm_bucket_fill_ms?: unknown
-            msm_reduce_ms?: unknown
-            msm_double_ms?: unknown
-            msm_ms?: unknown
-            compress_ms?: unknown
-            total_ms?: unknown
-            blobs?: unknown
-          }
-        }
+        const committedRaw = kzgCommitBackend.commitBlobsProfiled(data)
         const commitMs = performance.now() - commitStart
-        const witnessRaw = committedRaw?.witness_flat
-        if (!witnessRaw) {
-          throw new Error('commit_blobs_profiled returned no witness bytes')
-        }
-        const witnessFlat =
-          witnessRaw instanceof Uint8Array ? witnessRaw : new Uint8Array(witnessRaw as ArrayBufferLike)
-        const commitPerf = committedRaw?.perf
+        const witnessFlat = committedRaw.witnessFlat
+        const commitPerf = committedRaw.perf
 
         const rootStart = performance.now()
         const root = polyStoreWasmInstance.compute_mdu_root(witnessFlat) as unknown
@@ -261,15 +245,15 @@ self.onmessage = async (event) => {
                 blobCount: BLOBS_PER_MDU,
                 batchCount: 1,
                 batchSize: BLOBS_PER_MDU,
-                rustCommitDecodeMs: Number(commitPerf?.decode_ms ?? 0),
-                rustCommitTransformMs: Number(commitPerf?.transform_ms ?? 0),
-                rustCommitMsmScalarPrepMs: Number(commitPerf?.msm_scalar_prep_ms ?? 0),
-                rustCommitMsmBucketFillMs: Number(commitPerf?.msm_bucket_fill_ms ?? 0),
-                rustCommitMsmReduceMs: Number(commitPerf?.msm_reduce_ms ?? 0),
-                rustCommitMsmDoubleMs: Number(commitPerf?.msm_double_ms ?? 0),
-                rustCommitMsmMs: Number(commitPerf?.msm_ms ?? 0),
-                rustCommitCompressMs: Number(commitPerf?.compress_ms ?? 0),
-                rustCommitMs: Number(commitPerf?.total_ms ?? commitMs),
+                rustCommitDecodeMs: commitPerf.decodeMs,
+                rustCommitTransformMs: commitPerf.transformMs,
+                rustCommitMsmScalarPrepMs: commitPerf.msmScalarPrepMs,
+                rustCommitMsmBucketFillMs: commitPerf.msmBucketFillMs,
+                rustCommitMsmReduceMs: commitPerf.msmReduceMs,
+                rustCommitMsmDoubleMs: commitPerf.msmDoubleMs,
+                rustCommitMsmMs: commitPerf.msmMs,
+                rustCommitCompressMs: commitPerf.compressMs,
+                rustCommitMs: commitPerf.totalMs || commitMs,
                 rustCommitBackend: 'blst',
                 rustCommitMsmSubphasesAvailable: false,
               },

--- a/polystore-website/src/workers/gateway.worker.ts
+++ b/polystore-website/src/workers/gateway.worker.ts
@@ -6,12 +6,14 @@
 // The `init` function loads the WASM binary.
 // The `Mdu0Builder` and `PolyStoreWasm` classes are exposed by wasm-bindgen.
 import init, { WasmMdu0Builder, PolyStoreWasm } from '../lib/polystoreCoreRuntime.js';
+import { createWasmBlstKzgCommitBackend, type KzgCommitBackend } from '../lib/kzgCommitBackend';
 
 let wasmInitialized = false;
 let wasmInitPromise: Promise<void> | null = null;
 let wasmInitError: unknown = null;
 let mdu0BuilderInstance: WasmMdu0Builder | null = null;
 let polyStoreWasmInstance: PolyStoreWasm | null = null;
+let kzgCommitBackend: KzgCommitBackend | null = null;
 
 type CommitWorkerPending = {
     resolve: (value: unknown) => void;
@@ -114,10 +116,8 @@ function initializeCommitPool(trustedSetupBytes: Uint8Array): Promise<void> {
 
 function commitBlobsWithPool(data: Uint8Array): Promise<Uint8Array> {
     if (!commitWorkers || commitWorkers.length === 0) {
-        if (!polyStoreWasmInstance) return Promise.reject(new Error('PolyStoreWasm not initialized'));
-        const commitments = polyStoreWasmInstance.commit_blobs(data) as unknown;
-        const bytes = commitments instanceof Uint8Array ? commitments : new Uint8Array(commitments as ArrayBufferLike);
-        return Promise.resolve(bytes);
+        if (!kzgCommitBackend) return Promise.reject(new Error('PolyStoreWasm not initialized'));
+        return Promise.resolve(kzgCommitBackend.commitBlobs(data));
     }
 
     const w = commitWorkers[commitRoundRobin % commitWorkers.length];
@@ -180,6 +180,7 @@ self.onmessage = async (event) => {
                 }
                 if (!trustedSetupBytes) throw new Error('Trusted setup bytes required for PolyStoreWasm initialization');
                 polyStoreWasmInstance = new PolyStoreWasm(trustedSetupBytes);
+                kzgCommitBackend = createWasmBlstKzgCommitBackend(polyStoreWasmInstance);
                 // Initialize the blob-commit compute pool (best-effort).
                 try {
                     await initializeCommitPool(trustedSetupBytes);
@@ -411,37 +412,20 @@ self.onmessage = async (event) => {
                     perf.witnessRootSetMs + perf.userRootSetMs + perf.appendMs + perf.bytesMs;
 
                 const commitStart = performance.now();
-                const committedRaw = polyStoreWasmInstance.commit_blobs_profiled(mdu0Bytes) as {
-                    witness_flat?: Uint8Array | ArrayBufferLike;
-                    perf?: {
-                        decode_ms?: unknown;
-                        transform_ms?: unknown;
-                        msm_scalar_prep_ms?: unknown;
-                        msm_bucket_fill_ms?: unknown;
-                        msm_reduce_ms?: unknown;
-                        msm_double_ms?: unknown;
-                        msm_ms?: unknown;
-                        compress_ms?: unknown;
-                        total_ms?: unknown;
-                    };
-                };
+                if (!kzgCommitBackend) throw new Error('PolyStoreWasm not initialized. Call initPolyStoreWasm first.');
+                const committedRaw = kzgCommitBackend.commitBlobsProfiled(mdu0Bytes);
                 perf.commitMs = performance.now() - commitStart;
-                const witnessRaw = committedRaw?.witness_flat;
-                if (!witnessRaw) {
-                    throw new Error('commit_blobs_profiled returned no witness bytes');
-                }
-                const witnessFlat =
-                    witnessRaw instanceof Uint8Array ? witnessRaw : new Uint8Array(witnessRaw as ArrayBufferLike);
-                const commitPerf = committedRaw?.perf;
-                perf.rustCommitDecodeMs = Number(commitPerf?.decode_ms ?? 0);
-                perf.rustCommitTransformMs = Number(commitPerf?.transform_ms ?? 0);
-                perf.rustCommitMsmScalarPrepMs = Number(commitPerf?.msm_scalar_prep_ms ?? 0);
-                perf.rustCommitMsmBucketFillMs = Number(commitPerf?.msm_bucket_fill_ms ?? 0);
-                perf.rustCommitMsmReduceMs = Number(commitPerf?.msm_reduce_ms ?? 0);
-                perf.rustCommitMsmDoubleMs = Number(commitPerf?.msm_double_ms ?? 0);
-                perf.rustCommitMsmMs = Number(commitPerf?.msm_ms ?? 0);
-                perf.rustCommitCompressMs = Number(commitPerf?.compress_ms ?? 0);
-                perf.rustCommitMs = Number(commitPerf?.total_ms ?? perf.commitMs);
+                const witnessFlat = committedRaw.witnessFlat;
+                const commitPerf = committedRaw.perf;
+                perf.rustCommitDecodeMs = commitPerf.decodeMs;
+                perf.rustCommitTransformMs = commitPerf.transformMs;
+                perf.rustCommitMsmScalarPrepMs = commitPerf.msmScalarPrepMs;
+                perf.rustCommitMsmBucketFillMs = commitPerf.msmBucketFillMs;
+                perf.rustCommitMsmReduceMs = commitPerf.msmReduceMs;
+                perf.rustCommitMsmDoubleMs = commitPerf.msmDoubleMs;
+                perf.rustCommitMsmMs = commitPerf.msmMs;
+                perf.rustCommitCompressMs = commitPerf.compressMs;
+                perf.rustCommitMs = commitPerf.totalMs || perf.commitMs;
 
                 const rootStart = performance.now();
                 const root = polyStoreWasmInstance.compute_mdu_root(witnessFlat) as unknown;
@@ -548,29 +532,11 @@ self.onmessage = async (event) => {
 
                 const opStart = performance.now();
                 const commitStart = performance.now();
-                const committedRaw = polyStoreWasmInstance.commit_blobs_profiled(data) as {
-                    witness_flat?: Uint8Array | ArrayBufferLike;
-                    perf?: {
-                        decode_ms?: unknown;
-                        transform_ms?: unknown;
-                        msm_scalar_prep_ms?: unknown;
-                        msm_bucket_fill_ms?: unknown;
-                        msm_reduce_ms?: unknown;
-                        msm_double_ms?: unknown;
-                        msm_ms?: unknown;
-                        compress_ms?: unknown;
-                        total_ms?: unknown;
-                        blobs?: unknown;
-                    };
-                };
+                if (!kzgCommitBackend) throw new Error('PolyStoreWasm not initialized. Call initPolyStoreWasm first.');
+                const committedRaw = kzgCommitBackend.commitBlobsProfiled(data);
                 const commitMs = performance.now() - commitStart;
-                const witnessRaw = committedRaw?.witness_flat;
-                if (!witnessRaw) {
-                    throw new Error('commit_blobs_profiled returned no witness bytes');
-                }
-                const witnessFlat =
-                    witnessRaw instanceof Uint8Array ? witnessRaw : new Uint8Array(witnessRaw as ArrayBufferLike);
-                const commitPerf = committedRaw?.perf;
+                const witnessFlat = committedRaw.witnessFlat;
+                const commitPerf = committedRaw.perf;
 
                 const rootStart = performance.now();
                 const root = polyStoreWasmInstance.compute_mdu_root(witnessFlat) as unknown;
@@ -586,15 +552,15 @@ self.onmessage = async (event) => {
                         blobCount: BLOBS_PER_MDU,
                         batchCount: 1,
                         batchSize: BLOBS_PER_MDU,
-                        rustCommitDecodeMs: Number(commitPerf?.decode_ms ?? 0),
-                        rustCommitTransformMs: Number(commitPerf?.transform_ms ?? 0),
-                        rustCommitMsmScalarPrepMs: Number(commitPerf?.msm_scalar_prep_ms ?? 0),
-                        rustCommitMsmBucketFillMs: Number(commitPerf?.msm_bucket_fill_ms ?? 0),
-                        rustCommitMsmReduceMs: Number(commitPerf?.msm_reduce_ms ?? 0),
-                        rustCommitMsmDoubleMs: Number(commitPerf?.msm_double_ms ?? 0),
-                        rustCommitMsmMs: Number(commitPerf?.msm_ms ?? 0),
-                        rustCommitCompressMs: Number(commitPerf?.compress_ms ?? 0),
-                        rustCommitMs: Number(commitPerf?.total_ms ?? commitMs),
+                        rustCommitDecodeMs: commitPerf.decodeMs,
+                        rustCommitTransformMs: commitPerf.transformMs,
+                        rustCommitMsmScalarPrepMs: commitPerf.msmScalarPrepMs,
+                        rustCommitMsmBucketFillMs: commitPerf.msmBucketFillMs,
+                        rustCommitMsmReduceMs: commitPerf.msmReduceMs,
+                        rustCommitMsmDoubleMs: commitPerf.msmDoubleMs,
+                        rustCommitMsmMs: commitPerf.msmMs,
+                        rustCommitCompressMs: commitPerf.compressMs,
+                        rustCommitMs: commitPerf.totalMs || commitMs,
                         rustCommitBackend: 'blst',
                         rustCommitMsmSubphasesAvailable: false,
                     },


### PR DESCRIPTION
## Summary

- Adds a browser KZG commitment backend seam around the current WASM/blst implementation.
- Routes existing browser worker commitment paths through the seam without changing the default backend.
- Adds unit/parity coverage and a Playwright-driven browser baseline benchmark harness for the no-native-fallback path.

Closes #165.

## Scope Boundary

This PR intentionally does not add WebGPU yet. It creates the shrink-wrapped browser backend boundary and baseline measurement path needed before moving individual KZG phases to GPU-backed implementations.

## Validation

Local validation:

- `npx tsx --test src/lib/kzgCommitBackend.test.ts src/lib/mode2ArtifactsV1.test.ts` - passed, 7 tests
- `npm run test:unit` - passed, 223 tests
- `npm run lint` - passed
- `npm run build:app` - passed
- `KZG_BENCH_BLOBS=1,4,16 KZG_BENCH_WARMUP_RUNS=1 KZG_BENCH_MEASURE_RUNS=1 npm run perf:kzg-browser` - passed

Post-review focused validation on `eae2052e`:

- `npx tsx --test src/lib/kzgCommitBackend.test.ts` - passed, 7 tests
- `KZG_BENCH_BLOBS=1,foo,16 npm run perf:kzg-browser` - failed early as expected with `KZG_BENCH_BLOBS must be a comma-separated list of positive integers`
- `KZG_BENCH_BLOBS=1 KZG_BENCH_WARMUP_RUNS=1 KZG_BENCH_MEASURE_RUNS=1 npm run perf:kzg-browser` - passed
- `npm run lint` - passed
- `npm run build:app` - passed

Latest-head CI on `eae2052e`: all GitHub/Cloudflare checks passing. Merge state: `CLEAN`.

## Browser Benchmark Smoke

Environment: HeadlessChrome/143.0.7499.4, `hardwareConcurrency=12`, `deviceMemory=8`, `crossOriginIsolated=false`, backend `wasm-blst`, scheduling `direct-browser-wasm-profiled`.

| blobs | median wall ms | median per blob ms | median per MDU ms | median MiB/s |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 282.0 | 282.0 | 18048.0 | 0.443 |
| 4 | 1108.1 | 277.0 | 17729.6 | 0.451 |
| 16 | 4565.9 | 285.4 | 18263.6 | 0.438 |

Post-review one-blob smoke on `eae2052e`: median wall 307.3 ms, median MiB/s 0.407.

## AI Review Status

- Copilot: reviewed initial head and left 3 actionable threads. Fixed in `eae2052e`, replied on all 3 threads, and marked them resolved. Post-fix Copilot cloud-agent run succeeded.
- CodeRabbit: requested before and after `eae2052e`; no actionable CodeRabbit response observed.
- Codex: requested, but the connector replied that setup is unavailable for this repository. Local internal diff review completed.

## Merge Status

Readiness-only handoff. PR is mergeable from the agent side: latest-head CI is green, merge state is clean, and no unresolved review threads remain. Agents must not self-merge this repository; human approval/merge is required.
