### PR TITLE
Add browser WASM KZG baseline benchmark

### DIFF
--- a/polystore-website/package.json
+++ b/polystore-website/package.json
@@ -25,6 +25,7 @@
     "perf:prepare-stages": "tsx scripts/benchmark_prepare_stages.ts",
     "perf:prepare-compare": "tsx scripts/benchmark_prepare_compare.ts",
     "perf:user-stage-concurrency": "tsx scripts/benchmark_user_stage_concurrency.ts",
+    "perf:browser-kzg-baseline": "tsx scripts/benchmark_browser_kzg_baseline.ts",
     "perf:msm-windows": "tsx scripts/benchmark_pippenger_windows.ts",
     "perf:kzg-compare": "tsx scripts/benchmark_kzg_commit_compare.ts",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",

--- a/polystore-website/perf/browser-kzg-baseline-latest.json
+++ b/polystore-website/perf/browser-kzg-baseline-latest.json
@@ -1,0 +1,316 @@
+{
+  "generated_at": "2026-05-28T17:25:42.331Z",
+  "git": {
+    "branch": "perf/wasm-kzg-benchmark",
+    "commit": "f31c94eb16e99cdb7ba53f660a0cb6ad7b6da79d",
+    "commit_short": "f31c94eb"
+  },
+  "runtime": {
+    "node": "v24.14.1",
+    "v8": "13.6.233.17-node.44",
+    "platform": "linux",
+    "arch": "x64",
+    "os_release": "6.8.0-110-generic",
+    "cpu_model": "11th Gen Intel(R) Core(TM) i5-11400F @ 2.60GHz",
+    "logical_cpus": 12,
+    "total_memory_bytes": 33512767488
+  },
+  "commands": {
+    "baseline": "env SINGLE_BLOB_WARMUPS=1 SINGLE_BLOB_RUNS=5 ONE_MDU_RUNS=1 LARGE_CYCLES=1 LARGE_FILE_BYTES=49103158 CONCURRENCIES=5,6,7 PIPELINE_MODES=fused_batch_sampled npm --prefix polystore-website run perf:browser-kzg-baseline --silent",
+    "one_mdu": "env FILE_BYTES=8126464 WARMUP_RUNS=0 MEASURE_RUNS=1 BASIS_MODE=blst npm --prefix polystore-website run perf:prepare-stages --silent",
+    "large_worker": "env FILE_BYTES=49103158 CYCLES=1 CONCURRENCIES=5,6,7 PIPELINE_MODES=fused_batch_sampled BASIS_MODE=blst npm --prefix polystore-website run perf:user-stage-concurrency --silent"
+  },
+  "summary": {
+    "single_blob_wall_median_ms": 258.45477900000014,
+    "one_mdu_total_prepare_median_ms": 26567.780770999998,
+    "one_mdu_user_stage_median_ms": 26433.036531,
+    "one_mdu_user_msm_total_ms": 25792,
+    "one_mdu_implied_per_blob_msm_ms": 268.6666666666667,
+    "commitments_per_raw_user_mdu": 96
+  },
+  "single_blob": {
+    "blob_bytes": 131072,
+    "warmup_runs": 1,
+    "measure_runs": 5,
+    "init_ms": 2650.128383,
+    "wall_ms": {
+      "min": 257.4234220000003,
+      "median": 258.45477900000014,
+      "mean": 259.0532860000001,
+      "max": 262.8153379999999
+    },
+    "rust_total_ms": {
+      "min": 257,
+      "median": 258,
+      "mean": 259,
+      "max": 263
+    },
+    "rust_msm_ms": {
+      "min": 257,
+      "median": 258,
+      "mean": 259,
+      "max": 263
+    },
+    "last_perf": {
+      "decode_ms": 0,
+      "transform_ms": 0,
+      "msm_scalar_prep_ms": 0,
+      "msm_bucket_fill_ms": 0,
+      "msm_reduce_ms": 0,
+      "msm_double_ms": 0,
+      "msm_ms": 263,
+      "compress_ms": 0,
+      "total_ms": 263,
+      "blobs": 1
+    }
+  },
+  "one_mdu_prepare": {
+    "file_bytes": 8126464,
+    "raw_mdu_capacity": 8126464,
+    "total_user_mdus": 1,
+    "rs_k": 2,
+    "rs_m": 1,
+    "basis_mode": "blst",
+    "warmup_runs": 0,
+    "measure_runs": 1,
+    "init": {
+      "polystore_wasm_ms": 2643.014051
+    },
+    "stages": {
+      "total_ms": {
+        "min": 26567.780770999998,
+        "median": 26567.780770999998,
+        "mean": 26567.780770999998,
+        "max": 26567.780770999998
+      },
+      "user_stage_ms": {
+        "min": 26433.036531,
+        "median": 26433.036531,
+        "mean": 26433.036531,
+        "max": 26433.036531
+      },
+      "witness_stage_ms": {
+        "min": 52.63608699999895,
+        "median": 52.63608699999895,
+        "mean": 52.63608699999895,
+        "max": 52.63608699999895
+      },
+      "meta_stage_ms": {
+        "min": 42.540367000001424,
+        "median": 42.540367000001424,
+        "mean": 42.540367000001424,
+        "max": 42.540367000001424
+      },
+      "manifest_ms": {
+        "min": 34.98725600000034,
+        "median": 34.98725600000034,
+        "mean": 34.98725600000034,
+        "max": 34.98725600000034
+      }
+    },
+    "phase_totals": {
+      "user": {
+        "wall_ms": 26433.036531,
+        "phase_totals": {
+          "expand_ms": 6,
+          "commit_ms": 25797,
+          "root_ms": 1.0081690000006347,
+          "rust_encode_ms": 2,
+          "rust_rs_ms": 3,
+          "rust_commit_decode_ms": 4,
+          "rust_commit_transform_ms": 0,
+          "rust_commit_msm_scalar_prep_ms": 0,
+          "rust_commit_msm_bucket_fill_ms": 0,
+          "rust_commit_msm_reduce_ms": 0,
+          "rust_commit_msm_double_ms": 0,
+          "rust_commit_msm_ms": 25792,
+          "rust_commit_compress_ms": 1
+        }
+      },
+      "witness": {
+        "wall_ms": 52.63608699999895,
+        "phase_totals": {
+          "expand_ms": 0,
+          "commit_ms": 52.47536200000104,
+          "root_ms": 0.16072499999791034,
+          "rust_encode_ms": 0,
+          "rust_rs_ms": 0,
+          "rust_commit_decode_ms": 0,
+          "rust_commit_transform_ms": 0,
+          "rust_commit_msm_scalar_prep_ms": 0,
+          "rust_commit_msm_bucket_fill_ms": 0,
+          "rust_commit_msm_reduce_ms": 0,
+          "rust_commit_msm_double_ms": 0,
+          "rust_commit_msm_ms": 47,
+          "rust_commit_compress_ms": 0
+        }
+      },
+      "meta": {
+        "wall_ms": 42.540367000001424,
+        "phase_totals": {
+          "expand_ms": 0,
+          "commit_ms": 42.381375000000844,
+          "root_ms": 0.15899200000058045,
+          "rust_encode_ms": 0,
+          "rust_rs_ms": 0,
+          "rust_commit_decode_ms": 0,
+          "rust_commit_transform_ms": 0,
+          "rust_commit_msm_scalar_prep_ms": 0,
+          "rust_commit_msm_bucket_fill_ms": 0,
+          "rust_commit_msm_reduce_ms": 0,
+          "rust_commit_msm_double_ms": 0,
+          "rust_commit_msm_ms": 40,
+          "rust_commit_compress_ms": 0
+        }
+      }
+    },
+    "runs": [
+      {
+        "total_ms": 26567.780770999998,
+        "user_stage": {
+          "wall_ms": 26433.036531,
+          "records": [
+            {
+              "index": 0,
+              "kind": "user",
+              "raw_bytes": 8126464,
+              "encoded_mdu_bytes": 8388608,
+              "witness_bytes": 4608,
+              "wall_ms": 26433.036531,
+              "expand_ms": 6,
+              "commit_ms": 25797,
+              "root_ms": 1.0081690000006347,
+              "rust_encode_ms": 2,
+              "rust_rs_ms": 3,
+              "rust_commit_decode_ms": 4,
+              "rust_commit_transform_ms": 0,
+              "rust_commit_msm_scalar_prep_ms": 0,
+              "rust_commit_msm_bucket_fill_ms": 0,
+              "rust_commit_msm_reduce_ms": 0,
+              "rust_commit_msm_double_ms": 0,
+              "rust_commit_msm_ms": 25792,
+              "rust_commit_compress_ms": 1,
+              "mdu_root_hex": "0xa2b7fa7c36fcafb424bc559340489772ad72dac948cbe86c81a4543d4db3b9eb"
+            }
+          ]
+        },
+        "witness_stage": {
+          "wall_ms": 52.63608699999895,
+          "records": [
+            {
+              "index": 0,
+              "kind": "witness",
+              "raw_bytes": 4608,
+              "encoded_mdu_bytes": 8388608,
+              "witness_bytes": 3072,
+              "wall_ms": 52.63608699999895,
+              "expand_ms": 0,
+              "commit_ms": 52.47536200000104,
+              "root_ms": 0.16072499999791034,
+              "rust_encode_ms": 0,
+              "rust_rs_ms": 0,
+              "rust_commit_decode_ms": 0,
+              "rust_commit_transform_ms": 0,
+              "rust_commit_msm_scalar_prep_ms": 0,
+              "rust_commit_msm_bucket_fill_ms": 0,
+              "rust_commit_msm_reduce_ms": 0,
+              "rust_commit_msm_double_ms": 0,
+              "rust_commit_msm_ms": 47,
+              "rust_commit_compress_ms": 0,
+              "mdu_root_hex": "0x7a26d4e0decb1352c8c75f06463a80fc680819cd8fe7daa67fe6328daf535b7e"
+            }
+          ]
+        },
+        "meta_stage": {
+          "wall_ms": 42.540367000001424,
+          "records": [
+            {
+              "index": 0,
+              "kind": "meta",
+              "raw_bytes": 8388608,
+              "encoded_mdu_bytes": 8388608,
+              "witness_bytes": 3072,
+              "wall_ms": 42.540367000001424,
+              "expand_ms": 0,
+              "commit_ms": 42.381375000000844,
+              "root_ms": 0.15899200000058045,
+              "rust_encode_ms": 0,
+              "rust_rs_ms": 0,
+              "rust_commit_decode_ms": 0,
+              "rust_commit_transform_ms": 0,
+              "rust_commit_msm_scalar_prep_ms": 0,
+              "rust_commit_msm_bucket_fill_ms": 0,
+              "rust_commit_msm_reduce_ms": 0,
+              "rust_commit_msm_double_ms": 0,
+              "rust_commit_msm_ms": 40,
+              "rust_commit_compress_ms": 0,
+              "mdu_root_hex": "0x32ce41943ab54afacc773beb6ffacb1a274df460ac53200d6cecc5fa31652ad7"
+            }
+          ]
+        },
+        "manifest_ms": 34.98725600000034,
+        "user_count": 1,
+        "witness_count": 1,
+        "manifest_root_hex": "0xac1ee55408fb1dfaf1bbaa0aafc71b3d25a332296f42e09c4157b13d49110e566f88c5220427ea41c7fa301d866319f3"
+      }
+    ]
+  },
+  "large_worker_sweep": {
+    "file_bytes": 49103158,
+    "total_user_mdus": 7,
+    "basis_mode": "blst",
+    "pipeline_modes": [
+      "fused_batch_sampled"
+    ],
+    "cycles": 1,
+    "concurrencies": [
+      5,
+      6,
+      7
+    ],
+    "results": {
+      "fused_batch_sampled:5": {
+        "pipeline_mode": "fused_batch_sampled",
+        "concurrency": 5,
+        "worker_count": 5,
+        "runs": [
+          56170.163725
+        ],
+        "stats": {
+          "min": 56170.163725,
+          "median": 56170.163725,
+          "mean": 56170.163725,
+          "max": 56170.163725
+        }
+      },
+      "fused_batch_sampled:6": {
+        "pipeline_mode": "fused_batch_sampled",
+        "concurrency": 6,
+        "worker_count": 6,
+        "runs": [
+          40087.33147
+        ],
+        "stats": {
+          "min": 40087.33147,
+          "median": 40087.33147,
+          "mean": 40087.33147,
+          "max": 40087.33147
+        }
+      },
+      "fused_batch_sampled:7": {
+        "pipeline_mode": "fused_batch_sampled",
+        "concurrency": 7,
+        "worker_count": 7,
+        "runs": [
+          38378.566854000004
+        ],
+        "stats": {
+          "min": 38378.566854000004,
+          "median": 38378.566854000004,
+          "mean": 38378.566854000004,
+          "max": 38378.566854000004
+        }
+      }
+    }
+  }
+}

