### PR TITLE
Add browser compute/upload pipelining primitive

### DIFF
--- a/polystore-website/package.json
+++ b/polystore-website/package.json
@@ -26,6 +26,7 @@
     "perf:prepare-compare": "tsx scripts/benchmark_prepare_compare.ts",
     "perf:user-stage-concurrency": "tsx scripts/benchmark_user_stage_concurrency.ts",
     "perf:browser-kzg-baseline": "tsx scripts/benchmark_browser_kzg_baseline.ts",
+    "perf:upload-pipeline": "tsx scripts/benchmark_upload_pipelining.ts",
     "perf:msm-windows": "tsx scripts/benchmark_pippenger_windows.ts",
     "perf:kzg-compare": "tsx scripts/benchmark_kzg_commit_compare.ts",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",

--- a/polystore-website/scripts/benchmark_upload_pipelining.ts
+++ b/polystore-website/scripts/benchmark_upload_pipelining.ts
@@ -1,0 +1,124 @@
+import { createUploadEngine, type PipelinedUploadArtifact, type UploadTarget, type UploadTransportRequest } from '../src/lib/upload/engine'
+
+const artifactCount = Math.max(1, Number(process.env.ARTIFACTS || 8))
+const computeMs = Math.max(0, Number(process.env.COMPUTE_MS || 40))
+const uploadMs = Math.max(0, Number(process.env.UPLOAD_MS || 30))
+const concurrency = Math.max(1, Number(process.env.CONCURRENCY || 3))
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function nowMs(): number {
+  return typeof performance !== 'undefined' ? performance.now() : Date.now()
+}
+
+const target: UploadTarget = {
+  baseUrl: 'http://provider.test',
+  mduPath: '/sp/upload_mdu',
+  manifestPath: '/sp/upload_manifest',
+  label: 'provider.test',
+}
+
+function makeArtifact(index: number): PipelinedUploadArtifact {
+  return {
+    target,
+    artifact: {
+      kind: 'mdu',
+      index,
+      bytes: new Uint8Array([index & 0xff]),
+      fullSize: 8,
+    },
+  }
+}
+
+function makeTransport() {
+  const starts: Array<{ kind: string; tMs: number; manifestRoot: string; generation: string }> = []
+  return {
+    starts,
+    transport: {
+      async sendArtifact(request: UploadTransportRequest) {
+        starts.push({
+          kind: request.artifact.kind,
+          tMs: nowMs(),
+          manifestRoot: request.manifestRoot,
+          generation: request.uploadGeneration || '',
+        })
+        await sleep(uploadMs)
+      },
+    },
+  }
+}
+
+async function runSequential(): Promise<number> {
+  const prepared: PipelinedUploadArtifact[] = []
+  const startedAt = nowMs()
+  for (let i = 0; i < artifactCount; i += 1) {
+    await sleep(computeMs)
+    prepared.push(makeArtifact(i))
+  }
+  const transport = makeTransport()
+  const engine = createUploadEngine({ transport: transport.transport, parallelism: { direct: concurrency } })
+  await engine.uploadDirect({
+    dealId: '1',
+    manifestRoot: '0xnext',
+    manifestBlob: new Uint8Array([0xff]),
+    mdus: prepared.map((item) => {
+      if (item.artifact.kind !== 'mdu') throw new Error('expected mdu artifact')
+      return { index: item.artifact.index, data: item.artifact.bytes, fullSize: item.artifact.fullSize }
+    }),
+    target,
+  })
+  return nowMs() - startedAt
+}
+
+async function runPipelined(): Promise<{ elapsedMs: number; starts: ReturnType<typeof makeTransport>['starts'] }> {
+  const transport = makeTransport()
+  const engine = createUploadEngine({ transport: transport.transport, parallelism: { direct: concurrency } })
+  let computed = 0
+
+  async function* artifacts() {
+    for (let i = 0; i < artifactCount; i += 1) {
+      await sleep(computeMs)
+      computed += 1
+      yield makeArtifact(i)
+    }
+  }
+
+  const startedAt = nowMs()
+  const result = await engine.uploadPipelinedGeneration({
+    dealId: '1',
+    uploadGeneration: 'pipelined',
+    artifacts: artifacts(),
+    manifest: (async () => {
+      while (computed < artifactCount) {
+        await sleep(1)
+      }
+      return {
+        manifestRoot: '0xnext',
+        manifestBlob: new Uint8Array([0xff]),
+        manifestTargets: [target],
+      }
+    })(),
+  })
+  if (!result.ok) throw new Error(result.error || 'pipelined upload failed')
+  return { elapsedMs: nowMs() - startedAt, starts: transport.starts }
+}
+
+const sequentialMs = await runSequential()
+const pipelined = await runPipelined()
+const speedup = sequentialMs / pipelined.elapsedMs
+
+console.log(JSON.stringify({
+  scenario: {
+    artifact_count: artifactCount,
+    compute_ms_per_artifact: computeMs,
+    upload_ms_per_artifact: uploadMs,
+    upload_concurrency: concurrency,
+  },
+  sequential_ms: sequentialMs,
+  pipelined_ms: pipelined.elapsedMs,
+  speedup,
+  decision: speedup > 1.05 ? 'improvement' : speedup < 0.95 ? 'regression' : 'same',
+  pipelined_started_before_manifest_count: pipelined.starts.filter((start) => start.kind !== 'manifest' && start.manifestRoot === '').length,
+}, null, 2))

--- a/polystore-website/src/lib/upload/engine.test.ts
+++ b/polystore-website/src/lib/upload/engine.test.ts
@@ -207,6 +207,127 @@ test('upload engine: direct upload emits task events when requested', async () =
   ])
 })
 
