### PR TITLE
[codex] Document direct SP HTTPS ingress

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -50,6 +50,7 @@ This repo contains a mix of **normative protocol spec**, **RFC drafts**, **imple
 - `docs/TRUSTED_DEVNET_COLLABORATOR_PACKET.md`: “Send this to collaborators” quickstart (website testing + optional SP join).
 - `docs/REMOTE_SP_JOIN_QUICKSTART.md`: Remote provider join quickstart (fast path).
 - `docs/networking/PROVIDER_ENDPOINTS.md`: Provider endpoint profiles (`direct` and `cloudflare-tunnel`).
+- `docs/networking/DIRECT_SP_HTTPS_RUNBOOK.md`: DNS-only direct HTTPS runbook for multi-provider hosts.
 - `docs/TRUSTED_DEVNET_MONITORING_CHECKLIST.md`: Minimal monitoring checklist for the soft launch.
 
 ## Agent Runbooks

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This repo is currently geared toward a **trusted devnet soft launch (Feb 2026)**
 - Trusted devnet pack (hub + remote providers): `docs/TRUSTED_DEVNET_SOFT_LAUNCH.md`
 - Collaborator packet (“send this to testers”): `docs/TRUSTED_DEVNET_COLLABORATOR_PACKET.md`
 - Provider endpoint profiles (`direct` vs `cloudflare-tunnel`): `docs/networking/PROVIDER_ENDPOINTS.md`
+- Direct SP HTTPS runbook for DNS-only provider hostnames: `docs/networking/DIRECT_SP_HTTPS_RUNBOOK.md`
 
 ## Quick start (local, what CI exercises)
 

--- a/docs/ALPHA_PROVIDER_QUICKSTART.md
+++ b/docs/ALPHA_PROVIDER_QUICKSTART.md
@@ -5,10 +5,10 @@ This is the shortest supported path for a PolyStore testnet provider-daemon oper
 Note: this file keeps a legacy `ALPHA_` prefix for compatibility.
 
 Recommended target:
-- home server behind NAT with Cloudflare Tunnel
+- DNS-only direct HTTPS through a reverse proxy when inbound `443` can reach the provider host
 
 Fallback target:
-- public VPS or directly reachable host
+- Cloudflare Tunnel when inbound ports are unavailable
 
 ## What you need from the hub operator
 
@@ -45,7 +45,7 @@ You only need to override RPC/LCD/chain settings if you are deliberately targeti
    - use `./scripts/run_devnet_provider.sh link` for link-only repair when the host is already configured and only the on-chain link request is missing
 8. Confirm:
    - local `http://127.0.0.1:8091/health`
-   - public `https://sp.<domain>/health` for tunnel / hostname mode, or `http://<ip>:8091/health` for direct IPv4 mode
+   - public `https://sp.<domain>/health` for DNS-only direct HTTPS or tunnel hostname mode, or `http://<ip>:8091/health` for direct IPv4 debugging
    - provider appears on `https://lcd.<domain>/polystorechain/polystorechain/v1/providers`
    - provider appears in the website `My Providers` dashboard at `https://polynomialstore.com/#/sp-dashboard`
 
@@ -55,6 +55,7 @@ If you deliberately want partial bootstrap without provider link, use the manual
 
 - Fast join guide: `docs/REMOTE_SP_JOIN_QUICKSTART.md`
 - Endpoint formats: `docs/networking/PROVIDER_ENDPOINTS.md`
+- Direct HTTPS runbook: `docs/networking/DIRECT_SP_HTTPS_RUNBOOK.md`
 - Multi-provider guide: `DEVNET_MULTI_PROVIDER.md`
 
 ## Success criteria

--- a/docs/REMOTE_SP_JOIN_QUICKSTART.md
+++ b/docs/REMOTE_SP_JOIN_QUICKSTART.md
@@ -26,7 +26,7 @@ The web-first operator flow is:
 
 - This repo checked out
 - Go + Rust toolchains installed
-- A reachable provider endpoint (either direct public IP/port-forward, or Cloudflare Tunnel HTTPS)
+- A reachable provider endpoint (prefer DNS-only direct HTTPS when inbound `443` is available; use Cloudflare Tunnel HTTPS when inbound ports are unavailable)
 - (Optional, recommended) systemd + a reverse proxy:
   - systemd templates: `ops/systemd/polystore-gateway-provider.service` + `ops/systemd/env/polystore-gateway-provider.env`
   - HTTPS reverse proxy example: `ops/caddy/Caddyfile.provider.example`
@@ -49,7 +49,21 @@ PROVIDER_KEY=provider1 ./scripts/run_devnet_provider.sh print-config
 
 ### 2) Pick an endpoint multiaddr
 
