### PR TITLE
Add WebGPU KZG backend lifecycle

### DIFF
--- a/polystore-website/package.json
+++ b/polystore-website/package.json
@@ -28,6 +28,7 @@
     "perf:msm-windows": "tsx scripts/benchmark_pippenger_windows.ts",
     "perf:kzg-compare": "tsx scripts/benchmark_kzg_commit_compare.ts",
     "perf:kzg-browser": "tsx scripts/benchmark_browser_kzg_commit.ts",
+    "perf:kzg-webgpu-lifecycle": "tsx scripts/benchmark_browser_kzg_webgpu_lifecycle.ts",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },

--- a/polystore-website/scripts/benchmark_browser_kzg_webgpu_lifecycle.ts
+++ b/polystore-website/scripts/benchmark_browser_kzg_webgpu_lifecycle.ts
@@ -1,0 +1,122 @@
+import os from 'node:os'
+
+import { chromium } from '@playwright/test'
+import { createServer } from 'vite'
+
+const BLOB_SIZE = 128 * 1024
+
+const vite = await createServer({
+  root: process.cwd(),
+  server: {
+    host: '127.0.0.1',
+    port: 0,
+  },
+  logLevel: 'error',
+})
+
+await vite.listen()
+const address = vite.httpServer?.address()
+if (!address || typeof address === 'string') {
+  throw new Error('failed to allocate Vite benchmark server port')
+}
+
+const origin = `http://127.0.0.1:${address.port}`
+let browser: Awaited<ReturnType<typeof chromium.launch>> | null = null
+
+try {
+  browser = await chromium.launch({ headless: process.env.HEADLESS !== '0' })
+  const page = await browser.newPage()
+  await page.goto(`${origin}/`)
+  await page.addScriptTag({
+    content: `
+      window.__runPolyStoreKzgWebGpuLifecycleBenchmark = async function(config) {
+        function makeValidBlob(seed) {
+          const blob = new Uint8Array(config.blobSize);
+          const chunks = config.blobSize / 32;
+          for (let i = 0; i < chunks; i += 1) {
+            const offset = i * 32;
+            blob[offset] = 0;
+            for (let j = 1; j < 32; j += 1) {
+              blob[offset + j] = (seed + i * 17 + j * 29) & 0xff;
+            }
+          }
+          return blob;
+        }
+
+        const wasmMod = await import('/wasm/polystore_core.js');
+        const backendMod = await import('/src/lib/kzgCommitBackend.ts');
+        const wasmBytes = await fetch('/wasm/polystore_core_bg.wasm').then((response) => response.arrayBuffer());
+
+        const wasmInitStart = performance.now();
+        await wasmMod.default({ module_or_path: wasmBytes });
+        const trustedSetupBytes = new Uint8Array(
+          await fetch('/trusted_setup.txt').then((response) => response.arrayBuffer()),
+        );
+        const wasmSetupStart = performance.now();
+        const polyStoreWasm = new wasmMod.PolyStoreWasm(trustedSetupBytes);
+        const wasmSetupMs = performance.now() - wasmSetupStart;
+        const wasmInitMs = performance.now() - wasmInitStart;
+
+        const backendStart = performance.now();
+        const backend = await backendMod.createBrowserKzgCommitBackend(polyStoreWasm, trustedSetupBytes, {
+          preferWebGpu: true,
+        });
+        const backendInitMs = performance.now() - backendStart;
+
+        const blob = makeValidBlob(41);
+        const commitStart = performance.now();
+        const profiled = backend.commitBlobsProfiled(blob);
+        const commitWallMs = performance.now() - commitStart;
+
+        return {
+          backend_status: backend.getStatus(),
+          browser: {
+            user_agent: navigator.userAgent,
+            hardware_concurrency: navigator.hardwareConcurrency ?? null,
+            device_memory_gib: 'deviceMemory' in navigator ? navigator.deviceMemory ?? null : null,
+            cross_origin_isolated: crossOriginIsolated,
+            webgpu_present: Boolean(navigator.gpu),
+          },
+          wasm: {
+            init_ms: wasmInitMs,
+            setup_ms: wasmSetupMs,
+          },
+          backend_init_ms: backendInitMs,
+          commitment_smoke: {
+            blob_count: 1,
+            commitment_bytes: profiled.witnessFlat.byteLength,
+            wall_ms: commitWallMs,
+            rust_total_ms: profiled.perf.totalMs,
+            rust_msm_ms: profiled.perf.msmMs,
+          },
+        };
+      };
+    `,
+  })
+
+  const result = await page.evaluate(`window.__runPolyStoreKzgWebGpuLifecycleBenchmark(${JSON.stringify({
+    blobSize: BLOB_SIZE,
+  })})`)
+
+  console.log(
+    JSON.stringify(
+      {
+        benchmark: 'browser-kzg-webgpu-lifecycle',
+        timestamp: new Date().toISOString(),
+        host: {
+          platform: os.platform(),
+          release: os.release(),
+          arch: os.arch(),
+          cpus: os.cpus().length,
+          total_memory_gib: os.totalmem() / 1024 / 1024 / 1024,
+        },
+        result,
+      },
+      null,
+      2,
+    ),
+  )
+} finally {
+  await browser?.close()
+  await vite.close()
+}

