### PR TITLE
Add browser worker autotune benchmark foundation

### DIFF
--- a/polystore-website/scripts/benchmark_user_stage_concurrency.ts
+++ b/polystore-website/scripts/benchmark_user_stage_concurrency.ts
@@ -64,7 +64,7 @@ const basisMode = (process.env.BASIS_MODE || 'blst') as BasisMode
 const autotune = process.env.AUTOTUNE === '1'
 const hardwareConcurrency = Number.isFinite(Number(process.env.HARDWARE_CONCURRENCY))
   ? Math.max(1, Math.floor(Number(process.env.HARDWARE_CONCURRENCY)))
-  : os.cpus().length
+  : Math.max(1, os.cpus().length)
 const pipelineModes = (process.env.PIPELINE_MODES || process.env.PIPELINE_MODE || 'split')
   .split(',')
   .map((value) => value.trim())
@@ -78,7 +78,7 @@ const pipelineModes = (process.env.PIPELINE_MODES || process.env.PIPELINE_MODE |
       value === 'fused_batch_sampled',
   )
 const requestedConcurrencies = autotune
-  ? buildExpansionWorkerAutotuneCandidates(hardwareConcurrency, Math.ceil(fileBytes / RAW_MDU_CAPACITY)).join(',')
+  ? buildExpansionWorkerAutotuneCandidates(hardwareConcurrency, Math.ceil(Math.floor(fileBytes) / RAW_MDU_CAPACITY)).join(',')
   : process.env.CONCURRENCIES || '3,4,5,6'
 const concurrencies = requestedConcurrencies
   .split(',')

--- a/polystore-website/scripts/benchmark_user_stage_concurrency.ts
+++ b/polystore-website/scripts/benchmark_user_stage_concurrency.ts
@@ -56,7 +56,8 @@ const SCALAR_BYTES = 32
 const SCALAR_PAYLOAD_BYTES = 31
 const RAW_MDU_CAPACITY = Math.floor(MDU_SIZE_BYTES / SCALAR_BYTES) * SCALAR_PAYLOAD_BYTES
 
-const fileBytes = Number(process.env.FILE_BYTES || 49_103_158)
+const parsedFileBytes = Number(process.env.FILE_BYTES || 49_103_158)
+const fileBytes = Number.isFinite(parsedFileBytes) ? Math.floor(parsedFileBytes) : Number.NaN
 const rsK = Number(process.env.RS_K || 2)
 const rsM = Number(process.env.RS_M || 1)
 const cycles = Number(process.env.CYCLES || 3)
@@ -64,7 +65,7 @@ const basisMode = (process.env.BASIS_MODE || 'blst') as BasisMode
 const autotune = process.env.AUTOTUNE === '1'
 const hardwareConcurrency = Number.isFinite(Number(process.env.HARDWARE_CONCURRENCY))
   ? Math.max(1, Math.floor(Number(process.env.HARDWARE_CONCURRENCY)))
-  : os.cpus().length
+  : Math.max(1, os.cpus().length)
 const pipelineModes = (process.env.PIPELINE_MODES || process.env.PIPELINE_MODE || 'split')
   .split(',')
   .map((value) => value.trim())

--- a/polystore-website/scripts/benchmark_user_stage_concurrency.ts
+++ b/polystore-website/scripts/benchmark_user_stage_concurrency.ts
@@ -79,7 +79,7 @@ const pipelineModes = (process.env.PIPELINE_MODES || process.env.PIPELINE_MODE |
       value === 'fused_batch_sampled',
   )
 const requestedConcurrencies = autotune
-  ? buildExpansionWorkerAutotuneCandidates(hardwareConcurrency, Math.ceil(Math.floor(fileBytes) / RAW_MDU_CAPACITY)).join(',')
+  ? buildExpansionWorkerAutotuneCandidates(hardwareConcurrency, Math.ceil(fileBytes / RAW_MDU_CAPACITY)).join(',')
   : process.env.CONCURRENCIES || '3,4,5,6'
 const concurrencies = requestedConcurrencies
   .split(',')

--- a/polystore-website/scripts/benchmark_user_stage_concurrency.ts
+++ b/polystore-website/scripts/benchmark_user_stage_concurrency.ts
@@ -1,7 +1,14 @@
 import path from 'node:path'
+import os from 'node:os'
 import { Worker } from 'node:worker_threads'
 import { fileURLToPath } from 'node:url'
 import { performance } from 'node:perf_hooks'
+
+import {
+  buildExpansionWorkerAutotuneCandidates,
+  pickExpansionWorkerCount,
+  selectExpansionWorkerCountFromSamples,
+} from '../src/lib/expansionWorkers'
 
 type BasisMode = 'blst' | 'affine' | 'projective'
 type PipelineMode =
