### PR TITLE
Tune browser WebGPU KZG MSM benchmark path

### DIFF
--- a/notes/kzg_webgpu_msm_optimization.md
+++ b/notes/kzg_webgpu_msm_optimization.md
@@ -84,6 +84,20 @@ The diagnostic JSON includes:
 - top-level `error` and `device_lost` when the benchmark fails in diagnostic mode
 - the existing WASM/WebGPU timings and parity result
 
+The stable path is `POLYSTORE_WEBGPU_MSM_REDUCTION=serial`, which is also the
+default. PR #178 also exposes diagnostic-only generated reduction variants:
+
+```sh
+POLYSTORE_WEBGPU_MSM_REDUCTION=parallel16 POLYSTORE_WEBGPU_MSM_RUNS=1 npm run diagnose:kzg-webgpu-msm
+POLYSTORE_WEBGPU_MSM_REDUCTION=parallel32 POLYSTORE_WEBGPU_MSM_RUNS=1 npm run diagnose:kzg-webgpu-msm
+POLYSTORE_WEBGPU_MSM_REDUCTION=parallel64 POLYSTORE_WEBGPU_MSM_RUNS=1 npm run diagnose:kzg-webgpu-msm
+```
+
+These variants keep the stable per-bucket weighting shader and only replace the
+final per-window sum with 16/32/64-lane generated reductions. They are not
+scheduler candidates unless they return `error: null`, `device_lost: null`, and
+`parity: true` on real browser hardware.
+
 Local diagnostic run on Linux/HeadlessChrome 138:
 
 - `maxComputeWorkgroupStorageSize`: 32768
@@ -92,6 +106,12 @@ Local diagnostic run on Linux/HeadlessChrome 138:
 - WebGPU total: ~26.43 s
 - WASM total: ~389 ms
 - parity: true
+
+Local generated-reduction diagnostic result:
+
+- `POLYSTORE_WEBGPU_MSM_REDUCTION=parallel16` loses the SwiftShader GPU
+  instance before producing a run result:
+  `OperationError: Instance dropped in popErrorScope`.
 
 Use this runner on Apple M3 Chrome before spending more shader time. If the M3
 has a larger workgroup-storage budget or avoids device loss for the rejected

--- a/notes/kzg_webgpu_msm_optimization.md
+++ b/notes/kzg_webgpu_msm_optimization.md
@@ -45,6 +45,18 @@ accepted the TypeScript build, but the GPU device was lost before readback in
 the benchmark environment. That path was not kept in source because it was not
 browser-stable.
 
+Two follow-up reduction variants were also tested and rejected:
+
+- The vendored `subsum_phase1_g1` path was wired with explicit bind groups.
+  Chrome rejected the original 64-lane form because the workgroup array of G1
+  points exceeded the adapter's workgroup-storage limit.
+- A browser-sized 32-lane `subsum_phase1_g1` variant and a KZG-specific sparse
+  running-sum shader both compiled, but the benchmark lost the GPU instance
+  before readback, including at `POLYSTORE_WEBGPU_MSM_BUCKET_WIDTH=4`.
+
+These failures point to shader pressure/browser-stability limits in the current
+`webgpu-groth16`-derived G1 arithmetic, not just TypeScript overhead.
+
 ## Handoff To #168
 
 Do not enable the pure WebGPU MSM path by default in upload scheduling yet.

--- a/notes/kzg_webgpu_msm_optimization.md
+++ b/notes/kzg_webgpu_msm_optimization.md
@@ -6,8 +6,8 @@ Baseline PR: #174
 ## Current Result
 
 The pure WebGPU MSM path preserves byte-for-byte parity with the WASM `blst`
-oracle and is now faster than WASM on real Apple M3 browser hardware when using
-the `parallel16` reduction mode.
+oracle and is now faster than WASM on real Apple M3 and NVIDIA RTX 3060 Ti
+browser hardware. The fastest reduction mode is adapter-sensitive.
 
 On the local WebGPU-enabled Chrome benchmark environment, which resolves to
 SwiftShader rather than a native GPU:
@@ -26,9 +26,19 @@ On Apple M3 Chrome/Metal using the diagnostic runner at commit `69533f8e`:
 | `parallel32` | ~105.82 ms | ~259.70 ms | true | no |
 | `parallel64` | ~111.44 ms | ~251.26 ms | true | no |
 
-`parallel16` is the default reduction mode because it is the fastest passing
-mode on the native Apple Metal target and still preserves parity in the local
-SwiftShader smoke test.
+On Ubuntu 22.04, headed Chrome 148, NVIDIA RTX 3060 Ti/Vulkan using the
+diagnostic runner at commit `1b9dedd8`:
+
+| reduction mode | WebGPU total | WASM total | parity | device lost |
+| --- | ---: | ---: | --- | --- |
+| `serial` | ~92.66-105.28 ms | ~285.96-286.38 ms | true | no |
+| `parallel32` | ~7434.90 ms | ~290.28 ms | true | no |
+| `parallel64` | ~7601.74 ms | ~291.76 ms | true | no |
+| `parallel16` | ~21222.31 ms | ~286.96 ms | true | no |
+
+The default reduction mode is adapter-aware: Apple Metal uses `parallel16`,
+while other adapters use `serial`. This preserves the M3 win without regressing
+NVIDIA Vulkan.
 
 ## Window Sweep
 
@@ -98,8 +108,8 @@ The diagnostic JSON includes:
 - top-level `error` and `device_lost` when the benchmark fails in diagnostic mode
 - the existing WASM/WebGPU timings and parity result
 
-The default path is `POLYSTORE_WEBGPU_MSM_REDUCTION=parallel16`. PR #178 also
-keeps explicit reduction overrides for diagnostics:
+The default path is adapter-aware. Leave `POLYSTORE_WEBGPU_MSM_REDUCTION`
+unset to use the selected default, or set it explicitly for diagnostics:
 
 ```sh
 POLYSTORE_WEBGPU_MSM_REDUCTION=serial POLYSTORE_WEBGPU_MSM_RUNS=1 npm run diagnose:kzg-webgpu-msm
@@ -128,6 +138,15 @@ Local generated-reduction diagnostic result on SwiftShader:
 - `POLYSTORE_WEBGPU_MSM_REDUCTION=parallel16` returns `parity: true`,
   `error: null`, and `device_lost: null`, but remains slow at ~42.6 s because
   the adapter is software-backed.
+
+Local NVIDIA note:
+
+- Headless Chrome still selected SwiftShader even with native Vulkan flags.
+- Headed Chrome with `POLYSTORE_WEBGPU_HEADLESS=0` and
+  `POLYSTORE_WEBGPU_CHROME_ARGS='--use-vulkan=native --force_high_performance_gpu'`
+  selected `vendor: nvidia`, `architecture: ampere`, `isFallbackAdapter: false`.
+- With no explicit `POLYSTORE_WEBGPU_MSM_REDUCTION`, the adapter-aware default
+  selected `serial` on NVIDIA and returned ~92.66 ms WebGPU vs ~285.96 ms WASM.
 
 ## Handoff To #168
 

--- a/notes/kzg_webgpu_msm_optimization.md
+++ b/notes/kzg_webgpu_msm_optimization.md
@@ -5,16 +5,30 @@ Baseline PR: #174
 
 ## Current Result
 
-The pure WebGPU MSM path still preserves byte-for-byte parity with the WASM
-`blst` oracle, but it is not ready for default upload scheduling.
+The pure WebGPU MSM path preserves byte-for-byte parity with the WASM `blst`
+oracle and is now faster than WASM on real Apple M3 browser hardware when using
+the `parallel16` reduction mode.
 
-On the local WebGPU-enabled Chrome benchmark environment:
+On the local WebGPU-enabled Chrome benchmark environment, which resolves to
+SwiftShader rather than a native GPU:
 
 - Chrome: HeadlessChrome 138 with WebGPU flags
 - Host: Linux x64, 12 CPUs, ~31 GiB memory
 - Fixture: 1 blob, 128 KiB
 - WASM oracle: ~286-325 ms
-- WebGPU prototype: ~26.0-26.5 s depending on bucket width
+- WebGPU serial prototype: ~26.0-26.5 s depending on bucket width
+
+On Apple M3 Chrome/Metal using the diagnostic runner at commit `69533f8e`:
+
+| reduction mode | WebGPU total | WASM total | parity | device lost |
+| --- | ---: | ---: | --- | --- |
+| `parallel16` | ~99.19 ms | ~246.06 ms | true | no |
+| `parallel32` | ~105.82 ms | ~259.70 ms | true | no |
+| `parallel64` | ~111.44 ms | ~251.26 ms | true | no |
+
+`parallel16` is the default reduction mode because it is the fastest passing
+mode on the native Apple Metal target and still preserves parity in the local
+SwiftShader smoke test.
 
 ## Window Sweep
 
@@ -84,19 +98,21 @@ The diagnostic JSON includes:
 - top-level `error` and `device_lost` when the benchmark fails in diagnostic mode
 - the existing WASM/WebGPU timings and parity result
 
-The stable path is `POLYSTORE_WEBGPU_MSM_REDUCTION=serial`, which is also the
-default. PR #178 also exposes diagnostic-only generated reduction variants:
+The default path is `POLYSTORE_WEBGPU_MSM_REDUCTION=parallel16`. PR #178 also
+keeps explicit reduction overrides for diagnostics:
 
 ```sh