--- a/polystore-website/perf/browser-kzg-baseline-latest.md
+++ b/polystore-website/perf/browser-kzg-baseline-latest.md
@@ -1,0 +1,65 @@
+# Browser-Only WASM KZG Baseline
+
+Generated: 2026-05-28T17:25:42.331Z
+
+## Context
+
+| Field | Value |
+| --- | --- |
+| Branch | `perf/wasm-kzg-benchmark` |
+| Commit | `f31c94eb16e99cdb7ba53f660a0cb6ad7b6da79d` |
+| Node | `v24.14.1` |
+| V8 | `13.6.233.17-node.44` |
+| Platform | `linux/x64` |
+| OS release | `6.8.0-110-generic` |
+| CPU | 11th Gen Intel(R) Core(TM) i5-11400F @ 2.60GHz |
+| Logical CPUs | 12 |
+| Memory | 31.21 GiB |
+
+## Summary
+
+| Workload | Key Result | Notes |
+| --- | ---: | --- |
+| One nonzero 128 KiB blob | 258.45 ms | Median wall time over 5 measured runs. |
+| One raw user MDU prepare | 26567.78 ms | 1 user MDU, RS 2+1. |
+| One raw user MDU user stage | 26433.04 ms | KZG-dominated stage. |
+| One raw user MDU user MSM total | 25792.00 ms | Aggregated profiled Rust/WASM MSM time across measured runs. |
+| Implied per-blob MSM from one MDU | 268.67 ms | 96 commitments per raw user MDU. |
+
+## Single Blob Commitment
+
+| Metric | Median | Min | Max |
+| --- | ---: | ---: | ---: |
+| Wall time | 258.45 ms | 257.42 ms | 262.82 ms |
+| Rust total | 258.00 ms | 257.00 ms | 263.00 ms |
+| Rust MSM | 258.00 ms | 257.00 ms | 263.00 ms |
+
+## One Raw User MDU Prepare
+
+| Stage | Median |
+| --- | ---: |
+| Total prepare | 26567.78 ms |
+| User stage | 26433.04 ms |
+| Witness stage | 52.64 ms |
+| Metadata stage | 42.54 ms |
+| Manifest | 34.99 ms |
+
+## Large User-Stage Worker Sweep
+
+| Mode / Concurrency | Workers Used | Median | Min | Max |
+| --- | ---: | ---: | ---: | ---: |
+| fused_batch_sampled:5 | 5 | 56170.16 ms | 56170.16 ms | 56170.16 ms |
+| fused_batch_sampled:6 | 6 | 40087.33 ms | 40087.33 ms | 40087.33 ms |
+| fused_batch_sampled:7 | 7 | 38378.57 ms | 38378.57 ms | 38378.57 ms |
+
+## Commands
+
+```bash
+env SINGLE_BLOB_WARMUPS=1 SINGLE_BLOB_RUNS=5 ONE_MDU_RUNS=1 LARGE_CYCLES=1 LARGE_FILE_BYTES=49103158 CONCURRENCIES=5,6,7 PIPELINE_MODES=fused_batch_sampled npm --prefix polystore-website run perf:browser-kzg-baseline --silent
+env FILE_BYTES=8126464 WARMUP_RUNS=0 MEASURE_RUNS=1 BASIS_MODE=blst npm --prefix polystore-website run perf:prepare-stages --silent
+env FILE_BYTES=49103158 CYCLES=1 CONCURRENCIES=5,6,7 PIPELINE_MODES=fused_batch_sampled BASIS_MODE=blst npm --prefix polystore-website run perf:user-stage-concurrency --silent
+```
+
+The single-blob benchmark is run inside `scripts/benchmark_browser_kzg_baseline.ts`; set `SINGLE_BLOB_RUNS`, `ONE_MDU_RUNS`, `LARGE_CYCLES`, `LARGE_FILE_BYTES`, `CONCURRENCIES`, and `PIPELINE_MODES` to adjust runtime and coverage.
+
+Browser-runtime evidence is intentionally separate from this Node/V8 baseline. Use this artifact as the stable dependency contract for Rust/WASM KZG algorithm work and worker-thread scheduling comparisons.