-Option A (direct/public endpoint): register an IP+port endpoint:
+Option A (preferred when inbound `443` is available): register a DNS+HTTPS endpoint:
+
+- `/dns4/sp.<domain>/tcp/443/https`
+
+Set it:
+
+```bash
+export PROVIDER_ENDPOINT="/dns4/sp.<domain>/tcp/443/https"
+```
+
+The DNS record should be DNS-only when using Cloudflare DNS, with Caddy or
+another reverse proxy terminating HTTPS on the provider host and forwarding to
+the local provider listener. See `docs/networking/DIRECT_SP_HTTPS_RUNBOOK.md`.
+
+Option B (direct public IP/port debugging): register an IP+port endpoint:
 
 - `/ip4/<your-public-ip>/tcp/8091/http`
 
@@ -59,7 +73,7 @@ Set it:
 export PROVIDER_ENDPOINT="/ip4/<your-public-ip>/tcp/8091/http"
 ```
 
-Option B (behind NAT with Cloudflare Tunnel): register DNS+HTTPS endpoint:
+Option C (behind NAT with Cloudflare Tunnel): register DNS+HTTPS endpoint:
 
 - `/dns4/sp.<domain>/tcp/443/https`
 

--- a/docs/TRUSTED_DEVNET_COLLABORATOR_PACKET_POLYNOMIALSTORE_COM.md
+++ b/docs/TRUSTED_DEVNET_COLLABORATOR_PACKET_POLYNOMIALSTORE_COM.md
@@ -20,6 +20,13 @@ Provider public endpoints (striped `2+1` baseline):
 - `https://sp2.polynomialstore.com` → provider `nil1w98n98a8gnrwnyz62wfvya9wzvdr92uwz7dssk`
 - `https://sp3.polynomialstore.com` → provider `nil182f6qy5taazj5fa722p2ut4d0v5j2gkap0dprj`
 
+Provider ingress note:
+- These SP hostnames are expected to resolve directly to the provider host
+  through DNS-only records, with Caddy terminating HTTPS and proxying to local
+  provider-daemon ports. They should not be Cloudflare-proxied for normal bulk
+  provider traffic.
+- Runbook: `docs/networking/DIRECT_SP_HTTPS_RUNBOOK.md`
+
 ## What Collaborators Need From Hub Operator
 
 - Faucet auth token (shared pre-alpha devnet bootstrap token; may already be embedded in the website build)