+POLYSTORE_WEBGPU_MSM_REDUCTION=serial POLYSTORE_WEBGPU_MSM_RUNS=1 npm run diagnose:kzg-webgpu-msm
 POLYSTORE_WEBGPU_MSM_REDUCTION=parallel16 POLYSTORE_WEBGPU_MSM_RUNS=1 npm run diagnose:kzg-webgpu-msm
 POLYSTORE_WEBGPU_MSM_REDUCTION=parallel32 POLYSTORE_WEBGPU_MSM_RUNS=1 npm run diagnose:kzg-webgpu-msm
 POLYSTORE_WEBGPU_MSM_REDUCTION=parallel64 POLYSTORE_WEBGPU_MSM_RUNS=1 npm run diagnose:kzg-webgpu-msm
 ```
 
 These variants keep the stable per-bucket weighting shader and only replace the
-final per-window sum with 16/32/64-lane generated reductions. They are not
-scheduler candidates unless they return `error: null`, `device_lost: null`, and
-`parity: true` on real browser hardware.
+final per-window sum with generated reductions. The first shared-memory tree
+implementation produced invalid G1 points on Apple Metal; the retained
+implementation uses a safer two-phase reduction where phase 1 writes lane
+partials and phase 2 folds those partials serially per window.
 
 Local diagnostic run on Linux/HeadlessChrome 138:
 
@@ -107,25 +123,21 @@ Local diagnostic run on Linux/HeadlessChrome 138:
 - WASM total: ~389 ms
 - parity: true
 
-Local generated-reduction diagnostic result:
+Local generated-reduction diagnostic result on SwiftShader:
 
-- `POLYSTORE_WEBGPU_MSM_REDUCTION=parallel16` loses the SwiftShader GPU
-  instance before producing a run result:
-  `OperationError: Instance dropped in popErrorScope`.
-
-Use this runner on Apple M3 Chrome before spending more shader time. If the M3
-has a larger workgroup-storage budget or avoids device loss for the rejected
-reduction variants, the problem is adapter/backend sensitivity. If it matches
-the Linux result, the current shader architecture is the bottleneck rather than
-the local test machine.
+- `POLYSTORE_WEBGPU_MSM_REDUCTION=parallel16` returns `parity: true`,
+  `error: null`, and `device_lost: null`, but remains slow at ~42.6 s because
+  the adapter is software-backed.
 
 ## Handoff To #168
 
-Do not enable the pure WebGPU MSM path by default in upload scheduling yet.
-The #168 scheduler should treat this backend as forced/diagnostic-only unless
-a later shader change replaces the current point-arithmetic bottleneck.
+The #168 scheduler can gate the pure WebGPU MSM path behind capability detection
+and parity/perf evidence instead of treating it as diagnostic-only. Native
+Apple Metal evidence now shows the optimized path beating the WASM CPU method
+for the 1-blob browser benchmark.
 
 The next meaningful optimization is not more JavaScript tuning. The measured
 hot path is still GPU dispatch/readback around the BLS12-381 point arithmetic.
-Future work should focus on a browser-stable parallel reduction strategy or a
-different fixed-base approach with an explicit browser memory budget.
+Future work should focus on reducing bucket construction overhead, validating
+multi-blob batching, and testing the default mode across additional native
+browser adapters.

--- a/notes/kzg_webgpu_msm_optimization.md
+++ b/notes/kzg_webgpu_msm_optimization.md
@@ -57,6 +57,48 @@ Two follow-up reduction variants were also tested and rejected:
 These failures point to shader pressure/browser-stability limits in the current
 `webgpu-groth16`-derived G1 arithmetic, not just TypeScript overhead.
 
+## Cross-Device Diagnostic Runner
+
+PR #178 adds a diagnostic wrapper around the same browser benchmark:
+
+```sh
+cd polystore-website
+POLYSTORE_WEBGPU_MSM_RUNS=1 npm run diagnose:kzg-webgpu-msm
+```
+
+For local Chrome path or flag overrides:
+
+```sh
+POLYSTORE_CHROME_PATH=/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+POLYSTORE_WEBGPU_MSM_RUNS=1 \
+npm run diagnose:kzg-webgpu-msm
+```
+
+The diagnostic JSON includes:
+
+- `webgpu_diagnostics.adapter.info`
+- `webgpu_diagnostics.adapter.features`
+- `webgpu_diagnostics.adapter.limits.maxComputeWorkgroupStorageSize`
+- `webgpu_diagnostics.adapter.limits.maxComputeInvocationsPerWorkgroup`
+- per-run `device_lost_after_run`
+- top-level `error` and `device_lost` when the benchmark fails in diagnostic mode
+- the existing WASM/WebGPU timings and parity result
+
+Local diagnostic run on Linux/HeadlessChrome 138:
+
+- `maxComputeWorkgroupStorageSize`: 32768
+- `maxComputeInvocationsPerWorkgroup`: 256
+- `device_lost_after_run`: null on the stable path
+- WebGPU total: ~26.43 s
+- WASM total: ~389 ms
+- parity: true
+
+Use this runner on Apple M3 Chrome before spending more shader time. If the M3
+has a larger workgroup-storage budget or avoids device loss for the rejected
+reduction variants, the problem is adapter/backend sensitivity. If it matches
+the Linux result, the current shader architecture is the bottleneck rather than
+the local test machine.
+
 ## Handoff To #168
 
 Do not enable the pure WebGPU MSM path by default in upload scheduling yet.

--- a/notes/kzg_webgpu_msm_optimization.md
+++ b/notes/kzg_webgpu_msm_optimization.md
@@ -1,0 +1,57 @@
+# Browser WebGPU KZG MSM Optimization Notes
+
+Issue: #177
+Baseline PR: #174
+
+## Current Result
+
+The pure WebGPU MSM path still preserves byte-for-byte parity with the WASM
+`blst` oracle, but it is not ready for default upload scheduling.
+
+On the local WebGPU-enabled Chrome benchmark environment:
+
+- Chrome: HeadlessChrome 138 with WebGPU flags
+- Host: Linux x64, 12 CPUs, ~31 GiB memory
+- Fixture: 1 blob, 128 KiB
+- WASM oracle: ~286-325 ms
+- WebGPU prototype: ~26.0-26.5 s depending on bucket width
+
+## Window Sweep
+
+Command shape:
+
+```sh
+POLYSTORE_WEBGPU_MSM_BUCKET_WIDTH=<width> npm run perf:kzg-webgpu-msm
+```
+
+Measured single-run results:
+
+| bucket width | WebGPU total | WASM total | parity | notes |
+| --- | ---: | ---: | --- | --- |
+| 13 | ~26.30 s | ~290.6 ms | true | PR #174-style default |
+| 12 | ~26.00 s | ~288.6 ms | true | slightly faster than 13 in one run |
+| 11 | ~26.50 s | ~286.3 ms | true | slower than 12/13 |
+| 10 | ~26.09 s | ~325.3 ms | true | best safe tested width in this run |
+| 9 | ~26.24 s | ~307.9 ms | true | slower than 10 |
+
+Width 10 is now the prototype default because it was the best safe value in
+this local sweep, but the difference is small relative to the remaining gap.
+
+## Failed Reduction Experiment
+
+A KZG-specific dense Pippenger running-sum reduction was tested locally. The
+goal was to replace per-bucket scalar multiplication with additions. Chrome
+accepted the TypeScript build, but the GPU device was lost before readback in
+the benchmark environment. That path was not kept in source because it was not
+browser-stable.
+
+## Handoff To #168
+
+Do not enable the pure WebGPU MSM path by default in upload scheduling yet.
+The #168 scheduler should treat this backend as forced/diagnostic-only unless
+a later shader change replaces the current point-arithmetic bottleneck.
+
+The next meaningful optimization is not more JavaScript tuning. The measured
+hot path is still GPU dispatch/readback around the BLS12-381 point arithmetic.
+Future work should focus on a browser-stable parallel reduction strategy or a
+different fixed-base approach with an explicit browser memory budget.

--- a/polystore-website/package.json
+++ b/polystore-website/package.json
@@ -30,6 +30,7 @@
     "perf:kzg-browser": "tsx scripts/benchmark_browser_kzg_commit.ts",
     "perf:kzg-webgpu-lifecycle": "tsx scripts/benchmark_browser_kzg_webgpu_lifecycle.ts",
     "perf:kzg-webgpu-msm": "tsx scripts/benchmark_browser_kzg_webgpu_msm.ts",
+    "diagnose:kzg-webgpu-msm": "POLYSTORE_WEBGPU_MSM_DIAGNOSTIC=1 tsx scripts/benchmark_browser_kzg_webgpu_msm.ts",
     "preflight:webgpu": "tsx scripts/preflight_webgpu_chrome.ts",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"

--- a/polystore-website/scripts/benchmark_browser_kzg_webgpu_msm.ts
+++ b/polystore-website/scripts/benchmark_browser_kzg_webgpu_msm.ts
@@ -34,6 +34,14 @@ const blobCount = Number.parseInt(process.env.POLYSTORE_WEBGPU_MSM_BLOBS ?? '1',
 if (!Number.isInteger(blobCount) || blobCount < 1) {
   throw new Error('POLYSTORE_WEBGPU_MSM_BLOBS must be a positive integer')
 }
+const bucketWidth = Number.parseInt(process.env.POLYSTORE_WEBGPU_MSM_BUCKET_WIDTH ?? '10', 10)
+if (!Number.isInteger(bucketWidth) || bucketWidth < 4 || bucketWidth > 13) {
+  throw new Error('POLYSTORE_WEBGPU_MSM_BUCKET_WIDTH must be an integer between 4 and 13')
+}
+const runs = Number.parseInt(process.env.POLYSTORE_WEBGPU_MSM_RUNS ?? '1', 10)
+if (!Number.isInteger(runs) || runs < 1) {
+  throw new Error('POLYSTORE_WEBGPU_MSM_RUNS must be a positive integer')
+}
 
 const vite = await createServer({
   root: process.cwd(),
@@ -84,6 +92,17 @@ try {
         function hex(bytes) {
           return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
         }
+        function stats(values) {
+          const sorted = [...values].sort((a, b) => a - b);
+          const pick = (quantile) => sorted[Math.min(sorted.length - 1, Math.floor((sorted.length - 1) * quantile))] ?? 0;
+          return {
+            min: sorted[0] ?? 0,
+            median: pick(0.5),
+            p95: pick(0.95),
+            max: sorted[sorted.length - 1] ?? 0,
+            mean: values.length ? values.reduce((sum, value) => sum + value, 0) / values.length : 0,
+          };
+        }
 
         const wasmMod = await import('/wasm/polystore_core.js');
         const msmMod = await import('/src/lib/webgpuKzgMsm.ts');
@@ -103,15 +122,33 @@ try {
           blobs.set(makeValidBlob(41 + i), i * config.blobSize);
         }
 
-        const wasmStart = performance.now();
-        const wasmCommitments = polyStoreWasm.commit_blobs(blobs);
-        const wasmMs = performance.now() - wasmStart;
-
         const gpuInitStart = performance.now();
-        const committer = await msmMod.createWebGpuKzgMsmCommitter(polyStoreWasm);
+        const committer = await msmMod.createWebGpuKzgMsmCommitter(polyStoreWasm, navigator, {
+          bucketWidth: config.bucketWidth,
+        });
         const gpuInitMs = performance.now() - gpuInitStart;
-        const gpu = await committer.commitBlobs(blobs);
+
+        const runResults = [];
+        let wasmCommitments = null;
+        for (let run = 0; run < config.runs; run += 1) {
+          const wasmStart = performance.now();
+          wasmCommitments = polyStoreWasm.commit_blobs(blobs);
+          const wasmMs = performance.now() - wasmStart;
+          const gpu = await committer.commitBlobs(blobs);
+          runResults.push({
+            run,
+            wasm_ms: wasmMs,
+            gpu_timings: gpu.timings,
+            gpu_debug: gpu.debug ?? null,
+            parity: hex(wasmCommitments) === hex(gpu.commitments),
+            commitment_bytes: gpu.commitments.byteLength,
+            first_commitment: hex(gpu.commitments.slice(0, 48)),
+          });
+        }
         committer.destroy();
+
+        const totals = runResults.map((run) => run.gpu_timings.totalMs);
+        const wasmTotals = runResults.map((run) => run.wasm_ms);
 
         return {
           browser: {
@@ -121,13 +158,15 @@ try {
             webgpu_present: Boolean(navigator.gpu),
           },
           blob_count: config.blobCount,
-          wasm_ms: wasmMs,
+          bucket_width: config.bucketWidth,
+          runs: config.runs,
+          wasm_ms: stats(wasmTotals),
           gpu_init_ms: gpuInitMs,
-          gpu_timings: gpu.timings,
-          gpu_debug: gpu.debug ?? null,
-          parity: hex(wasmCommitments) === hex(gpu.commitments),
-          commitment_bytes: gpu.commitments.byteLength,
-          first_commitment: hex(gpu.commitments.slice(0, 48)),
+          gpu_total_ms: stats(totals),
+          run_results: runResults,
+          parity: runResults.every((run) => run.parity),
+          commitment_bytes: runResults[0]?.commitment_bytes ?? 0,
+          first_commitment: runResults[0]?.first_commitment ?? '',
         };
       };
     `,