--- a/polystore-website/perf/browser-kzg-scoreboard.md
+++ b/polystore-website/perf/browser-kzg-scoreboard.md
@@ -5,9 +5,25 @@ Use this file to record the largest wins on `perf/browser-kzg-next` against the 
 Recommended commands:
 
 ```bash
+npm --prefix polystore-website run perf:browser-kzg-baseline
 npm --prefix polystore-website run perf:prepare-stages
 npm --prefix polystore-website run perf:prepare
 ```
+
+## Current Baseline Artifact
+
+The reproducible baseline for the no-local-helper browser/WASM KZG path is recorded in:
+
+- `polystore-website/perf/browser-kzg-baseline-latest.md`
+- `polystore-website/perf/browser-kzg-baseline-latest.json`
+
+The baseline runner covers:
+
+- one nonzero 128 KiB blob commitment using the checked-in PolyStore WASM bundle;
+- one raw user MDU full prepare with staged timing;
+- one large user-stage worker sweep across configured worker counts.
+
+Use this artifact as the before-state for fixed-base MSM, batched MSM, and worker-autotune PRs. Browser-runtime evidence should be captured separately when a browser harness is available; this baseline is the stable Node/V8 contract.
 
 Fields to track:
 - `full_prepare_ms`

--- a/polystore-website/scripts/benchmark_browser_kzg_baseline.ts
+++ b/polystore-website/scripts/benchmark_browser_kzg_baseline.ts
@@ -1,0 +1,316 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { performance } from 'node:perf_hooks'
+
+import init, { PolyStoreWasm } from '../public/wasm/polystore_core.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const websiteRoot = path.resolve(__dirname, '..')
+const repoRoot = path.resolve(websiteRoot, '..')
+
+const BLOB_SIZE = 128 * 1024
+const MDU_SIZE_BYTES = 8 * 1024 * 1024
+const SCALAR_BYTES = 32
+const SCALAR_PAYLOAD_BYTES = 31
+const RAW_MDU_CAPACITY = Math.floor(MDU_SIZE_BYTES / SCALAR_BYTES) * SCALAR_PAYLOAD_BYTES
+
+type Stats = {
+  min: number
+  median: number
+  mean: number
+  max: number
+}
+
+type CommitPerf = {
+  decode_ms?: number
+  transform_ms?: number
+  msm_scalar_prep_ms?: number
+  msm_bucket_fill_ms?: number
+  msm_reduce_ms?: number
+  msm_double_ms?: number
+  msm_ms?: number
+  compress_ms?: number
+  total_ms?: number
+  blobs?: number
+}
+
+type StagesSummary = {
+  file_bytes: number
+  raw_mdu_capacity: number
+  total_user_mdus: number
+  rs_k: number
+  rs_m: number
+  basis_mode: string
+  warmup_runs: number
+  measure_runs: number
+  init: { polystore_wasm_ms: number }
+  stages: {
+    total_ms: Stats
+    user_stage_ms: Stats
+    witness_stage_ms: Stats
+    meta_stage_ms: Stats
+    manifest_ms: Stats
+  }
+  phase_totals: {
+    user: { phase_totals: Record<string, number> }
+    witness: { phase_totals: Record<string, number> }
+    meta: { phase_totals: Record<string, number> }
+  }
+}
+
+type ConcurrencySummary = {
+  file_bytes: number
+  total_user_mdus: number
+  basis_mode: string
+  pipeline_modes: string[]
+  cycles: number
+  concurrencies: number[]
+  results: Record<string, { pipeline_mode: string; concurrency: number; worker_count: number; runs: number[]; stats: Stats }>
+}
+
+function makeDeterministicBytes(length: number): Uint8Array {
+  const bytes = new Uint8Array(length)
+  for (let i = 0; i < length; i += 1) bytes[i] = (i * 17 + 31) & 0xff
+  return bytes
+}
+
+function toU8(value: unknown): Uint8Array {
+  if (value instanceof Uint8Array) return value
+  return new Uint8Array(value as ArrayBufferLike)
+}
+
+function readStats(values: number[]): Stats {
+  const sorted = [...values].filter((value) => Number.isFinite(value)).sort((a, b) => a - b)
+  if (sorted.length === 0) return { min: 0, median: 0, mean: 0, max: 0 }
+  const middle = Math.floor(sorted.length / 2)
+  const median = sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle]
+  const mean = sorted.reduce((sum, value) => sum + value, 0) / sorted.length
+  return { min: sorted[0], median, mean, max: sorted[sorted.length - 1] }
+}
+
+function fmtMs(value: number | undefined): string {
+  if (!Number.isFinite(value ?? Number.NaN)) return 'n/a'
+  return `${(value as number).toFixed(2)} ms`
+}
+
+function runCommandJson<T>(label: string, args: string[], env: Record<string, string>): T {
+  const child = spawnSync('npm', args, {
+    cwd: repoRoot,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  })
+  if (child.status !== 0) {
+    throw new Error(`${label} failed with exit ${child.status}\nstdout:\n${child.stdout}\nstderr:\n${child.stderr}`)
+  }
+  try {
+    return JSON.parse(child.stdout) as T
+  } catch (error) {
+    throw new Error(`${label} did not emit JSON: ${error instanceof Error ? error.message : String(error)}\nstdout:\n${child.stdout}`)
+  }
+}
+
+function gitValue(args: string[]): string {
+  const child = spawnSync('git', args, { cwd: repoRoot, encoding: 'utf8' })
+  if (child.status !== 0) return 'unknown'
+  return child.stdout.trim()
+}
+
+async function benchmarkSingleBlob(measureRuns: number, warmupRuns: number) {
+  const wasmPath = path.resolve(websiteRoot, 'public', 'wasm', 'polystore_core_bg.wasm')
+  const wasmBuffer = await fs.readFile(wasmPath)
+  const initStart = performance.now()
+  await init({ module_or_path: wasmBuffer })
+  const trustedSetup = new Uint8Array(await fs.readFile(path.resolve(websiteRoot, 'public', 'trusted_setup.txt')))
+  const wasm = new PolyStoreWasm(trustedSetup)
+  wasm.set_wasm_msm_basis_mode('blst')
+  const initMs = performance.now() - initStart
+  const blob = makeDeterministicBytes(BLOB_SIZE)
+  const runs: number[] = []
+  const msmRuns: number[] = []
+  const totalRuns: number[] = []
+  let lastPerf: CommitPerf = {}
+
+  for (let i = 0; i < warmupRuns + measureRuns; i += 1) {
+    const start = performance.now()
+    const raw = wasm.commit_blobs_profiled(blob) as unknown
+    const wallMs = performance.now() - start
+    const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw
+    const witnessFlat = toU8((parsed as { witness_flat?: unknown }).witness_flat)
+    if (witnessFlat.byteLength !== 48) {
+      throw new Error(`single-blob witness length mismatch: ${witnessFlat.byteLength}`)
+    }
+    const perf = ((parsed as { perf?: unknown }).perf ?? {}) as CommitPerf
+    if (i >= warmupRuns) {
+      runs.push(wallMs)
+      msmRuns.push(Number(perf.msm_ms ?? 0))
+      totalRuns.push(Number(perf.total_ms ?? wallMs))
+      lastPerf = perf
+    }
+  }
+
+  return {
+    blob_bytes: BLOB_SIZE,
+    warmup_runs: warmupRuns,
+    measure_runs: measureRuns,
+    init_ms: initMs,
+    wall_ms: readStats(runs),
+    rust_total_ms: readStats(totalRuns),
+    rust_msm_ms: readStats(msmRuns),
+    last_perf: lastPerf,
+  }
+}
+
+const outputDir = path.resolve(repoRoot, process.env.OUTPUT_DIR || 'polystore-website/perf')
+const outputBase = process.env.OUTPUT_BASENAME || 'browser-kzg-baseline-latest'
+const singleBlobRuns = Number(process.env.SINGLE_BLOB_RUNS || 5)
+const singleBlobWarmups = Number(process.env.SINGLE_BLOB_WARMUPS || 1)
+const oneMduRuns = Number(process.env.ONE_MDU_RUNS || 1)
+const largeCycles = Number(process.env.LARGE_CYCLES || 1)
+const largeFileBytes = Number(process.env.LARGE_FILE_BYTES || 49_103_158)
+const concurrencies = process.env.CONCURRENCIES || '5,6,7'
+const pipelineModes = process.env.PIPELINE_MODES || 'fused_batch_sampled'
+
+const singleBlob = await benchmarkSingleBlob(singleBlobRuns, singleBlobWarmups)
+const oneMdu = runCommandJson<StagesSummary>(
+  'one-MDU prepare-stages benchmark',
+  ['--silent', '--prefix', 'polystore-website', 'run', 'perf:prepare-stages'],
+  {
+    FILE_BYTES: String(RAW_MDU_CAPACITY),
+    WARMUP_RUNS: '0',
+    MEASURE_RUNS: String(oneMduRuns),
+    BASIS_MODE: 'blst',
+  },
+)
+const largeWorker = runCommandJson<ConcurrencySummary>(
+  'large user-stage worker benchmark',
+  ['--silent', '--prefix', 'polystore-website', 'run', 'perf:user-stage-concurrency'],
+  {
+    FILE_BYTES: String(largeFileBytes),
+    CYCLES: String(largeCycles),
+    CONCURRENCIES: concurrencies,
+    PIPELINE_MODES: pipelineModes,
+    BASIS_MODE: 'blst',
+  },
+)
+
+const generatedAt = new Date().toISOString()
+const userPhase = oneMdu.phase_totals.user.phase_totals
+const commitmentsPerRawMdu = 64 * (1 + oneMdu.rs_m / oneMdu.rs_k)
+const perBlobFromMdu = userPhase.rust_commit_msm_ms / Math.max(1, commitmentsPerRawMdu * oneMdu.measure_runs)
+const baseline = {
+  generated_at: generatedAt,
+  git: {
+    branch: gitValue(['branch', '--show-current']),
+    commit: gitValue(['rev-parse', 'HEAD']),
+    commit_short: gitValue(['rev-parse', '--short', 'HEAD']),
+  },
+  runtime: {
+    node: process.version,
+    v8: process.versions.v8,
+    platform: process.platform,
+    arch: process.arch,
+    os_release: os.release(),
+    cpu_model: os.cpus()[0]?.model ?? 'unknown',
+    logical_cpus: os.cpus().length,
+    total_memory_bytes: os.totalmem(),
+  },
+  commands: {
+    baseline: `env SINGLE_BLOB_WARMUPS=${singleBlobWarmups} SINGLE_BLOB_RUNS=${singleBlobRuns} ONE_MDU_RUNS=${oneMduRuns} LARGE_CYCLES=${largeCycles} LARGE_FILE_BYTES=${largeFileBytes} CONCURRENCIES=${concurrencies} PIPELINE_MODES=${pipelineModes} npm --prefix polystore-website run perf:browser-kzg-baseline --silent`,
+    one_mdu: `env FILE_BYTES=${RAW_MDU_CAPACITY} WARMUP_RUNS=0 MEASURE_RUNS=${oneMduRuns} BASIS_MODE=blst npm --prefix polystore-website run perf:prepare-stages --silent`,
+    large_worker: `env FILE_BYTES=${largeFileBytes} CYCLES=${largeCycles} CONCURRENCIES=${concurrencies} PIPELINE_MODES=${pipelineModes} BASIS_MODE=blst npm --prefix polystore-website run perf:user-stage-concurrency --silent`,
+  },
+  summary: {
+    single_blob_wall_median_ms: singleBlob.wall_ms.median,
+    one_mdu_total_prepare_median_ms: oneMdu.stages.total_ms.median,
+    one_mdu_user_stage_median_ms: oneMdu.stages.user_stage_ms.median,
+    one_mdu_user_msm_total_ms: userPhase.rust_commit_msm_ms,
+    one_mdu_implied_per_blob_msm_ms: perBlobFromMdu,
+    commitments_per_raw_user_mdu: commitmentsPerRawMdu,
+  },
+  single_blob: singleBlob,
+  one_mdu_prepare: oneMdu,
+  large_worker_sweep: largeWorker,
+}
+
+const workerRows = Object.entries(largeWorker.results)
+  .sort(([, a], [, b]) => a.concurrency - b.concurrency || a.pipeline_mode.localeCompare(b.pipeline_mode))
+  .map(
+    ([key, result]) =>
+      `| ${key} | ${result.worker_count} | ${fmtMs(result.stats.median)} | ${fmtMs(result.stats.min)} | ${fmtMs(result.stats.max)} |`,
+  )
+  .join('\n')
+
+const markdown = `# Browser-Only WASM KZG Baseline
+
+Generated: ${generatedAt}
+
+## Context
+
+| Field | Value |
+| --- | --- |
+| Branch | \`${baseline.git.branch}\` |
+| Commit | \`${baseline.git.commit}\` |
+| Node | \`${baseline.runtime.node}\` |
+| V8 | \`${baseline.runtime.v8}\` |
+| Platform | \`${baseline.runtime.platform}/${baseline.runtime.arch}\` |
+| OS release | \`${baseline.runtime.os_release}\` |
+| CPU | ${baseline.runtime.cpu_model} |
+| Logical CPUs | ${baseline.runtime.logical_cpus} |
+| Memory | ${(baseline.runtime.total_memory_bytes / 1024 / 1024 / 1024).toFixed(2)} GiB |
+
+## Summary
+
+| Workload | Key Result | Notes |
+| --- | ---: | --- |
+| One nonzero 128 KiB blob | ${fmtMs(singleBlob.wall_ms.median)} | Median wall time over ${singleBlob.measure_runs} measured runs. |
+| One raw user MDU prepare | ${fmtMs(oneMdu.stages.total_ms.median)} | ${oneMdu.total_user_mdus} user MDU, RS ${oneMdu.rs_k}+${oneMdu.rs_m}. |
+| One raw user MDU user stage | ${fmtMs(oneMdu.stages.user_stage_ms.median)} | KZG-dominated stage. |
+| One raw user MDU user MSM total | ${fmtMs(userPhase.rust_commit_msm_ms)} | Aggregated profiled Rust/WASM MSM time across measured runs. |
+| Implied per-blob MSM from one MDU | ${fmtMs(perBlobFromMdu)} | ${commitmentsPerRawMdu} commitments per raw user MDU. |
+
+## Single Blob Commitment
+
+| Metric | Median | Min | Max |
+| --- | ---: | ---: | ---: |
+| Wall time | ${fmtMs(singleBlob.wall_ms.median)} | ${fmtMs(singleBlob.wall_ms.min)} | ${fmtMs(singleBlob.wall_ms.max)} |
+| Rust total | ${fmtMs(singleBlob.rust_total_ms.median)} | ${fmtMs(singleBlob.rust_total_ms.min)} | ${fmtMs(singleBlob.rust_total_ms.max)} |
+| Rust MSM | ${fmtMs(singleBlob.rust_msm_ms.median)} | ${fmtMs(singleBlob.rust_msm_ms.min)} | ${fmtMs(singleBlob.rust_msm_ms.max)} |
+
+## One Raw User MDU Prepare
+
+| Stage | Median |
+| --- | ---: |
+| Total prepare | ${fmtMs(oneMdu.stages.total_ms.median)} |
+| User stage | ${fmtMs(oneMdu.stages.user_stage_ms.median)} |
+| Witness stage | ${fmtMs(oneMdu.stages.witness_stage_ms.median)} |
+| Metadata stage | ${fmtMs(oneMdu.stages.meta_stage_ms.median)} |
+| Manifest | ${fmtMs(oneMdu.stages.manifest_ms.median)} |
+
+## Large User-Stage Worker Sweep
+
+| Mode / Concurrency | Workers Used | Median | Min | Max |
+| --- | ---: | ---: | ---: | ---: |
+${workerRows}
+
+## Commands
+
+\`\`\`bash
+${baseline.commands.baseline}
+${baseline.commands.one_mdu}
+${baseline.commands.large_worker}
+\`\`\`
+
+The single-blob benchmark is run inside \`scripts/benchmark_browser_kzg_baseline.ts\`; set \`SINGLE_BLOB_RUNS\`, \`ONE_MDU_RUNS\`, \`LARGE_CYCLES\`, \`LARGE_FILE_BYTES\`, \`CONCURRENCIES\`, and \`PIPELINE_MODES\` to adjust runtime and coverage.
+
+Browser-runtime evidence is intentionally separate from this Node/V8 baseline. Use this artifact as the stable dependency contract for Rust/WASM KZG algorithm work and worker-thread scheduling comparisons.
+`
+
+await fs.mkdir(outputDir, { recursive: true })
+await fs.writeFile(path.join(outputDir, `${outputBase}.json`), `${JSON.stringify(baseline, null, 2)}\n`)
+await fs.writeFile(path.join(outputDir, `${outputBase}.md`), markdown)
+console.log(JSON.stringify(baseline, null, 2))


