### PR TITLE
Integrate browser WebGPU KZG scheduler fallback

### DIFF
--- a/polystore-website/src/components/FileSharder.tsx
+++ b/polystore-website/src/components/FileSharder.tsx
@@ -181,6 +181,15 @@ type PreparePerfSample = {
   workerRustCommitMs: number
   workerRustCommitBackend?: string
   workerRustCommitMsmSubphasesAvailable?: boolean
+  workerKzgCommitBackend?: string
+  workerKzgWebGpuFallbackReason?: string
+  workerKzgWebGpuProbeStatus?: string
+  workerKzgWebGpuCircuitOpen?: boolean
+  workerKzgWebGpuReductionMode?: string
+  workerKzgWebGpuProbeTimeoutMs?: number
+  workerKzgWebGpuCommitTimeoutMs?: number
+  workerKzgWebGpuMinBlobs?: number
+  workerCommitWorkerCount?: number
   totalMs: number
   batchBlobs?: number
   shardCount?: number
@@ -262,6 +271,15 @@ type PreparePerfProfile = {
     unaccountedMsIsWallClockRemainder: true
     rustCommitBackend?: string
     rustCommitMsmSubphasesAvailable?: boolean
+    kzgCommitBackend?: string
+    kzgWebGpuFallbackReason?: string
+    kzgWebGpuProbeStatus?: string
+    kzgWebGpuCircuitOpen?: boolean
+    kzgWebGpuReductionMode?: string
+    kzgWebGpuProbeTimeoutMs?: number
+    kzgWebGpuCommitTimeoutMs?: number
+    kzgWebGpuMinBlobs?: number
+    commitWorkerCount?: number
   }
   samples: {
     user: PreparePerfSample[]
@@ -3268,7 +3286,20 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
               typeof result.perf?.rustCommitMsmSubphasesAvailable === 'boolean'
                 ? result.perf.rustCommitMsmSubphasesAvailable
                 : undefined
-
+            const workerKzgCommitBackend =
+              typeof result.perf?.kzgCommitBackend === 'string' ? result.perf.kzgCommitBackend : undefined
+            const workerKzgWebGpuFallbackReason =
+              typeof result.perf?.kzgWebGpuFallbackReason === 'string' ? result.perf.kzgWebGpuFallbackReason : undefined
+            const workerKzgWebGpuProbeStatus =
+              typeof result.perf?.kzgWebGpuProbeStatus === 'string' ? result.perf.kzgWebGpuProbeStatus : undefined
+            const workerKzgWebGpuCircuitOpen =
+              typeof result.perf?.kzgWebGpuCircuitOpen === 'boolean' ? result.perf.kzgWebGpuCircuitOpen : undefined
+            const workerKzgWebGpuReductionMode =
+              typeof result.perf?.kzgWebGpuReductionMode === 'string' ? result.perf.kzgWebGpuReductionMode : undefined
+            const workerKzgWebGpuProbeTimeoutMs = Number(result.perf?.kzgWebGpuProbeTimeoutMs ?? 0)
+            const workerKzgWebGpuCommitTimeoutMs = Number(result.perf?.kzgWebGpuCommitTimeoutMs ?? 0)
+            const workerKzgWebGpuMinBlobs = Number(result.perf?.kzgWebGpuMinBlobs ?? 0)
+            const workerCommitWorkerCount = Number(result.perf?.commitWorkerCount ?? 0)
             if (!encodedMdu) {
               const encodeStart = performance.now()
               encodedMdu = encodeToMdu(rawChunk)
@@ -3323,6 +3354,15 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
               workerRustCommitMs,
               workerRustCommitBackend,
               workerRustCommitMsmSubphasesAvailable,
+              workerKzgCommitBackend,
+              workerKzgWebGpuFallbackReason,
+              workerKzgWebGpuProbeStatus,
+              workerKzgWebGpuCircuitOpen,
+              workerKzgWebGpuReductionMode,
+              workerKzgWebGpuProbeTimeoutMs,
+              workerKzgWebGpuCommitTimeoutMs,
+              workerKzgWebGpuMinBlobs,
+              workerCommitWorkerCount,
               totalMs: opMs,
               shardCount:
                 result.shards_flat && Number(result.shard_len ?? 0) > 0
@@ -3611,6 +3651,22 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
               typeof result.perf?.rustCommitMsmSubphasesAvailable === 'boolean'
                 ? result.perf.rustCommitMsmSubphasesAvailable
                 : undefined
+            const workerKzgCommitBackend =
+              typeof result.perf?.kzgCommitBackend === 'string' ? result.perf.kzgCommitBackend : undefined
+            const workerKzgWebGpuFallbackReason =
+              typeof result.perf?.kzgWebGpuFallbackReason === 'string'
+                ? result.perf.kzgWebGpuFallbackReason
+                : undefined
+            const workerKzgWebGpuProbeStatus =
+              typeof result.perf?.kzgWebGpuProbeStatus === 'string' ? result.perf.kzgWebGpuProbeStatus : undefined
+            const workerKzgWebGpuCircuitOpen =
+              typeof result.perf?.kzgWebGpuCircuitOpen === 'boolean' ? result.perf.kzgWebGpuCircuitOpen : undefined
+            const workerKzgWebGpuReductionMode =
+              typeof result.perf?.kzgWebGpuReductionMode === 'string' ? result.perf.kzgWebGpuReductionMode : undefined
+            const workerKzgWebGpuProbeTimeoutMs = Number(result.perf?.kzgWebGpuProbeTimeoutMs ?? 0)
+            const workerKzgWebGpuCommitTimeoutMs = Number(result.perf?.kzgWebGpuCommitTimeoutMs ?? 0)
+            const workerKzgWebGpuMinBlobs = Number(result.perf?.kzgWebGpuMinBlobs ?? 0)
+            const workerCommitWorkerCount = Number(result.perf?.commitWorkerCount ?? 0)
 
             const rootBytes = toU8(result.mdu_root);
             witnessRoots.push(rootBytes);
@@ -3643,6 +3699,15 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
               workerRustCommitMs,
               workerRustCommitBackend,
               workerRustCommitMsmSubphasesAvailable,
+              workerKzgCommitBackend,
+              workerKzgWebGpuFallbackReason,
+              workerKzgWebGpuProbeStatus,
+              workerKzgWebGpuCircuitOpen,
+              workerKzgWebGpuReductionMode,
+              workerKzgWebGpuProbeTimeoutMs,
+              workerKzgWebGpuCommitTimeoutMs,
+              workerKzgWebGpuMinBlobs,
+              workerCommitWorkerCount,
               totalMs: opMs,
             };
             perfSamples.witness.push(perfSample);
@@ -3867,6 +3932,7 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
         const rustCommitMsmSubphasesAvailable = perfSamples.user.some(
           (sample) => sample.workerRustCommitMsmSubphasesAvailable === true,
         )
+        const kzgDiagnosticSample = allSamples.find((sample) => typeof sample.workerKzgCommitBackend === 'string')
         const slowestUserSample =
           perfSamples.user.reduce<PreparePerfSample | null>(
             (best, sample) => (!best || sample.totalMs > best.totalMs ? sample : best),
@@ -3950,6 +4016,15 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
             unaccountedMsIsWallClockRemainder: true,
             rustCommitBackend,
             rustCommitMsmSubphasesAvailable,
+            kzgCommitBackend: kzgDiagnosticSample?.workerKzgCommitBackend,
+            kzgWebGpuFallbackReason: kzgDiagnosticSample?.workerKzgWebGpuFallbackReason,
+            kzgWebGpuProbeStatus: kzgDiagnosticSample?.workerKzgWebGpuProbeStatus,
+            kzgWebGpuCircuitOpen: kzgDiagnosticSample?.workerKzgWebGpuCircuitOpen,
+            kzgWebGpuReductionMode: kzgDiagnosticSample?.workerKzgWebGpuReductionMode,
+            kzgWebGpuProbeTimeoutMs: kzgDiagnosticSample?.workerKzgWebGpuProbeTimeoutMs,
+            kzgWebGpuCommitTimeoutMs: kzgDiagnosticSample?.workerKzgWebGpuCommitTimeoutMs,
+            kzgWebGpuMinBlobs: kzgDiagnosticSample?.workerKzgWebGpuMinBlobs,
+            commitWorkerCount: kzgDiagnosticSample?.workerCommitWorkerCount,
           },
           samples: perfSamples,
         }

--- a/polystore-website/src/lib/kzgCommitBackend.test.ts
+++ b/polystore-website/src/lib/kzgCommitBackend.test.ts
@@ -74,14 +74,77 @@ function mockWasm(blobs = 1): PolyStoreWasmLike {
   }
 }
 