+test('upload engine: pipelined generation uploads artifacts before manifest binding resolves', async () => {
+  const starts: string[] = []
+  const requests: UploadTransportRequest[] = []
+  let resolveManifest!: (value: {
+    manifestRoot: string
+    manifestBlob: Uint8Array
+    manifestTargets: Array<{
+      baseUrl: string
+      mduPath: string
+      manifestPath: string
+      label: string
+    }>
+  }) => void
+  const manifest = new Promise<{
+    manifestRoot: string
+    manifestBlob: Uint8Array
+    manifestTargets: Array<{
+      baseUrl: string
+      mduPath: string
+      manifestPath: string
+      label: string
+    }>
+  }>((resolve) => {
+    resolveManifest = resolve
+  })
+  const target = {
+    baseUrl: 'http://provider-a',
+    mduPath: '/sp/upload_mdu',
+    manifestPath: '/sp/upload_manifest',
+    label: 'provider-a',
+  }
+  const transport = {
+    async sendArtifact(request: UploadTransportRequest) {
+      starts.push(`${request.artifact.kind}:${request.manifestRoot || 'staged'}:${request.uploadGeneration || '-'}`)
+      requests.push(request)
+      await new Promise((resolve) => setTimeout(resolve, 5))
+    },
+  }
+  const engine = createUploadEngine({ transport, parallelism: { direct: 2 } })
+
+  async function* artifacts() {
+    yield {
+      target,
+      artifact: { kind: 'mdu' as const, index: 0, bytes: new Uint8Array([1]), fullSize: 8 },
+    }
+    yield {
+      target,
+      artifact: { kind: 'mdu' as const, index: 1, bytes: new Uint8Array([2]), fullSize: 8 },
+    }
+  }
+
+  const pending = engine.uploadPipelinedGeneration({
+    dealId: '24',
+    previousManifestRoot: '0xprev',
+    uploadGeneration: 'browser-run-1',
+    artifacts: artifacts(),
+    manifest,
+  })
+  await new Promise((resolve) => setTimeout(resolve, 20))
+
+  assert.deepEqual(starts, [
+    'mdu:staged:browser-run-1',
+    'mdu:staged:browser-run-1',
+  ])
+
+  resolveManifest({
+    manifestRoot: '0xnext',
+    manifestBlob: new Uint8Array([9]),
+    manifestTargets: [target],
+  })
+  const result = await pending
+
+  assert.equal(result.ok, true)
+  assert.deepEqual(starts, [
+    'mdu:staged:browser-run-1',
+    'mdu:staged:browser-run-1',
+    'manifest:0xnext:browser-run-1',
+  ])
+  assert.equal(requests[0].previousManifestRoot, '0xprev')
+  assert.equal(requests[2].previousManifestRoot, '0xprev')
+})
+
+test('upload engine: pipelined generation does not finalize manifest after artifact failure', async () => {
+  const starts: string[] = []
+  const target = {
+    baseUrl: 'http://provider-a',
+    mduPath: '/sp/upload_mdu',
+    manifestPath: '/sp/upload_manifest',
+    label: 'provider-a',
+  }
+  const transport = {
+    async sendArtifact(request: UploadTransportRequest) {
+      starts.push(request.artifact.kind)
+      if (request.artifact.kind === 'mdu') throw new Error('provider rejected staged mdu')
+    },
+  }
+  const engine = createUploadEngine({ transport })
+
+  async function* artifacts() {
+    yield {
+      target,
+      artifact: { kind: 'mdu' as const, index: 0, bytes: new Uint8Array([1]), fullSize: 8 },
+    }
+  }
+
+  const result = await engine.uploadPipelinedGeneration({
+    dealId: '25',
+    uploadGeneration: 'browser-run-2',
+    artifacts: artifacts(),
+    manifest: Promise.resolve({
+      manifestRoot: '0xnext',
+      manifestBlob: new Uint8Array([9]),
+      manifestTargets: [target],
+    }),
+  })
+
+  assert.equal(result.ok, false)
+  assert.equal(result.error, 'provider rejected staged mdu')
+  assert.deepEqual(starts, ['mdu'])
+})
+
 test('upload engine: striped upload overlaps metadata and shard requests with combined bounded concurrency', async () => {
   let activeTotal = 0
   let peakTotal = 0

--- a/polystore-website/src/lib/upload/engine.ts
+++ b/polystore-website/src/lib/upload/engine.ts
@@ -53,6 +53,7 @@ export interface UploadTransportRequest {
   dealId: string
   manifestRoot: string
   previousManifestRoot?: string
+  uploadGeneration?: string
   target: UploadTarget
   artifact: SparseArtifactInput
 }
@@ -133,6 +134,27 @@ export interface StripedSlotUploadInput {
   slot: number
   target: UploadTarget
   onProgress?: (steps: UploadProgressStep[]) => void
+  onTaskEvent?: (event: UploadTaskEvent) => void
+}
+
+export interface PipelinedUploadArtifact {
+  target: UploadTarget
+  artifact: SparseArtifactInput
+}
+
+export interface PipelinedManifestBinding {
+  manifestRoot: string
+  manifestBlob: Uint8Array
+  manifestBlobFullSize?: number
+  manifestTargets: UploadTarget[]
+}
+
+export interface PipelinedGenerationUploadInput {
+  dealId: string
+  previousManifestRoot?: string
+  uploadGeneration: string
+  artifacts: AsyncIterable<PipelinedUploadArtifact>
+  manifest: Promise<PipelinedManifestBinding>
   onTaskEvent?: (event: UploadTaskEvent) => void
 }
 
@@ -413,6 +435,115 @@ async function runUploadTasks(
           })
       }
 