--- a/polystore-website/src/lib/kzgCommitBackend.test.ts
+++ b/polystore-website/src/lib/kzgCommitBackend.test.ts
@@ -7,8 +7,11 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 import {
   KZG_BLOB_SIZE,
   KZG_COMMITMENT_SIZE,
+  POLYSTORE_TRUSTED_SETUP_SHA256,
   WasmBlstKzgCommitBackend,
+  createBrowserKzgCommitBackend,
   createWasmBlstKzgCommitBackend,
+  parseTrustedSetupG1Srs,
   parseKzgCommitProfiledResult,
 } from './kzgCommitBackend'
 
@@ -62,6 +65,27 @@ function commitments(blobs: number, seed = 1): Uint8Array {
     out[i] = (seed + i) & 0xff
   }
   return out
+}
+
+function mockWasm(blobs = 1): PolyStoreWasmLike {
+  return {
+    commit_blobs: () => commitments(blobs),
+    commit_blobs_profiled: () => ({ witness_flat: commitments(blobs), perf: { blobs } }),
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+async function loadTrustedSetupBytes(): Promise<Uint8Array> {
+  return new Uint8Array(await fs.readFile(path.resolve(__dirname, '../../public/trusted_setup.txt')))
 }
 
 test('wasm blst backend reports default status', () => {
@@ -164,6 +188,168 @@ test('profiled parser normalizes wasm field names', () => {
 
 test('createWasmBlstKzgCommitBackend fails closed before wasm init', () => {
   assert.throws(() => createWasmBlstKzgCommitBackend(null), /PolyStoreWasm not initialized/)
+})
+
+test('trusted setup parser validates pinned SRS shape for WebGPU residency', async () => {
+  const parsed = parseTrustedSetupG1Srs(await loadTrustedSetupBytes())
+
+  assert.equal(parsed.g1Count, 4096)
+  assert.equal(parsed.g2Count, 65)
+  assert.equal(parsed.g1Bytes, 4096 * KZG_COMMITMENT_SIZE)
+  assert.equal(parsed.g1Compressed.byteLength, 4096 * KZG_COMMITMENT_SIZE)
+  assert.equal(parsed.basis, 'lagrange-or-monomial-g1-compressed')
+})
+
+test('browser backend falls back when WebGPU is unavailable', async () => {
+  const backend = await createBrowserKzgCommitBackend(mockWasm(1), await loadTrustedSetupBytes(), {
+    preferWebGpu: true,
+    navigatorLike: {} as unknown as Navigator,
+  })
+
+  assert.equal(backend.kind, 'webgpu-wasm-fallback')
+  assert.deepEqual(backend.commitBlobs(blobBatch(1)), commitments(1))
+  const status = backend.getStatus()
+  assert.equal(status.webgpu?.supported, false)
+  assert.equal(status.webgpu?.available, false)
+  assert.equal(status.webgpu?.fallbackActive, true)
+  assert.match(status.fallbackReason || '', /navigator\.gpu is unavailable/)
+})
+
+test('browser backend uploads SRS to a persistent WebGPU buffer and keeps WASM as commit path', async () => {
+  const setupBytes = await loadTrustedSetupBytes()
+  const writes: Array<{ offset: number; bytes: number }> = []
+  const buffer = { destroyed: false, destroy() { this.destroyed = true } }
+  const deviceLost = deferred<{ reason?: string; message?: string }>()
+  const backend = await createBrowserKzgCommitBackend(mockWasm(2), setupBytes, {
+    preferWebGpu: true,
+    navigatorLike: {
+      gpu: {
+        requestAdapter: async () => ({
+          requestDevice: async () => ({
+            queue: {
+              writeBuffer: (_buffer: unknown, offset: number, data: Uint8Array) => {
+                writes.push({ offset, bytes: data.byteLength })
+              },
+            },
+            lost: deviceLost.promise,
+            createBuffer: (descriptor: { size: number }) => {
+              assert.equal(descriptor.size, 4096 * KZG_COMMITMENT_SIZE)
+              return buffer
+            },
+          }),
+        }),
+      },
+    } as unknown as Navigator,
+    bufferUsage: { STORAGE: 1, COPY_DST: 2 },
+  })
+
+  assert.equal(backend.kind, 'webgpu-wasm-fallback')
+  assert.deepEqual(backend.commitBlobs(blobBatch(2)), commitments(2))
+  assert.deepEqual(writes, [{ offset: 0, bytes: 4096 * KZG_COMMITMENT_SIZE }])
+  const status = backend.getStatus()
+  assert.equal(status.webgpu?.supported, true)
+  assert.equal(status.webgpu?.available, true)
+  assert.equal(status.webgpu?.fallbackActive, true)
+  assert.equal(status.webgpu?.srs?.sha256, POLYSTORE_TRUSTED_SETUP_SHA256)
+  assert.match(status.fallbackReason || '', /commitments use WASM/)
+})
+
+test('browser backend contains WebGPU init failure and falls back to WASM', async () => {
+  const backend = await createBrowserKzgCommitBackend(mockWasm(1), await loadTrustedSetupBytes(), {
+    preferWebGpu: true,
+    navigatorLike: {
+      gpu: {
+        requestAdapter: async () => {
+          throw new Error('adapter denied')
+        },
+      },
+    } as unknown as Navigator,
+    bufferUsage: { STORAGE: 1, COPY_DST: 2 },
+  })
+
+  assert.deepEqual(backend.commitBlobs(blobBatch(1)), commitments(1))
+  const status = backend.getStatus()
+  assert.equal(status.webgpu?.supported, true)
+  assert.equal(status.webgpu?.available, false)
+  assert.match(status.fallbackReason || '', /adapter denied/)
+})
+
+test('browser backend marks device loss unavailable without changing commitment output', async () => {
+  const deviceLost = deferred<{ reason?: string; message?: string }>()
+  const buffer = { destroyed: false, destroy() { this.destroyed = true } }
+  const backend = await createBrowserKzgCommitBackend(mockWasm(1), await loadTrustedSetupBytes(), {
+    preferWebGpu: true,
+    navigatorLike: {
+      gpu: {
+        requestAdapter: async () => ({
+          requestDevice: async () => ({
+            queue: { writeBuffer: () => undefined },
+            lost: deviceLost.promise,
+            createBuffer: () => buffer,
+          }),
+        }),
+      },
+    } as unknown as Navigator,
+    bufferUsage: { STORAGE: 1, COPY_DST: 2 },
+  })
+
+  assert.equal(backend.getStatus().webgpu?.available, true)
+  deviceLost.resolve({ reason: 'destroyed', message: 'test device loss' })
+  await new Promise((resolve) => setTimeout(resolve, 0))
+
+  const status = backend.getStatus()
+  assert.equal(buffer.destroyed, true)
+  assert.equal(status.webgpu?.available, false)
+  assert.equal(status.webgpu?.deviceLost, true)
+  assert.match(status.fallbackReason || '', /destroyed/)
+  assert.deepEqual(backend.commitBlobs(blobBatch(1)), commitments(1))
+})
+
+test('browser backend fails closed on incompatible trusted setup bytes before GPU upload', async () => {
+  let adapterRequested = false
+  const backend = await createBrowserKzgCommitBackend(mockWasm(1), new TextEncoder().encode('1\n0\n00\n'), {
+    preferWebGpu: true,
+    navigatorLike: {
+      gpu: {
+        requestAdapter: async () => {
+          adapterRequested = true
+          return null
+        },
+      },
+    } as unknown as Navigator,
+    bufferUsage: { STORAGE: 1, COPY_DST: 2 },
+  })
+
+  assert.equal(adapterRequested, false)
+  assert.deepEqual(backend.commitBlobs(blobBatch(1)), commitments(1))
+  const status = backend.getStatus()
+  assert.equal(status.webgpu?.available, false)
+  assert.match(status.fallbackReason || '', /below required blob domain/)
+})
+
+test('browser backend fails closed on trusted setup hash mismatch before adapter request', async () => {
+  const setupBytes = await loadTrustedSetupBytes()
+  const tampered = setupBytes.slice()
+  const firstG1ByteOffset = new TextDecoder().decode(tampered).indexOf('\n', new TextDecoder().decode(tampered).indexOf('\n') + 1) + 1
+  tampered[firstG1ByteOffset] = tampered[firstG1ByteOffset] === 'a'.charCodeAt(0) ? 'b'.charCodeAt(0) : 'a'.charCodeAt(0)
+  let adapterRequested = false
+
+  const backend = await createBrowserKzgCommitBackend(mockWasm(1), tampered, {
+    preferWebGpu: true,
+    navigatorLike: {
+      gpu: {
+        requestAdapter: async () => {
+          adapterRequested = true
+          return null
+        },
+      },
+    } as unknown as Navigator,
+    bufferUsage: { STORAGE: 1, COPY_DST: 2 },
+  })
+
+  assert.equal(adapterRequested, false)
+  assert.deepEqual(backend.commitBlobs(blobBatch(1)), commitments(1))
+  assert.match(backend.getStatus().fallbackReason || '', /Trusted setup SHA-256 mismatch/)
 })
 
 test('wasm blst backend output matches direct PolyStoreWasm commit_blobs', async (t) => {

--- a/polystore-website/src/lib/kzgCommitBackend.ts
+++ b/polystore-website/src/lib/kzgCommitBackend.ts
@@ -1,7 +1,9 @@
 export const KZG_BLOB_SIZE = 128 * 1024
 export const KZG_COMMITMENT_SIZE = 48
+export const KZG_CELLS_PER_BLOB = KZG_BLOB_SIZE / 32
+export const POLYSTORE_TRUSTED_SETUP_SHA256 = 'd39b9f2d047cc9dca2de58f264b6a09448ccd34db967881a6713eacacf0f26b7'
 
-export type KzgCommitBackendKind = 'wasm-blst'
+export type KzgCommitBackendKind = 'wasm-blst' | 'webgpu-wasm-fallback'
 
 export type PolyStoreCommitApi = {
   commit_blobs(blobBytes: Uint8Array): Uint8Array | ArrayBufferLike
@@ -30,6 +32,8 @@ export type KzgCommitBackendStatus = {
   kind: KzgCommitBackendKind
   initialized: boolean
   label: string
+  fallbackReason?: string
+  webgpu?: WebGpuKzgStatus
 }
 
 export type KzgCommitBackend = {
@@ -37,6 +41,76 @@ export type KzgCommitBackend = {
   getStatus(): KzgCommitBackendStatus
   commitBlobs(blobsFlat: Uint8Array): Uint8Array
   commitBlobsProfiled(blobsFlat: Uint8Array): KzgCommitProfiledResult
+}
+
+type GpuBufferLike = {
+  destroy?: () => void
+}
+
+type GpuQueueLike = {
+  writeBuffer: (buffer: GpuBufferLike, bufferOffset: number, data: Uint8Array) => void
+}
+
+type GpuDeviceLike = {
+  label?: string
+  queue: GpuQueueLike
+  lost?: Promise<{ reason?: string; message?: string }>
+  createBuffer: (descriptor: {
+    label?: string
+    size: number
+    usage: number
+  }) => GpuBufferLike
+}
+
+type GpuAdapterLike = {
+  requestDevice: () => Promise<GpuDeviceLike>
+}
+
+type GpuLike = {
+  requestAdapter: () => Promise<GpuAdapterLike | null>
+}
+
+type WebGpuNavigator = Navigator & {
+  gpu?: GpuLike
+}
+
+type WebGpuBufferUsageLike = {
+  STORAGE: number
+  COPY_DST: number
+}
+
+export type WebGpuKzgInitTimings = {
+  setupParseMs: number
+  setupHashMs: number
+  adapterMs: number
+  deviceMs: number
+  srsUploadMs: number
+  totalMs: number
+}
+
+export type WebGpuSrsMetadata = {
+  g1Count: number
+  g2Count: number
+  g1Bytes: number
+  sha256: string
+  basis: 'lagrange-or-monomial-g1-compressed'
+}
+
+export type WebGpuKzgStatus = {
+  supported: boolean
+  available: boolean
+  deviceLost: boolean
+  fallbackActive: boolean
+  reason?: string
+  srs?: WebGpuSrsMetadata
+  timings?: WebGpuKzgInitTimings
+}
+
+export type CreateKzgCommitBackendOptions = {
+  preferWebGpu?: boolean
+  navigatorLike?: WebGpuNavigator
+  bufferUsage?: WebGpuBufferUsageLike
+  now?: () => number
 }
 
 export function toUint8Array(value: Uint8Array | ArrayBufferLike): Uint8Array {
@@ -55,6 +129,77 @@ function assertBlobBatch(blobsFlat: Uint8Array): number {
 
 function numberField(value: unknown): number {
   return Number(value ?? 0)
+}
+
+function nowMs(now: (() => number) | undefined): number {
+  if (now) return now()
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') return performance.now()
+  return Date.now()
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')
+}
+
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const subtle = globalThis.crypto?.subtle
+  if (!subtle) {
+    throw new Error('crypto.subtle is required to validate trusted setup bytes')
+  }
+  const digestInput = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer
+  return bytesToHex(new Uint8Array(await subtle.digest('SHA-256', digestInput)))
+}
+
+function hexLineToBytes(line: string, expectedBytes: number, label: string): Uint8Array {
+  const trimmed = line.trim()
+  if (trimmed.length !== expectedBytes * 2 || !/^[0-9a-fA-F]+$/.test(trimmed)) {
+    throw new Error(`Trusted setup ${label} line must be ${expectedBytes} bytes of hex`)
+  }
+  const out = new Uint8Array(expectedBytes)
+  for (let i = 0; i < expectedBytes; i += 1) {
+    out[i] = Number.parseInt(trimmed.slice(i * 2, i * 2 + 2), 16)
+  }
+  return out
+}
+
+export function parseTrustedSetupG1Srs(
+  trustedSetupBytes: Uint8Array,
+): Omit<WebGpuSrsMetadata, 'sha256'> & { g1Compressed: Uint8Array; g2StartLine: number } {
+  const text = new TextDecoder().decode(trustedSetupBytes)
+  const lines = text.split(/\r?\n/).filter((line) => line.length > 0)
+  if (lines.length < 2) {
+    throw new Error('Trusted setup is missing G1/G2 counts')
+  }
+
+  const g1Count = Number(lines[0])
+  const g2Count = Number(lines[1])
+  if (!Number.isInteger(g1Count) || g1Count < KZG_CELLS_PER_BLOB) {
+    throw new Error(`Trusted setup G1 count ${lines[0]} is below required blob domain ${KZG_CELLS_PER_BLOB}`)
+  }
+  if (!Number.isInteger(g2Count) || g2Count < 2) {
+    throw new Error('Trusted setup G2 count must be at least 2')
+  }
+  if (lines.length < 2 + g1Count + g2Count) {
+    throw new Error('Trusted setup ended before declared G1/G2 points')
+  }
+
+  const g1Compressed = new Uint8Array(g1Count * KZG_COMMITMENT_SIZE)
+  for (let i = 0; i < g1Count; i += 1) {
+    g1Compressed.set(hexLineToBytes(lines[2 + i], KZG_COMMITMENT_SIZE, `G1[${i}]`), i * KZG_COMMITMENT_SIZE)
+  }
+
+  for (let i = 0; i < g2Count; i += 1) {
+    hexLineToBytes(lines[2 + g1Count + i], 96, `G2[${i}]`)
+  }
+
+  return {
+    g1Count,
+    g2Count,
+    g1Bytes: g1Compressed.byteLength,
+    basis: 'lagrange-or-monomial-g1-compressed',
+    g1Compressed,
+    g2StartLine: 2 + g1Count,
+  }
 }
 
 export function parseKzgCommitProfiledResult(raw: unknown, expectedBlobs: number): KzgCommitProfiledResult {
@@ -133,9 +278,162 @@ export class WasmBlstKzgCommitBackend implements KzgCommitBackend {
   }
 }
 
+export class WebGpuKzgLifecycleBackend implements KzgCommitBackend {
+  readonly kind = 'webgpu-wasm-fallback' as const
+  private srsBuffer: GpuBufferLike | null
+  private status: WebGpuKzgStatus
+
+  constructor(
+    private readonly wasmFallback: KzgCommitBackend,
+    initialStatus: WebGpuKzgStatus,
+    srsBuffer: GpuBufferLike | null,
+  ) {
+    this.status = initialStatus
+    this.srsBuffer = srsBuffer
+  }
+
+  getStatus(): KzgCommitBackendStatus {
+    const reason = this.status.reason || 'WebGPU MSM is not implemented in this milestone; commitments use WASM'
+    return {
+      kind: this.kind,
+      initialized: this.wasmFallback.getStatus().initialized,
+      label: this.status.available ? 'WebGPU SRS resident, WASM commit fallback' : 'WASM blst fallback',
+      fallbackReason: reason,
+      webgpu: { ...this.status, reason },
+    }
+  }
+
+  markDeviceLost(reason: string): void {
+    this.srsBuffer?.destroy?.()
+    this.srsBuffer = null
+    this.status = {
+      ...this.status,
+      available: false,
+      deviceLost: true,
+      fallbackActive: true,
+      reason,
+    }
+  }
+
+  commitBlobs(blobsFlat: Uint8Array): Uint8Array {
+    return this.wasmFallback.commitBlobs(blobsFlat)
+  }
+
+  commitBlobsProfiled(blobsFlat: Uint8Array): KzgCommitProfiledResult {
+    return this.wasmFallback.commitBlobsProfiled(blobsFlat)
+  }
+}
+
 export function createWasmBlstKzgCommitBackend(wasm: PolyStoreCommitApi | null | undefined): KzgCommitBackend {
   if (!wasm) {
     throw new Error('PolyStoreWasm not initialized')
   }
   return new WasmBlstKzgCommitBackend(wasm)
+}
+
+export async function createBrowserKzgCommitBackend(
+  wasm: PolyStoreCommitApi | null | undefined,
+  trustedSetupBytes: Uint8Array,
+  options: CreateKzgCommitBackendOptions = {},
+): Promise<KzgCommitBackend> {
+  const wasmFallback = createWasmBlstKzgCommitBackend(wasm)
+  if (!options.preferWebGpu) {
+    return wasmFallback
+  }
+
+  const started = nowMs(options.now)
+  const timings: WebGpuKzgInitTimings = {
+    setupParseMs: 0,
+    setupHashMs: 0,
+    adapterMs: 0,
+    deviceMs: 0,
+    srsUploadMs: 0,
+    totalMs: 0,
+  }
+
+  try {
+    const gpu = options.navigatorLike?.gpu ?? (globalThis.navigator as WebGpuNavigator | undefined)?.gpu
+    if (!gpu) {
+      throw new Error('navigator.gpu is unavailable')
+    }
+
+    const parseStart = nowMs(options.now)
+    const parsed = parseTrustedSetupG1Srs(trustedSetupBytes)
+    timings.setupParseMs = nowMs(options.now) - parseStart
+
+    const hashStart = nowMs(options.now)
+    const setupSha256 = await sha256Hex(trustedSetupBytes)
+    timings.setupHashMs = nowMs(options.now) - hashStart
+    if (setupSha256 !== POLYSTORE_TRUSTED_SETUP_SHA256) {
+      throw new Error(`Trusted setup SHA-256 mismatch: ${setupSha256}`)
+    }
+
+    const adapterStart = nowMs(options.now)
+    const adapter = await gpu.requestAdapter()
+    timings.adapterMs = nowMs(options.now) - adapterStart
+    if (!adapter) {
+      throw new Error('WebGPU adapter request returned null')
+    }
+
+    const deviceStart = nowMs(options.now)
+    const device = await adapter.requestDevice()
+    timings.deviceMs = nowMs(options.now) - deviceStart
+
+    const usage = options.bufferUsage ?? (globalThis as unknown as { GPUBufferUsage?: WebGpuBufferUsageLike }).GPUBufferUsage
+    if (!usage) {
+      throw new Error('GPUBufferUsage constants are unavailable')
+    }
+
+    const uploadStart = nowMs(options.now)
+    const srsBuffer = device.createBuffer({
+      label: 'polystore-kzg-g1-srs-compressed',
+      size: parsed.g1Compressed.byteLength,
+      usage: usage.STORAGE | usage.COPY_DST,
+    })
+    device.queue.writeBuffer(srsBuffer, 0, parsed.g1Compressed)
+    timings.srsUploadMs = nowMs(options.now) - uploadStart
+    timings.totalMs = nowMs(options.now) - started
+
+    const backend = new WebGpuKzgLifecycleBackend(
+      wasmFallback,
+      {
+        supported: true,
+        available: true,
+        deviceLost: false,
+        fallbackActive: true,
+        reason: 'WebGPU MSM is not implemented in this milestone; commitments use WASM',
+        srs: {
+          g1Count: parsed.g1Count,
+          g2Count: parsed.g2Count,
+          g1Bytes: parsed.g1Bytes,
+          sha256: setupSha256,
+          basis: parsed.basis,
+        },
+        timings,
+      },
+      srsBuffer,
+    )
+
+    device.lost?.then((info) => {
+      backend.markDeviceLost(`WebGPU device lost${info?.reason ? `: ${info.reason}` : ''}${info?.message ? ` (${info.message})` : ''}`)
+    }).catch((error) => {
+      backend.markDeviceLost(`WebGPU device lost: ${error instanceof Error ? error.message : String(error)}`)
+    })
+
+    return backend
+  } catch (error) {
+    timings.totalMs = nowMs(options.now) - started
+    return new WebGpuKzgLifecycleBackend(
+      wasmFallback,
+      {
+        supported: Boolean(options.navigatorLike?.gpu ?? (globalThis.navigator as WebGpuNavigator | undefined)?.gpu),
+        available: false,
+        deviceLost: false,
+        fallbackActive: true,
+        reason: error instanceof Error ? error.message : String(error),
+        timings,
+      },
+      null,
+    )
+  }
 }

--- a/polystore-website/src/workers/commit.worker.ts
+++ b/polystore-website/src/workers/commit.worker.ts
@@ -4,7 +4,7 @@
 // across multiple single-threaded WASM instances (no SharedArrayBuffer required).
 
 import init, { PolyStoreWasm } from '../lib/polystoreCoreRuntime.js'
-import { createWasmBlstKzgCommitBackend, type KzgCommitBackend } from '../lib/kzgCommitBackend'
+import { createBrowserKzgCommitBackend, type KzgCommitBackend } from '../lib/kzgCommitBackend'
 
 let wasmInitialized = false
 let wasmInitPromise: Promise<void> | null = null
@@ -48,7 +48,7 @@ self.onmessage = async (event) => {
         const { trustedSetupBytes } = payload as { trustedSetupBytes: Uint8Array }
         if (!trustedSetupBytes) throw new Error('Trusted setup bytes required')
         polyStoreWasmInstance = new PolyStoreWasm(trustedSetupBytes)
-        kzgCommitBackend = createWasmBlstKzgCommitBackend(polyStoreWasmInstance)
+        kzgCommitBackend = await createBrowserKzgCommitBackend(polyStoreWasmInstance, trustedSetupBytes, { preferWebGpu: true })
         ;(self as unknown as Worker).postMessage({ id, type: 'result', payload: 'ok' })
         return
       }

--- a/polystore-website/src/workers/expand.worker.ts
+++ b/polystore-website/src/workers/expand.worker.ts
@@ -1,5 +1,5 @@
 import init, { PolyStoreWasm } from '../lib/polystoreCoreRuntime.js'
-import { createWasmBlstKzgCommitBackend, type KzgCommitBackend } from '../lib/kzgCommitBackend'
+import { createBrowserKzgCommitBackend, type KzgCommitBackend } from '../lib/kzgCommitBackend'
 
 let wasmInitialized = false
 let wasmInitPromise: Promise<void> | null = null
@@ -41,7 +41,7 @@ self.onmessage = async (event) => {
         const { trustedSetupBytes } = payload as { trustedSetupBytes: Uint8Array }
         if (!trustedSetupBytes) throw new Error('Trusted setup bytes required')
         polyStoreWasmInstance = new PolyStoreWasm(trustedSetupBytes)
-        kzgCommitBackend = createWasmBlstKzgCommitBackend(polyStoreWasmInstance)
+        kzgCommitBackend = await createBrowserKzgCommitBackend(polyStoreWasmInstance, trustedSetupBytes, { preferWebGpu: true })
         ;(self as unknown as Worker).postMessage({ id, type: 'result', payload: 'ok' })
         return
       }

--- a/polystore-website/src/workers/gateway.worker.ts
+++ b/polystore-website/src/workers/gateway.worker.ts
@@ -6,7 +6,7 @@
 // The `init` function loads the WASM binary.
 // The `Mdu0Builder` and `PolyStoreWasm` classes are exposed by wasm-bindgen.
 import init, { WasmMdu0Builder, PolyStoreWasm } from '../lib/polystoreCoreRuntime.js';
-import { createWasmBlstKzgCommitBackend, type KzgCommitBackend } from '../lib/kzgCommitBackend';
+import { createBrowserKzgCommitBackend, type KzgCommitBackend } from '../lib/kzgCommitBackend';
 
 let wasmInitialized = false;
 let wasmInitPromise: Promise<void> | null = null;
@@ -180,7 +180,7 @@ self.onmessage = async (event) => {
                 }
                 if (!trustedSetupBytes) throw new Error('Trusted setup bytes required for PolyStoreWasm initialization');
                 polyStoreWasmInstance = new PolyStoreWasm(trustedSetupBytes);
-                kzgCommitBackend = createWasmBlstKzgCommitBackend(polyStoreWasmInstance);
+                kzgCommitBackend = await createBrowserKzgCommitBackend(polyStoreWasmInstance, trustedSetupBytes, { preferWebGpu: true });
                 // Initialize the blob-commit compute pool (best-effort).
                 try {
                     await initializeCommitPool(trustedSetupBytes);


### PR DESCRIPTION
## Summary

- Adds an optional browser WebGPU lifecycle wrapper behind the KZG commitment backend seam.
- Validates the pinned trusted setup, parses the G1 SRS, uploads the compressed G1 SRS into a persistent GPU buffer when WebGPU device creation succeeds, and tracks device-loss fallback state.
- Keeps all commitment output delegated to the WASM/blst backend in this milestone; no WebGPU MSM commitment implementation is included.
- Adds mocked WebGPU lifecycle coverage and a browser benchmark/status harness.

Depends on #169. Closes #166.

## Scope Boundary

This PR intentionally does not implement WebGPU MSM. It only proves lifecycle, SRS residency, diagnostics, and safe fallback. Commitment bytes still come from the WASM oracle.

## Validation

- `npx tsx --test src/lib/kzgCommitBackend.test.ts src/lib/mode2ArtifactsV1.test.ts` - passed, 15 tests
- `npm run test:unit` - passed, 231 tests
- `npm run lint` - passed
- `npm run build:app` - passed
- `npm run perf:kzg-webgpu-lifecycle` - passed

## Browser Lifecycle Benchmark Smoke

Environment: HeadlessChrome/143.0.7499.4 on Linux x64, 12 host CPUs, browser `hardwareConcurrency=12`, browser `deviceMemory=8`, `crossOriginIsolated=true`.

Observed WebGPU status in this environment: `navigator.gpu` present, but adapter request returned null, so fallback stayed active.

| Metric | Value |
| --- | ---: |
| WASM init ms | 3886.95 |
| WASM setup ms | 3881.59 |
| WebGPU lifecycle backend init ms | 30.93 |
| SRS parse ms | 18.40 |
| SRS hash ms | 10.95 |
| Adapter request ms | 1.01 |
| Device/SRS upload ms | 0.00, adapter unavailable |
| Resident SRS bytes when available | 196608 |
| 1-blob smoke commitment bytes | 48 |
| 1-blob smoke wall ms | 469.04 |

## Regression Assessment

Commitment throughput is intentionally unchanged in this issue because the WebGPU backend delegates commitments to WASM/blst. The additional lifecycle work is initialization-time only and falls back without changing commitment output.

## AI Review Status

- Codex: not requested yet for this stacked PR.
- Copilot: not requested yet for this stacked PR.
- CodeRabbit: not requested yet for this stacked PR.

## Merge Status

Ready for review as a stacked PR after #169. Agents must not self-merge this repository.