@@ -54,6 +61,10 @@ const rsK = Number(process.env.RS_K || 2)
 const rsM = Number(process.env.RS_M || 1)
 const cycles = Number(process.env.CYCLES || 3)
 const basisMode = (process.env.BASIS_MODE || 'blst') as BasisMode
+const autotune = process.env.AUTOTUNE === '1'
+const hardwareConcurrency = Number.isFinite(Number(process.env.HARDWARE_CONCURRENCY))
+  ? Math.max(1, Math.floor(Number(process.env.HARDWARE_CONCURRENCY)))
+  : os.cpus().length
 const pipelineModes = (process.env.PIPELINE_MODES || process.env.PIPELINE_MODE || 'split')
   .split(',')
   .map((value) => value.trim())
@@ -66,7 +77,10 @@ const pipelineModes = (process.env.PIPELINE_MODES || process.env.PIPELINE_MODE |
       value === 'fused_batch_unprofiled' ||
       value === 'fused_batch_sampled',
   )
-const concurrencies = (process.env.CONCURRENCIES || '3,4,5,6')
+const requestedConcurrencies = autotune
+  ? buildExpansionWorkerAutotuneCandidates(hardwareConcurrency, Math.ceil(fileBytes / RAW_MDU_CAPACITY)).join(',')
+  : process.env.CONCURRENCIES || '3,4,5,6'
+const concurrencies = requestedConcurrencies
   .split(',')
   .map((value) => Number(value.trim()))
   .filter((value) => Number.isFinite(value) && value > 0)