-function deferred<T>() {
-  let resolve!: (value: T) => void
-  let reject!: (reason?: unknown) => void
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res
-    reject = rej
-  })
-  return { promise, resolve, reject }
+function dynamicMockWasm(): PolyStoreWasmLike {
+  return {
+    commit_blobs: (input) => commitments(input.byteLength / KZG_BLOB_SIZE),
+    commit_blobs_profiled: (input) => {
+      const blobs = input.byteLength / KZG_BLOB_SIZE
+      return { witness_flat: commitments(blobs), perf: { blobs } }
+    },
+  }
+}
+
+function fakeNavigator(info: Record<string, unknown> = {}) {
+  return {
+    gpu: {
+      requestAdapter: async () => ({
+        info,
+        requestDevice: async () => ({
+          queue: { writeBuffer: () => undefined },
+          createBuffer: () => ({}),
+        }),
+      }),
+    },
+  } as unknown as Navigator
+}
+
+function fakeCommitter(options: {
+  totalMs?: number
+  delayMs?: number
+  commitmentsSeed?: number
+  reductionMode?: 'serial' | 'parallel16' | 'parallel32' | 'parallel64'
+}) {
+  const destroyed = { value: false }
+  return {
+    destroyed,
+    committer: {
+      destroy: () => {
+        destroyed.value = true
+      },
+      getDeviceLostInfo: async () => null,
+      commitBlobs: async (input: Uint8Array) => {
+        if (options.delayMs) {
+          await new Promise((resolve) => setTimeout(resolve, options.delayMs))
+        }
+        const blobs = input.byteLength / KZG_BLOB_SIZE
+        const totalMs = options.totalMs ?? 10
+        return {
+          commitments: commitments(blobs, options.commitmentsSeed ?? 1),
+          timings: {
+            scalarPrepMs: 0,
+            bucketBuildMs: 0,
+            uploadMs: 0,
+            dispatchReadbackMs: totalMs,
+            foldMs: 0,
+            totalMs,
+          },
+          blobs,
+          debug: {
+            bucketWidth: 10,
+            reductionMode: options.reductionMode ?? 'serial',
+            bucketCount: 1,
+            baseIndexCount: 1,
+            numWindows: 1,
+            maxBucketSize: 1,
+            meanBucketSize: 1,
+            uploadBytes: 4,
+            readbackBytes: 384,
+            windowSumNonZeroBytes: 1,
+          },
+        }
+      },
+    },
+  }
 }
 
 async function loadTrustedSetupBytes(): Promise<Uint8Array> {
@@ -215,43 +278,21 @@ test('browser backend falls back when WebGPU is unavailable', async () => {
   assert.match(status.fallbackReason || '', /navigator\.gpu is unavailable/)
 })
 
-test('browser backend uploads SRS to a persistent WebGPU buffer and keeps WASM as commit path', async () => {
+test('browser backend starts with a bounded WebGPU scheduler and WASM fallback', async () => {
   const setupBytes = await loadTrustedSetupBytes()
-  const writes: Array<{ offset: number; bytes: number }> = []
-  const buffer = { destroyed: false, destroy() { this.destroyed = true } }
-  const deviceLost = deferred<{ reason?: string; message?: string }>()
   const backend = await createBrowserKzgCommitBackend(mockWasm(2), setupBytes, {
     preferWebGpu: true,
-    navigatorLike: {
-      gpu: {
-        requestAdapter: async () => ({
-          requestDevice: async () => ({
-            queue: {
-              writeBuffer: (_buffer: unknown, offset: number, data: Uint8Array) => {
-                writes.push({ offset, bytes: data.byteLength })
-              },
-            },
-            lost: deviceLost.promise,
-            createBuffer: (descriptor: { size: number }) => {
-              assert.equal(descriptor.size, 4096 * KZG_COMMITMENT_SIZE)
-              return buffer
-            },
-          }),
-        }),
-      },
-    } as unknown as Navigator,
-    bufferUsage: { STORAGE: 1, COPY_DST: 2 },
+    navigatorLike: fakeNavigator({ vendor: 'nvidia', architecture: 'ampere', isFallbackAdapter: false }),
   })
 
-  assert.equal(backend.kind, 'webgpu-wasm-fallback')
-  assert.deepEqual(backend.commitBlobs(blobBatch(2)), commitments(2))
-  assert.deepEqual(writes, [{ offset: 0, bytes: 4096 * KZG_COMMITMENT_SIZE }])
+  assert.equal(backend.kind, 'webgpu-scheduler')
   const status = backend.getStatus()
   assert.equal(status.webgpu?.supported, true)
-  assert.equal(status.webgpu?.available, true)
+  assert.equal(status.webgpu?.available, false)
   assert.equal(status.webgpu?.fallbackActive, true)
+  assert.equal(status.selectedBackend, 'wasm-blst')
   assert.equal(status.webgpu?.srs?.sha256, POLYSTORE_TRUSTED_SETUP_SHA256)
-  assert.match(status.fallbackReason || '', /commitments use WASM/)
+  assert.equal(status.webgpu?.scheduler?.probeStatus, 'not-run')
 })
 
 test('browser backend contains WebGPU init failure and falls back to WASM', async () => {
@@ -274,35 +315,78 @@ test('browser backend contains WebGPU init failure and falls back to WASM', asyn
   assert.match(status.fallbackReason || '', /adapter denied/)
 })
 
-test('browser backend marks device loss unavailable without changing commitment output', async () => {
-  const deviceLost = deferred<{ reason?: string; message?: string }>()
-  const buffer = { destroyed: false, destroy() { this.destroyed = true } }
+test('browser backend rejects fallback adapters before scheduler selection', async () => {
   const backend = await createBrowserKzgCommitBackend(mockWasm(1), await loadTrustedSetupBytes(), {
     preferWebGpu: true,
-    navigatorLike: {
-      gpu: {
-        requestAdapter: async () => ({
-          requestDevice: async () => ({
-            queue: { writeBuffer: () => undefined },
-            lost: deviceLost.promise,
-            createBuffer: () => buffer,
-          }),
-        }),
-      },
-    } as unknown as Navigator,
-    bufferUsage: { STORAGE: 1, COPY_DST: 2 },
+    navigatorLike: fakeNavigator({ vendor: 'google', architecture: 'swiftshader', isFallbackAdapter: true }),
   })
 
-  assert.equal(backend.getStatus().webgpu?.available, true)
-  deviceLost.resolve({ reason: 'destroyed', message: 'test device loss' })
-  await new Promise((resolve) => setTimeout(resolve, 0))
-
   const status = backend.getStatus()
-  assert.equal(buffer.destroyed, true)
   assert.equal(status.webgpu?.available, false)
-  assert.equal(status.webgpu?.deviceLost, true)
-  assert.match(status.fallbackReason || '', /destroyed/)
-  assert.deepEqual(backend.commitBlobs(blobBatch(1)), commitments(1))
+  assert.match(status.fallbackReason || '', /fallback\/software adapter/)
+})
+
+test('browser backend selects WebGPU after bounded parity probe', async () => {
+  const fake = fakeCommitter({ totalMs: 5, reductionMode: 'serial' })
+  const backend = await createBrowserKzgCommitBackend(dynamicMockWasm(), await loadTrustedSetupBytes(), {
+    preferWebGpu: true,
+    webGpuMode: 'force',
+    navigatorLike: fakeNavigator({ vendor: 'nvidia', architecture: 'ampere', isFallbackAdapter: false }),
+    webGpuCommitterFactory: async () => fake.committer as never,
+    now: (() => {
+      let current = 0
+      return () => {
+        current += 1
+        return current
+      }
+    })(),
+  })
+
+  assert.deepEqual(await backend.commitBlobs(blobBatch(2)), commitments(2))
+  const status = backend.getStatus()
+  assert.equal(status.selectedBackend, 'webgpu')
+  assert.equal(status.webgpu?.fallbackActive, false)
+  assert.equal(status.webgpu?.scheduler?.probeStatus, 'passed')
+  assert.equal(status.webgpu?.reductionMode, 'serial')
+})
+
+test('browser backend falls back when auto probe is slower than WASM', async () => {
+  const fake = fakeCommitter({ totalMs: 500 })
+  const backend = await createBrowserKzgCommitBackend(dynamicMockWasm(), await loadTrustedSetupBytes(), {
+    preferWebGpu: true,
+    navigatorLike: fakeNavigator({ vendor: 'nvidia', architecture: 'ampere', isFallbackAdapter: false }),
+    webGpuCommitterFactory: async () => fake.committer as never,
+    now: (() => {
+      let current = 0
+      return () => {
+        current += 1
+        return current
+      }
+    })(),
+  })
+
+  assert.deepEqual(await backend.commitBlobs(blobBatch(1)), commitments(1))
+  const status = backend.getStatus()
+  assert.equal(status.selectedBackend, 'wasm-blst')
+  assert.equal(status.webgpu?.scheduler?.probeStatus, 'failed')
+  assert.match(status.fallbackReason || '', /slower than WASM/)
+})
+
+test('browser backend opens session circuit breaker on WebGPU timeout', async () => {
+  const fake = fakeCommitter({ delayMs: 25 })
+  const backend = await createBrowserKzgCommitBackend(dynamicMockWasm(), await loadTrustedSetupBytes(), {
+    preferWebGpu: true,
+    webGpuProbeTimeoutMs: 5,
+    navigatorLike: fakeNavigator({ vendor: 'nvidia', architecture: 'ampere', isFallbackAdapter: false }),
+    webGpuCommitterFactory: async () => fake.committer as never,
+  })
+
+  assert.deepEqual(await backend.commitBlobs(blobBatch(1)), commitments(1))
+  const status = backend.getStatus()
+  assert.equal(status.selectedBackend, 'wasm-blst')
+  assert.equal(status.webgpu?.scheduler?.circuitOpen, true)
+  assert.equal(status.webgpu?.scheduler?.probeStatus, 'timeout')
+  assert.match(status.fallbackReason || '', /probe exceeded/)
 })
 
 test('browser backend fails closed on incompatible trusted setup bytes before GPU upload', async () => {

--- a/polystore-website/src/lib/kzgCommitBackend.ts
+++ b/polystore-website/src/lib/kzgCommitBackend.ts
@@ -1,9 +1,21 @@
+import {
+  createWebGpuKzgMsmCommitter,
+  type WebGpuKzgMsmCommitter,
+  type WebGpuKzgMsmReductionMode,
+  type WebGpuKzgMsmResult,
+} from './webgpuKzgMsm'
+
 export const KZG_BLOB_SIZE = 128 * 1024
 export const KZG_COMMITMENT_SIZE = 48
 export const KZG_CELLS_PER_BLOB = KZG_BLOB_SIZE / 32
 export const POLYSTORE_TRUSTED_SETUP_SHA256 = 'd39b9f2d047cc9dca2de58f264b6a09448ccd34db967881a6713eacacf0f26b7'
+const DEFAULT_WEBGPU_PROBE_TIMEOUT_MS = 1500
+const DEFAULT_WEBGPU_COMMIT_TIMEOUT_MS = 3000
+const DEFAULT_WEBGPU_MIN_BLOBS = 1
 
-export type KzgCommitBackendKind = 'wasm-blst' | 'webgpu-wasm-fallback'
+export type KzgCommitBackendKind = 'wasm-blst' | 'webgpu-scheduler' | 'webgpu-wasm-fallback'
+export type KzgCommitBackendChoice = 'wasm-blst' | 'webgpu'
+export type WebGpuKzgMode = 'auto' | 'force' | 'off'
 
 export type PolyStoreCommitApi = {
   commit_blobs(blobBytes: Uint8Array): Uint8Array | ArrayBufferLike
@@ -33,14 +45,15 @@ export type KzgCommitBackendStatus = {
   initialized: boolean
   label: string
   fallbackReason?: string
+  selectedBackend?: KzgCommitBackendChoice
   webgpu?: WebGpuKzgStatus
 }
 
 export type KzgCommitBackend = {
   readonly kind: KzgCommitBackendKind
   getStatus(): KzgCommitBackendStatus
-  commitBlobs(blobsFlat: Uint8Array): Uint8Array
-  commitBlobsProfiled(blobsFlat: Uint8Array): KzgCommitProfiledResult
+  commitBlobs(blobsFlat: Uint8Array): Uint8Array | Promise<Uint8Array>
+  commitBlobsProfiled(blobsFlat: Uint8Array): KzgCommitProfiledResult | Promise<KzgCommitProfiledResult>
 }
 
 type GpuBufferLike = {
@@ -63,6 +76,8 @@ type GpuDeviceLike = {
 }
 
 type GpuAdapterLike = {
+  info?: WebGpuKzgAdapterInfo
+  requestAdapterInfo?: () => Promise<WebGpuKzgAdapterInfo>
   requestDevice: () => Promise<GpuDeviceLike>
 }
 
@@ -102,12 +117,44 @@ export type WebGpuKzgStatus = {
   deviceLost: boolean
   fallbackActive: boolean
   reason?: string
+  adapter?: WebGpuKzgAdapterInfo | null
+  selectedBackend?: KzgCommitBackendChoice
+  reductionMode?: WebGpuKzgMsmReductionMode
+  scheduler?: WebGpuKzgSchedulerStatus
   srs?: WebGpuSrsMetadata
   timings?: WebGpuKzgInitTimings
 }
 
+export type WebGpuKzgAdapterInfo = {
+  vendor?: string
+  architecture?: string
+  device?: string
+  description?: string
+  isFallbackAdapter?: boolean
+}
+
+export type WebGpuKzgSchedulerStatus = {
+  mode: WebGpuKzgMode
+  probeStatus: 'not-run' | 'running' | 'passed' | 'failed' | 'timeout' | 'disabled'
+  probeTimeoutMs: number
+  commitTimeoutMs: number
+  minBlobs: number
+  circuitOpen: boolean
+  circuitReason?: string
+  lastProbeMs?: number
+  lastWebGpuMs?: number
+  lastWasmMs?: number
+  lastFallbackReason?: string
+}
+
 export type CreateKzgCommitBackendOptions = {
   preferWebGpu?: boolean
+  webGpuMode?: WebGpuKzgMode
+  webGpuProbeTimeoutMs?: number
+  webGpuCommitTimeoutMs?: number
+  webGpuMinBlobs?: number
+  allowFallbackAdapter?: boolean
+  webGpuCommitterFactory?: () => Promise<WebGpuKzgMsmCommitter>
   navigatorLike?: WebGpuNavigator
   bufferUsage?: WebGpuBufferUsageLike
   now?: () => number
@@ -139,6 +186,69 @@ function nowMs(now: (() => number) | undefined): number {
 
 function bytesToHex(bytes: Uint8Array): string {
   return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')
+}
+
+function makeProbeBlob(): Uint8Array {
+  const blob = new Uint8Array(KZG_BLOB_SIZE)
+  for (let i = 0; i < KZG_CELLS_PER_BLOB; i += 1) {
+    const offset = i * 32
+    blob[offset] = 0
+    for (let j = 1; j < 32; j += 1) {
+      blob[offset + j] = (41 + i * 17 + j * 29) & 0xff
+    }
+  }
+  return blob
+}
+
+function profileFromWebGpuResult(result: WebGpuKzgMsmResult): KzgCommitPerf {
+  return {
+    decodeMs: 0,
+    transformMs: 0,
+    msmScalarPrepMs: result.timings.scalarPrepMs,
+    msmBucketFillMs: result.timings.bucketBuildMs,
+    msmReduceMs: result.timings.dispatchReadbackMs,
+    msmDoubleMs: 0,
+    msmMs: result.timings.dispatchReadbackMs,
+    compressMs: result.timings.foldMs,
+    totalMs: result.timings.totalMs,
+    blobs: result.blobs,
+  }
+}
+
+function normalizeTimeout(value: number | undefined, fallback: number): number {
+  if (!Number.isFinite(value) || !value || value <= 0) return fallback
+  return Math.floor(value)
+}
+
+function normalizeMinBlobs(value: number | undefined): number {
+  if (!Number.isFinite(value) || !value || value < 1) return DEFAULT_WEBGPU_MIN_BLOBS
+  return Math.floor(value)
+}
+
+function delay<T>(ms: number, value: T): Promise<T> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(value), ms)
+  })
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+): Promise<{ timedOut: false; value: T } | { timedOut: true }> {
+  return Promise.race([
+    promise.then((value) => ({ timedOut: false as const, value })),
+    delay(timeoutMs, { timedOut: true as const }),
+  ])
+}
+
+async function readAdapterInfo(adapter: GpuAdapterLike): Promise<WebGpuKzgAdapterInfo | null> {
+  try {
+    if (adapter.info) return adapter.info
+    if (typeof adapter.requestAdapterInfo === 'function') return await adapter.requestAdapterInfo()
+  } catch {
+    return null
+  }
+  return null
 }
 
 async function sha256Hex(bytes: Uint8Array): Promise<string> {
@@ -315,12 +425,257 @@ export class WebGpuKzgLifecycleBackend implements KzgCommitBackend {
     }
   }
 
-  commitBlobs(blobsFlat: Uint8Array): Uint8Array {
+  commitBlobs(blobsFlat: Uint8Array): Uint8Array | Promise<Uint8Array> {
     return this.wasmFallback.commitBlobs(blobsFlat)
   }
 
-  commitBlobsProfiled(blobsFlat: Uint8Array): KzgCommitProfiledResult {
+  commitBlobsProfiled(blobsFlat: Uint8Array): KzgCommitProfiledResult | Promise<KzgCommitProfiledResult> {
     return this.wasmFallback.commitBlobsProfiled(blobsFlat)
+  }
+}
+
+export class ScheduledWebGpuKzgCommitBackend implements KzgCommitBackend {
+  readonly kind = 'webgpu-scheduler' as const
+  private status: WebGpuKzgStatus
+  private committer: WebGpuKzgMsmCommitter | null = null
+  private probePromise: Promise<boolean> | null = null
+  private readonly mode: WebGpuKzgMode
+  private readonly probeTimeoutMs: number
+  private readonly commitTimeoutMs: number
+  private readonly minBlobs: number
+
+  constructor(
+    private readonly wasmFallback: KzgCommitBackend,
+    private readonly wasmInterop: PolyStoreCommitApi,
+    private readonly navigatorLike: WebGpuNavigator | undefined,
+    initialStatus: WebGpuKzgStatus,
+    private readonly options: CreateKzgCommitBackendOptions,
+  ) {
+    this.mode = options.webGpuMode ?? (options.preferWebGpu ? 'auto' : 'off')
+    this.probeTimeoutMs = normalizeTimeout(options.webGpuProbeTimeoutMs, DEFAULT_WEBGPU_PROBE_TIMEOUT_MS)
+    this.commitTimeoutMs = normalizeTimeout(options.webGpuCommitTimeoutMs, DEFAULT_WEBGPU_COMMIT_TIMEOUT_MS)
+    this.minBlobs = normalizeMinBlobs(options.webGpuMinBlobs)
+    this.status = {
+      ...initialStatus,
+      fallbackActive: true,
+      selectedBackend: 'wasm-blst',
+      scheduler: {
+        mode: this.mode,
+        probeStatus: this.mode === 'off' ? 'disabled' : 'not-run',
+        probeTimeoutMs: this.probeTimeoutMs,
+        commitTimeoutMs: this.commitTimeoutMs,
+        minBlobs: this.minBlobs,
+        circuitOpen: false,
+      },
+    }
+  }
+
+  getStatus(): KzgCommitBackendStatus {
+    return {
+      kind: this.kind,
+      initialized: this.wasmFallback.getStatus().initialized,
+      label: this.status.selectedBackend === 'webgpu' ? 'WebGPU KZG MSM' : 'WASM blst fallback',
+      fallbackReason: this.status.scheduler?.lastFallbackReason ?? this.status.reason,
+      selectedBackend: this.status.selectedBackend,
+      webgpu: { ...this.status, scheduler: this.status.scheduler ? { ...this.status.scheduler } : undefined },
+    }
+  }
+
+  private updateScheduler(update: Partial<WebGpuKzgSchedulerStatus>): void {
+    const scheduler = this.status.scheduler ?? {
+      mode: this.mode,
+      probeStatus: 'not-run' as const,
+      probeTimeoutMs: this.probeTimeoutMs,
+      commitTimeoutMs: this.commitTimeoutMs,
+      minBlobs: this.minBlobs,
+      circuitOpen: false,
+    }
+    this.status = {
+      ...this.status,
+      scheduler: { ...scheduler, ...update },
+    }
+  }
+
+  private fallBack(reason: string): void {
+    this.status = {
+      ...this.status,
+      available: Boolean(this.committer),
+      fallbackActive: true,
+      selectedBackend: 'wasm-blst',
+      reason,
+    }
+    this.updateScheduler({ lastFallbackReason: reason })
+  }
+
+  private openCircuit(reason: string): void {
+    this.committer?.destroy()
+    this.committer = null
+    this.status = {
+      ...this.status,
+      available: false,
+      fallbackActive: true,
+      selectedBackend: 'wasm-blst',
+      reason,
+    }
+    this.updateScheduler({
+      circuitOpen: true,
+      circuitReason: reason,
+      lastFallbackReason: reason,
+    })
+  }
+
+  private async initCommitter(): Promise<WebGpuKzgMsmCommitter> {
+    if (this.committer) return this.committer
+    const committer = this.options.webGpuCommitterFactory
+      ? await this.options.webGpuCommitterFactory()
+      : await createWebGpuKzgMsmCommitter(
+          this.wasmInterop as unknown as Parameters<typeof createWebGpuKzgMsmCommitter>[0],
+          this.navigatorLike as unknown as Parameters<typeof createWebGpuKzgMsmCommitter>[1],
+          { allowFallbackAdapter: this.options.allowFallbackAdapter ?? false },
+        )
+    this.committer = committer
+    this.status = {
+      ...this.status,
+      supported: true,
+      available: true,
+      deviceLost: false,
+    }
+    committer.getDeviceLostInfo().then((info) => {
+      if (info) {
+        this.openCircuit(`WebGPU device lost${info.reason ? `: ${info.reason}` : ''}${info.message ? ` (${info.message})` : ''}`)
+      }
+    }).catch((error) => {
+      this.openCircuit(`WebGPU device lost: ${error instanceof Error ? error.message : String(error)}`)
+    })
+    return committer
+  }
+
+  private async probe(): Promise<boolean> {
+    if (this.mode === 'off') {
+      this.fallBack('WebGPU KZG scheduler disabled')
+      return false
+    }
+    if (this.status.scheduler?.circuitOpen) return false
+    if (this.status.scheduler?.probeStatus === 'passed') return true
+    if (this.probePromise) return this.probePromise
+
+    this.updateScheduler({ probeStatus: 'running' })
+    this.probePromise = this.runProbe().finally(() => {
+      this.probePromise = null
+    })
+    return this.probePromise
+  }
+
+  private async runProbe(): Promise<boolean> {
+    const probeStarted = nowMs(this.options.now)
+    const probeBlob = makeProbeBlob()
+    try {
+      const wasmStarted = nowMs(this.options.now)
+      const wasmCommitments = await this.wasmFallback.commitBlobs(probeBlob)
+      const wasmMs = nowMs(this.options.now) - wasmStarted
+      const committer = await this.initCommitter()
+      const gpuPromise = committer.commitBlobs(probeBlob)
+      const timed = await withTimeout(gpuPromise, this.probeTimeoutMs)
+      if (timed.timedOut) {
+        gpuPromise.catch(() => undefined).finally(() => this.committer?.destroy())
+        this.openCircuit(`WebGPU probe exceeded ${this.probeTimeoutMs}ms`)
+        this.updateScheduler({ probeStatus: 'timeout', lastProbeMs: nowMs(this.options.now) - probeStarted, lastWasmMs: wasmMs })
+        return false
+      }
+
+      const gpu = timed.value
+      const gpuMs = gpu.timings.totalMs
+      const parity = bytesToHex(wasmCommitments) === bytesToHex(gpu.commitments)
+      this.updateScheduler({
+        lastProbeMs: nowMs(this.options.now) - probeStarted,
+        lastWebGpuMs: gpuMs,
+        lastWasmMs: wasmMs,
+      })
+      if (!parity) {
+        this.openCircuit('WebGPU probe commitment parity failed')
+        this.updateScheduler({ probeStatus: 'failed' })
+        return false
+      }
+      if (this.mode === 'auto' && gpuMs > wasmMs) {
+        this.fallBack(`WebGPU probe slower than WASM (${gpuMs.toFixed(2)}ms > ${wasmMs.toFixed(2)}ms)`)
+        this.updateScheduler({ probeStatus: 'failed' })
+        return false
+      }
+      this.status = {
+        ...this.status,
+        available: true,
+        fallbackActive: false,
+        selectedBackend: 'webgpu',
+        reductionMode: gpu.debug?.reductionMode,
+        reason: undefined,
+      }
+      this.updateScheduler({ probeStatus: 'passed', lastFallbackReason: undefined })
+      return true
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error)
+      this.openCircuit(reason)
+      this.updateScheduler({ probeStatus: 'failed', lastProbeMs: nowMs(this.options.now) - probeStarted })
+      return false
+    }
+  }
+
+  async commitBlobs(blobsFlat: Uint8Array): Promise<Uint8Array> {
+    const blobs = assertBlobBatch(blobsFlat)
+    if (blobs < this.minBlobs) {
+      this.fallBack(`batch below WebGPU threshold: ${blobs} < ${this.minBlobs}`)
+      return this.wasmFallback.commitBlobs(blobsFlat)
+    }
+    if (!(await this.probe()) || !this.committer) {
+      return this.wasmFallback.commitBlobs(blobsFlat)
+    }
+
+    const gpuPromise = this.committer.commitBlobs(blobsFlat)
+    const timed = await withTimeout(gpuPromise, this.commitTimeoutMs)
+    if (timed.timedOut) {
+      gpuPromise.catch(() => undefined).finally(() => this.committer?.destroy())
+      this.openCircuit(`WebGPU commit exceeded ${this.commitTimeoutMs}ms`)
+      return this.wasmFallback.commitBlobs(blobsFlat)
+    }
+
+    this.status = {
+      ...this.status,
+      fallbackActive: false,
+      selectedBackend: 'webgpu',
+      reductionMode: timed.value.debug?.reductionMode ?? this.status.reductionMode,
+    }
+    this.updateScheduler({ lastWebGpuMs: timed.value.timings.totalMs, lastFallbackReason: undefined })
+    return timed.value.commitments
+  }
+
+  async commitBlobsProfiled(blobsFlat: Uint8Array): Promise<KzgCommitProfiledResult> {
+    const blobs = assertBlobBatch(blobsFlat)
+    if (blobs < this.minBlobs) {
+      this.fallBack(`batch below WebGPU threshold: ${blobs} < ${this.minBlobs}`)
+      return this.wasmFallback.commitBlobsProfiled(blobsFlat)
+    }
+    if (!(await this.probe()) || !this.committer) {
+      return this.wasmFallback.commitBlobsProfiled(blobsFlat)
+    }
+
+    const gpuPromise = this.committer.commitBlobs(blobsFlat)
+    const timed = await withTimeout(gpuPromise, this.commitTimeoutMs)
+    if (timed.timedOut) {
+      gpuPromise.catch(() => undefined).finally(() => this.committer?.destroy())
+      this.openCircuit(`WebGPU commit exceeded ${this.commitTimeoutMs}ms`)
+      return this.wasmFallback.commitBlobsProfiled(blobsFlat)
+    }
+
+    this.status = {
+      ...this.status,
+      fallbackActive: false,
+      selectedBackend: 'webgpu',
+      reductionMode: timed.value.debug?.reductionMode ?? this.status.reductionMode,
+    }
+    this.updateScheduler({ lastWebGpuMs: timed.value.timings.totalMs, lastFallbackReason: undefined })
+    return {
+      witnessFlat: timed.value.commitments,
+      perf: profileFromWebGpuResult(timed.value),
+    }
   }
 }
 
@@ -337,7 +692,8 @@ export async function createBrowserKzgCommitBackend(
   options: CreateKzgCommitBackendOptions = {},
 ): Promise<KzgCommitBackend> {
   const wasmFallback = createWasmBlstKzgCommitBackend(wasm)
-  if (!options.preferWebGpu) {
+  const mode = options.webGpuMode ?? (options.preferWebGpu ? 'auto' : 'off')
+  if (!options.preferWebGpu || mode === 'off') {
     return wasmFallback
   }
 
@@ -368,40 +724,30 @@ export async function createBrowserKzgCommitBackend(
       throw new Error(`Trusted setup SHA-256 mismatch: ${setupSha256}`)
     }
 
+    timings.totalMs = nowMs(options.now) - started
+
     const adapterStart = nowMs(options.now)
     const adapter = await gpu.requestAdapter()
     timings.adapterMs = nowMs(options.now) - adapterStart
     if (!adapter) {
       throw new Error('WebGPU adapter request returned null')
     }
-
-    const deviceStart = nowMs(options.now)
-    const device = await adapter.requestDevice()
-    timings.deviceMs = nowMs(options.now) - deviceStart
-
-    const usage = options.bufferUsage ?? (globalThis as unknown as { GPUBufferUsage?: WebGpuBufferUsageLike }).GPUBufferUsage
-    if (!usage) {
-      throw new Error('GPUBufferUsage constants are unavailable')
+    const adapterInfo = await readAdapterInfo(adapter)
+    if (!options.allowFallbackAdapter && adapterInfo?.isFallbackAdapter) {
+      throw new Error('WebGPU adapter is a fallback/software adapter')
     }
 
-    const uploadStart = nowMs(options.now)
-    const srsBuffer = device.createBuffer({
-      label: 'polystore-kzg-g1-srs-compressed',
-      size: parsed.g1Compressed.byteLength,
-      usage: usage.STORAGE | usage.COPY_DST,
-    })
-    device.queue.writeBuffer(srsBuffer, 0, parsed.g1Compressed)
-    timings.srsUploadMs = nowMs(options.now) - uploadStart
-    timings.totalMs = nowMs(options.now) - started
-
-    const backend = new WebGpuKzgLifecycleBackend(
+    return new ScheduledWebGpuKzgCommitBackend(
       wasmFallback,
+      wasm as PolyStoreCommitApi,
+      options.navigatorLike,
       {
         supported: true,
-        available: true,
+        available: false,
         deviceLost: false,
         fallbackActive: true,
-        reason: 'WebGPU MSM is not implemented in this milestone; commitments use WASM',
+        reason: 'WebGPU scheduler has not completed its bounded probe',
+        adapter: adapterInfo,
         srs: {
           g1Count: parsed.g1Count,
           g2Count: parsed.g2Count,
@@ -411,16 +757,8 @@ export async function createBrowserKzgCommitBackend(
         },
         timings,
       },
-      srsBuffer,
+      options,
     )
-
-    device.lost?.then((info) => {
-      backend.markDeviceLost(`WebGPU device lost${info?.reason ? `: ${info.reason}` : ''}${info?.message ? ` (${info.message})` : ''}`)
-    }).catch((error) => {
-      backend.markDeviceLost(`WebGPU device lost: ${error instanceof Error ? error.message : String(error)}`)
-    })
-
-    return backend
   } catch (error) {
     timings.totalMs = nowMs(options.now) - started
     return new WebGpuKzgLifecycleBackend(

--- a/polystore-website/src/lib/webgpuKzgMsm.ts
+++ b/polystore-website/src/lib/webgpuKzgMsm.ts
@@ -53,6 +53,9 @@ type WebGpuAdapter = {
 type WebGpuAdapterInfo = {
   vendor?: string
   architecture?: string
+  device?: string
+  description?: string
+  isFallbackAdapter?: boolean
 }
 
 export const WEBGPU_KZG_MSM_BUCKET_WIDTH = 10
@@ -73,6 +76,7 @@ export type WebGpuKzgMsmReductionMode = 'serial' | 'parallel16' | 'parallel32' |
 export type WebGpuKzgMsmOptions = {
   bucketWidth?: number
   reductionMode?: WebGpuKzgMsmReductionMode
+  allowFallbackAdapter?: boolean
 }
 
 export type WebGpuKzgMsmTimings = {
@@ -296,6 +300,10 @@ function defaultReductionModeForAdapter(info: WebGpuAdapterInfo | null): WebGpuK
   const architecture = info?.architecture?.toLowerCase() ?? ''
   if (vendor.includes('apple') || architecture.includes('metal')) return 'parallel16'
   return WEBGPU_KZG_MSM_REDUCTION_MODE
+}
+
+export function selectWebGpuKzgMsmReductionMode(info: WebGpuAdapterInfo | null): WebGpuKzgMsmReductionMode {
+  return defaultReductionModeForAdapter(info)
 }
 
 function reductionWorkgroupSize(mode: WebGpuKzgMsmReductionMode): 16 | 32 | 64 {
@@ -702,9 +710,13 @@ export async function createWebGpuKzgMsmCommitter(
   if (!gpu) throw new Error('navigator.gpu is unavailable')
   const adapter = await gpu.requestAdapter()
   if (!adapter) throw new Error('WebGPU adapter request returned null')
+  const adapterInfo = await readAdapterInfo(adapter)
+  if (!options.allowFallbackAdapter && adapterInfo?.isFallbackAdapter) {
+    throw new Error('WebGPU adapter is a fallback/software adapter')
+  }
   const resolvedOptions: WebGpuKzgMsmOptions = {
     ...options,
-    reductionMode: options.reductionMode ?? defaultReductionModeForAdapter(await readAdapterInfo(adapter)),
+    reductionMode: options.reductionMode ?? defaultReductionModeForAdapter(adapterInfo),
   }
   const device = await adapter.requestDevice()
   return new WebGpuKzgMsmCommitter(device, wasm, resolvedOptions)

--- a/polystore-website/src/lib/worker-client.ts
+++ b/polystore-website/src/lib/worker-client.ts
@@ -169,7 +169,7 @@ function sendExpansionMessageToWorker(
 export interface ExpandedMdu {
     witness_flat: Uint8Array | number[]; // 96 * 48 bytes
     mdu_root: Uint8Array | number[]; // 32 bytes
-    perf?: {
+    perf?: KzgCommitDiagnostics & {
       commitMs?: number;
       rootMs?: number;
       totalMs?: number;
@@ -192,7 +192,7 @@ export interface ExpandedMdu {
 
 export interface PreparedMdu0 {
   mdu0_bytes: Uint8Array | number[]
-  perf?: {
+  perf?: KzgCommitDiagnostics & {
     witnessRootSetMs?: number
     userRootSetMs?: number
     appendMs?: number
@@ -203,7 +203,7 @@ export interface PreparedMdu0 {
 
 export interface PreparedCommittedMdu0 extends PreparedMdu0 {
   mdu_root: Uint8Array | number[]
-  perf?: {
+  perf?: KzgCommitDiagnostics & {
     witnessRootSetMs?: number
     userRootSetMs?: number
     appendMs?: number
@@ -232,7 +232,7 @@ export interface ExpandedStripe {
     shards?: Array<Uint8Array | number[]>;
     shards_flat?: Uint8Array | number[];
     shard_len?: number;
-    perf?: {
+    perf?: KzgCommitDiagnostics & {
       expandMs?: number;
       rootMs?: number;
       totalMs?: number;
@@ -255,6 +255,20 @@ export interface ExpandedStripe {
       rows?: number;
       shardsTotal?: number;
     };
+}
+
+export type KzgCommitDiagnostics = {
+  rustCommitBackend?: string
+  kzgCommitBackend?: string
+  kzgWebGpuAvailable?: boolean
+  kzgWebGpuFallbackReason?: string
+  kzgWebGpuProbeStatus?: string
+  kzgWebGpuCircuitOpen?: boolean
+  kzgWebGpuProbeTimeoutMs?: number
+  kzgWebGpuCommitTimeoutMs?: number
+  kzgWebGpuMinBlobs?: number
+  kzgWebGpuReductionMode?: string
+  commitWorkerCount?: number
 }
 
 type ExpandStripeOptions = {

--- a/polystore-website/src/workers/commit.worker.ts
+++ b/polystore-website/src/workers/commit.worker.ts
@@ -48,7 +48,10 @@ self.onmessage = async (event) => {
         const { trustedSetupBytes } = payload as { trustedSetupBytes: Uint8Array }
         if (!trustedSetupBytes) throw new Error('Trusted setup bytes required')
         polyStoreWasmInstance = new PolyStoreWasm(trustedSetupBytes)
-        kzgCommitBackend = await createBrowserKzgCommitBackend(polyStoreWasmInstance, trustedSetupBytes, { preferWebGpu: true })
+        kzgCommitBackend = await createBrowserKzgCommitBackend(polyStoreWasmInstance, trustedSetupBytes, {
+          preferWebGpu: false,
+          webGpuMode: 'off',
+        })
         ;(self as unknown as Worker).postMessage({ id, type: 'result', payload: 'ok' })
         return
       }
@@ -56,7 +59,7 @@ self.onmessage = async (event) => {
         if (!kzgCommitBackend) throw new Error('PolyStoreWasm not initialized')
         const { data } = payload as { data: Uint8Array }
         if (!(data instanceof Uint8Array)) throw new Error('data must be Uint8Array')
-        const commitments = kzgCommitBackend.commitBlobs(data)
+        const commitments = await kzgCommitBackend.commitBlobs(data)
         ;(self as unknown as Worker).postMessage({ id, type: 'result', payload: commitments }, [commitments.buffer])
         return
       }

--- a/polystore-website/src/workers/expand.worker.ts
+++ b/polystore-website/src/workers/expand.worker.ts
@@ -26,6 +26,23 @@ function initializeWasm(): Promise<void> {
 
 void initializeWasm()
 
+function kzgCommitDiagnostics() {
+  const status = kzgCommitBackend?.getStatus()
+  const scheduler = status?.webgpu?.scheduler
+  return {
+    rustCommitBackend: status?.selectedBackend === 'webgpu' ? 'webgpu-msm' : 'blst',
+    kzgCommitBackend: status?.selectedBackend ?? status?.kind ?? 'unknown',
+    kzgWebGpuAvailable: Boolean(status?.webgpu?.available),
+    kzgWebGpuFallbackReason: status?.fallbackReason ?? '',
+    kzgWebGpuProbeStatus: scheduler?.probeStatus ?? '',
+    kzgWebGpuCircuitOpen: Boolean(scheduler?.circuitOpen),
+    kzgWebGpuProbeTimeoutMs: scheduler?.probeTimeoutMs ?? 0,
+    kzgWebGpuCommitTimeoutMs: scheduler?.commitTimeoutMs ?? 0,
+    kzgWebGpuMinBlobs: scheduler?.minBlobs ?? 0,
+    kzgWebGpuReductionMode: status?.webgpu?.reductionMode ?? '',
+  }
+}
+
 self.onmessage = async (event) => {
   const { type, payload, id } = event.data as {
     id: number
@@ -222,7 +239,7 @@ self.onmessage = async (event) => {
 
         const opStart = performance.now()
         const commitStart = performance.now()
-        const committedRaw = kzgCommitBackend.commitBlobsProfiled(data)
+        const committedRaw = await kzgCommitBackend.commitBlobsProfiled(data)
         const commitMs = performance.now() - commitStart
         const witnessFlat = committedRaw.witnessFlat
         const commitPerf = committedRaw.perf
@@ -254,8 +271,8 @@ self.onmessage = async (event) => {
                 rustCommitMsmMs: commitPerf.msmMs,
                 rustCommitCompressMs: commitPerf.compressMs,
                 rustCommitMs: commitPerf.totalMs || commitMs,
-                rustCommitBackend: 'blst',
                 rustCommitMsmSubphasesAvailable: false,
+                ...kzgCommitDiagnostics(),
               },
             },
           },

--- a/polystore-website/src/workers/gateway.worker.ts
+++ b/polystore-website/src/workers/gateway.worker.ts
@@ -115,6 +115,21 @@ function initializeCommitPool(trustedSetupBytes: Uint8Array): Promise<void> {
 }
 
 function commitBlobsWithPool(data: Uint8Array): Promise<Uint8Array> {
+    if (kzgCommitBackend) {
+        const status = kzgCommitBackend.getStatus();
+        const scheduler = status.webgpu?.scheduler;
+        const shouldUseDirectScheduler =
+            status.kind === 'webgpu-scheduler' &&
+            scheduler &&
+            !scheduler.circuitOpen &&
+            scheduler.probeStatus !== 'failed' &&
+            scheduler.probeStatus !== 'timeout' &&
+            scheduler.probeStatus !== 'disabled';
+        if (shouldUseDirectScheduler) {
+            return Promise.resolve(kzgCommitBackend.commitBlobs(data));
+        }
+    }
+
     if (!commitWorkers || commitWorkers.length === 0) {
         if (!kzgCommitBackend) return Promise.reject(new Error('PolyStoreWasm not initialized'));
         return Promise.resolve(kzgCommitBackend.commitBlobs(data));
@@ -132,6 +147,23 @@ function commitBlobsWithPool(data: Uint8Array): Promise<Uint8Array> {
         commitPendingByWorker.get(w)?.add(id);
         w.postMessage({ id, type: 'commitBlobs', payload: { data } }, [data.buffer]);
     });
+}
+
+function kzgCommitDiagnostics() {
+    const status = kzgCommitBackend?.getStatus();
+    const scheduler = status?.webgpu?.scheduler;
+    return {
+        rustCommitBackend: status?.selectedBackend === 'webgpu' ? 'webgpu-msm' : 'blst',
+        kzgCommitBackend: status?.selectedBackend ?? status?.kind ?? 'unknown',
+        kzgWebGpuAvailable: Boolean(status?.webgpu?.available),
+        kzgWebGpuFallbackReason: status?.fallbackReason ?? '',
+        kzgWebGpuProbeStatus: scheduler?.probeStatus ?? '',
+        kzgWebGpuCircuitOpen: Boolean(scheduler?.circuitOpen),
+        kzgWebGpuProbeTimeoutMs: scheduler?.probeTimeoutMs ?? 0,
+        kzgWebGpuCommitTimeoutMs: scheduler?.commitTimeoutMs ?? 0,
+        kzgWebGpuMinBlobs: scheduler?.minBlobs ?? 0,
+        kzgWebGpuReductionMode: status?.webgpu?.reductionMode ?? '',
+    };
 }
 
 // Start fetching + compiling the WASM as soon as the worker loads so the first
@@ -413,7 +445,7 @@ self.onmessage = async (event) => {
 
                 const commitStart = performance.now();
                 if (!kzgCommitBackend) throw new Error('PolyStoreWasm not initialized. Call initPolyStoreWasm first.');
-                const committedRaw = kzgCommitBackend.commitBlobsProfiled(mdu0Bytes);
+                const committedRaw = await kzgCommitBackend.commitBlobsProfiled(mdu0Bytes);
                 perf.commitMs = performance.now() - commitStart;
                 const witnessFlat = committedRaw.witnessFlat;
                 const commitPerf = committedRaw.perf;
@@ -426,6 +458,7 @@ self.onmessage = async (event) => {
                 perf.rustCommitMsmMs = commitPerf.msmMs;
                 perf.rustCommitCompressMs = commitPerf.compressMs;
                 perf.rustCommitMs = commitPerf.totalMs || perf.commitMs;
+                Object.assign(perf, kzgCommitDiagnostics());
 
                 const rootStart = performance.now();
                 const root = polyStoreWasmInstance.compute_mdu_root(witnessFlat) as unknown;
@@ -519,6 +552,8 @@ self.onmessage = async (event) => {
                         batchCount: Math.ceil(BLOBS_PER_MDU / batch),
                         batchSize: batch,
                         blobCount: BLOBS_PER_MDU,
+                        commitWorkerCount: commitWorkers.length,
+                        ...kzgCommitDiagnostics(),
                     },
                 };
                 break;
@@ -533,7 +568,7 @@ self.onmessage = async (event) => {
                 const opStart = performance.now();
                 const commitStart = performance.now();
                 if (!kzgCommitBackend) throw new Error('PolyStoreWasm not initialized. Call initPolyStoreWasm first.');
-                const committedRaw = kzgCommitBackend.commitBlobsProfiled(data);
+                const committedRaw = await kzgCommitBackend.commitBlobsProfiled(data);
                 const commitMs = performance.now() - commitStart;
                 const witnessFlat = committedRaw.witnessFlat;
                 const commitPerf = committedRaw.perf;
@@ -561,8 +596,8 @@ self.onmessage = async (event) => {
                         rustCommitMsmMs: commitPerf.msmMs,
                         rustCommitCompressMs: commitPerf.compressMs,
                         rustCommitMs: commitPerf.totalMs || commitMs,
-                        rustCommitBackend: 'blst',
                         rustCommitMsmSubphasesAvailable: false,
+                        ...kzgCommitDiagnostics(),
                     },
                 };
                 break;


### PR DESCRIPTION
## Summary

Closes #168.

This is stacked on #178 / `website/kzg-webgpu-msm-optimize`.

Adds the browser-only WebGPU KZG mode-selection layer around the optimized MSM backend:

- introduces a `webgpu-scheduler` commit backend with adapter preflight, bounded parity/perf probe, timeout fallback, and a session-level circuit breaker
- rejects fallback/software WebGPU adapters by default before selecting the scheduler
- keeps pool commit workers WASM-only, while the gateway worker routes eligible batches through the scheduler so WebGPU is probed once and then reused when it wins
- surfaces KZG backend/probe/fallback diagnostics in worker perf samples and FileSharder profiling notes
- preserves WASM blst as the deterministic fallback for unavailable, slower, timed out, failed-parity, or circuit-open WebGPU paths

## Validation

- `npx tsc --noEmit --pretty false`
- `npm run lint`
- `npm run test:unit -- --run src/lib/kzgCommitBackend.test.ts src/lib/webgpuKzgMsm.test.ts`
- `npm run build`

## Stack / merge notes

- Base PR #178 should land first.
- This PR should be reviewed/merged only after #178 is mergeable and merged/rebased per repo policy.
- Do not merge automatically; human approval required.