+      settleIfDone()
+    }
+
+    launchNext()
+  })
+}
+
+async function runPipelinedUploadTaskProducer(
+  input: PipelinedGenerationUploadInput,
+  concurrency: number,
+  transport: UploadTransportPort,
+): Promise<UploadEngineResult> {
+  const trackTaskEvents = Boolean(input.onTaskEvent)
+  const tasks = input.artifacts[Symbol.asyncIterator]()
+  let active = 0
+  let producerDone = false
+  let firstError: string | null = null
+
+  const uploadOne = async (item: PipelinedUploadArtifact): Promise<void> => {
+    const request: UploadTransportRequest = {
+      dealId: input.dealId,
+      manifestRoot: '',
+      previousManifestRoot: input.previousManifestRoot,
+      uploadGeneration: input.uploadGeneration,
+      target: item.target,
+      artifact: item.artifact,
+    }
+    const startedAt = trackTaskEvents ? (typeof performance !== 'undefined' ? performance.now() : Date.now()) : 0
+    const target = trackTaskEvents ? request.target.label || request.target.baseUrl : ''
+    const index = trackTaskEvents && 'index' in request.artifact ? request.artifact.index : undefined
+    const slot = trackTaskEvents && 'slot' in request.artifact ? request.artifact.slot : undefined
+    const bytes = trackTaskEvents ? request.artifact.bytes.byteLength : 0
+    const fullSize = trackTaskEvents ? request.artifact.fullSize : undefined
+    if (trackTaskEvents) {
+      input.onTaskEvent?.({
+        phase: 'start',
+        kind: request.artifact.kind,
+        target,
+        index,
+        slot,
+        bytes,
+        fullSize,
+      })
+    }
+    try {
+      await transport.sendArtifact(request)
+      if (trackTaskEvents) {
+        const finishedAt = typeof performance !== 'undefined' ? performance.now() : Date.now()
+        input.onTaskEvent?.({
+          phase: 'end',
+          kind: request.artifact.kind,
+          target,
+          index,
+          slot,
+          bytes,
+          fullSize,
+          durationMs: finishedAt - startedAt,
+          ok: true,
+        })
+      }
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error)
+      if (trackTaskEvents) {
+        const finishedAt = typeof performance !== 'undefined' ? performance.now() : Date.now()
+        input.onTaskEvent?.({
+          phase: 'end',
+          kind: request.artifact.kind,
+          target,
+          index,
+          slot,
+          bytes,
+          fullSize,
+          durationMs: finishedAt - startedAt,
+          ok: false,
+          error: message,
+        })
+      }
+      throw new Error(message)
+    }
+  }
+
+  return await new Promise<UploadEngineResult>((resolve) => {
+    const settleIfDone = () => {
+      if (!producerDone || active !== 0) return
+      resolve(firstError ? { ok: false, steps: [], error: firstError } : { ok: true, steps: [] })
+    }
+
+    const launchNext = () => {
+      while (!firstError && active < concurrency && !producerDone) {
+        active += 1
+        void tasks
+          .next()
+          .then((next) => {
+            if (next.done) {
+              producerDone = true
+              return
+            }
+            return uploadOne(next.value)
+          })
+          .catch((error: unknown) => {
+            if (!firstError) firstError = error instanceof Error ? error.message : String(error)
+            producerDone = true
+          })
+          .finally(() => {
+            active -= 1
+            launchNext()
+            settleIfDone()
+          })
+      }
       settleIfDone()
     }
 
@@ -886,6 +1017,26 @@ export function createUploadEngine(options: UploadEngineOptions) {
 
       const slotConcurrency = Math.max(1, Math.min(tasks.length, stripedMetadataConcurrency + stripedShardConcurrency))
       return runUploadTasks(tasks, steps, input.onProgress, input.onTaskEvent, slotConcurrency, ports.transport)
+    },
+
+    async uploadPipelinedGeneration(input: PipelinedGenerationUploadInput): Promise<UploadEngineResult> {
+      const artifactResult = await runPipelinedUploadTaskProducer(input, directConcurrency, ports.transport)
+      if (!artifactResult.ok) {
+        return artifactResult
+      }
+      const manifest = await input.manifest
+      const manifestTasks: UploadTask[] = manifest.manifestTargets.map((target) => ({
+        stepIndex: -1,
+        request: {
+          dealId: input.dealId,
+          manifestRoot: manifest.manifestRoot,
+          previousManifestRoot: input.previousManifestRoot,
+          uploadGeneration: input.uploadGeneration,
+          target,
+          artifact: { kind: 'manifest', bytes: manifest.manifestBlob, fullSize: manifest.manifestBlobFullSize } as const,
+        },
+      }))
+      return runUploadTasks(manifestTasks, [], undefined, input.onTaskEvent, directConcurrency, ports.transport)
     },
 
     async commitPreparedContent(input: PreparedCommitInput): Promise<ChainCommitRequest> {

--- a/polystore-website/src/lib/upload/engine.ts
+++ b/polystore-website/src/lib/upload/engine.ts
@@ -448,10 +448,23 @@ async function runPipelinedUploadTaskProducer(
   transport: UploadTransportPort,
 ): Promise<UploadEngineResult> {
   const trackTaskEvents = Boolean(input.onTaskEvent)
-  const tasks = input.artifacts[Symbol.asyncIterator]()
-  let active = 0
   let producerDone = false
   let firstError: string | null = null
+  const queue: PipelinedUploadArtifact[] = []
+  const waiters: Array<() => void> = []
+
+  const wakeWorkers = () => {
+    while (waiters.length > 0) {
+      waiters.shift()?.()
+    }
+  }
+
+  const waitForWork = async () => {
+    if (queue.length > 0 || producerDone || firstError) return
+    await new Promise<void>((resolve) => {
+      waiters.push(resolve)
+    })
+  }
 
   const uploadOne = async (item: PipelinedUploadArtifact): Promise<void> => {
     const request: UploadTransportRequest = {
@@ -516,39 +529,39 @@ async function runPipelinedUploadTaskProducer(
     }
   }
 
-  return await new Promise<UploadEngineResult>((resolve) => {
-    const settleIfDone = () => {
-      if (!producerDone || active !== 0) return
-      resolve(firstError ? { ok: false, steps: [], error: firstError } : { ok: true, steps: [] })
-    }
-
-    const launchNext = () => {
-      while (!firstError && active < concurrency && !producerDone) {
-        active += 1
-        void tasks
-          .next()
-          .then((next) => {
-            if (next.done) {
-              producerDone = true
-              return
-            }
-            return uploadOne(next.value)
-          })
-          .catch((error: unknown) => {
-            if (!firstError) firstError = error instanceof Error ? error.message : String(error)
-            producerDone = true
-          })
-          .finally(() => {
-            active -= 1
-            launchNext()
-            settleIfDone()
-          })
+  const produce = async () => {
+    try {
+      for await (const item of input.artifacts) {
+        if (firstError) break
+        queue.push(item)
+        wakeWorkers()
       }
-      settleIfDone()
+    } catch (error: unknown) {
+      if (!firstError) firstError = error instanceof Error ? error.message : String(error)
+    } finally {
+      producerDone = true
+      wakeWorkers()
     }
+  }
 
-    launchNext()
-  })
+  const worker = async () => {
+    for (;;) {
+      await waitForWork()
+      if (firstError || (producerDone && queue.length === 0)) return
+      const item = queue.shift()
+      if (!item) continue
+      try {
+        await uploadOne(item)
+      } catch (error: unknown) {
+        if (!firstError) firstError = error instanceof Error ? error.message : String(error)
+        wakeWorkers()
+        return
+      }
+    }
+  }
+
+  await Promise.all([produce(), ...Array.from({ length: Math.max(1, concurrency) }, () => worker())])
+  return firstError ? { ok: false, steps: [], error: firstError } : { ok: true, steps: [] }
 }
 
 function groupUploadTasksByTarget(tasks: UploadTask[]): UploadTaskBundle[] {

--- a/polystore-website/src/lib/upload/httpTransport.test.ts
+++ b/polystore-website/src/lib/upload/httpTransport.test.ts
@@ -40,6 +40,44 @@ test('http transport forwards X-PolyStore-Previous-Manifest-Root when provided',
   assert.equal(calls[0].headers['X-PolyStore-Previous-Manifest-Root'], '0xprev')
 })
 
+test('http transport can send generation-scoped artifacts before manifest root exists', async () => {
+  const calls: Array<{ url: string; headers: Record<string, string> }> = []
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = (async (input: URL | RequestInfo, init?: RequestInit) => {
+    calls.push({
+      url: String(input),
+      headers: { ...((init?.headers as Record<string, string>) || {}) },
+    })
+    return new Response('OK', { status: 200 })
+  }) as typeof fetch
+  try {
+    const transport = createSparseHttpTransportPort()
+    await transport.sendArtifact({
+      dealId: '42',
+      manifestRoot: '',
+      uploadGeneration: 'browser-run-123',
+      target: {
+        baseUrl: 'http://provider.test',
+        mduPath: '/sp/upload_mdu',
+        manifestPath: '/sp/upload_manifest',
+      },
+      artifact: {
+        kind: 'mdu',
+        index: 0,
+        bytes: new Uint8Array([1, 2, 3]),
+        fullSize: 8,
+      },
+    })
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0].url, 'http://provider.test/sp/upload_mdu')
+  assert.equal(calls[0].headers['X-PolyStore-Upload-Generation'], 'browser-run-123')
+  assert.equal(calls[0].headers['X-PolyStore-Manifest-Root'], undefined)
+})
+
 test('http transport normalizes target base url once across repeated requests', async () => {
   const calls: string[] = []
   const originalFetch = globalThis.fetch

--- a/polystore-website/src/lib/upload/httpTransport.ts
+++ b/polystore-website/src/lib/upload/httpTransport.ts
@@ -88,12 +88,20 @@ function buildHeaders(
   dealId: string,
   manifestRoot: string,
   previousManifestRoot: string | undefined,
+  uploadGeneration: string | undefined,
   artifact: SparseArtifactInput,
 ): Record<string, string> {
   const headers: Record<string, string> = {
     'X-PolyStore-Deal-ID': dealId,
-    'X-PolyStore-Manifest-Root': manifestRoot,
     'Content-Type': 'application/octet-stream',
+  }
+  const normalizedManifestRoot = String(manifestRoot || '').trim()
+  const normalizedUploadGeneration = String(uploadGeneration || '').trim()
+  if (normalizedManifestRoot !== '') {
+    headers['X-PolyStore-Manifest-Root'] = normalizedManifestRoot
+  }
+  if (normalizedUploadGeneration !== '') {
+    headers['X-PolyStore-Upload-Generation'] = normalizedUploadGeneration
   }
   const normalizedPreviousManifestRoot = String(previousManifestRoot || '').trim()
   if (normalizedPreviousManifestRoot !== '') {
@@ -112,7 +120,13 @@ export function createSparseHttpTransportPort(): UploadTransportPort {
   const sendArtifact: UploadTransportPort['sendArtifact'] = async (request) => {
     const response = await postSparseArtifact({
       url: targetUrl(request.target, request.artifact),
-      headers: buildHeaders(request.dealId, request.manifestRoot, request.previousManifestRoot, request.artifact),
+      headers: buildHeaders(
+        request.dealId,
+        request.manifestRoot,
+        request.previousManifestRoot,
+        request.uploadGeneration,
+        request.artifact,
+      ),
       artifact: request.artifact,
     })
 
@@ -145,6 +159,7 @@ export function createSparseHttpTransportPort(): UploadTransportPort {
         deal_id: parsedDealId,
         manifest_root: first.manifestRoot,
         previous_manifest_root: String(first.previousManifestRoot || '').trim(),
+        upload_generation: String(first.uploadGeneration || '').trim(),
         artifacts: artifacts.map(({ request, sparseArtifact, part }) => ({
           part,
           kind: request.artifact.kind,

--- a/polystore_gateway/main.go
+++ b/polystore_gateway/main.go
@@ -4793,7 +4793,7 @@ func fastShardQuick(path string) (string, uint64, uint64, error) {
 
 const defaultCORSAllowMethods = "GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD"
 
-const defaultCORSAllowHeaders = "Content-Type, Accept, Range, Origin, Authorization, X-PolyStore-Req-Sig, X-PolyStore-Req-Nonce, X-PolyStore-Req-Expires-At, X-PolyStore-Req-Range-Start, X-PolyStore-Req-Range-Len, X-PolyStore-Download-Session, X-PolyStore-Session-Id, X-PolyStore-Manifest-Root, X-PolyStore-Previous-Manifest-Root, X-PolyStore-Deal-ID, X-PolyStore-Mdu-Index, X-PolyStore-Slot, X-PolyStore-Full-Size, X-PolyStore-Gateway-Auth, X-PolyStore-Deputy"
+const defaultCORSAllowHeaders = "Content-Type, Accept, Range, Origin, Authorization, X-PolyStore-Req-Sig, X-PolyStore-Req-Nonce, X-PolyStore-Req-Expires-At, X-PolyStore-Req-Range-Start, X-PolyStore-Req-Range-Len, X-PolyStore-Download-Session, X-PolyStore-Session-Id, X-PolyStore-Manifest-Root, X-PolyStore-Previous-Manifest-Root, X-PolyStore-Upload-Generation, X-PolyStore-Deal-ID, X-PolyStore-Mdu-Index, X-PolyStore-Slot, X-PolyStore-Full-Size, X-PolyStore-Gateway-Auth, X-PolyStore-Deputy"
 
 const defaultCORSExposeHeaders = "Accept-Ranges, Content-Range, X-PolyStore-Deal-ID, X-PolyStore-Epoch, X-PolyStore-Bytes-Served, X-PolyStore-Provider, X-PolyStore-File-Path, X-PolyStore-Range-Start, X-PolyStore-Range-Len, X-PolyStore-Proof-JSON, X-PolyStore-Proof-Hash, X-PolyStore-Fetch-Session, X-PolyStore-Gateway-Proof-MS, X-PolyStore-Gateway-Fetch-MS"
 
@@ -6423,6 +6423,7 @@ func SpUploadMdu(w http.ResponseWriter, r *http.Request) {
 	dealIDStr := strings.TrimSpace(r.Header.Get("X-PolyStore-Deal-ID"))
 	mduIndexStr := strings.TrimSpace(r.Header.Get("X-PolyStore-Mdu-Index"))
 	clientManifestRoot := strings.TrimSpace(r.Header.Get("X-PolyStore-Manifest-Root"))
+	uploadGenerationRaw := strings.TrimSpace(r.Header.Get(polystoreUploadGenerationHeader))
 	fullSizeHeader := strings.TrimSpace(r.Header.Get("X-PolyStore-Full-Size"))
 	if r.ContentLength > 0 {
 		profile.setCount("content_length_bytes", uint64(r.ContentLength))
@@ -6444,34 +6445,44 @@ func SpUploadMdu(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if clientManifestRoot == "" {
+	uploadGenerationID, err := normalizeUploadGenerationID(uploadGenerationRaw)
+	if err != nil {
+		statusCode = http.StatusBadRequest
+		outcome = "invalid_upload_generation"
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if clientManifestRoot == "" && uploadGenerationID == "" {
 		statusCode = http.StatusBadRequest
 		outcome = "missing_manifest_root"
-		http.Error(w, "X-PolyStore-Manifest-Root header is required", http.StatusBadRequest)
+		http.Error(w, "X-PolyStore-Manifest-Root or X-PolyStore-Upload-Generation header is required", http.StatusBadRequest)
 		return
 	}
-	validatePrevStarted := time.Now()
-	if err := validatePolyfsUploadPreviousManifestRoot(r.Context(), dealID, clientManifestRoot, uploadPreviousManifestRootHeader(r)); err != nil {
-		profile.addDuration("validate_previous_root_ms", time.Since(validatePrevStarted))
-		statusCode = classifyPolyfsUploadPreviousManifestRootError(err)
-		switch statusCode {
-		case http.StatusBadRequest:
-			outcome = "validate_previous_root_failed"
-			http.Error(w, err.Error(), statusCode)
-		case http.StatusNotFound:
-			outcome = "deal_not_found"
-			http.Error(w, "deal not found", statusCode)
-		case http.StatusConflict:
-			outcome = "validate_previous_root_failed"
-			http.Error(w, err.Error(), statusCode)
-		default:
-			log.Printf("SpUploadMdu: failed to validate deal %d previous root: %v", dealID, err)
-			outcome = "validate_previous_root_failed"
-			http.Error(w, "failed to validate deal", statusCode)
+	if clientManifestRoot != "" {
+		validatePrevStarted := time.Now()
+		if err := validatePolyfsUploadPreviousManifestRoot(r.Context(), dealID, clientManifestRoot, uploadPreviousManifestRootHeader(r)); err != nil {
+			profile.addDuration("validate_previous_root_ms", time.Since(validatePrevStarted))
+			statusCode = classifyPolyfsUploadPreviousManifestRootError(err)
+			switch statusCode {
+			case http.StatusBadRequest:
+				outcome = "validate_previous_root_failed"
+				http.Error(w, err.Error(), statusCode)
+			case http.StatusNotFound:
+				outcome = "deal_not_found"
+				http.Error(w, "deal not found", statusCode)
+			case http.StatusConflict:
+				outcome = "validate_previous_root_failed"
+				http.Error(w, err.Error(), statusCode)
+			default:
+				log.Printf("SpUploadMdu: failed to validate deal %d previous root: %v", dealID, err)
+				outcome = "validate_previous_root_failed"
+				http.Error(w, "failed to validate deal", statusCode)
+			}
+			return
 		}
-		return
+		profile.addDuration("validate_previous_root_ms", time.Since(validatePrevStarted))
 	}
-	profile.addDuration("validate_previous_root_ms", time.Since(validatePrevStarted))
 	declaredFullSize := int64(0)
 	hasDeclaredFullSize := false
 	if fullSizeHeader != "" {
@@ -6487,16 +6498,19 @@ func SpUploadMdu(w http.ResponseWriter, r *http.Request) {
 		profile.setCount("declared_full_size_bytes", uint64(declaredFullSize))
 	}
 
-	// Canonicalize Root
-	parsed, err := parseManifestRoot(clientManifestRoot)
-	if err != nil {
-		statusCode = http.StatusBadRequest
-		outcome = "invalid_manifest_root"
-		http.Error(w, "invalid manifest root", http.StatusBadRequest)
-		return
+	rootDir := ""
+	if clientManifestRoot != "" {
+		parsed, err := parseManifestRoot(clientManifestRoot)
+		if err != nil {
+			statusCode = http.StatusBadRequest
+			outcome = "invalid_manifest_root"
+			http.Error(w, "invalid manifest root", http.StatusBadRequest)
+			return
+		}
+		rootDir = dealScopedDir(dealID, parsed)
+	} else {
+		rootDir = stagedUploadDir(dealID, uploadGenerationID)
 	}
-	// Store under deal-scoped directory to avoid collisions across deals.
-	rootDir := dealScopedDir(dealID, parsed)
 
 	// Write MDU
 	filename := fmt.Sprintf("mdu_%s.bin", mduIndexStr)
@@ -6664,6 +6678,7 @@ func SpUploadShard(w http.ResponseWriter, r *http.Request) {
 	mduIndexStr := strings.TrimSpace(r.Header.Get("X-PolyStore-Mdu-Index"))
 	slotStr := strings.TrimSpace(r.Header.Get("X-PolyStore-Slot"))
 	clientManifestRoot := strings.TrimSpace(r.Header.Get("X-PolyStore-Manifest-Root"))
+	uploadGenerationRaw := strings.TrimSpace(r.Header.Get(polystoreUploadGenerationHeader))
 	fullSizeHeader := strings.TrimSpace(r.Header.Get("X-PolyStore-Full-Size"))
 	if r.ContentLength > 0 {
 		profile.setCount("content_length_bytes", uint64(r.ContentLength))
@@ -6693,34 +6708,44 @@ func SpUploadShard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if clientManifestRoot == "" {
+	uploadGenerationID, err := normalizeUploadGenerationID(uploadGenerationRaw)
+	if err != nil {
+		statusCode = http.StatusBadRequest
+		outcome = "invalid_upload_generation"
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if clientManifestRoot == "" && uploadGenerationID == "" {
 		statusCode = http.StatusBadRequest
 		outcome = "missing_manifest_root"
-		http.Error(w, "X-PolyStore-Manifest-Root header is required", http.StatusBadRequest)
+		http.Error(w, "X-PolyStore-Manifest-Root or X-PolyStore-Upload-Generation header is required", http.StatusBadRequest)
 		return
 	}
-	validatePrevStarted := time.Now()
-	if err := validatePolyfsUploadPreviousManifestRoot(r.Context(), dealID, clientManifestRoot, uploadPreviousManifestRootHeader(r)); err != nil {
-		profile.addDuration("validate_previous_root_ms", time.Since(validatePrevStarted))
-		statusCode = classifyPolyfsUploadPreviousManifestRootError(err)
-		switch statusCode {
-		case http.StatusBadRequest:
-			outcome = "validate_previous_root_failed"
-			http.Error(w, err.Error(), statusCode)
-		case http.StatusNotFound:
-			outcome = "deal_not_found"
-			http.Error(w, "deal not found", statusCode)
-		case http.StatusConflict:
-			outcome = "validate_previous_root_failed"
-			http.Error(w, err.Error(), statusCode)
-		default:
-			log.Printf("SpUploadShard: failed to validate deal %d previous root: %v", dealID, err)
-			outcome = "validate_previous_root_failed"
-			http.Error(w, "failed to validate deal", statusCode)
+	if clientManifestRoot != "" {
+		validatePrevStarted := time.Now()
+		if err := validatePolyfsUploadPreviousManifestRoot(r.Context(), dealID, clientManifestRoot, uploadPreviousManifestRootHeader(r)); err != nil {
+			profile.addDuration("validate_previous_root_ms", time.Since(validatePrevStarted))
+			statusCode = classifyPolyfsUploadPreviousManifestRootError(err)
+			switch statusCode {
+			case http.StatusBadRequest:
+				outcome = "validate_previous_root_failed"
+				http.Error(w, err.Error(), statusCode)
+			case http.StatusNotFound:
+				outcome = "deal_not_found"
+				http.Error(w, "deal not found", statusCode)
+			case http.StatusConflict:
+				outcome = "validate_previous_root_failed"
+				http.Error(w, err.Error(), statusCode)
+			default:
+				log.Printf("SpUploadShard: failed to validate deal %d previous root: %v", dealID, err)
+				outcome = "validate_previous_root_failed"
+				http.Error(w, "failed to validate deal", statusCode)
+			}
+			return
 		}
-		return
+		profile.addDuration("validate_previous_root_ms", time.Since(validatePrevStarted))
 	}
-	profile.addDuration("validate_previous_root_ms", time.Since(validatePrevStarted))
 	declaredFullSize := int64(0)
 	hasDeclaredFullSize := false
 	if fullSizeHeader != "" {
@@ -6742,14 +6767,19 @@ func SpUploadShard(w http.ResponseWriter, r *http.Request) {
 		profile.setCount("declared_full_size_bytes", uint64(declaredFullSize))
 	}
 
-	parsed, err := parseManifestRoot(clientManifestRoot)
-	if err != nil {
-		statusCode = http.StatusBadRequest
-		outcome = "invalid_manifest_root"
-		http.Error(w, "invalid manifest root", http.StatusBadRequest)
-		return
+	rootDir := ""
+	if clientManifestRoot != "" {
+		parsed, err := parseManifestRoot(clientManifestRoot)
+		if err != nil {
+			statusCode = http.StatusBadRequest
+			outcome = "invalid_manifest_root"
+			http.Error(w, "invalid manifest root", http.StatusBadRequest)
+			return
+		}
+		rootDir = dealScopedDir(dealID, parsed)
+	} else {
+		rootDir = stagedUploadDir(dealID, uploadGenerationID)
 	}
-	rootDir := dealScopedDir(dealID, parsed)
 
 	filename := fmt.Sprintf("mdu_%s_slot_%d.bin", mduIndexStr, slot)
 	path := filepath.Join(rootDir, filename)
@@ -6978,6 +7008,7 @@ func SpUploadManifest(w http.ResponseWriter, r *http.Request) {
 
 	dealIDStr := strings.TrimSpace(r.Header.Get("X-PolyStore-Deal-ID"))
 	clientManifestRoot := strings.TrimSpace(r.Header.Get("X-PolyStore-Manifest-Root"))
+	uploadGenerationRaw := strings.TrimSpace(r.Header.Get(polystoreUploadGenerationHeader))
 	fullSizeHeader := strings.TrimSpace(r.Header.Get("X-PolyStore-Full-Size"))
 	if r.ContentLength > 0 {
 		profile.setCount("content_length_bytes", uint64(r.ContentLength))
@@ -7012,6 +7043,13 @@ func SpUploadManifest(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid deal_id", http.StatusBadRequest)
 		return
 	}
+	uploadGenerationID, err := normalizeUploadGenerationID(uploadGenerationRaw)
+	if err != nil {
+		statusCode = http.StatusBadRequest
+		outcome = "invalid_upload_generation"
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 
 	parsed, err := parseManifestRoot(clientManifestRoot)
 	if err != nil {
@@ -7044,19 +7082,30 @@ func SpUploadManifest(w http.ResponseWriter, r *http.Request) {
 	profile.addDuration("validate_previous_root_ms", time.Since(validatePrevStarted))
 
 	rootDir := dealScopedDir(dealID, parsed)
+	writeDir := rootDir
+	if uploadGenerationID != "" {
+		writeDir = stagedUploadDir(dealID, uploadGenerationID)
+	}
 
-	path := filepath.Join(rootDir, "manifest.bin")
-	if info, err := os.Stat(path); err == nil && info.Mode().IsRegular() && info.Size() == int64(types.BLOB_SIZE) {
-		storedPath = path
-		profile.setCount("stored_size_bytes", uint64(info.Size()))
-		outcome = "already_present"
-		logVerboseMode2Uploadf("SpUploadManifest: already present %s for deal %d", path, dealID)
-		w.WriteHeader(http.StatusOK)
+	path := filepath.Join(writeDir, "manifest.bin")
+	if uploadGenerationID == "" {
+		if info, err := os.Stat(path); err == nil && info.Mode().IsRegular() && info.Size() == int64(types.BLOB_SIZE) {
+			storedPath = path
+			profile.setCount("stored_size_bytes", uint64(info.Size()))
+			outcome = "already_present"
+			logVerboseMode2Uploadf("SpUploadManifest: already present %s for deal %d", path, dealID)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+	} else if _, err := os.Stat(writeDir); err != nil {
+		statusCode = http.StatusNotFound
+		outcome = "staged_generation_not_found"
+		http.Error(w, "staged upload generation not found", http.StatusNotFound)
 		return
 	}
 
 	mkdirStarted := time.Now()
-	if err := ensureUploadRootDir(rootDir); err != nil {
+	if err := ensureUploadRootDir(writeDir); err != nil {
 		profile.addDuration("mkdir_all_ms", time.Since(mkdirStarted))
 		statusCode = http.StatusInternalServerError
 		outcome = "mkdir_failed"
@@ -7065,7 +7114,7 @@ func SpUploadManifest(w http.ResponseWriter, r *http.Request) {
 	}
 	profile.addDuration("mkdir_all_ms", time.Since(mkdirStarted))
 
-	tmp, err := createTempInUploadRoot(rootDir, "manifest.bin.tmp-*")
+	tmp, err := createTempInUploadRoot(writeDir, "manifest.bin.tmp-*")
 	if err != nil {
 		statusCode = http.StatusInternalServerError
 		outcome = "create_temp_failed"
@@ -7156,6 +7205,20 @@ func SpUploadManifest(w http.ResponseWriter, r *http.Request) {
 	profile.addDuration("rename_ms", time.Since(renameStarted))
 	committed = true
 	storedPath = path
+
+	if uploadGenerationID != "" {
+		promoteStarted := time.Now()
+		if err := promoteStagedUploadGeneration(dealID, uploadGenerationID, rootDir); err != nil {
+			profile.addDuration("promote_generation_ms", time.Since(promoteStarted))
+			statusCode = http.StatusInternalServerError
+			outcome = "promote_generation_failed"
+			http.Error(w, "failed to finalize staged upload generation", http.StatusInternalServerError)
+			return
+		}
+		profile.addDuration("promote_generation_ms", time.Since(promoteStarted))
+		storedPath = filepath.Join(rootDir, "manifest.bin")
+		outcome = "staged_generation_promoted"
+	}
 
 	logVerboseMode2Uploadf("SpUploadManifest: stored %s (%d bytes) for deal %d", path, storedSize, dealID)
 	w.WriteHeader(http.StatusOK)

--- a/polystore_gateway/sp_upload_manifest_test.go
+++ b/polystore_gateway/sp_upload_manifest_test.go
@@ -132,6 +132,94 @@ func TestSpUploadManifest_AcceptsSparseBodyWithFullSizeHeader(t *testing.T) {
 	}
 }
 
+func TestSpUploadManifest_PromotesStagedGenerationArtifacts(t *testing.T) {
+	useTempUploadDir(t)
+	resetPolyfsCASStatusCountersForTest()
+	resetPolyfsUploadRootPreflightCacheForTest()
+
+	manifestRoot := mustTestManifestRoot(t, "sp-upload-staged-generation")
+	dealID := uint64(1)
+	owner := "nil1owner"
+	generationID := "browser-run-123"
+
+	srv := dynamicMockDealServer(map[uint64]struct {
+		Owner string
+		CID   string
+	}{
+		dealID: {Owner: owner, CID: ""},
+	})
+	defer srv.Close()
+	oldLCD := lcdBase
+	lcdBase = srv.URL
+	t.Cleanup(func() { lcdBase = oldLCD })
+
+	r := testRouter()
+
+	mduReq := httptest.NewRequest(http.MethodPost, "/sp/upload_mdu", bytes.NewReader([]byte{0xAA}))
+	mduReq.Header.Set("X-PolyStore-Deal-ID", "1")
+	mduReq.Header.Set("X-PolyStore-Mdu-Index", "0")
+	mduReq.Header.Set(polystoreUploadGenerationHeader, generationID)
+	mduReq.Header.Set("X-PolyStore-Full-Size", "8388608")
+	mduReq.Header.Set("Content-Type", "application/octet-stream")
+	mduW := httptest.NewRecorder()
+	r.ServeHTTP(mduW, mduReq)
+	if mduW.Code != http.StatusOK {
+		t.Fatalf("expected staged mdu upload 200, got %d: %s", mduW.Code, mduW.Body.String())
+	}
+
+	shardReq := httptest.NewRequest(http.MethodPost, "/sp/upload_shard", bytes.NewReader([]byte{0xBB}))
+	shardReq.Header.Set("X-PolyStore-Deal-ID", "1")
+	shardReq.Header.Set("X-PolyStore-Mdu-Index", "2")
+	shardReq.Header.Set("X-PolyStore-Slot", "1")
+	shardReq.Header.Set(polystoreUploadGenerationHeader, generationID)
+	shardReq.Header.Set("X-PolyStore-Full-Size", "1024")
+	shardReq.Header.Set("Content-Type", "application/octet-stream")
+	shardW := httptest.NewRecorder()
+	r.ServeHTTP(shardW, shardReq)
+	if shardW.Code != http.StatusOK {
+		t.Fatalf("expected staged shard upload 200, got %d: %s", shardW.Code, shardW.Body.String())
+	}
+
+	stageDir := stagedUploadDir(dealID, generationID)
+	if _, err := os.Stat(filepath.Join(stageDir, "mdu_0.bin")); err != nil {
+		t.Fatalf("expected staged mdu before manifest finalize: %v", err)
+	}
+
+	manifestReq := httptest.NewRequest(http.MethodPost, "/sp/upload_manifest", bytes.NewReader([]byte{0xCC}))
+	manifestReq.Header.Set("X-PolyStore-Deal-ID", "1")
+	manifestReq.Header.Set("X-PolyStore-Manifest-Root", manifestRoot.Canonical)
+	manifestReq.Header.Set(polystoreUploadPreviousManifestRootHeader, "")
+	manifestReq.Header.Set(polystoreUploadGenerationHeader, generationID)
+	manifestReq.Header.Set("X-PolyStore-Full-Size", "131072")
+	manifestReq.Header.Set("Content-Type", "application/octet-stream")
+	manifestW := httptest.NewRecorder()
+	r.ServeHTTP(manifestW, manifestReq)
+	if manifestW.Code != http.StatusOK {
+		t.Fatalf("expected staged manifest finalize 200, got %d: %s", manifestW.Code, manifestW.Body.String())
+	}
+
+	finalDir := filepath.Join(uploadDir, "deals", "1", manifestRoot.Key)
+	for _, item := range []struct {
+		name string
+		size int64
+	}{
+		{name: "mdu_0.bin", size: 8388608},
+		{name: "mdu_2_slot_1.bin", size: 1024},
+		{name: "manifest.bin", size: 131072},
+	} {
+		info, err := os.Stat(filepath.Join(finalDir, item.name))
+		if err != nil {
+			t.Fatalf("expected promoted %s: %v", item.name, err)
+		}
+		if info.Size() != item.size {
+			t.Fatalf("promoted %s size mismatch: got=%d want=%d", item.name, info.Size(), item.size)
+		}
+	}
+	if _, err := os.Stat(stageDir); !os.IsNotExist(err) {
+		t.Fatalf("expected staged generation to be removed, stat err=%v", err)
+	}
+}
+
 func TestSpUploadManifest_RejectsStalePreviousManifestRoot(t *testing.T) {
 	useTempUploadDir(t)
 	resetPolyfsCASStatusCountersForTest()

--- a/polystore_gateway/staged_upload.go
+++ b/polystore_gateway/staged_upload.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+const polystoreUploadGenerationHeader = "X-PolyStore-Upload-Generation"
+
+func normalizeUploadGenerationID(raw string) (string, error) {
+	generation := strings.TrimSpace(raw)
+	if generation == "" {
+		return "", nil
+	}
+	if len(generation) > 96 {
+		return "", fmt.Errorf("upload generation id is too long")
+	}
+	for _, r := range generation {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' || r == '_' || r == '.' {
+			continue
+		}
+		return "", fmt.Errorf("upload generation id contains invalid character %q", r)
+	}
+	if generation == "." || generation == ".." || strings.Contains(generation, "..") {
+		return "", fmt.Errorf("upload generation id must not contain path traversal")
+	}
+	return generation, nil
+}
+
+func stagedUploadDir(dealID uint64, generationID string) string {
+	return filepath.Join(uploadDir, "deals", strconv.FormatUint(dealID, 10), "staging", generationID)
+}
+
+func promoteStagedUploadGeneration(dealID uint64, generationID string, finalDir string) error {
+	stageDir := stagedUploadDir(dealID, generationID)
+	entries, err := os.ReadDir(stageDir)
+	if err != nil {
+		return fmt.Errorf("read staged upload generation: %w", err)
+	}
+	if err := ensureUploadRootDir(finalDir); err != nil {
+		return fmt.Errorf("create final slab directory: %w", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			return fmt.Errorf("staged upload generation contains unexpected directory %q", entry.Name())
+		}
+		src := filepath.Join(stageDir, entry.Name())
+		dst := filepath.Join(finalDir, entry.Name())
+		if err := os.Remove(dst); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("replace existing staged artifact %q: %w", entry.Name(), err)
+		}
+		if err := os.Rename(src, dst); err != nil {
+			return fmt.Errorf("promote staged artifact %q: %w", entry.Name(), err)
+		}
+	}
+	_ = os.Remove(stageDir)
+	return nil
+}


### PR DESCRIPTION
## Summary

Implements the first mergeable slice for #158: a manifest-deferred upload pipeline primitive for browser-only uploads.

The prior upload API required `X-PolyStore-Manifest-Root` on every MDU/shard request, which meant the browser could not upload provider artifacts until all KZG work completed and the final manifest root was known. This PR adds a generation-scoped staging path so artifacts can be uploaded before the manifest root exists, then promoted when the manifest upload binds the generation to the final root.

## Changes

- Gateway/provider-daemon accepts `X-PolyStore-Upload-Generation` on `/sp/upload_mdu` and `/sp/upload_shard` when `X-PolyStore-Manifest-Root` is not known yet.
- `/sp/upload_manifest` can include both `X-PolyStore-Manifest-Root` and `X-PolyStore-Upload-Generation`; after normal previous-root validation it promotes staged artifacts into the final deal/manifest-root directory.
- Website upload transport can send generation-scoped artifacts without a manifest root.
- Upload engine exposes `uploadPipelinedGeneration`, which uses a single async artifact producer plus bounded upload workers, uploads artifacts under a generation id, then uploads the manifest after the final binding resolves.
- Adds controlled benchmark script: `npm --prefix polystore-website run perf:upload-pipeline`.

## Benchmark / Decision

Decision: improvement for controlled compute/upload overlap; production FileSharder wiring is the next PR-sized step.

Heavier upload-overlap benchmark:

```json
{
  "scenario": {
    "artifact_count": 8,
    "compute_ms_per_artifact": 40,
    "upload_ms_per_artifact": 80,
    "upload_concurrency": 3
  },
  "sequential_ms": 561.336126,
  "pipelined_ms": 481.16051300000004,
  "speedup": 1.1666296606513096,
  "decision": "improvement",
  "pipelined_started_before_manifest_count": 8
}
```

Default smoke benchmark also showed improvement:

```json
{
  "scenario": {
    "artifact_count": 8,
    "compute_ms_per_artifact": 40,
    "upload_ms_per_artifact": 30,
    "upload_concurrency": 3
  },
  "sequential_ms": 411.93751,
  "pipelined_ms": 380.457442,
  "speedup": 1.0827426790090229,
  "decision": "improvement",
  "pipelined_started_before_manifest_count": 8
}
```

## Validation

Latest local validation on head `56e15045`:

- `npx --prefix polystore-website tsx --test polystore-website/src/lib/upload/engine.test.ts polystore-website/src/lib/upload/httpTransport.test.ts`
- `LD_LIBRARY_PATH=/home/mikers/dev/polynomialstore/_worktrees/website-compute-upload-pipeline/polystore_core/target/release go test .` in `polystore_gateway`
- `npm --prefix polystore-website run perf:upload-pipeline --silent`
- `ARTIFACTS=8 COMPUTE_MS=40 UPLOAD_MS=80 CONCURRENCY=3 npm --prefix polystore-website run perf:upload-pipeline --silent`
- `git diff --check`

Earlier validation on this branch:

- `npm --prefix polystore-website run test:unit`
- `npm --prefix polystore-website run build:app`
- `cargo build --release` in `polystore_core`

Refs #158.