@@ -244,6 +258,25 @@ const output = {
   basis_mode: basisMode,
   pipeline_modes: pipelineModes,
   cycles,
+  autotune: autotune
+    ? {
+        hardware_concurrency: hardwareConcurrency,
+        static_worker_count: pickExpansionWorkerCount(hardwareConcurrency, chunks.length),
+        candidates: concurrencies,
+        selected_by_pipeline_mode: Object.fromEntries(
+          pipelineModes.map((pipelineMode) => {
+            const samples = concurrencies.map((concurrency) => {
+              const result = results.get(`${pipelineMode}:${concurrency}`)
+              return {
+                workerCount: concurrency,
+                wallMs: result ? readStats(result.runs).median : Number.NaN,
+              }
+            })
+            return [pipelineMode, selectExpansionWorkerCountFromSamples(samples, hardwareConcurrency, chunks.length)]
+          }),
+        ),
+      }
+    : null,
   concurrencies,
   results: Object.fromEntries(
     [...results.entries()].map(([key, result]) => [

--- a/polystore-website/src/lib/expansionWorkers.test.ts
+++ b/polystore-website/src/lib/expansionWorkers.test.ts
@@ -1,7 +1,13 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { pickExpansionWorkerCount } from './expansionWorkers'
+import {
+  EXPANSION_WORKER_AUTOTUNE_VERSION,
+  buildExpansionWorkerAutotuneCandidates,
+  isUsableExpansionWorkerAutotuneCache,
+  pickExpansionWorkerCount,
+  selectExpansionWorkerCountFromSamples,
+} from './expansionWorkers'
 
 test('pickExpansionWorkerCount falls back safely for undefined and NaN hardware concurrency', () => {
   assert.equal(pickExpansionWorkerCount(undefined), 3)
@@ -34,4 +40,64 @@ test('pickExpansionWorkerCount floors fractional inputs and clamps invalid job c
   assert.equal(pickExpansionWorkerCount(5.9, 2.9), 2)
   assert.equal(pickExpansionWorkerCount(12, 0), 1)
   assert.equal(pickExpansionWorkerCount(12, Number.NaN), 6)
+})
+
+test('buildExpansionWorkerAutotuneCandidates probes near the static worker count', () => {
+  assert.deepEqual(buildExpansionWorkerAutotuneCandidates(12, 32), [5, 6, 7, 8])
+  assert.deepEqual(buildExpansionWorkerAutotuneCandidates(8, 12), [4, 5, 6, 7])
+  assert.deepEqual(buildExpansionWorkerAutotuneCandidates(4, 16), [2, 3, 4])
+})
+
+test('buildExpansionWorkerAutotuneCandidates skips tiny jobs and single-worker machines', () => {
+  assert.deepEqual(buildExpansionWorkerAutotuneCandidates(12, 1), [1])
+  assert.deepEqual(buildExpansionWorkerAutotuneCandidates(12, 3), [3])
+  assert.deepEqual(buildExpansionWorkerAutotuneCandidates(2, 16), [1])
+})
+
+test('selectExpansionWorkerCountFromSamples picks the fastest allowed sample', () => {
+  assert.equal(
+    selectExpansionWorkerCountFromSamples(
+      [
+        { workerCount: 5, wallMs: 1200 },
+        { workerCount: 6, wallMs: 980 },
+        { workerCount: 7, wallMs: 760 },
+        { workerCount: 9, wallMs: 100 },
+      ],
+      12,
+      32,
+    ),
+    7,
+  )
+})
+
+test('selectExpansionWorkerCountFromSamples falls back to static count when samples are invalid', () => {
+  assert.equal(
+    selectExpansionWorkerCountFromSamples(
+      [
+        { workerCount: 9, wallMs: 100 },
+        { workerCount: 6, wallMs: Number.NaN },
+      ],
+      12,
+      32,
+    ),
+    6,
+  )
+})
+
+test('isUsableExpansionWorkerAutotuneCache validates version, hardware, and candidate bounds', () => {
+  const cache = {
+    version: EXPANSION_WORKER_AUTOTUNE_VERSION,
+    hardwareConcurrency: 12,
+    selectedWorkerCount: 7,
+    measuredAtMs: 1000,
+    scoreMs: 760,
+  }
+
+  assert.equal(isUsableExpansionWorkerAutotuneCache(cache, 12, 32), true)
+  assert.equal(isUsableExpansionWorkerAutotuneCache({ ...cache, version: 0 }, 12, 32), false)
+  assert.equal(isUsableExpansionWorkerAutotuneCache({ ...cache, hardwareConcurrency: 8 }, 12, 32), false)
+  assert.equal(isUsableExpansionWorkerAutotuneCache({ ...cache, selectedWorkerCount: 9 }, 12, 32), false)
+  assert.equal(isUsableExpansionWorkerAutotuneCache({ ...cache, selectedWorkerCount: 7.5 }, 12, 32), false)
+  assert.equal(isUsableExpansionWorkerAutotuneCache({ ...cache, measuredAtMs: 0 }, 12, 32), false)
+  assert.equal(isUsableExpansionWorkerAutotuneCache({ ...cache, scoreMs: Number.NaN }, 12, 32), false)
 })

--- a/polystore-website/src/lib/expansionWorkers.ts
+++ b/polystore-website/src/lib/expansionWorkers.ts
@@ -1,5 +1,20 @@
 export const DEFAULT_EXPANSION_HARDWARE_CONCURRENCY = 4
 const MAX_EXPANSION_WORKERS = 6
+export const EXPANSION_WORKER_AUTOTUNE_VERSION = 1
+export const MAX_AUTOTUNE_EXPANSION_WORKERS = 8
+
+export type ExpansionWorkerAutotuneCache = {
+  version: number
+  hardwareConcurrency: number
+  selectedWorkerCount: number
+  measuredAtMs: number
+  scoreMs: number
+}
+
+export type ExpansionWorkerAutotuneSample = {
+  workerCount: number
+  wallMs: number
+}
 
 export function pickExpansionWorkerCount(hardwareConcurrency?: number, totalJobs?: number): number {
   const hc = Number.isFinite(hardwareConcurrency)
@@ -15,4 +30,66 @@ export function pickExpansionWorkerCount(hardwareConcurrency?: number, totalJobs
   else if (hc >= 3) desired = 2
 
   return Math.max(1, Math.min(desired, jobCap))
+}
+
+export function buildExpansionWorkerAutotuneCandidates(hardwareConcurrency?: number, totalJobs?: number): number[] {
+  const staticCount = pickExpansionWorkerCount(hardwareConcurrency, totalJobs)
+  const jobCap = Number.isFinite(totalJobs) ? Math.max(1, Math.floor(Number(totalJobs))) : Number.POSITIVE_INFINITY
+  if (jobCap < 4 || staticCount <= 1) return [staticCount]
+
+  const hc = Number.isFinite(hardwareConcurrency)
+    ? Math.max(1, Math.floor(Number(hardwareConcurrency)))
+    : DEFAULT_EXPANSION_HARDWARE_CONCURRENCY
+  const upper = Math.max(staticCount, Math.min(MAX_AUTOTUNE_EXPANSION_WORKERS, jobCap, hc))
+  const lower = Math.max(1, staticCount - 2)
+  const preferred = [staticCount - 1, staticCount, staticCount + 1, staticCount + 2]
+
+  const candidates = new Set<number>()
+  for (const candidate of preferred) {
+    const normalized = Math.floor(candidate)
+    if (normalized >= lower && normalized <= upper) candidates.add(normalized)
+  }
+  candidates.add(staticCount)
+
+  return [...candidates].sort((a, b) => a - b)
+}
+
+export function isUsableExpansionWorkerAutotuneCache(
+  cache: ExpansionWorkerAutotuneCache | null | undefined,
+  hardwareConcurrency?: number,
+  totalJobs?: number,
+): cache is ExpansionWorkerAutotuneCache {
+  if (!cache || cache.version !== EXPANSION_WORKER_AUTOTUNE_VERSION) return false
+  const hc = Number.isFinite(hardwareConcurrency)
+    ? Math.max(1, Math.floor(Number(hardwareConcurrency)))
+    : DEFAULT_EXPANSION_HARDWARE_CONCURRENCY
+  if (cache.hardwareConcurrency !== hc) return false
+  if (!Number.isInteger(cache.selectedWorkerCount) || cache.selectedWorkerCount < 1) return false
+  if (!Number.isFinite(cache.measuredAtMs) || cache.measuredAtMs <= 0) return false
+  if (!Number.isFinite(cache.scoreMs) || cache.scoreMs <= 0) return false
+  const candidates = buildExpansionWorkerAutotuneCandidates(hardwareConcurrency, totalJobs)
+  return candidates.includes(cache.selectedWorkerCount)
+}
+
+export function selectExpansionWorkerCountFromSamples(
+  samples: ExpansionWorkerAutotuneSample[],
+  hardwareConcurrency?: number,
+  totalJobs?: number,
+): number {
+  const candidates = buildExpansionWorkerAutotuneCandidates(hardwareConcurrency, totalJobs)
+  const allowed = new Set(candidates)
+  let bestWorkerCount = pickExpansionWorkerCount(hardwareConcurrency, totalJobs)
+  let bestScore = Number.POSITIVE_INFINITY
+
+  for (const sample of samples) {
+    const workerCount = Math.floor(Number(sample.workerCount))
+    const wallMs = Number(sample.wallMs)
+    if (!allowed.has(workerCount) || !Number.isFinite(wallMs) || wallMs <= 0) continue
+    if (wallMs < bestScore || (wallMs === bestScore && workerCount < bestWorkerCount)) {
+      bestScore = wallMs
+      bestWorkerCount = workerCount
+    }
+  }
+
+  return bestWorkerCount
 }


### PR DESCRIPTION
## Summary

Refs #157. Parent tracker: #152. Stacked on #170 / `perf/wasm-kzg-benchmark`.

Adds the first browser KZG worker-autotune foundation without changing production upload scheduling yet:

- adds unit-tested autotune candidate generation around the current static worker heuristic;
- adds a versioned cache shape and cache validation for future persisted worker-count selection;
- adds sample selection logic that chooses the fastest valid measured worker count;
- extends `perf:user-stage-concurrency` with `AUTOTUNE=1` so benchmark runs can derive candidates from hardware concurrency and MDU count and report the selected worker count.

## Benchmark Decision

Decision: measurement/control-plane improvement, production throughput neutral in this PR.

This PR does not route production uploads through the selected worker count, so live upload throughput should be unchanged. It does improve the benchmark harness by automatically finding the fastest candidate for a given machine/job shape, which is the prerequisite for safely changing production scheduling in a later PR.

Node/V8 evidence on this machine, `HARDWARE_CONCURRENCY=12`, `FILE_BYTES=32505856` (~4 raw user MDUs), `CYCLES=1`, `PIPELINE_MODES=fused_batch_sampled`:

| Candidate workers | Median wall time | Decision |
| ---: | ---: | --- |
| 3 | 74411.85 ms | slower |
| 4 | 43835.50 ms | selected / faster |

Autotune selected `4` workers for this scenario. The result is an improvement in benchmark decision quality, not yet a production throughput improvement.

Small smoke evidence, `FILE_BYTES=8126464` (~1 raw user MDU): candidates `[1]`, selected `1`, median `33508.88 ms`. This confirms tiny jobs avoid noisy over-probing.

## Validation

- `npm --prefix polystore-website ci`
- `npm --prefix polystore-website run test:unit` (`222` passing)
- `env AUTOTUNE=1 HARDWARE_CONCURRENCY=12 FILE_BYTES=8126464 CYCLES=1 PIPELINE_MODES=fused_batch_sampled npm --prefix polystore-website run perf:user-stage-concurrency --silent > /tmp/worker_autotune_smoke.json`
- `env AUTOTUNE=1 HARDWARE_CONCURRENCY=12 FILE_BYTES=32505856 CYCLES=1 PIPELINE_MODES=fused_batch_sampled npm --prefix polystore-website run perf:user-stage-concurrency --silent > /tmp/worker_autotune_4mdu.json`
- `npm --prefix polystore-website run build:app`
- `git diff --check`

Build emits existing dependency/chunk warnings only.

## Branch And Review Contract

Branch: `website/worker-autotune`
Base: `perf/wasm-kzg-benchmark`

This PR is not independently mergeable to `main` until #170 lands or this branch is rebased onto `main` after #170. Per repo policy, agents must not self-merge; human approval is required.