@@ -136,6 +175,8 @@ try {
   const result = await page.evaluate(`window.__runPolyStoreKzgWebGpuMsmBenchmark(${JSON.stringify({
     blobSize: BLOB_SIZE,
     blobCount,
+    bucketWidth,
+    runs,
   })})`)
 
   console.log(

--- a/polystore-website/scripts/benchmark_browser_kzg_webgpu_msm.ts
+++ b/polystore-website/scripts/benchmark_browser_kzg_webgpu_msm.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import os from 'node:os'
+import { execFileSync } from 'node:child_process'
 
 import { chromium } from '@playwright/test'
 import { createServer } from 'vite'
@@ -28,6 +29,24 @@ function launchArgs(): string[] {
     ? process.env.POLYSTORE_WEBGPU_CHROME_ARGS.split(/\s+/).filter(Boolean)
     : []
   return [...DEFAULT_WEBGPU_ARGS, ...extra]
+}
+
+function gitValue(args: string[]): string | null {
+  try {
+    return execFileSync('git', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim()
+  } catch {
+    return null
+  }
+}
+
+function gitMetadata() {
+  const status = gitValue(['status', '--porcelain'])
+  return {
+    branch: gitValue(['branch', '--show-current']),
+    commit: gitValue(['rev-parse', 'HEAD']),
+    short_commit: gitValue(['rev-parse', '--short=8', 'HEAD']),
+    dirty: status === null ? null : status.length > 0,
+  }
 }
 
 const blobCount = Number.parseInt(process.env.POLYSTORE_WEBGPU_MSM_BLOBS ?? '1', 10)
@@ -311,6 +330,7 @@ try {
       {
         benchmark: 'browser-kzg-webgpu-msm',
         timestamp: new Date().toISOString(),
+        git: gitMetadata(),
         host: {
           platform: os.platform(),
           release: os.release(),

--- a/polystore-website/scripts/benchmark_browser_kzg_webgpu_msm.ts
+++ b/polystore-website/scripts/benchmark_browser_kzg_webgpu_msm.ts
@@ -43,6 +43,10 @@ if (!Number.isInteger(runs) || runs < 1) {
   throw new Error('POLYSTORE_WEBGPU_MSM_RUNS must be a positive integer')
 }
 const diagnostic = process.env.POLYSTORE_WEBGPU_MSM_DIAGNOSTIC === '1'
+const reductionMode = process.env.POLYSTORE_WEBGPU_MSM_REDUCTION ?? 'serial'
+if (!['serial', 'parallel16', 'parallel32', 'parallel64'].includes(reductionMode)) {
+  throw new Error('POLYSTORE_WEBGPU_MSM_REDUCTION must be serial, parallel16, parallel32, or parallel64')
+}
 
 const vite = await createServer({
   root: process.cwd(),
@@ -235,6 +239,7 @@ try {
         try {
           committer = await msmMod.createWebGpuKzgMsmCommitter(polyStoreWasm, navigator, {
             bucketWidth: config.bucketWidth,
+            reductionMode: config.reductionMode,
           });
           gpuInitMs = performance.now() - gpuInitStart;
 
@@ -276,6 +281,7 @@ try {
           webgpu_diagnostics: webgpuDiagnostics,
           blob_count: config.blobCount,
           bucket_width: config.bucketWidth,
+          reduction_mode: config.reductionMode,
           runs: config.runs,
           wasm_ms: stats(wasmTotals),
           gpu_init_ms: gpuInitMs,
@@ -297,6 +303,7 @@ try {
     bucketWidth,
     runs,
     diagnostic,
+    reductionMode,
   })})`)
 
   console.log(

--- a/polystore-website/scripts/benchmark_browser_kzg_webgpu_msm.ts
+++ b/polystore-website/scripts/benchmark_browser_kzg_webgpu_msm.ts
@@ -62,7 +62,7 @@ if (!Number.isInteger(runs) || runs < 1) {
   throw new Error('POLYSTORE_WEBGPU_MSM_RUNS must be a positive integer')
 }
 const diagnostic = process.env.POLYSTORE_WEBGPU_MSM_DIAGNOSTIC === '1'
-const reductionMode = process.env.POLYSTORE_WEBGPU_MSM_REDUCTION ?? 'serial'
+const reductionMode = process.env.POLYSTORE_WEBGPU_MSM_REDUCTION ?? 'parallel16'
 if (!['serial', 'parallel16', 'parallel32', 'parallel64'].includes(reductionMode)) {
   throw new Error('POLYSTORE_WEBGPU_MSM_REDUCTION must be serial, parallel16, parallel32, or parallel64')
 }

--- a/polystore-website/scripts/benchmark_browser_kzg_webgpu_msm.ts
+++ b/polystore-website/scripts/benchmark_browser_kzg_webgpu_msm.ts
@@ -42,6 +42,7 @@ const runs = Number.parseInt(process.env.POLYSTORE_WEBGPU_MSM_RUNS ?? '1', 10)
 if (!Number.isInteger(runs) || runs < 1) {
   throw new Error('POLYSTORE_WEBGPU_MSM_RUNS must be a positive integer')
 }
+const diagnostic = process.env.POLYSTORE_WEBGPU_MSM_DIAGNOSTIC === '1'
 
 const vite = await createServer({
   root: process.cwd(),
@@ -77,6 +78,106 @@ try {
   await page.addScriptTag({
     content: `
       window.__runPolyStoreKzgWebGpuMsmBenchmark = async function(config) {
+        function serializeError(error) {
+          if (!error) return null;
+          return {
+            name: error.name ?? null,
+            message: error.message ?? String(error),
+            stack: error.stack ?? null,
+          };
+        }
+        function serializeRecord(record) {
+          if (!record) return null;
+          const out = {};
+          for (const key of Object.keys(record)) out[key] = record[key];
+          for (const key of [
+            'vendor',
+            'architecture',
+            'device',
+            'description',
+            'subgroupMinSize',
+            'subgroupMaxSize',
+            'isFallbackAdapter',
+          ]) {
+            if (typeof record[key] !== 'undefined') out[key] = record[key];
+          }
+          return out;
+        }
+        function pickLimits(limits) {
+          if (!limits) return null;
+          const keys = [
+            'maxTextureDimension1D',
+            'maxTextureDimension2D',
+            'maxTextureDimension3D',
+            'maxTextureArrayLayers',
+            'maxBindGroups',
+            'maxBindGroupsPlusVertexBuffers',
+            'maxBindingsPerBindGroup',
+            'maxDynamicUniformBuffersPerPipelineLayout',
+            'maxDynamicStorageBuffersPerPipelineLayout',
+            'maxSampledTexturesPerShaderStage',
+            'maxSamplersPerShaderStage',
+            'maxStorageBuffersPerShaderStage',
+            'maxStorageTexturesPerShaderStage',
+            'maxUniformBuffersPerShaderStage',
+            'maxUniformBufferBindingSize',
+            'maxStorageBufferBindingSize',
+            'minUniformBufferOffsetAlignment',
+            'minStorageBufferOffsetAlignment',
+            'maxVertexBuffers',
+            'maxBufferSize',
+            'maxVertexAttributes',
+            'maxVertexBufferArrayStride',
+            'maxInterStageShaderComponents',
+            'maxInterStageShaderVariables',
+            'maxColorAttachments',
+            'maxColorAttachmentBytesPerSample',
+            'maxComputeWorkgroupStorageSize',
+            'maxComputeInvocationsPerWorkgroup',
+            'maxComputeWorkgroupSizeX',
+            'maxComputeWorkgroupSizeY',
+            'maxComputeWorkgroupSizeZ',
+            'maxComputeWorkgroupsPerDimension',
+          ];
+          const out = {};
+          for (const key of keys) {
+            if (typeof limits[key] !== 'undefined') out[key] = limits[key];
+          }
+          return out;
+        }
+        async function collectWebGpuDiagnostics() {
+          const diagnostics = {
+            present: Boolean(navigator.gpu),
+            adapter: null,
+            adapter_error: null,
+          };
+          if (!navigator.gpu) return diagnostics;
+          try {
+            const adapter = await navigator.gpu.requestAdapter();
+            if (!adapter) {
+              diagnostics.adapter_error = 'requestAdapter returned null';
+              return diagnostics;
+            }
+            let info = null;
+            try {
+              if (adapter.info) info = serializeRecord(adapter.info);
+              else if (typeof adapter.requestAdapterInfo === 'function') {
+                info = serializeRecord(await adapter.requestAdapterInfo());
+              }
+            } catch (error) {
+              info = { error: serializeError(error) };
+            }
+            diagnostics.adapter = {
+              info,
+              features: adapter.features ? Array.from(adapter.features).sort() : [],
+              limits: pickLimits(adapter.limits),
+            };
+            return diagnostics;
+          } catch (error) {
+            diagnostics.adapter_error = serializeError(error);
+            return diagnostics;
+          }
+        }
         function makeValidBlob(seed) {
           const blob = new Uint8Array(config.blobSize);
           const chunks = config.blobSize / 32;
@@ -106,6 +207,7 @@ try {
 
         const wasmMod = await import('/wasm/polystore_core.js');
         const msmMod = await import('/src/lib/webgpuKzgMsm.ts');
+        const webgpuDiagnostics = await collectWebGpuDiagnostics();
         const wasmBytes = await fetch('/wasm/polystore_core_bg.wasm').then((response) => response.arrayBuffer());
         await wasmMod.default({ module_or_path: wasmBytes });
         const trustedSetupBytes = new Uint8Array(
@@ -123,40 +225,55 @@ try {
         }
 
         const gpuInitStart = performance.now();
-        const committer = await msmMod.createWebGpuKzgMsmCommitter(polyStoreWasm, navigator, {
-          bucketWidth: config.bucketWidth,
-        });
-        const gpuInitMs = performance.now() - gpuInitStart;
+        let committer = null;
+        let gpuInitMs = 0;
 
         const runResults = [];
         let wasmCommitments = null;
-        for (let run = 0; run < config.runs; run += 1) {
-          const wasmStart = performance.now();
-          wasmCommitments = polyStoreWasm.commit_blobs(blobs);
-          const wasmMs = performance.now() - wasmStart;
-          const gpu = await committer.commitBlobs(blobs);
-          runResults.push({
-            run,
-            wasm_ms: wasmMs,
-            gpu_timings: gpu.timings,
-            gpu_debug: gpu.debug ?? null,
-            parity: hex(wasmCommitments) === hex(gpu.commitments),
-            commitment_bytes: gpu.commitments.byteLength,
-            first_commitment: hex(gpu.commitments.slice(0, 48)),
+        let error = null;
+        let deviceLost = null;
+        try {
+          committer = await msmMod.createWebGpuKzgMsmCommitter(polyStoreWasm, navigator, {
+            bucketWidth: config.bucketWidth,
           });
+          gpuInitMs = performance.now() - gpuInitStart;
+
+          for (let run = 0; run < config.runs; run += 1) {
+            const wasmStart = performance.now();
+            wasmCommitments = polyStoreWasm.commit_blobs(blobs);
+            const wasmMs = performance.now() - wasmStart;
+            const gpu = await committer.commitBlobs(blobs);
+            runResults.push({
+              run,
+              wasm_ms: wasmMs,
+              gpu_timings: gpu.timings,
+              gpu_debug: gpu.debug ?? null,
+              device_lost_after_run: await committer.getDeviceLostInfo(25),
+              parity: hex(wasmCommitments) === hex(gpu.commitments),
+              commitment_bytes: gpu.commitments.byteLength,
+              first_commitment: hex(gpu.commitments.slice(0, 48)),
+            });
+          }
+        } catch (caught) {
+          error = serializeError(caught);
+          if (committer) deviceLost = await committer.getDeviceLostInfo(500);
+          if (!config.diagnostic) throw caught;
+        } finally {
+          committer?.destroy();
         }
-        committer.destroy();
 
         const totals = runResults.map((run) => run.gpu_timings.totalMs);
         const wasmTotals = runResults.map((run) => run.wasm_ms);
 
         return {
+          diagnostic: config.diagnostic,
           browser: {
             user_agent: navigator.userAgent,
             hardware_concurrency: navigator.hardwareConcurrency ?? null,
             cross_origin_isolated: crossOriginIsolated,
             webgpu_present: Boolean(navigator.gpu),
           },
+          webgpu_diagnostics: webgpuDiagnostics,
           blob_count: config.blobCount,
           bucket_width: config.bucketWidth,
           runs: config.runs,
@@ -164,7 +281,9 @@ try {
           gpu_init_ms: gpuInitMs,
           gpu_total_ms: stats(totals),
           run_results: runResults,
-          parity: runResults.every((run) => run.parity),
+          error,
+          device_lost: deviceLost,
+          parity: runResults.length > 0 && runResults.every((run) => run.parity),
           commitment_bytes: runResults[0]?.commitment_bytes ?? 0,
           first_commitment: runResults[0]?.first_commitment ?? '',
         };
@@ -177,6 +296,7 @@ try {
     blobCount,
     bucketWidth,
     runs,
+    diagnostic,
   })})`)
 
   console.log(
@@ -198,7 +318,11 @@ try {
     ),
   )
 
-  if (!(result as { parity?: boolean }).parity) {
+  if (!diagnostic && (result as { error?: unknown }).error) {
+    throw new Error('WebGPU MSM diagnostic captured a benchmark failure')
+  }
+
+  if (!diagnostic && !(result as { parity?: boolean }).parity) {
     throw new Error('WebGPU MSM commitment parity failed')
   }
 } finally {

--- a/polystore-website/scripts/benchmark_browser_kzg_webgpu_msm.ts
+++ b/polystore-website/scripts/benchmark_browser_kzg_webgpu_msm.ts
@@ -62,8 +62,8 @@ if (!Number.isInteger(runs) || runs < 1) {
   throw new Error('POLYSTORE_WEBGPU_MSM_RUNS must be a positive integer')
 }
 const diagnostic = process.env.POLYSTORE_WEBGPU_MSM_DIAGNOSTIC === '1'
-const reductionMode = process.env.POLYSTORE_WEBGPU_MSM_REDUCTION ?? 'parallel16'
-if (!['serial', 'parallel16', 'parallel32', 'parallel64'].includes(reductionMode)) {
+const reductionMode = process.env.POLYSTORE_WEBGPU_MSM_REDUCTION
+if (reductionMode && !['serial', 'parallel16', 'parallel32', 'parallel64'].includes(reductionMode)) {
   throw new Error('POLYSTORE_WEBGPU_MSM_REDUCTION must be serial, parallel16, parallel32, or parallel64')
 }
 
@@ -300,7 +300,8 @@ try {
           webgpu_diagnostics: webgpuDiagnostics,
           blob_count: config.blobCount,
           bucket_width: config.bucketWidth,
-          reduction_mode: config.reductionMode,
+          requested_reduction_mode: config.reductionMode ?? null,
+          reduction_mode: runResults[0]?.gpu_debug?.reductionMode ?? config.reductionMode ?? null,
           runs: config.runs,
           wasm_ms: stats(wasmTotals),
           gpu_init_ms: gpuInitMs,

--- a/polystore-website/src/lib/webgpuKzgMsm.test.ts
+++ b/polystore-website/src/lib/webgpuKzgMsm.test.ts
@@ -37,7 +37,7 @@ test('WebGPU KZG MSM bucket data maps one canonical scalar to one positive bucke
 })
 
 test('WebGPU KZG MSM bucket data uses signed windows for high window values', () => {
-  const buckets = buildWebGpuKzgMsmBucketData(blobWithCell(9, 4097n))
+  const buckets = buildWebGpuKzgMsmBucketData(blobWithCell(9, 4097n), 13)
 
   assert.equal(buckets.baseIndices[0], (9 | WEBGPU_KZG_MSM_SIGN_BIT) >>> 0)
   assert.equal(buckets.bucketValues[0], 4095)

--- a/polystore-website/src/lib/webgpuKzgMsm.ts
+++ b/polystore-website/src/lib/webgpuKzgMsm.ts
@@ -279,15 +279,6 @@ function reductionWorkgroupSize(mode: WebGpuKzgMsmReductionMode): 16 | 32 | 64 {
 }
 
 function buildParallelSubsumShader(workgroupSize: 16 | 32 | 64): string {
-  const reductions = [32, 16, 8, 4, 2]
-    .filter((step) => step < workgroupSize)
-    .map(
-      (step) => `
-    if tid < ${step}u { subsum_shared_g1[tid] = add_g1_safe(subsum_shared_g1[tid], subsum_shared_g1[tid + ${step}u]); }
-    workgroupBarrier();`,
-    )
-    .join('\n')
-
   return WEBGPU_GROTH16_MSM_G1_SUBSUM_SHADER
     .replace('const G1_SUBSUM_WG_SIZE: u32 = 64u;', `const G1_SUBSUM_WG_SIZE: u32 = ${workgroupSize}u;`)
     .replace(
@@ -298,20 +289,17 @@ function buildParallelSubsumShader(workgroupSize: 16 | 32 | 64): string {
       '@compute @workgroup_size(64)\nfn subsum_phase1_g1',
       `@compute @workgroup_size(${workgroupSize})\nfn subsum_phase1_g1`,
     )
-    .replace(
-      `
-    if tid < 32u { subsum_shared_g1[tid] = add_g1_safe(subsum_shared_g1[tid], subsum_shared_g1[tid + 32u]); }
-    workgroupBarrier();
-    if tid < 16u { subsum_shared_g1[tid] = add_g1_safe(subsum_shared_g1[tid], subsum_shared_g1[tid + 16u]); }
-    workgroupBarrier();
-    if tid < 8u { subsum_shared_g1[tid] = add_g1_safe(subsum_shared_g1[tid], subsum_shared_g1[tid + 8u]); }
-    workgroupBarrier();
-    if tid < 4u { subsum_shared_g1[tid] = add_g1_safe(subsum_shared_g1[tid], subsum_shared_g1[tid + 4u]); }
-    workgroupBarrier();
-    if tid < 2u { subsum_shared_g1[tid] = add_g1_safe(subsum_shared_g1[tid], subsum_shared_g1[tid + 2u]); }
-    workgroupBarrier();`,
-      reductions,
-    )
+    .replace(/ {4}subsum_shared_g1\[tid\] = local_sum;[\s\S]*? {4}}\n}\n\n@group\(0\) @binding\(0\) var<storage, read> partial_sums_ph2_g1:/, `    partial_sums_g1[window_id * G1_SUBSUM_WG_SIZE + tid] = local_sum;
+}
+
+@group(0) @binding(0) var<storage, read> partial_sums_ph2_g1:`)
+    .replace(/ {4}let window_id = global_id.x;\n {4}win_sums_ph2_g1\[window_id\] = partial_sums_ph2_g1\[window_id\];/, `    let window_id = global_id.x;
+    var sum = G1_INFINITY;
+    let start = window_id * G1_SUBSUM_WG_SIZE;
+    for (var i = 0u; i < G1_SUBSUM_WG_SIZE; i = i + 1u) {
+        sum = add_g1_safe(sum, partial_sums_ph2_g1[start + i]);
+    }
+    win_sums_ph2_g1[window_id] = store_g1(sum);`)
 }
 
 async function readBuffer(device: GPUDevice, source: GPUBuffer, size: number): Promise<Uint8Array> {
@@ -529,7 +517,9 @@ export class WebGpuKzgMsmCommitter {
           : createEmptyStorageBuffer(
               this.device,
               `polystore-kzg-msm-${reductionMode}-partial-window-sums`,
-              Math.max(1, bucketData.numWindows) * WEBGPU_KZG_MSM_POINT_BYTES,
+              Math.max(1, bucketData.numWindows) *
+                reductionWorkgroupSize(reductionMode) *
+                WEBGPU_KZG_MSM_POINT_BYTES,
             )
       timings.uploadMs += nowMs() - uploadStart
 

--- a/polystore-website/src/lib/webgpuKzgMsm.ts
+++ b/polystore-website/src/lib/webgpuKzgMsm.ts
@@ -42,12 +42,21 @@ type GPUDevice = {
 }
 type WebGpuNavigator = Navigator & {
   gpu?: {
-    requestAdapter: () => Promise<null | { requestDevice: () => Promise<GPUDevice> }>
+    requestAdapter: () => Promise<null | WebGpuAdapter>
   }
+}
+type WebGpuAdapter = {
+  info?: WebGpuAdapterInfo
+  requestAdapterInfo?: () => Promise<WebGpuAdapterInfo>
+  requestDevice: () => Promise<GPUDevice>
+}
+type WebGpuAdapterInfo = {
+  vendor?: string
+  architecture?: string
 }
 
 export const WEBGPU_KZG_MSM_BUCKET_WIDTH = 10
-export const WEBGPU_KZG_MSM_REDUCTION_MODE: WebGpuKzgMsmReductionMode = 'parallel16'
+export const WEBGPU_KZG_MSM_REDUCTION_MODE: WebGpuKzgMsmReductionMode = 'serial'
 export const WEBGPU_KZG_MSM_POINT_BYTES = 384
 export const WEBGPU_KZG_MSM_SIGN_BIT = 0x80000000
 export const WEBGPU_KZG_MSM_BLOB_SIZE = 128 * 1024
@@ -270,6 +279,23 @@ function createEmptyStorageBuffer(device: GPUDevice, label: string, size: number
 function assertReductionMode(mode: WebGpuKzgMsmReductionMode): WebGpuKzgMsmReductionMode {
   if (mode === 'serial' || mode === 'parallel16' || mode === 'parallel32' || mode === 'parallel64') return mode
   throw new Error('WebGPU KZG MSM reduction mode must be serial, parallel16, parallel32, or parallel64')
+}
+
+async function readAdapterInfo(adapter: WebGpuAdapter): Promise<WebGpuAdapterInfo | null> {
+  try {
+    if (adapter.info) return adapter.info
+    if (typeof adapter.requestAdapterInfo === 'function') return await adapter.requestAdapterInfo()
+  } catch {
+    return null
+  }
+  return null
+}
+
+function defaultReductionModeForAdapter(info: WebGpuAdapterInfo | null): WebGpuKzgMsmReductionMode {
+  const vendor = info?.vendor?.toLowerCase() ?? ''
+  const architecture = info?.architecture?.toLowerCase() ?? ''
+  if (vendor.includes('apple') || architecture.includes('metal')) return 'parallel16'
+  return WEBGPU_KZG_MSM_REDUCTION_MODE
 }
 
 function reductionWorkgroupSize(mode: WebGpuKzgMsmReductionMode): 16 | 32 | 64 {
@@ -676,6 +702,10 @@ export async function createWebGpuKzgMsmCommitter(
   if (!gpu) throw new Error('navigator.gpu is unavailable')
   const adapter = await gpu.requestAdapter()
   if (!adapter) throw new Error('WebGPU adapter request returned null')
+  const resolvedOptions: WebGpuKzgMsmOptions = {
+    ...options,
+    reductionMode: options.reductionMode ?? defaultReductionModeForAdapter(await readAdapterInfo(adapter)),
+  }
   const device = await adapter.requestDevice()
-  return new WebGpuKzgMsmCommitter(device, wasm, options)
+  return new WebGpuKzgMsmCommitter(device, wasm, resolvedOptions)
 }

--- a/polystore-website/src/lib/webgpuKzgMsm.ts
+++ b/polystore-website/src/lib/webgpuKzgMsm.ts
@@ -29,6 +29,7 @@ type GPUDevice = {
     submit: (commandBuffers: object[]) => void
     writeBuffer: (buffer: GPUBuffer, bufferOffset: number, data: Uint8Array | Uint32Array) => void
   }
+  lost?: Promise<{ reason?: string; message?: string }>
   createBindGroup: (descriptor: object) => object
   createBindGroupLayout: (descriptor: object) => GPUBindGroupLayout
   createBuffer: (descriptor: object) => GPUBuffer
@@ -85,6 +86,11 @@ export type WebGpuKzgMsmResult = {
     readbackBytes: number
     windowSumNonZeroBytes: number
   }
+}
+
+export type WebGpuKzgMsmDeviceLostInfo = {
+  reason: string | null
+  message: string | null
 }
 
 type BucketData = {
@@ -377,6 +383,21 @@ export class WebGpuKzgMsmCommitter {
 
   destroy(): void {
     this.srsBuffer.destroy()
+  }
+
+  async getDeviceLostInfo(timeoutMs = 0): Promise<WebGpuKzgMsmDeviceLostInfo | null> {
+    if (!this.device.lost) return null
+    const lost = this.device.lost.then((info) => ({
+      reason: info.reason ?? null,
+      message: info.message ?? null,
+    }))
+    if (timeoutMs <= 0) return lost
+    return Promise.race([
+      lost,
+      new Promise<null>((resolve) => {
+        setTimeout(() => resolve(null), timeoutMs)
+      }),
+    ])
   }
 
   async commitBlobs(blobsFlat: Uint8Array): Promise<WebGpuKzgMsmResult> {

--- a/polystore-website/src/lib/webgpuKzgMsm.ts
+++ b/polystore-website/src/lib/webgpuKzgMsm.ts
@@ -266,17 +266,6 @@ function createEmptyStorageBuffer(device: GPUDevice, label: string, size: number
   })
 }
 
-function createUniformBuffer(device: GPUDevice, label: string, bytes: Uint32Array): GPUBuffer {
-  const usage = gpuBufferUsage()
-  const buffer = device.createBuffer({
-    label,
-    size: Math.max(16, Math.ceil(bytes.byteLength / 16) * 16),
-    usage: usage.UNIFORM | usage.COPY_DST,
-  })
-  device.queue.writeBuffer(buffer, 0, bytes)
-  return buffer
-}
-
 function assertReductionMode(mode: WebGpuKzgMsmReductionMode): WebGpuKzgMsmReductionMode {
   if (mode === 'serial' || mode === 'parallel16' || mode === 'parallel32' || mode === 'parallel64') return mode
   throw new Error('WebGPU KZG MSM reduction mode must be serial, parallel16, parallel32, or parallel64')
@@ -542,10 +531,6 @@ export class WebGpuKzgMsmCommitter {
               `polystore-kzg-msm-${reductionMode}-partial-window-sums`,
               Math.max(1, bucketData.numWindows) * WEBGPU_KZG_MSM_POINT_BYTES,
             )
-      const parallelSubsumParams =
-        reductionMode === 'serial'
-          ? null
-          : createUniformBuffer(this.device, `polystore-kzg-msm-${reductionMode}-params`, new Uint32Array([1, 0, 0, 0]))
       timings.uploadMs += nowMs() - uploadStart
 
       const dispatchStart = nowMs()
@@ -580,10 +565,7 @@ export class WebGpuKzgMsmCommitter {
         ],
       })
       const parallelPhase1BindGroup =
-        reductionMode === 'serial' ||
-        !partialWindowSums ||
-        !parallelSubsumParams ||
-        !this.parallelSubsumPhase1Layout
+        reductionMode === 'serial' || !partialWindowSums || !this.parallelSubsumPhase1Layout
           ? null
           : this.device.createBindGroup({
               label: `polystore-kzg-msm-${reductionMode}-phase1-bg`,
@@ -593,11 +575,10 @@ export class WebGpuKzgMsmCommitter {
                 { binding: 1, resource: { buffer: windowStarts } },
                 { binding: 2, resource: { buffer: windowCounts } },
                 { binding: 3, resource: { buffer: partialWindowSums } },
-                { binding: 4, resource: { buffer: parallelSubsumParams } },
               ],
             })
       const parallelPhase2BindGroup =
-        reductionMode === 'serial' || !partialWindowSums || !parallelSubsumParams || !this.parallelSubsumPhase2Layout
+        reductionMode === 'serial' || !partialWindowSums || !this.parallelSubsumPhase2Layout
           ? null
           : this.device.createBindGroup({
               label: `polystore-kzg-msm-${reductionMode}-phase2-bg`,
@@ -605,7 +586,6 @@ export class WebGpuKzgMsmCommitter {
               entries: [
                 { binding: 0, resource: { buffer: partialWindowSums } },
                 { binding: 1, resource: { buffer: windowSums } },
-                { binding: 2, resource: { buffer: parallelSubsumParams } },
               ],
             })
 
@@ -686,7 +666,6 @@ export class WebGpuKzgMsmCommitter {
         aggregatedBuckets,
         windowSums,
         partialWindowSums,
-        parallelSubsumParams,
       ]) {
         buffer?.destroy()
       }

--- a/polystore-website/src/lib/webgpuKzgMsm.ts
+++ b/polystore-website/src/lib/webgpuKzgMsm.ts
@@ -58,8 +58,11 @@ export type WebGpuKzgMsmWasmInterop = {
   webgpu_fold_g1_window_sums: (windowSums: Uint8Array, bucketWidth: number) => Uint8Array
 }
 
+export type WebGpuKzgMsmReductionMode = 'serial' | 'parallel16' | 'parallel32' | 'parallel64'
+
 export type WebGpuKzgMsmOptions = {
   bucketWidth?: number
+  reductionMode?: WebGpuKzgMsmReductionMode
 }
 
 export type WebGpuKzgMsmTimings = {
@@ -77,6 +80,7 @@ export type WebGpuKzgMsmResult = {
   blobs: number
   debug?: {
     bucketWidth: number
+    reductionMode: WebGpuKzgMsmReductionMode
     bucketCount: number
     baseIndexCount: number
     numWindows: number
@@ -262,6 +266,65 @@ function createEmptyStorageBuffer(device: GPUDevice, label: string, size: number
   })
 }
 
+function createUniformBuffer(device: GPUDevice, label: string, bytes: Uint32Array): GPUBuffer {
+  const usage = gpuBufferUsage()
+  const buffer = device.createBuffer({
+    label,
+    size: Math.max(16, Math.ceil(bytes.byteLength / 16) * 16),
+    usage: usage.UNIFORM | usage.COPY_DST,
+  })
+  device.queue.writeBuffer(buffer, 0, bytes)
+  return buffer
+}
+
+function assertReductionMode(mode: WebGpuKzgMsmReductionMode): WebGpuKzgMsmReductionMode {
+  if (mode === 'serial' || mode === 'parallel16' || mode === 'parallel32' || mode === 'parallel64') return mode
+  throw new Error('WebGPU KZG MSM reduction mode must be serial, parallel16, parallel32, or parallel64')
+}
+
+function reductionWorkgroupSize(mode: WebGpuKzgMsmReductionMode): 16 | 32 | 64 {
+  if (mode === 'parallel16') return 16
+  if (mode === 'parallel32') return 32
+  if (mode === 'parallel64') return 64
+  throw new Error('serial reduction mode does not have a parallel workgroup size')
+}
+
+function buildParallelSubsumShader(workgroupSize: 16 | 32 | 64): string {
+  const reductions = [32, 16, 8, 4, 2]
+    .filter((step) => step < workgroupSize)
+    .map(
+      (step) => `
+    if tid < ${step}u { subsum_shared_g1[tid] = add_g1_safe(subsum_shared_g1[tid], subsum_shared_g1[tid + ${step}u]); }
+    workgroupBarrier();`,
+    )
+    .join('\n')
+
+  return WEBGPU_GROTH16_MSM_G1_SUBSUM_SHADER
+    .replace('const G1_SUBSUM_WG_SIZE: u32 = 64u;', `const G1_SUBSUM_WG_SIZE: u32 = ${workgroupSize}u;`)
+    .replace(
+      'var<workgroup> subsum_shared_g1: array<PointG1, 64>;',
+      `var<workgroup> subsum_shared_g1: array<PointG1, ${workgroupSize}>;`,
+    )
+    .replace(
+      '@compute @workgroup_size(64)\nfn subsum_phase1_g1',
+      `@compute @workgroup_size(${workgroupSize})\nfn subsum_phase1_g1`,
+    )
+    .replace(
+      `
+    if tid < 32u { subsum_shared_g1[tid] = add_g1_safe(subsum_shared_g1[tid], subsum_shared_g1[tid + 32u]); }
+    workgroupBarrier();
+    if tid < 16u { subsum_shared_g1[tid] = add_g1_safe(subsum_shared_g1[tid], subsum_shared_g1[tid + 16u]); }
+    workgroupBarrier();
+    if tid < 8u { subsum_shared_g1[tid] = add_g1_safe(subsum_shared_g1[tid], subsum_shared_g1[tid + 8u]); }
+    workgroupBarrier();
+    if tid < 4u { subsum_shared_g1[tid] = add_g1_safe(subsum_shared_g1[tid], subsum_shared_g1[tid + 4u]); }
+    workgroupBarrier();
+    if tid < 2u { subsum_shared_g1[tid] = add_g1_safe(subsum_shared_g1[tid], subsum_shared_g1[tid + 2u]); }
+    workgroupBarrier();`,
+      reductions,
+    )
+}
+
 async function readBuffer(device: GPUDevice, source: GPUBuffer, size: number): Promise<Uint8Array> {
   const usage = gpuBufferUsage()
   const readback = device.createBuffer({
@@ -286,16 +349,21 @@ export class WebGpuKzgMsmCommitter {
   private readonly montgomeryPipeline: GPUComputePipeline
   private readonly weightPipeline: GPUComputePipeline
   private readonly subsumPipeline: GPUComputePipeline
+  private readonly parallelSubsumPhase1Pipeline?: GPUComputePipeline
+  private readonly parallelSubsumPhase2Pipeline?: GPUComputePipeline
   private readonly aggregateLayout: GPUBindGroupLayout
   private readonly montgomeryLayout: GPUBindGroupLayout
   private readonly weightLayout: GPUBindGroupLayout
   private readonly subsumLayout: GPUBindGroupLayout
+  private readonly parallelSubsumPhase1Layout?: GPUBindGroupLayout
+  private readonly parallelSubsumPhase2Layout?: GPUBindGroupLayout
 
   constructor(
     private readonly device: GPUDevice,
     private readonly wasm: WebGpuKzgMsmWasmInterop,
     private readonly options: WebGpuKzgMsmOptions = {},
   ) {
+    const reductionMode = assertReductionMode(options.reductionMode ?? 'serial')
     const srs = wasm.webgpu_g1_srs_lagrange()
     if (srs.byteLength < WEBGPU_KZG_MSM_CELLS_PER_BLOB * WEBGPU_KZG_MSM_POINT_BYTES) {
       throw new Error('WebGPU KZG MSM SRS export is smaller than one blob domain')
@@ -310,6 +378,13 @@ export class WebGpuKzgMsmCommitter {
       label: 'polystore-kzg-msm-g1-subsum',
       code: WEBGPU_GROTH16_MSM_G1_SUBSUM_SHADER,
     })
+    const parallelSubsumModule =
+      reductionMode === 'serial'
+        ? null
+        : device.createShaderModule({
+            label: `polystore-kzg-msm-g1-${reductionMode}`,
+            code: buildParallelSubsumShader(reductionWorkgroupSize(reductionMode)),
+          })
 
     const shaderStage = gpuShaderStage()
     this.montgomeryLayout = device.createBindGroupLayout({
@@ -366,6 +441,20 @@ export class WebGpuKzgMsmCommitter {
       compute: { module: subsumModule, entryPoint: 'subsum_accumulation_g1' },
     })
     this.subsumLayout = this.subsumPipeline.getBindGroupLayout(0)
+    if (parallelSubsumModule) {
+      this.parallelSubsumPhase1Pipeline = device.createComputePipeline({
+        label: `polystore-kzg-msm-${reductionMode}-phase1`,
+        layout: 'auto',
+        compute: { module: parallelSubsumModule, entryPoint: 'subsum_phase1_g1' },
+      })
+      this.parallelSubsumPhase1Layout = this.parallelSubsumPhase1Pipeline.getBindGroupLayout(0)
+      this.parallelSubsumPhase2Pipeline = device.createComputePipeline({
+        label: `polystore-kzg-msm-${reductionMode}-phase2`,
+        layout: 'auto',
+        compute: { module: parallelSubsumModule, entryPoint: 'subsum_phase2_g1' },
+      })
+      this.parallelSubsumPhase2Layout = this.parallelSubsumPhase2Pipeline.getBindGroupLayout(0)
+    }
 
     const montgomeryBindGroup = device.createBindGroup({
       label: 'polystore-kzg-msm-srs-montgomery-bg',
@@ -404,6 +493,7 @@ export class WebGpuKzgMsmCommitter {
     const started = nowMs()
     const blobs = assertBlobBatch(blobsFlat)
     const bucketWidth = assertBucketWidth(this.options.bucketWidth ?? WEBGPU_KZG_MSM_BUCKET_WIDTH)
+    const reductionMode = assertReductionMode(this.options.reductionMode ?? 'serial')
     const commitments = new Uint8Array(blobs * 48)
     let debug: WebGpuKzgMsmResult['debug']
     const timings: WebGpuKzgMsmTimings = {
@@ -444,6 +534,18 @@ export class WebGpuKzgMsmCommitter {
         'polystore-kzg-msm-window-sums',
         Math.max(1, bucketData.numWindows) * WEBGPU_KZG_MSM_POINT_BYTES,
       )
+      const partialWindowSums =
+        reductionMode === 'serial'
+          ? null
+          : createEmptyStorageBuffer(
+              this.device,
+              `polystore-kzg-msm-${reductionMode}-partial-window-sums`,
+              Math.max(1, bucketData.numWindows) * WEBGPU_KZG_MSM_POINT_BYTES,
+            )
+      const parallelSubsumParams =
+        reductionMode === 'serial'
+          ? null
+          : createUniformBuffer(this.device, `polystore-kzg-msm-${reductionMode}-params`, new Uint32Array([1, 0, 0, 0]))
       timings.uploadMs += nowMs() - uploadStart
 
       const dispatchStart = nowMs()
@@ -477,6 +579,35 @@ export class WebGpuKzgMsmCommitter {
           { binding: 4, resource: { buffer: windowSums } },
         ],
       })
+      const parallelPhase1BindGroup =
+        reductionMode === 'serial' ||
+        !partialWindowSums ||
+        !parallelSubsumParams ||
+        !this.parallelSubsumPhase1Layout
+          ? null
+          : this.device.createBindGroup({
+              label: `polystore-kzg-msm-${reductionMode}-phase1-bg`,
+              layout: this.parallelSubsumPhase1Layout,
+              entries: [
+                { binding: 0, resource: { buffer: aggregatedBuckets } },
+                { binding: 1, resource: { buffer: windowStarts } },
+                { binding: 2, resource: { buffer: windowCounts } },
+                { binding: 3, resource: { buffer: partialWindowSums } },
+                { binding: 4, resource: { buffer: parallelSubsumParams } },
+              ],
+            })
+      const parallelPhase2BindGroup =
+        reductionMode === 'serial' || !partialWindowSums || !parallelSubsumParams || !this.parallelSubsumPhase2Layout
+          ? null
+          : this.device.createBindGroup({
+              label: `polystore-kzg-msm-${reductionMode}-phase2-bg`,
+              layout: this.parallelSubsumPhase2Layout,
+              entries: [
+                { binding: 0, resource: { buffer: partialWindowSums } },
+                { binding: 1, resource: { buffer: windowSums } },
+                { binding: 2, resource: { buffer: parallelSubsumParams } },
+              ],
+            })
 
       const encoder = this.device.createCommandEncoder({ label: 'polystore-kzg-msm-encoder' })
       const pass = encoder.beginComputePass({ label: 'polystore-kzg-msm-pass' })
@@ -486,9 +617,26 @@ export class WebGpuKzgMsmCommitter {
       pass.setPipeline(this.weightPipeline)
       pass.setBindGroup(0, weightBindGroup)
       pass.dispatchWorkgroups(Math.max(1, Math.ceil(bucketData.bucketValues.length / 64)))
-      pass.setPipeline(this.subsumPipeline)
-      pass.setBindGroup(0, subsumBindGroup)
-      pass.dispatchWorkgroups(Math.max(1, bucketData.numWindows))
+      if (reductionMode === 'serial') {
+        pass.setPipeline(this.subsumPipeline)
+        pass.setBindGroup(0, subsumBindGroup)
+        pass.dispatchWorkgroups(Math.max(1, bucketData.numWindows))
+      } else {
+        if (
+          !this.parallelSubsumPhase1Pipeline ||
+          !this.parallelSubsumPhase2Pipeline ||
+          !parallelPhase1BindGroup ||
+          !parallelPhase2BindGroup
+        ) {
+          throw new Error(`WebGPU KZG MSM ${reductionMode} pipeline was not initialized`)
+        }
+        pass.setPipeline(this.parallelSubsumPhase1Pipeline)
+        pass.setBindGroup(0, parallelPhase1BindGroup)
+        pass.dispatchWorkgroups(Math.max(1, bucketData.numWindows))
+        pass.setPipeline(this.parallelSubsumPhase2Pipeline)
+        pass.setBindGroup(0, parallelPhase2BindGroup)
+        pass.dispatchWorkgroups(Math.max(1, bucketData.numWindows))
+      }
       pass.end()
       this.device.queue.submit([encoder.finish()])
       const validationError = await this.device.popErrorScope?.()
@@ -503,6 +651,7 @@ export class WebGpuKzgMsmCommitter {
       )
       debug ??= {
         bucketWidth,
+        reductionMode,
         bucketCount: bucketData.bucketValues.length,
         baseIndexCount: bucketData.baseIndices.length,
         numWindows: bucketData.numWindows,
@@ -536,8 +685,10 @@ export class WebGpuKzgMsmCommitter {
         windowCounts,
         aggregatedBuckets,
         windowSums,
+        partialWindowSums,
+        parallelSubsumParams,
       ]) {
-        buffer.destroy()
+        buffer?.destroy()
       }
     }
 

--- a/polystore-website/src/lib/webgpuKzgMsm.ts
+++ b/polystore-website/src/lib/webgpuKzgMsm.ts
@@ -45,7 +45,7 @@ type WebGpuNavigator = Navigator & {
   }
 }
 
-export const WEBGPU_KZG_MSM_BUCKET_WIDTH = 13
+export const WEBGPU_KZG_MSM_BUCKET_WIDTH = 10
 export const WEBGPU_KZG_MSM_POINT_BYTES = 384
 export const WEBGPU_KZG_MSM_SIGN_BIT = 0x80000000
 export const WEBGPU_KZG_MSM_BLOB_SIZE = 128 * 1024
@@ -55,6 +55,10 @@ const FR_MODULUS = BigInt('0x73eda753299d7d483339d80809a1d80553bda402fffe5bfefff
 export type WebGpuKzgMsmWasmInterop = {
   webgpu_g1_srs_lagrange: () => Uint8Array
   webgpu_fold_g1_window_sums: (windowSums: Uint8Array, bucketWidth: number) => Uint8Array
+}
+
+export type WebGpuKzgMsmOptions = {
+  bucketWidth?: number
 }
 
 export type WebGpuKzgMsmTimings = {
@@ -71,9 +75,14 @@ export type WebGpuKzgMsmResult = {
   timings: WebGpuKzgMsmTimings
   blobs: number
   debug?: {
+    bucketWidth: number
     bucketCount: number
     baseIndexCount: number
     numWindows: number
+    maxBucketSize: number
+    meanBucketSize: number
+    uploadBytes: number
+    readbackBytes: number
     windowSumNonZeroBytes: number
   }
 }
@@ -86,6 +95,7 @@ type BucketData = {
   windowStarts: Uint32Array
   windowCounts: Uint32Array
   numWindows: number
+  maxBucketSize: number
 }
 
 function nowMs(): number {
@@ -118,6 +128,13 @@ function assertBlobBatch(blobsFlat: Uint8Array): number {
     throw new Error('WebGPU KZG MSM input length must be a multiple of 128 KiB')
   }
   return blobsFlat.byteLength / WEBGPU_KZG_MSM_BLOB_SIZE
+}
+
+function assertBucketWidth(bucketWidth: number): number {
+  if (!Number.isInteger(bucketWidth) || bucketWidth < 4 || bucketWidth > 13) {
+    throw new Error('WebGPU KZG MSM bucket width must be an integer between 4 and 13')
+  }
+  return bucketWidth
 }
 
 function blobCellToScalar(cell: Uint8Array): bigint {
@@ -187,6 +204,7 @@ export function buildWebGpuKzgMsmBucketData(blob: Uint8Array, bucketWidth = WEBG
   const bucketValues: number[] = []
   const windowStarts = new Uint32Array(numWindows)
   const windowCounts = new Uint32Array(numWindows)
+  let maxBucketSize = 0
 
   for (let windowIndex = 0; windowIndex < numWindows; windowIndex += 1) {
     const buckets = perWindow.get(windowIndex)
@@ -197,6 +215,7 @@ export function buildWebGpuKzgMsmBucketData(blob: Uint8Array, bucketWidth = WEBG
     windowCounts[windowIndex] = values.length
     for (const value of values) {
       const entries = buckets.get(value) ?? []
+      maxBucketSize = Math.max(maxBucketSize, entries.length)
       bucketPointers.push(baseIndices.length)
       bucketSizes.push(entries.length)
       bucketValues.push(value)
@@ -212,6 +231,7 @@ export function buildWebGpuKzgMsmBucketData(blob: Uint8Array, bucketWidth = WEBG
     windowStarts,
     windowCounts,
     numWindows,
+    maxBucketSize,
   }
 }
 
@@ -268,6 +288,7 @@ export class WebGpuKzgMsmCommitter {
   constructor(
     private readonly device: GPUDevice,
     private readonly wasm: WebGpuKzgMsmWasmInterop,
+    private readonly options: WebGpuKzgMsmOptions = {},
   ) {
     const srs = wasm.webgpu_g1_srs_lagrange()
     if (srs.byteLength < WEBGPU_KZG_MSM_CELLS_PER_BLOB * WEBGPU_KZG_MSM_POINT_BYTES) {
@@ -361,6 +382,7 @@ export class WebGpuKzgMsmCommitter {
   async commitBlobs(blobsFlat: Uint8Array): Promise<WebGpuKzgMsmResult> {
     const started = nowMs()
     const blobs = assertBlobBatch(blobsFlat)
+    const bucketWidth = assertBucketWidth(this.options.bucketWidth ?? WEBGPU_KZG_MSM_BUCKET_WIDTH)
     const commitments = new Uint8Array(blobs * 48)
     let debug: WebGpuKzgMsmResult['debug']
     const timings: WebGpuKzgMsmTimings = {
@@ -376,12 +398,12 @@ export class WebGpuKzgMsmCommitter {
       const blob = blobsFlat.subarray(i * WEBGPU_KZG_MSM_BLOB_SIZE, (i + 1) * WEBGPU_KZG_MSM_BLOB_SIZE)
       if (blob.every((byte) => byte === 0)) {
         const emptyWindows = new Uint8Array(WEBGPU_KZG_MSM_POINT_BYTES)
-        commitments.set(this.wasm.webgpu_fold_g1_window_sums(emptyWindows, WEBGPU_KZG_MSM_BUCKET_WIDTH), i * 48)
+        commitments.set(this.wasm.webgpu_fold_g1_window_sums(emptyWindows, bucketWidth), i * 48)
         continue
       }
 
       const bucketStart = nowMs()
-      const bucketData = buildWebGpuKzgMsmBucketData(blob)
+      const bucketData = buildWebGpuKzgMsmBucketData(blob, bucketWidth)
       timings.bucketBuildMs += nowMs() - bucketStart
 
       const uploadStart = nowMs()
@@ -459,15 +481,28 @@ export class WebGpuKzgMsmCommitter {
         Math.max(1, bucketData.numWindows) * WEBGPU_KZG_MSM_POINT_BYTES,
       )
       debug ??= {
+        bucketWidth,
         bucketCount: bucketData.bucketValues.length,
         baseIndexCount: bucketData.baseIndices.length,
         numWindows: bucketData.numWindows,
+        maxBucketSize: bucketData.maxBucketSize,
+        meanBucketSize: bucketData.bucketValues.length
+          ? bucketData.baseIndices.length / bucketData.bucketValues.length
+          : 0,
+        uploadBytes:
+          bucketData.baseIndices.byteLength +
+          bucketData.bucketPointers.byteLength +
+          bucketData.bucketSizes.byteLength +
+          bucketData.bucketValues.byteLength +
+          bucketData.windowStarts.byteLength +
+          bucketData.windowCounts.byteLength,
+        readbackBytes: Math.max(1, bucketData.numWindows) * WEBGPU_KZG_MSM_POINT_BYTES,
         windowSumNonZeroBytes: windowSumBytes.reduce((count, byte) => count + (byte === 0 ? 0 : 1), 0),
       }
       timings.dispatchReadbackMs += nowMs() - dispatchStart
 
       const foldStart = nowMs()
-      const commitment = this.wasm.webgpu_fold_g1_window_sums(windowSumBytes, WEBGPU_KZG_MSM_BUCKET_WIDTH)
+      const commitment = this.wasm.webgpu_fold_g1_window_sums(windowSumBytes, bucketWidth)
       timings.foldMs += nowMs() - foldStart
       commitments.set(commitment, i * 48)
 
@@ -493,11 +528,12 @@ export class WebGpuKzgMsmCommitter {
 export async function createWebGpuKzgMsmCommitter(
   wasm: WebGpuKzgMsmWasmInterop,
   navigatorLike: WebGpuNavigator = navigator as WebGpuNavigator,
+  options: WebGpuKzgMsmOptions = {},
 ): Promise<WebGpuKzgMsmCommitter> {
   const gpu = navigatorLike.gpu
   if (!gpu) throw new Error('navigator.gpu is unavailable')
   const adapter = await gpu.requestAdapter()
   if (!adapter) throw new Error('WebGPU adapter request returned null')
   const device = await adapter.requestDevice()
-  return new WebGpuKzgMsmCommitter(device, wasm)
+  return new WebGpuKzgMsmCommitter(device, wasm, options)
 }

--- a/polystore-website/src/lib/webgpuKzgMsm.ts
+++ b/polystore-website/src/lib/webgpuKzgMsm.ts
@@ -47,6 +47,7 @@ type WebGpuNavigator = Navigator & {
 }
 
 export const WEBGPU_KZG_MSM_BUCKET_WIDTH = 10
+export const WEBGPU_KZG_MSM_REDUCTION_MODE: WebGpuKzgMsmReductionMode = 'parallel16'
 export const WEBGPU_KZG_MSM_POINT_BYTES = 384
 export const WEBGPU_KZG_MSM_SIGN_BIT = 0x80000000
 export const WEBGPU_KZG_MSM_BLOB_SIZE = 128 * 1024
@@ -340,7 +341,7 @@ export class WebGpuKzgMsmCommitter {
     private readonly wasm: WebGpuKzgMsmWasmInterop,
     private readonly options: WebGpuKzgMsmOptions = {},
   ) {
-    const reductionMode = assertReductionMode(options.reductionMode ?? 'serial')
+    const reductionMode = assertReductionMode(options.reductionMode ?? WEBGPU_KZG_MSM_REDUCTION_MODE)
     const srs = wasm.webgpu_g1_srs_lagrange()
     if (srs.byteLength < WEBGPU_KZG_MSM_CELLS_PER_BLOB * WEBGPU_KZG_MSM_POINT_BYTES) {
       throw new Error('WebGPU KZG MSM SRS export is smaller than one blob domain')
@@ -470,7 +471,7 @@ export class WebGpuKzgMsmCommitter {
     const started = nowMs()
     const blobs = assertBlobBatch(blobsFlat)
     const bucketWidth = assertBucketWidth(this.options.bucketWidth ?? WEBGPU_KZG_MSM_BUCKET_WIDTH)
-    const reductionMode = assertReductionMode(this.options.reductionMode ?? 'serial')
+    const reductionMode = assertReductionMode(this.options.reductionMode ?? WEBGPU_KZG_MSM_REDUCTION_MODE)
     const commitments = new Uint8Array(blobs * 48)
     let debug: WebGpuKzgMsmResult['debug']
     const timings: WebGpuKzgMsmTimings = {


### PR DESCRIPTION
## Summary

Implements the issue #177 optimization/handoff slice for the browser-only WebGPU KZG MSM path stacked on PR #174.

This PR keeps the byte-correct WebGPU prototype intact, adds diagnostic/benchmark coverage, wires browser-valid reduction variants, and makes the default reduction mode adapter-aware:

- Apple/Metal defaults to `parallel16`.
- Other adapters default to `serial`.
- `POLYSTORE_WEBGPU_MSM_REDUCTION` can still force `serial`, `parallel16`, `parallel32`, or `parallel64` for diagnostics.

The current result is no longer diagnostic-only on native adapters. Apple M3 and NVIDIA RTX 3060 Ti headed Chrome runs both show WebGPU beating the current WASM CPU method for the one-blob benchmark, while fallback/software adapters remain unsafe for default scheduling.

## Scope

- Add `WebGpuKzgMsmOptions` with `bucketWidth` and `reductionMode` validation.
- Default bucket width to 10 for the current benchmark path.
- Add generated reduction variants for `parallel16`, `parallel32`, and `parallel64`.
- Resolve the default reduction mode from WebGPU adapter info.
- Expand the benchmark/diagnostic runner with git metadata, adapter info/features/limits, requested/actual reduction mode, device-loss capture, repeated-run stats, and diagnostic success output on captured failures.
- Document Apple Metal, NVIDIA Vulkan, SwiftShader/headless, and known failed shader experiments in `notes/kzg_webgpu_msm_optimization.md`.

## Current benchmark evidence

Apple M3 Chrome/Metal, diagnostic runner at commit `69533f8e`:

| reduction mode | WebGPU total | WASM total | parity | device lost |
| --- | ---: | ---: | --- | --- |
| `parallel16` | ~99.19 ms | ~246.06 ms | true | no |
| `parallel32` | ~105.82 ms | ~259.70 ms | true | no |
| `parallel64` | ~111.44 ms | ~251.26 ms | true | no |

Ubuntu 22.04 headed Chrome 148, NVIDIA RTX 3060 Ti/Vulkan, diagnostic runner at commit `1b9dedd8`:

| reduction mode | WebGPU total | WASM total | parity | device lost |
| --- | ---: | ---: | --- | --- |
| `serial` | ~92.66-105.28 ms | ~285.96-286.38 ms | true | no |
| `parallel32` | ~7434.90 ms | ~290.28 ms | true | no |
| `parallel64` | ~7601.74 ms | ~291.76 ms | true | no |
| `parallel16` | ~21222.31 ms | ~286.96 ms | true | no |

Latest adapter-aware NVIDIA smoke at commit `41f59823`:

- command shape: `POLYSTORE_WEBGPU_HEADLESS=0 POLYSTORE_WEBGPU_CHROME_ARGS='--use-vulkan=native --force_high_performance_gpu' POLYSTORE_WEBGPU_MSM_RUNS=1 npm run diagnose:kzg-webgpu-msm`
- adapter: `vendor: nvidia`, `architecture: ampere`, `isFallbackAdapter: false`
- requested reduction mode: unset
- selected reduction mode: `serial`
- WebGPU total: ~92.66 ms
- WASM total: ~285.96 ms
- parity: true

Known caveat: local headless Chrome on Ubuntu still selected SwiftShader even after the NVIDIA driver repair. #168 should reject fallback adapters and use timeout/probe/circuit-breaker behavior before defaulting WebGPU into upload preparation.

## Handoff to #168

#168 can now treat the browser WebGPU MSM backend as capability-gated rather than diagnostic-only:

- Accept native adapters only; reject fallback/software adapters by default.
- Probe with a bounded timeout and parity check before selecting WebGPU for uploads.
- Use adapter-aware reduction defaults from this PR.
- Add a session-level circuit breaker so pathological modes or device loss return the session to WASM.
- Keep deeper sustained-throughput work in #179.

## Validation

Latest local checks on commit `41f59823`:

- `npx tsc --noEmit --pretty false` passed
- `npm run lint` passed
- `npm run test:unit -- --run src/lib/webgpuKzgMsm.test.ts` passed 234 tests
- headed NVIDIA diagnostic smoke passed parity with adapter-aware `serial` selection

Latest CI on commit `41f59823` is tracked on this PR; the PR should not be considered merge-ready until all latest-head required jobs are green.

Refs #177.