@@ -77,7 +84,7 @@ If the key is new and gas funding is still missing, fund the printed provider ad
 
 ```bash
 export PROVIDER_KEY="provider1"
-export PROVIDER_ENDPOINT="/dns4/sp1.polynomialstore.com/tcp/443/https" # or /ip4/<public-ip>/tcp/8091/http
+export PROVIDER_ENDPOINT="/dns4/sp1.polynomialstore.com/tcp/443/https"
 export POLYSTORE_GATEWAY_SP_AUTH="<shared-secret-from-hub>"
 export OPERATOR_ADDRESS="<operator-nil1-or-0x-address>"         # from website wallet step
 

--- a/docs/TRUSTED_DEVNET_SOFT_LAUNCH.md
+++ b/docs/TRUSTED_DEVNET_SOFT_LAUNCH.md
@@ -16,7 +16,7 @@ Related:
   - `user-gateway` (legacy runtime alias: `polystore_gateway` in router mode)
   - `polystore_faucet` (enabled, rate-limited; collaborator-only)
   - `polystore-website` (static build behind HTTPS)
-- **Providers (remote SPs)** run (direct endpoint or Cloudflare Tunnel endpoint):
+- **Providers (remote SPs)** run (direct endpoint preferred, Cloudflare Tunnel fallback):
   - `provider-daemon` (legacy runtime alias: `polystore_gateway` in provider mode, one per SP)
 - **Users** interact via:
   - Website + MetaMask (wallet-first), or curl for debugging
@@ -43,6 +43,7 @@ Gateway policy for this soft launch:
 
 Reverse proxy templates:
 - Caddy examples live in `ops/caddy/` (`ops/caddy/Caddyfile.hub.example` + `ops/caddy/Caddyfile.provider.example`).
+- Current direct SP HTTPS runbook: `docs/networking/DIRECT_SP_HTTPS_RUNBOOK.md`.
 
 ## Connectivity profiles (choose one)
 
@@ -51,13 +52,15 @@ Reverse proxy templates:
 - Hub has reachable inbound `80/443`.
 - DNS (`rpc/lcd/evm/faucet/web`) resolves directly to the hub public IP.
 - Caddy terminates TLS and proxies to localhost ports.
+- Provider hosts with reachable inbound `443` should also use direct DNS-only
+  HTTPS for SP payload paths.
 
 ### Profile B — Home server behind NAT/CGNAT + Cloudflare Tunnel
 
 - Hub is not directly reachable from the internet.
 - `cloudflared` publishes the same public hostnames and forwards to localhost ports.
 - Inbound `80/443` on the hub is not required.
-- Provider machines can also use Cloudflare Tunnel endpoints (`/dns4/<host>/tcp/443/https`) when they cannot open inbound ports.
+- Provider machines can use Cloudflare Tunnel endpoints (`/dns4/<host>/tcp/443/https`) when they cannot open inbound ports.
 - Endpoint details for providers: `docs/networking/PROVIDER_ENDPOINTS.md`.
 
 ## Hub runbook (blank box → running devnet)

--- a/docs/networking/DIRECT_SP_HTTPS_RUNBOOK.md
+++ b/docs/networking/DIRECT_SP_HTTPS_RUNBOOK.md
@@ -36,7 +36,12 @@ Direct DNS-only HTTPS keeps the provider endpoint shape browser-friendly and
 compatible with the existing multiaddrs while avoiding Cloudflare as the bulk
 data path.
 
-Empirical same-host transfer checks during the cutover showed:
+This recommendation is empirical, not theoretical. It was adopted after
+same-origin transfer checks showed that the provider-daemon and local reverse
+proxy were healthy, while the Cloudflare transit path was the bottleneck for
+large payloads in the Hawaii deployment.
+
+Same-host transfer checks during the cutover showed:
 
 - DNS-only direct HTTPS: tens of MB/s for 64 MiB uploads/downloads through the
   SP hostnames.
@@ -46,6 +51,11 @@ Empirical same-host transfer checks during the cutover showed:
 Treat those numbers as deployment evidence, not a universal benchmark. The
 operational conclusion is stable for this devnet: use direct DNS-only HTTPS for
 SP payload paths when inbound `443` is available.
+
+If future agents see slow provider upload or retrieval again, validate the
+network path before changing provider code. A direct-origin path that is fast
+and a Cloudflare path that is slow points at the DNS/proxy/tunnel layer, not the
+provider-daemon.
 
 ## Certificate Strategy
 
@@ -202,10 +212,131 @@ Expected:
 - TLS verify result is `0`.
 - HTTP version is usually `2`.
 
-For a safe network-path throughput check, add a temporary Caddy-only benchmark
-route above the provider routes and remove it immediately after testing. Do not
-POST arbitrary benchmark blobs to the live provider API unless the payload is a
-valid protocol upload you intend to keep.
+## Validating Cloudflare Slowdown
+
+Use this procedure when troubleshooting slow uploads/downloads. It compares the
+same origin server through two paths:
+
+- direct origin HTTPS
+- Cloudflare-proxied or Cloudflare Tunnel HTTPS
+
+Do not POST arbitrary benchmark blobs to the live provider API unless the
+payload is a valid protocol upload you intend to keep. Use a temporary
+Caddy-only benchmark route or a disposable benchmark hostname.
+
+### 1. Start a local benchmark sink
+
+Create a 64 MiB payload:
+
+```bash
+dd if=/dev/urandom of=/tmp/polystore-netbench-64m.bin bs=1M count=64 status=progress
+```
+
+This small Go server uses only the standard library. It consumes upload bodies
+and serves a fixed-size download stream without touching provider state.
+
+```bash
+cat >/tmp/polystore-netbench.go <<'EOF'
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+func main() {
+	http.HandleFunc("/__netbench/upload", func(w http.ResponseWriter, r *http.Request) {
+		n, err := io.Copy(io.Discard, r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		_, _ = fmt.Fprintf(w, "read=%d\n", n)
+	})
+
+	http.HandleFunc("/__netbench/download", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		http.ServeFile(w, r, "/tmp/polystore-netbench-64m.bin")
+	})
+
+	log.Fatal(http.ListenAndServe("127.0.0.1:18181", nil))
+}
+EOF
+
+go run /tmp/polystore-netbench.go
+```
+
+### 2. Add a temporary Caddy route
+
+Use either an existing SP hostname during a maintenance window or a temporary
+benchmark hostname whose certificate is valid on the origin.
+
+```caddyfile
+sp-bench.example.com {
+	tls /path/to/sp-bench.example.com.crt /path/to/sp-bench.example.com.key
+	reverse_proxy /__netbench/* 127.0.0.1:18181
+}
+```
+
+Validate and reload Caddy:
+
+```bash
+sudo caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile
+sudo systemctl reload caddy || sudo systemctl restart caddy
+```
+
+Remove this route when testing is complete.
+
+### 3. Measure direct origin HTTPS
+
+Bypass DNS with `--connect-to` or `--resolve` so the request uses the same
+hostname and SNI but connects directly to the provider host public address.
+
+```bash
+BENCH_HOST=sp-bench.example.com
+ORIGIN_IP=<provider-public-ip>
+
+curl --noproxy '*' --connect-to "$BENCH_HOST:443:$ORIGIN_IP:443" \
+  -o /dev/null -w "direct download bytes=%{size_download} rate=%{speed_download} remote=%{remote_ip} time=%{time_total}\n" \
+  "https://$BENCH_HOST/__netbench/download"
+
+curl --noproxy '*' --connect-to "$BENCH_HOST:443:$ORIGIN_IP:443" \
+  --data-binary "@/tmp/polystore-netbench-64m.bin" \
+  -o /dev/null -w "direct upload bytes=%{size_upload} rate=%{speed_upload} remote=%{remote_ip} time=%{time_total}\n" \
+  "https://$BENCH_HOST/__netbench/upload"
+```
+
+The `rate` values are bytes per second. Divide by `1048576` for MiB/s.
+
+### 4. Measure Cloudflare path
+
+For Cloudflare-proxied `A` testing, temporarily set the benchmark hostname to
+proxied mode in Cloudflare DNS. For Tunnel testing, route the benchmark hostname
+through `cloudflared` to the same local `127.0.0.1:18181` sink.
+
+Then run the same requests without `--connect-to`:
+
+```bash
+curl --noproxy '*' \
+  -o /dev/null -w "cloudflare download bytes=%{size_download} rate=%{speed_download} remote=%{remote_ip} time=%{time_total}\n" \
+  "https://$BENCH_HOST/__netbench/download"
+
+curl --noproxy '*' \
+  --data-binary "@/tmp/polystore-netbench-64m.bin" \
+  -o /dev/null -w "cloudflare upload bytes=%{size_upload} rate=%{speed_upload} remote=%{remote_ip} time=%{time_total}\n" \
+  "https://$BENCH_HOST/__netbench/upload"
+```
+
+Expected troubleshooting signal:
+
+- If direct origin HTTPS is fast and Cloudflare is much slower for the same
+  payload, the bottleneck is the Cloudflare proxy/tunnel path.
+- If both paths are slow, inspect local provider-daemon health, Caddy, NAT,
+  disk, CPU, and uplink saturation before blaming Cloudflare.
+- If `remote_ip` is a Cloudflare anycast address during the supposed direct
+  test, the record is still proxied or the test did not bypass DNS correctly.
 
 ## Rollback
 

--- a/docs/networking/DIRECT_SP_HTTPS_RUNBOOK.md
+++ b/docs/networking/DIRECT_SP_HTTPS_RUNBOOK.md
@@ -1,0 +1,232 @@
+# Direct Storage Provider HTTPS Runbook
+
+This runbook documents the preferred provider-daemon ingress shape for the
+trusted devnet when the operator can forward inbound TCP `443` to the provider
+host.
+
+Use this shape for bulk provider traffic. Keep Cloudflare Tunnel as a fallback
+for hosts that cannot receive inbound traffic.
+
+## Current Network Shape
+
+The current `polynomialstore.com` provider hostnames are expected to use:
+
+- Cloudflare DNS records in **DNS-only** mode, not proxied.
+- `A` records for `sp1.polynomialstore.com`, `sp2.polynomialstore.com`, and
+  `sp3.polynomialstore.com` pointing at the current provider host public
+  address.
+- Caddy listening on public TCP `443` on the provider host.
+- One public Let's Encrypt certificate covering all three SP hostnames.
+- Host-based Caddy reverse proxy:
+  - `sp1.polynomialstore.com` -> `127.0.0.1:8091`
+  - `sp2.polynomialstore.com` -> `127.0.0.1:8092`
+  - `sp3.polynomialstore.com` -> `127.0.0.1:8093`
+- On-chain provider endpoints remain:
+  - `/dns4/sp1.polynomialstore.com/tcp/443/https`
+  - `/dns4/sp2.polynomialstore.com/tcp/443/https`
+  - `/dns4/sp3.polynomialstore.com/tcp/443/https`
+
+Do not commit the current provider host public IP address to the repo. Read it
+from Cloudflare DNS, the router/NAT configuration, or operator notes when
+operating the live deployment.
+
+## Why DNS-only Direct HTTPS
+
+Direct DNS-only HTTPS keeps the provider endpoint shape browser-friendly and
+compatible with the existing multiaddrs while avoiding Cloudflare as the bulk
+data path.
+
+Empirical same-host transfer checks during the cutover showed:
+
+- DNS-only direct HTTPS: tens of MB/s for 64 MiB uploads/downloads through the
+  SP hostnames.
+- Cloudflare Tunnel and Cloudflare-proxied `A` records: around 1 MiB/s for the
+  same class of transfer in the Hawaii deployment.
+
+Treat those numbers as deployment evidence, not a universal benchmark. The
+operational conclusion is stable for this devnet: use direct DNS-only HTTPS for
+SP payload paths when inbound `443` is available.
+
+## Certificate Strategy
+
+Use a local publicly trusted certificate. A Cloudflare Origin Certificate is not
+enough for DNS-only mode because clients connect directly to the provider host.
+
+Preferred certificate:
+
+- one SAN certificate for exactly:
+  - `sp1.polynomialstore.com`
+  - `sp2.polynomialstore.com`
+  - `sp3.polynomialstore.com`
+- issued with ACME DNS-01 before DNS cutover
+- loaded explicitly by Caddy
+
+DNS-01 avoids the cutover window where DNS has moved but the origin does not yet
+have a valid certificate.
+
+Example with `lego` and a scoped Cloudflare token:
+
+```bash
+export CLOUDFLARE_DNS_API_TOKEN="<token-with-zone-dns-edit>"
+export CLOUDFLARE_ZONE_API_TOKEN="$CLOUDFLARE_DNS_API_TOKEN"
+
+lego \
+  --path "$HOME/.config/polystore-bench/lego" \
+  --email "<operator-email>" \
+  --accept-tos \
+  --dns cloudflare \
+  --domains sp1.polynomialstore.com \
+  --domains sp2.polynomialstore.com \
+  --domains sp3.polynomialstore.com \
+  --key-type ec256 \
+  run
+```
+
+The live Caddy service must be able to read the resulting certificate and key.
+Prefer a root-owned deployment path under `/etc/caddy` or `/var/lib/caddy`.
+For local operator-owned cert storage, grant only the `caddy` service user read
+access to the cert/key and traverse access to parent directories.
+
+Renew before expiry:
+
+```bash
+export CLOUDFLARE_DNS_API_TOKEN="<token-with-zone-dns-edit>"
+export CLOUDFLARE_ZONE_API_TOKEN="$CLOUDFLARE_DNS_API_TOKEN"
+
+lego \
+  --path "$HOME/.config/polystore-bench/lego" \
+  --email "<operator-email>" \
+  --accept-tos \
+  --dns cloudflare \
+  --domains sp1.polynomialstore.com \
+  --domains sp2.polynomialstore.com \
+  --domains sp3.polynomialstore.com \
+  --key-type ec256 \
+  renew
+
+sudo systemctl reload caddy || sudo systemctl restart caddy
+```
+
+## Caddy Configuration
+
+For the three-provider host, Caddy should terminate TLS on `443` and proxy each
+hostname to its local provider-daemon port.
+
+```caddyfile
+{
+	auto_https off
+}
+
+(polystore_sp_tls) {
+	tls /path/to/sp1.polynomialstore.com.crt /path/to/sp1.polynomialstore.com.key
+}
+
+sp1.polynomialstore.com {
+	import polystore_sp_tls
+	reverse_proxy 127.0.0.1:8091
+}
+
+sp2.polynomialstore.com {
+	import polystore_sp_tls
+	reverse_proxy 127.0.0.1:8092
+}
+
+sp3.polynomialstore.com {
+	import polystore_sp_tls
+	reverse_proxy 127.0.0.1:8093
+}
+```
+
+Keep `auto_https off` if this Caddy instance is intentionally not managing ACME
+for these names. This prevents accidental HTTP redirect listeners and makes the
+explicit cert/key the source of truth.
+
+Validate before restarting:
+
+```bash
+sudo caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile
+sudo systemctl restart caddy
+```
+
+## DNS Cutover
+
+Before cutover:
+
+1. Confirm provider-daemons are healthy locally:
+
+```bash
+curl -sf http://127.0.0.1:8091/health
+curl -sf http://127.0.0.1:8092/health
+curl -sf http://127.0.0.1:8093/health
+```
+
+2. Confirm direct HTTPS works before DNS changes:
+
+```bash
+curl --resolve sp1.polynomialstore.com:443:<provider-public-ip> https://sp1.polynomialstore.com/health
+curl --resolve sp2.polynomialstore.com:443:<provider-public-ip> https://sp2.polynomialstore.com/health
+curl --resolve sp3.polynomialstore.com:443:<provider-public-ip> https://sp3.polynomialstore.com/health
+```
+
+3. Back up the existing Cloudflare DNS records.
+
+Then replace the old tunnel CNAMEs with DNS-only `A` records:
+
+```text
+sp1.polynomialstore.com A <provider-public-ip> DNS-only
+sp2.polynomialstore.com A <provider-public-ip> DNS-only
+sp3.polynomialstore.com A <provider-public-ip> DNS-only
+```
+
+Do not use orange-cloud/proxied mode for provider payload paths unless you are
+intentionally testing Cloudflare as the data path.
+
+## Validation
+
+After DNS changes:
+
+```bash
+for host in sp1.polynomialstore.com sp2.polynomialstore.com sp3.polynomialstore.com; do
+  dig +short "$host" A
+  curl --noproxy '*' -fsS -o /dev/null \
+    -w "$host code=%{http_code} version=%{http_version} remote=%{remote_ip} tls=%{ssl_verify_result} time=%{time_total}\n" \
+    "https://$host/health"
+done
+```
+
+Expected:
+
+- DNS returns the provider host public address, not Cloudflare anycast IPs.
+- `remote_ip` is the provider host public address.
+- HTTP status is `200`.
+- TLS verify result is `0`.
+- HTTP version is usually `2`.
+
+For a safe network-path throughput check, add a temporary Caddy-only benchmark
+route above the provider routes and remove it immediately after testing. Do not
+POST arbitrary benchmark blobs to the live provider API unless the payload is a
+valid protocol upload you intend to keep.
+
+## Rollback
+
+Rollback is DNS-only:
+
+1. Restore the previous Cloudflare Tunnel CNAME records for
+   `sp1.polynomialstore.com`, `sp2.polynomialstore.com`, and
+   `sp3.polynomialstore.com`.
+2. Set them back to proxied mode if they were proxied before.
+3. Confirm `cloudflared-providers.service` is running on the provider host.
+
+The on-chain multiaddrs do not need to change for rollback because both direct
+HTTPS and Tunnel HTTPS use `/dns4/<host>/tcp/443/https`.
+
+## Future Agent Notes
+
+- Do not assume `cloudflared-providers.service` carries live SP traffic. In the
+  current deployment it is a fallback while DNS-only direct HTTPS is primary.
+- If `spN.polynomialstore.com` resolves to Cloudflare anycast IPs, the record is
+  proxied or stale in a resolver cache.
+- If it resolves to the provider host public address but HTTPS fails, inspect
+  Caddy first, then provider-daemon health on the local `809N` port.
+- If transfer speed regresses to around Tunnel-like throughput, check for an
+  accidental orange-cloud/proxied DNS record before investigating provider code.

--- a/docs/networking/PROVIDER_ENDPOINTS.md
+++ b/docs/networking/PROVIDER_ENDPOINTS.md
@@ -4,8 +4,11 @@ PolyStore providers (SPs) must register at least one reachable **endpoint multia
 
 This doc defines the two supported endpoint "types" for testnet onboarding:
 
-- `cloudflare-tunnel` (recommended for the trusted soft-launch / home-server path): expose HTTPS via Cloudflare Tunnel.
-- `direct` (recommended when you already control stable public ingress): provider has an open inbound port or reverse proxy.
+- `direct` (recommended when inbound `443` can reach the provider host): provider has an open inbound port or reverse proxy.
+- `cloudflare-tunnel` (fallback when inbound ports are unavailable): expose HTTPS via Cloudflare Tunnel.
+
+For the current `polynomialstore.com` SP deployment, direct DNS-only HTTPS is
+the primary shape. See `docs/networking/DIRECT_SP_HTTPS_RUNBOOK.md`.
 
 Future (not testnet-blocking):
 
@@ -69,6 +72,27 @@ Example TLS reverse proxy (Caddy):
 caddy reverse-proxy --from sp.example.com --to localhost:8082
 ```
 
+For a multi-provider host, Caddy can terminate TLS once on `443` and route by
+hostname:
+
+```caddyfile
+sp1.example.com {
+  reverse_proxy 127.0.0.1:8091
+}
+
+sp2.example.com {
+  reverse_proxy 127.0.0.1:8092
+}
+
+sp3.example.com {
+  reverse_proxy 127.0.0.1:8093
+}
+```
+
+When using Cloudflare DNS with this profile, the SP records must be **DNS-only**
+for bulk transfer. Orange-cloud/proxied records route traffic through
+Cloudflare and can behave like the tunnel path for large provider payloads.
+
 Now print the endpoint to register:
 
 ```bash
@@ -97,11 +121,13 @@ polystorechaind tx polystorechain update-provider-endpoints \
   --endpoint "/dns4/sp.example.com/tcp/443/https"
 ```
 
-## Type: cloudflare-tunnel (recommended soft-launch default)
+## Type: cloudflare-tunnel (fallback when inbound ports are unavailable)
 
 Goal: expose the provider at `https://sp.example.com` without opening inbound ports.
 
 This routes traffic through Cloudflare, but is simple and works behind NAT.
+Use it when the provider host cannot expose inbound `443`. If inbound `443` is
+available, prefer the direct DNS-only HTTPS profile above.
 
 ### Minimal tunnel setup
 

--- a/docs/networking/PROVIDER_ENDPOINTS.md
+++ b/docs/networking/PROVIDER_ENDPOINTS.md
@@ -8,7 +8,10 @@ This doc defines the two supported endpoint "types" for testnet onboarding:
 - `cloudflare-tunnel` (fallback when inbound ports are unavailable): expose HTTPS via Cloudflare Tunnel.
 
 For the current `polynomialstore.com` SP deployment, direct DNS-only HTTPS is
-the primary shape. See `docs/networking/DIRECT_SP_HTTPS_RUNBOOK.md`.
+the primary shape. This was chosen after empirical transfer tests showed a large
+slowdown when Cloudflare Tunnel or orange-cloud/proxied `A` records carried SP
+payload traffic, while the same origin was fast over direct HTTPS. See
+`docs/networking/DIRECT_SP_HTTPS_RUNBOOK.md` for the validation procedure.
 
 Future (not testnet-blocking):
 
@@ -91,7 +94,9 @@ sp3.example.com {
 
 When using Cloudflare DNS with this profile, the SP records must be **DNS-only**
 for bulk transfer. Orange-cloud/proxied records route traffic through
-Cloudflare and can behave like the tunnel path for large provider payloads.
+Cloudflare and can behave like the tunnel path for large provider payloads. If
+large uploads or retrievals regress, benchmark direct origin HTTPS against the
+Cloudflare path before changing provider-daemon code.
 
 Now print the endpoint to register:
 

--- a/ops/caddy/Caddyfile.provider.example
+++ b/ops/caddy/Caddyfile.provider.example
@@ -12,3 +12,16 @@ sp1.example.com {
   reverse_proxy 127.0.0.1:8091
 }
 
+# Multi-provider host example:
+#
+# sp1.example.com {
+#   reverse_proxy 127.0.0.1:8091
+# }
+#
+# sp2.example.com {
+#   reverse_proxy 127.0.0.1:8092
+# }
+#
+# sp3.example.com {
+#   reverse_proxy 127.0.0.1:8093
+# }

--- a/ops/caddy/README.md
+++ b/ops/caddy/README.md
@@ -37,4 +37,8 @@ If a provider wants a clean HTTPS endpoint on port 443:
 
 Notes:
 - Caddy automatically handles TLS and WebSockets for these reverse proxies.
-
+- For the current `polynomialstore.com` provider deployment, the SP hostnames use
+  DNS-only records and Caddy terminates HTTPS directly on the provider host. Do
+  not orange-cloud/proxy the SP records for bulk provider traffic.
+- The current direct HTTPS provider runbook is
+  `docs/networking/DIRECT_SP_HTTPS_RUNBOOK.md`.

--- a/ops/systemd/README.md
+++ b/ops/systemd/README.md
@@ -57,8 +57,7 @@ journalctl -u polystorechaind -f
 
 ## User-level Cloudflare tunnel units
 
-For the current `polynomialstore.com` deployment, the Cloudflare tunnels run cleanly as
-user services:
+Cloudflare tunnels can run cleanly as user services:
 
 ```bash
 mkdir -p ~/.config/systemd/user
@@ -71,6 +70,12 @@ systemctl --user enable --now cloudflared-providers.service
 
 These units intentionally use `Restart=always`. `cloudflared` can exit with status `0`
 after all connections drop, and `Restart=on-failure` leaves the tunnel down.
+
+For the current `polynomialstore.com` provider deployment, the three SP
+hostnames are expected to use DNS-only direct HTTPS through Caddy, not
+Cloudflare Tunnel. `cloudflared-providers.service` may still exist as a fallback,
+but future agents should not assume it carries live `sp1`/`sp2`/`sp3` traffic.
+See `docs/networking/DIRECT_SP_HTTPS_RUNBOOK.md`.
 
 ## Provider quick usage
 

--- a/polystore-website/src/pages/TestnetDocs.tsx
+++ b/polystore-website/src/pages/TestnetDocs.tsx
@@ -269,8 +269,8 @@ export const TestnetDocs = () => {
                 For testnet onboarding, keep it simple:
               </p>
               <ul className="list-disc pl-5 text-muted-foreground space-y-1">
-                <li><strong>direct</strong> (recommended): SP has inbound 443 on a public IP / port-forward; expose <code className="px-1 py-0.5 rounded-none bg-secondary/60">https://sp.example.com</code> via a reverse proxy. If Cloudflare manages DNS, keep SP payload hostnames DNS-only.</li>
-                <li><strong>cloudflare-tunnel</strong> (fallback): SP is behind NAT; expose <code className="px-1 py-0.5 rounded-none bg-secondary/60">https://sp.example.com</code> via Cloudflare Tunnel (no router changes, bytes transit Cloudflare).</li>
+                <li><strong>direct</strong> (recommended): SP has inbound 443 on a public IP / port-forward; expose <code className="px-1 py-0.5 rounded-none bg-secondary/60">https://sp.example.com</code> via a reverse proxy. Use this for bulk provider payloads when possible.</li>
+                <li><strong>cloudflare-tunnel</strong> (fallback): SP is behind NAT; expose <code className="px-1 py-0.5 rounded-none bg-secondary/60">https://sp.example.com</code> via Cloudflare Tunnel. This is operationally convenient, but bytes transit Cloudflare and should be benchmarked if large transfers are slow.</li>
                 <li><strong>webrtc</strong> (future): NAT traversal optimization; not testnet-blocking.</li>
               </ul>
               <p className="text-muted-foreground">
@@ -290,7 +290,7 @@ export const TestnetDocs = () => {
             <div className="space-y-2">
               <h3 className="font-bold text-foreground">2A) direct (reverse proxy on 443)</h3>
               <p className="text-muted-foreground">
-                If the SP has an open inbound port, terminate TLS on 443 and proxy to <code className="px-1 py-0.5 rounded-none bg-secondary/60">localhost:8082</code>. When using Cloudflare DNS, keep the hostname DNS-only instead of proxied. Example with Caddy:
+                If the SP has an open inbound port, terminate TLS on 443 and proxy to <code className="px-1 py-0.5 rounded-none bg-secondary/60">localhost:8082</code>. When using Cloudflare DNS, keep the hostname DNS-only instead of proxied; this recommendation comes from devnet measurements where the Cloudflare proxy path was much slower for large transfers than direct origin HTTPS. Example with Caddy:
               </p>
               <div className="font-mono text-xs text-muted-foreground space-y-2 bg-secondary/30 p-4 rounded-none overflow-x-auto">
                 <p>$ caddy reverse-proxy --from sp.example.com --to localhost:8082</p>

--- a/polystore-website/src/pages/TestnetDocs.tsx
+++ b/polystore-website/src/pages/TestnetDocs.tsx
@@ -269,8 +269,8 @@ export const TestnetDocs = () => {
                 For testnet onboarding, keep it simple:
               </p>
               <ul className="list-disc pl-5 text-muted-foreground space-y-1">
-                <li><strong>direct</strong> (recommended): SP has an open port on a public IP / port-forward; expose <code className="px-1 py-0.5 rounded-none bg-secondary/60">https://sp.example.com</code> via a reverse proxy.</li>
-                <li><strong>cloudflare-tunnel</strong> (fallback): SP is behind NAT; expose <code className="px-1 py-0.5 rounded-none bg-secondary/60">https://sp.example.com</code> via Cloudflare Tunnel (no router changes).</li>
+                <li><strong>direct</strong> (recommended): SP has inbound 443 on a public IP / port-forward; expose <code className="px-1 py-0.5 rounded-none bg-secondary/60">https://sp.example.com</code> via a reverse proxy. If Cloudflare manages DNS, keep SP payload hostnames DNS-only.</li>
+                <li><strong>cloudflare-tunnel</strong> (fallback): SP is behind NAT; expose <code className="px-1 py-0.5 rounded-none bg-secondary/60">https://sp.example.com</code> via Cloudflare Tunnel (no router changes, bytes transit Cloudflare).</li>
                 <li><strong>webrtc</strong> (future): NAT traversal optimization; not testnet-blocking.</li>
               </ul>
               <p className="text-muted-foreground">
@@ -290,7 +290,7 @@ export const TestnetDocs = () => {
             <div className="space-y-2">
               <h3 className="font-bold text-foreground">2A) direct (reverse proxy on 443)</h3>
               <p className="text-muted-foreground">
-                If the SP has an open inbound port, terminate TLS on 443 and proxy to <code className="px-1 py-0.5 rounded-none bg-secondary/60">localhost:8082</code>. Example with Caddy:
+                If the SP has an open inbound port, terminate TLS on 443 and proxy to <code className="px-1 py-0.5 rounded-none bg-secondary/60">localhost:8082</code>. When using Cloudflare DNS, keep the hostname DNS-only instead of proxied. Example with Caddy:
               </p>
               <div className="font-mono text-xs text-muted-foreground space-y-2 bg-secondary/30 p-4 rounded-none overflow-x-auto">
                 <p>$ caddy reverse-proxy --from sp.example.com --to localhost:8082</p>


### PR DESCRIPTION
## Summary

- Add a direct SP HTTPS runbook documenting the current DNS-only multi-provider ingress shape without committing the provider public IP.
- Explain that the DNS-only direct shape was empirically chosen after large-transfer tests showed Cloudflare Tunnel/proxied `A` records were much slower than direct origin HTTPS for the same provider host.
- Add a repeatable troubleshooting procedure that compares direct origin HTTPS against Cloudflare proxy/tunnel using a temporary benchmark sink and Caddy route.
- Update provider onboarding, trusted devnet, Caddy, systemd, README, docs index, and website provider guidance so future agents understand direct HTTPS is the primary SP payload path and Cloudflare Tunnel/proxy is fallback/testing transport.

## Validation

- `npm run build` in `polystore-website`
- `git diff --check`
- Staged diff scanned for the live public IP and temporary benchmark hostnames; no matches found.