### PR DESCRIPTION
## Summary

Closes #153. Parent tracker: #152.

Adds a reproducible browser-only WASM KZG baseline runner and committed baseline artifacts for the no-local-helper upload path:

- `npm --prefix polystore-website run perf:browser-kzg-baseline`
- `polystore-website/perf/browser-kzg-baseline-latest.md`
- `polystore-website/perf/browser-kzg-baseline-latest.json`
- scoreboard pointer in `polystore-website/perf/browser-kzg-scoreboard.md`

The runner covers one nonzero 128 KiB blob, one raw user MDU full prepare, and a large user-stage worker sweep. It uses the checked-in PolyStore WASM bundle and avoids native/local-helper evidence.

## Benchmark Decision

Decision: neutral baseline / reference measurement.

This PR intentionally does not optimize throughput. It establishes the benchmark contract and reference numbers that dependent optimization PRs must compare against. No throughput improvement or regression is expected from this PR itself.

## Baseline Evidence

Environment: Node `v24.14.1`, V8 `13.6.233.17-node.44`, Linux x64, i5-11400F, 12 logical CPUs.

| Workload | Median/result |
| --- | ---: |
| One nonzero 128 KiB blob | 258.45 ms |
| One raw user MDU prepare | 26567.78 ms |
| One raw user MDU user stage | 26433.04 ms |
| One raw user MDU user MSM total | 25792.00 ms |
| Implied per-blob MSM from one MDU | 268.67 ms |
| Large worker sweep, 5 workers | 56170.16 ms |
| Large worker sweep, 6 workers | 40087.33 ms |
| Large worker sweep, 7 workers | 38378.57 ms |

Browser-runtime evidence remains separate from this Node/V8 baseline; this PR establishes the stable dependency contract for #154, #155, #157, and #158.

## Validation

- `npm --prefix polystore-website run wasm:ensure`
- `env SINGLE_BLOB_WARMUPS=1 SINGLE_BLOB_RUNS=5 ONE_MDU_RUNS=1 LARGE_CYCLES=1 LARGE_FILE_BYTES=49103158 CONCURRENCIES=5,6,7 PIPELINE_MODES=fused_batch_sampled npm --prefix polystore-website run perf:browser-kzg-baseline --silent`
- `npm --prefix polystore-website run build:app`
- `npm --prefix polystore-website run test:unit` (`217` passing)
- `cd polystore-website && npx tsx scripts/parity_wasm.ts`
- `git diff --check`

Build emits existing dependency/chunk warnings only.

## Branch And Review Contract

Branch: `perf/wasm-kzg-benchmark`
Base: `main`

This PR should be made mergeable before dependent optimization PRs are considered mergeable. Per repo policy, agents must not self-merge; human approval is required.
