### PR TITLE
Optimize browser WebGPU KZG MSM throughput buffers

### DIFF
--- a/notes/kzg_webgpu_msm_optimization.md
+++ b/notes/kzg_webgpu_msm_optimization.md
@@ -1,6 +1,6 @@
 # Browser WebGPU KZG MSM Optimization Notes
 
-Issue: #177
+Issue: #177, #179
 Baseline PR: #174
 
 ## Current Result
@@ -160,3 +160,88 @@ hot path is still GPU dispatch/readback around the BLS12-381 point arithmetic.
 Future work should focus on reducing bucket construction overhead, validating
 multi-blob batching, and testing the default mode across additional native
 browser adapters.
+
+## #179 Throughput Follow-up
+
+The first #179 pass removes the allocation-heavy `Map<number, Map<number,
+number[]>>` bucket builder from the browser MSM path. Bucket construction now
+uses typed-array counting, prefix offsets, and a second fill pass, keeping
+buckets sorted by window/value while avoiding per-bucket JS arrays.
+
+The WebGPU committer also keeps reusable scratch buffers for bucket metadata,
+aggregated buckets, window sums, parallel partial sums, and readback. Buffers
+grow geometrically and are retained across blobs and calls until the committer
+is destroyed. Benchmark diagnostics now report `scratchCapacityBytes`,
+`scratchResizeCount`, aggregate bucket/readback/upload counters, per-stage
+medians/min/p95, and throughput in blobs/sec and MiB/sec for both WASM and
+WebGPU runs.
+
+The diagnostic runner now supports matrix sweeps so PR evidence can compare
+batch size, bucket width, and reduction mode without rerunning one command per
+cell:
+
+```sh
+POLYSTORE_WEBGPU_MSM_BLOBS_LIST=1,4,16,64 \
+POLYSTORE_WEBGPU_MSM_BUCKET_WIDTHS=9,10,11 \
+POLYSTORE_WEBGPU_MSM_REDUCTIONS=auto,serial,parallel16,parallel32,parallel64 \
+POLYSTORE_WEBGPU_MSM_RUNS=3 \
+npm run diagnose:kzg-webgpu-msm
+```
+
+For multi-cell runs the JSON includes `result.matrix.results` plus
+`result.matrix.recommendation`, which identifies the lowest blob count where a
+successful WebGPU median beats or matches WASM for that adapter/Chrome run.
+The timing source is explicitly reported as `cpu-wall-clock`; `timestamp-query`
+availability is captured in diagnostics, but the harness intentionally keeps
+the CPU wall-clock fallback because Chrome does not expose timestamp queries on
+all native and software adapters.
+
+Adapter defaults are codified and test-covered:
+
+- Apple/Metal defaults to `parallel16`, matching the M3 diagnostic evidence.
+- NVIDIA/Vulkan and unknown native adapters default to `serial`, matching the
+  RTX 3060 Ti diagnostic evidence.
+- Fallback/software adapters remain rejected unless diagnostics explicitly opt
+  in through `allowFallbackAdapter`.
+
+The code also has an adapter-scoped calibration cache helper. Runtime selection
+still uses conservative built-in defaults in this PR; benchmark-matrix output
+can be converted into cached thresholds by the scheduler without changing the
+MSM committer API.
+
+Native NVIDIA diagnostic command:
+
+```sh
+POLYSTORE_WEBGPU_HEADLESS=0 \
+POLYSTORE_WEBGPU_CHROME_ARGS='--use-vulkan=native --force_high_performance_gpu' \
+POLYSTORE_WEBGPU_MSM_RUNS=1 \
+npm run diagnose:kzg-webgpu-msm
+```
+
+On the #179 branch, headed Chrome 148 selected `vendor: nvidia`,
+`architecture: ampere`, and `isFallbackAdapter: false`. Matrix diagnostic
+results with `POLYSTORE_WEBGPU_MSM_RUNS=3` on a clean tree:
+
+| blobs | WebGPU total | WASM total | WebGPU throughput | parity | notes |
+| ---: | ---: | ---: | ---: | --- | --- |
+| 1 | 96.87 ms | 286.83 ms | 10.32 blobs/s | true | serial mode, clean tree |
+| 4 | 386.48 ms | 1158.68 ms | 10.35 blobs/s | true | serial mode, clean tree |
+| 16 | 1704.76 ms | 4904.21 ms | 9.39 blobs/s | true | serial mode, clean tree |
+| 64 | 6811.54 ms | 20539.38 ms | 9.40 blobs/s | true | serial mode, clean tree |
+
+The matrix recommendation for this adapter was `webgpu_recommended: true`,
+`min_blobs: 1`, `bucket_width: 10`, and `reduction_mode: serial`.
+
+Apple M3 diagnostic comment on PR #183 at the same commit selected `vendor:
+apple`, `architecture: metal-3`, and `isFallbackAdapter: false`. For 1 blob,
+default adapter selection used `parallel16` and measured ~152.19 ms WebGPU
+versus ~235.20 ms WASM, ~6.57 blobs/s WebGPU throughput, and parity true.
+
+Multi-blob dispatch is intentionally still one blob per GPU command plan with
+reused scratch buffers. The attempted deeper shader-level reductions above
+were unstable or adapter-hostile, and the current native results show the main
+remaining bottleneck is GPU dispatch/readback plus BLS12-381 point arithmetic,
+not JavaScript allocation churn. The PR therefore closes #179 by making the
+measured throughput path reproducible, adapter-aware, lower-allocation, and
+guarded by benchmark evidence rather than by landing a new unproven batched
+shader pipeline.

--- a/polystore-website/scripts/benchmark_browser_kzg_webgpu_msm.ts
+++ b/polystore-website/scripts/benchmark_browser_kzg_webgpu_msm.ts
@@ -18,6 +18,27 @@ const DEFAULT_WEBGPU_ARGS = [
   '--ignore-gpu-blocklist',
   '--disable-software-rasterizer',
 ]
+const REDUCTION_MODES = ['auto', 'serial', 'parallel16', 'parallel32', 'parallel64'] as const
+type ReductionModeName = (typeof REDUCTION_MODES)[number]
+type BenchmarkStats = {
+  min?: number
+  median?: number
+  p95?: number
+  max?: number
+  mean?: number
+}
+type BenchmarkRunResult = {
+  diagnostic?: boolean
+  blob_count?: number
+  bucket_width?: number
+  reduction_mode?: string | null
+  requested_reduction_mode?: string | null
+  parity?: boolean
+  error?: unknown
+  wasm_ms?: BenchmarkStats
+  gpu_total_ms?: BenchmarkStats
+  gpu_throughput?: { blobs_per_sec?: BenchmarkStats; mib_per_sec?: BenchmarkStats }
+}
 
 function detectChromePath(): string | undefined {
   if (process.env.POLYSTORE_CHROME_PATH) return process.env.POLYSTORE_CHROME_PATH
@@ -49,23 +70,96 @@ function gitMetadata() {
   }
 }
 
-const blobCount = Number.parseInt(process.env.POLYSTORE_WEBGPU_MSM_BLOBS ?? '1', 10)
-if (!Number.isInteger(blobCount) || blobCount < 1) {
-  throw new Error('POLYSTORE_WEBGPU_MSM_BLOBS must be a positive integer')
+function parsePositiveIntegerList(value: string | undefined, fallback: number[], label: string): number[] {
+  const raw = value?.trim()
+  if (!raw) return fallback
+  const values = raw.split(',').map((part) => Number.parseInt(part.trim(), 10))
+  if (values.some((item) => !Number.isInteger(item) || item < 1)) {
+    throw new Error(`${label} must be a comma-separated list of positive integers`)
+  }
+  return [...new Set(values)]
 }
-const bucketWidth = Number.parseInt(process.env.POLYSTORE_WEBGPU_MSM_BUCKET_WIDTH ?? '10', 10)
-if (!Number.isInteger(bucketWidth) || bucketWidth < 4 || bucketWidth > 13) {
-  throw new Error('POLYSTORE_WEBGPU_MSM_BUCKET_WIDTH must be an integer between 4 and 13')
+
+function parseBucketWidthList(value: string | undefined): number[] {
+  const values = parsePositiveIntegerList(
+    value ?? process.env.POLYSTORE_WEBGPU_MSM_BUCKET_WIDTH,
+    [10],
+    'POLYSTORE_WEBGPU_MSM_BUCKET_WIDTHS',
+  )
+  if (values.some((item) => item < 4 || item > 13)) {
+    throw new Error('POLYSTORE_WEBGPU_MSM_BUCKET_WIDTHS must only contain integers between 4 and 13')
+  }
+  return values
 }
+
+function assertReductionModeName(mode: string, label: string): asserts mode is ReductionModeName {
+  if (!(REDUCTION_MODES as readonly string[]).includes(mode)) {
+    throw new Error(`${label} must contain auto, serial, parallel16, parallel32, or parallel64`)
+  }
+}
+
+function parseReductionModes(value: string | undefined): Array<string | undefined> {
+  const raw = value?.trim()
+  if (!raw) {
+    const legacy = process.env.POLYSTORE_WEBGPU_MSM_REDUCTION?.trim()
+    if (!legacy) return [undefined]
+    assertReductionModeName(legacy, 'POLYSTORE_WEBGPU_MSM_REDUCTION')
+    return [legacy === 'auto' ? undefined : legacy]
+  }
+  const modes = raw.split(',').map((part) => part.trim()).filter(Boolean)
+  for (const mode of modes) assertReductionModeName(mode, 'POLYSTORE_WEBGPU_MSM_REDUCTIONS')
+  return modes.map((mode) => (mode === 'auto' ? undefined : mode))
+}
+
+function successfulBenchmarkResults(matrixResults: BenchmarkRunResult[]): BenchmarkRunResult[] {
+  return matrixResults.filter((result) => {
+    return !result.error && result.parity
+  })
+}
+
+function recommendMatrixThreshold(matrixResults: BenchmarkRunResult[]) {
+  const winners = successfulBenchmarkResults(matrixResults)
+    .filter((result) => Number(result.gpu_total_ms?.median ?? 0) <= Number(result.wasm_ms?.median ?? 0))
+    .sort((a, b) => {
+      const blobDelta = Number(a.blob_count ?? 0) - Number(b.blob_count ?? 0)
+      if (blobDelta !== 0) return blobDelta
+      return Number(a.gpu_total_ms?.median ?? 0) - Number(b.gpu_total_ms?.median ?? 0)
+    })
+  const firstWinner = winners[0]
+  if (!firstWinner) {
+    return {
+      webgpu_recommended: false,
+      min_blobs: null,
+      min_mib: null,
+      reason: 'No successful WebGPU run beat or matched WASM in this matrix',
+    }
+  }
+  const minBlobs = firstWinner.blob_count ?? 1
+  return {
+    webgpu_recommended: true,
+    min_blobs: minBlobs,
+    min_mib: (minBlobs * BLOB_SIZE) / 1024 / 1024,
+    bucket_width: firstWinner.bucket_width ?? null,
+    reduction_mode: firstWinner.reduction_mode ?? firstWinner.requested_reduction_mode ?? null,
+    gpu_median_ms: firstWinner.gpu_total_ms?.median ?? null,
+    wasm_median_ms: firstWinner.wasm_ms?.median ?? null,
+    gpu_blobs_per_sec: firstWinner.gpu_throughput?.blobs_per_sec?.median ?? null,
+    gpu_mib_per_sec: firstWinner.gpu_throughput?.mib_per_sec?.median ?? null,
+  }
+}
+
+const blobCounts = parsePositiveIntegerList(
+  process.env.POLYSTORE_WEBGPU_MSM_BLOBS_LIST ?? process.env.POLYSTORE_WEBGPU_MSM_BLOBS,
+  [1],
+  'POLYSTORE_WEBGPU_MSM_BLOBS_LIST',
+)
+const bucketWidths = parseBucketWidthList(process.env.POLYSTORE_WEBGPU_MSM_BUCKET_WIDTHS)
 const runs = Number.parseInt(process.env.POLYSTORE_WEBGPU_MSM_RUNS ?? '1', 10)
 if (!Number.isInteger(runs) || runs < 1) {
   throw new Error('POLYSTORE_WEBGPU_MSM_RUNS must be a positive integer')
 }
 const diagnostic = process.env.POLYSTORE_WEBGPU_MSM_DIAGNOSTIC === '1'
-const reductionMode = process.env.POLYSTORE_WEBGPU_MSM_REDUCTION
-if (reductionMode && !['serial', 'parallel16', 'parallel32', 'parallel64'].includes(reductionMode)) {
-  throw new Error('POLYSTORE_WEBGPU_MSM_REDUCTION must be serial, parallel16, parallel32, or parallel64')
-}
+const reductionModes = parseReductionModes(process.env.POLYSTORE_WEBGPU_MSM_REDUCTIONS)
 
 const vite = await createServer({
   root: process.cwd(),
@@ -227,6 +321,15 @@ try {
             mean: values.length ? values.reduce((sum, value) => sum + value, 0) / values.length : 0,
           };
         }
+        function throughputStats(totalMsValues) {
+          return {
+            blobs_per_sec: stats(totalMsValues.map((ms) => ms > 0 ? (config.blobCount * 1000) / ms : 0)),
+            mib_per_sec: stats(totalMsValues.map((ms) => ms > 0 ? ((config.blobCount * config.blobSize) / 1024 / 1024 * 1000) / ms : 0)),
+          };
+        }
+        function timingStats(runResults, key) {
+          return stats(runResults.map((run) => run.gpu_timings[key] ?? 0));
+        }
 
         const wasmMod = await import('/wasm/polystore_core.js');
         const msmMod = await import('/src/lib/webgpuKzgMsm.ts');
@@ -298,14 +401,28 @@ try {
             webgpu_present: Boolean(navigator.gpu),
           },
           webgpu_diagnostics: webgpuDiagnostics,
+          timing_source: {
+            selected: 'cpu-wall-clock',
+            gpu_timestamp_query_available: Boolean(webgpuDiagnostics.adapter?.features?.includes('timestamp-query')),
+            reason: 'Browser benchmark uses performance.now around upload, dispatch/readback, and WASM fold stages so it also works on adapters without timestamp-query.',
+          },
           blob_count: config.blobCount,
           bucket_width: config.bucketWidth,
           requested_reduction_mode: config.reductionMode ?? null,
           reduction_mode: runResults[0]?.gpu_debug?.reductionMode ?? config.reductionMode ?? null,
           runs: config.runs,
           wasm_ms: stats(wasmTotals),
+          wasm_throughput: throughputStats(wasmTotals),
           gpu_init_ms: gpuInitMs,
           gpu_total_ms: stats(totals),
+          gpu_throughput: throughputStats(totals),
+          gpu_stage_ms: {
+            scalar_prep: timingStats(runResults, 'scalarPrepMs'),
+            bucket_build: timingStats(runResults, 'bucketBuildMs'),
+            upload: timingStats(runResults, 'uploadMs'),
+            dispatch_readback: timingStats(runResults, 'dispatchReadbackMs'),
+            fold: timingStats(runResults, 'foldMs'),
+          },
           run_results: runResults,
           error,
           device_lost: deviceLost,
@@ -317,14 +434,34 @@ try {
     `,
   })
 
-  const result = await page.evaluate(`window.__runPolyStoreKzgWebGpuMsmBenchmark(${JSON.stringify({
-    blobSize: BLOB_SIZE,
-    blobCount,
-    bucketWidth,
-    runs,
+  const matrixResults: BenchmarkRunResult[] = []
+  for (const blobCount of blobCounts) {
+    for (const bucketWidth of bucketWidths) {
+      for (const reductionMode of reductionModes) {
+        const result = await page.evaluate(`window.__runPolyStoreKzgWebGpuMsmBenchmark(${JSON.stringify({
+          blobSize: BLOB_SIZE,
+          blobCount,
+          bucketWidth,
+          runs,
+          diagnostic,
+          reductionMode,
+        })})`)
+        matrixResults.push(result as BenchmarkRunResult)
+      }
+    }
+  }
+
+  const result = matrixResults.length === 1 ? matrixResults[0] : {
     diagnostic,
-    reductionMode,
-  })})`)
+    matrix: {
+      blob_counts: blobCounts,
+      bucket_widths: bucketWidths,
+      reduction_modes: reductionModes.map((mode) => mode ?? 'auto'),
+      runs,
+      results: matrixResults,
+      recommendation: recommendMatrixThreshold(matrixResults),
+    },
+  }
 
   console.log(
     JSON.stringify(
@@ -346,11 +483,11 @@ try {
     ),
   )
 
-  if (!diagnostic && (result as { error?: unknown }).error) {
+  if (!diagnostic && matrixResults.some((item) => (item as { error?: unknown }).error)) {
     throw new Error('WebGPU MSM diagnostic captured a benchmark failure')
   }
 
-  if (!diagnostic && !(result as { parity?: boolean }).parity) {
+  if (!diagnostic && matrixResults.some((item) => !(item as { parity?: boolean }).parity)) {
     throw new Error('WebGPU MSM commitment parity failed')
   }
 } finally {

--- a/polystore-website/src/lib/kzgCommitBackend.test.ts
+++ b/polystore-website/src/lib/kzgCommitBackend.test.ts
@@ -140,6 +140,11 @@ function fakeCommitter(options: {
             uploadBytes: 4,
             readbackBytes: 384,
             windowSumNonZeroBytes: 1,
+            processedBlobs: blobs,
+            commandSubmissions: blobs,
+            readbackCount: blobs,
+            scratchCapacityBytes: 4096,
+            scratchResizeCount: 1,
           },
         }
       },

--- a/polystore-website/src/lib/webgpuKzgMsm.test.ts
+++ b/polystore-website/src/lib/webgpuKzgMsm.test.ts
@@ -5,6 +5,10 @@ import {
   WEBGPU_KZG_MSM_BLOB_SIZE,
   WEBGPU_KZG_MSM_SIGN_BIT,
   buildWebGpuKzgMsmBucketData,
+  createWebGpuKzgMsmAdapterCacheKey,
+  defaultWebGpuKzgMsmAdapterCalibration,
+  selectWebGpuKzgMsmReductionMode,
+  WebGpuKzgMsmCalibrationCache,
 } from './webgpuKzgMsm'
 
 function blobWithCell(index: number, value: bigint): Uint8Array {
@@ -44,4 +48,53 @@ test('WebGPU KZG MSM bucket data uses signed windows for high window values', ()
   assert.equal(buckets.baseIndices[1], 9)
   assert.equal(buckets.bucketValues[1], 1)
   assert.equal(buckets.numWindows, 2)
+})
+
+test('WebGPU KZG MSM bucket data keeps buckets sorted and grouped with typed arrays', () => {
+  const blob = new Uint8Array(WEBGPU_KZG_MSM_BLOB_SIZE)
+  blob.set(blobWithCell(1, 3n).subarray(32, 64), 32)
+  blob.set(blobWithCell(2, 1n).subarray(64, 96), 64)
+  blob.set(blobWithCell(4, 3n).subarray(128, 160), 128)
+
+  const buckets = buildWebGpuKzgMsmBucketData(blob)
+
+  assert.deepEqual([...buckets.bucketValues], [1, 3])
+  assert.deepEqual([...buckets.bucketPointers], [0, 1])
+  assert.deepEqual([...buckets.bucketSizes], [1, 2])
+  assert.deepEqual([...buckets.baseIndices], [2, 1, 4])
+  assert.equal(buckets.maxBucketSize, 2)
+})
+
+test('WebGPU KZG MSM adapter defaults preserve measured Apple and NVIDIA modes', () => {
+  const apple = { vendor: 'apple', architecture: 'metal-3', isFallbackAdapter: false }
+  const nvidia = { vendor: 'nvidia', architecture: 'ampere', isFallbackAdapter: false }
+
+  assert.equal(selectWebGpuKzgMsmReductionMode(apple), 'parallel16')
+  assert.equal(defaultWebGpuKzgMsmAdapterCalibration(apple).bucketWidth, 10)
+  assert.equal(selectWebGpuKzgMsmReductionMode(nvidia), 'serial')
+  assert.equal(defaultWebGpuKzgMsmAdapterCalibration(nvidia).minBlobs, 1)
+})
+
+test('WebGPU KZG MSM calibration cache keys and invalidation are adapter scoped', () => {
+  const cache = new WebGpuKzgMsmCalibrationCache()
+  const nvidia = { vendor: 'nvidia', architecture: 'ampere', device: 'rtx-3060-ti', isFallbackAdapter: false }
+  const apple = { vendor: 'apple', architecture: 'metal-3', device: 'm3', isFallbackAdapter: false }
+  const calibration = {
+    ...defaultWebGpuKzgMsmAdapterCalibration(nvidia),
+    source: 'benchmark-matrix' as const,
+    reason: 'test calibration',
+  }
+
+  cache.set(nvidia, calibration)
+
+  assert.equal(createWebGpuKzgMsmAdapterCacheKey(nvidia), calibration.cacheKey)
+  assert.deepEqual(cache.get(nvidia), calibration)
+  assert.equal(cache.get(apple), null)
+
+  cache.invalidate(nvidia)
+  assert.equal(cache.get(nvidia), null)
+
+  cache.set(nvidia, calibration)
+  cache.invalidate()
+  assert.equal(cache.get(nvidia), null)
 })

--- a/polystore-website/src/lib/webgpuKzgMsm.ts
+++ b/polystore-website/src/lib/webgpuKzgMsm.ts
@@ -79,6 +79,16 @@ export type WebGpuKzgMsmOptions = {
   allowFallbackAdapter?: boolean
 }
 
+export type WebGpuKzgMsmAdapterCalibration = {
+  cacheKey: string
+  bucketWidth: number
+  reductionMode: WebGpuKzgMsmReductionMode
+  minBlobs: number
+  minBytes: number
+  source: 'default-adapter-rule' | 'benchmark-matrix'
+  reason: string
+}
+
 export type WebGpuKzgMsmTimings = {
   scalarPrepMs: number
   bucketBuildMs: number
@@ -103,6 +113,11 @@ export type WebGpuKzgMsmResult = {
     uploadBytes: number
     readbackBytes: number
     windowSumNonZeroBytes: number
+    processedBlobs: number
+    commandSubmissions: number
+    readbackCount: number
+    scratchCapacityBytes: number
+    scratchResizeCount: number
   }
 }
 
@@ -120,6 +135,11 @@ type BucketData = {
   windowCounts: Uint32Array
   numWindows: number
   maxBucketSize: number
+}
+
+type ScratchBufferStats = {
+  capacityBytes: number
+  resizeCount: number
 }
 
 function nowMs(): number {
@@ -169,27 +189,32 @@ function blobCellToScalar(cell: Uint8Array): bigint {
   return value % FR_MODULUS
 }
 
-function scalarToSignedWindows(scalar: bigint, width: number): Array<{ value: number; negative: boolean }> {
+function visitSignedWindows(
+  scalar: bigint,
+  width: number,
+  visit: (windowIndex: number, value: number, negative: boolean) => void,
+): void {
   const mask = (1n << BigInt(width)) - 1n
   const half = 1n << BigInt(width - 1)
   const full = 1n << BigInt(width)
   let remaining = scalar
   let carry = 0n
-  const windows: Array<{ value: number; negative: boolean }> = []
+  let windowIndex = 0
 
   while (remaining > 0n || carry > 0n) {
     const raw = (remaining & mask) + carry
     remaining >>= BigInt(width)
     carry = 0n
     if (raw >= half) {
-      windows.push({ value: Number(full - raw), negative: true })
+      const value = Number(full - raw)
+      if (value !== 0) visit(windowIndex, value, true)
       carry = 1n
     } else {
-      windows.push({ value: Number(raw), negative: false })
+      const value = Number(raw)
+      if (value !== 0) visit(windowIndex, value, false)
     }
+    windowIndex += 1
   }
-
-  return windows
 }
 
 export function buildWebGpuKzgMsmBucketData(blob: Uint8Array, bucketWidth = WEBGPU_KZG_MSM_BUCKET_WIDTH): BucketData {
@@ -197,61 +222,82 @@ export function buildWebGpuKzgMsmBucketData(blob: Uint8Array, bucketWidth = WEBG
     throw new Error('WebGPU KZG MSM currently commits one 128 KiB blob per dispatch')
   }
 
-  const perWindow = new Map<number, Map<number, number[]>>()
+  const width = assertBucketWidth(bucketWidth)
+  const bucketSlots = 1 << width
+  const maxWindows = Math.ceil(256 / width) + 1
+  const counts = new Uint32Array(maxWindows * bucketSlots)
   let maxWindow = 0
+  let baseIndexCount = 0
 
   for (let pointIndex = 0; pointIndex < WEBGPU_KZG_MSM_CELLS_PER_BLOB; pointIndex += 1) {
     const scalar = blobCellToScalar(blob.subarray(pointIndex * 32, pointIndex * 32 + 32))
     if (scalar === 0n) continue
 
-    const windows = scalarToSignedWindows(scalar, bucketWidth)
-    for (let windowIndex = 0; windowIndex < windows.length; windowIndex += 1) {
-      const { value, negative } = windows[windowIndex]
-      if (value === 0) continue
+    visitSignedWindows(scalar, width, (windowIndex, value) => {
       maxWindow = Math.max(maxWindow, windowIndex)
-      let buckets = perWindow.get(windowIndex)
-      if (!buckets) {
-        buckets = new Map()
-        perWindow.set(windowIndex, buckets)
-      }
-      const encoded = pointIndex | (negative ? WEBGPU_KZG_MSM_SIGN_BIT : 0)
-      const entries = buckets.get(value)
-      if (entries) entries.push(encoded >>> 0)
-      else buckets.set(value, [encoded >>> 0])
-    }
+      counts[windowIndex * bucketSlots + value] += 1
+      baseIndexCount += 1
+    })
   }
 
   const numWindows = maxWindow + 1
-  const baseIndices: number[] = []
-  const bucketPointers: number[] = []
-  const bucketSizes: number[] = []
-  const bucketValues: number[] = []
-  const windowStarts = new Uint32Array(numWindows)
-  const windowCounts = new Uint32Array(numWindows)
+  let bucketCount = 0
   let maxBucketSize = 0
-
   for (let windowIndex = 0; windowIndex < numWindows; windowIndex += 1) {
-    const buckets = perWindow.get(windowIndex)
-    windowStarts[windowIndex] = bucketValues.length
-    if (!buckets) continue
-
-    const values = [...buckets.keys()].sort((a, b) => a - b)
-    windowCounts[windowIndex] = values.length
-    for (const value of values) {
-      const entries = buckets.get(value) ?? []
-      maxBucketSize = Math.max(maxBucketSize, entries.length)
-      bucketPointers.push(baseIndices.length)
-      bucketSizes.push(entries.length)
-      bucketValues.push(value)
-      baseIndices.push(...entries)
+    const windowOffset = windowIndex * bucketSlots
+    for (let value = 1; value < bucketSlots; value += 1) {
+      const count = counts[windowOffset + value]
+      if (count === 0) continue
+      bucketCount += 1
+      maxBucketSize = Math.max(maxBucketSize, count)
     }
   }
 
+  const baseIndices = new Uint32Array(baseIndexCount)
+  const bucketPointers = new Uint32Array(bucketCount)
+  const bucketSizes = new Uint32Array(bucketCount)
+  const bucketValues = new Uint32Array(bucketCount)
+  const windowStarts = new Uint32Array(numWindows)
+  const windowCounts = new Uint32Array(numWindows)
+  const entryOffsets = new Uint32Array(counts.length)
+  const fillCounts = new Uint32Array(counts.length)
+  let bucketIndex = 0
+  let baseIndexOffset = 0
+
+  for (let windowIndex = 0; windowIndex < numWindows; windowIndex += 1) {
+    const windowOffset = windowIndex * bucketSlots
+    windowStarts[windowIndex] = bucketIndex
+    for (let value = 1; value < bucketSlots; value += 1) {
+      const count = counts[windowOffset + value]
+      if (count === 0) continue
+      const offset = windowOffset + value
+      entryOffsets[offset] = baseIndexOffset
+      bucketPointers[bucketIndex] = baseIndexOffset
+      bucketSizes[bucketIndex] = count
+      bucketValues[bucketIndex] = value
+      baseIndexOffset += count
+      bucketIndex += 1
+      windowCounts[windowIndex] += 1
+    }
+  }
+
+  for (let pointIndex = 0; pointIndex < WEBGPU_KZG_MSM_CELLS_PER_BLOB; pointIndex += 1) {
+    const scalar = blobCellToScalar(blob.subarray(pointIndex * 32, pointIndex * 32 + 32))
+    if (scalar === 0n) continue
+
+    visitSignedWindows(scalar, width, (windowIndex, value, negative) => {
+      const offset = windowIndex * bucketSlots + value
+      const writeIndex = entryOffsets[offset] + fillCounts[offset]
+      baseIndices[writeIndex] = (pointIndex | (negative ? WEBGPU_KZG_MSM_SIGN_BIT : 0)) >>> 0
+      fillCounts[offset] += 1
+    })
+  }
+
   return {
-    baseIndices: new Uint32Array(baseIndices),
-    bucketPointers: new Uint32Array(bucketPointers),
-    bucketSizes: new Uint32Array(bucketSizes),
-    bucketValues: new Uint32Array(bucketValues),
+    baseIndices,
+    bucketPointers,
+    bucketSizes,
+    bucketValues,
     windowStarts,
     windowCounts,
     numWindows,
@@ -271,13 +317,124 @@ function createStorageBuffer(device: GPUDevice, label: string, bytes: Uint8Array
   return buffer
 }
 
-function createEmptyStorageBuffer(device: GPUDevice, label: string, size: number): GPUBuffer {
-  const usage = gpuBufferUsage()
-  return device.createBuffer({
-    label,
-    size: Math.max(4, size),
-    usage: usage.STORAGE | usage.COPY_SRC,
-  })
+function alignBufferSize(size: number): number {
+  return Math.max(4, Math.ceil(size / 4) * 4)
+}
+
+function growBufferCapacity(current: number, required: number): number {
+  let next = Math.max(4, current)
+  while (next < required) next *= 2
+  return next
+}
+
+class ReusableGpuBuffer {
+  private buffer: GPUBuffer | null = null
+  private capacity = 0
+  private resizes = 0
+
+  constructor(
+    private readonly device: GPUDevice,
+    private readonly label: string,
+    private readonly usage: number,
+  ) {}
+
+  get stats(): ScratchBufferStats {
+    return { capacityBytes: this.capacity, resizeCount: this.resizes }
+  }
+
+  ensure(size: number): GPUBuffer {
+    const required = alignBufferSize(size)
+    if (this.buffer && this.capacity >= required) return this.buffer
+    this.buffer?.destroy()
+    this.capacity = growBufferCapacity(this.capacity, required)
+    this.resizes += 1
+    this.buffer = this.device.createBuffer({
+      label: this.label,
+      size: this.capacity,
+      usage: this.usage,
+    })
+    return this.buffer
+  }
+
+  write(bytes: Uint8Array | Uint32Array): GPUBuffer {
+    const buffer = this.ensure(bytes.byteLength)
+    this.device.queue.writeBuffer(buffer, 0, bytes)
+    return buffer
+  }
+
+  destroy(): void {
+    this.buffer?.destroy()
+    this.buffer = null
+    this.capacity = 0
+  }
+}
+
+class WebGpuKzgMsmScratch {
+  readonly baseIndices: ReusableGpuBuffer
+  readonly bucketPointers: ReusableGpuBuffer
+  readonly bucketSizes: ReusableGpuBuffer
+  readonly bucketValues: ReusableGpuBuffer
+  readonly windowStarts: ReusableGpuBuffer
+  readonly windowCounts: ReusableGpuBuffer
+  readonly aggregatedBuckets: ReusableGpuBuffer
+  readonly windowSums: ReusableGpuBuffer
+  readonly partialWindowSums: ReusableGpuBuffer
+  readonly readback: ReusableGpuBuffer
+  private readonly buffers: ReusableGpuBuffer[]
+
+  constructor(device: GPUDevice) {
+    const usage = gpuBufferUsage()
+    this.baseIndices = new ReusableGpuBuffer(device, 'polystore-kzg-msm-base-indices', usage.STORAGE | usage.COPY_DST)
+    this.bucketPointers = new ReusableGpuBuffer(
+      device,
+      'polystore-kzg-msm-bucket-pointers',
+      usage.STORAGE | usage.COPY_DST,
+    )
+    this.bucketSizes = new ReusableGpuBuffer(device, 'polystore-kzg-msm-bucket-sizes', usage.STORAGE | usage.COPY_DST)
+    this.bucketValues = new ReusableGpuBuffer(device, 'polystore-kzg-msm-bucket-values', usage.STORAGE | usage.COPY_DST)
+    this.windowStarts = new ReusableGpuBuffer(device, 'polystore-kzg-msm-window-starts', usage.STORAGE | usage.COPY_DST)
+    this.windowCounts = new ReusableGpuBuffer(device, 'polystore-kzg-msm-window-counts', usage.STORAGE | usage.COPY_DST)
+    this.aggregatedBuckets = new ReusableGpuBuffer(
+      device,
+      'polystore-kzg-msm-aggregated-buckets',
+      usage.STORAGE | usage.COPY_SRC,
+    )
+    this.windowSums = new ReusableGpuBuffer(device, 'polystore-kzg-msm-window-sums', usage.STORAGE | usage.COPY_SRC)
+    this.partialWindowSums = new ReusableGpuBuffer(
+      device,
+      'polystore-kzg-msm-partial-window-sums',
+      usage.STORAGE | usage.COPY_SRC,
+    )
+    this.readback = new ReusableGpuBuffer(device, 'polystore-kzg-msm-readback', usage.COPY_DST | usage.MAP_READ)
+    this.buffers = [
+      this.baseIndices,
+      this.bucketPointers,
+      this.bucketSizes,
+      this.bucketValues,
+      this.windowStarts,
+      this.windowCounts,
+      this.aggregatedBuckets,
+      this.windowSums,
+      this.partialWindowSums,
+      this.readback,
+    ]
+  }
+
+  stats(): ScratchBufferStats {
+    return this.buffers.reduce(
+      (stats, buffer) => {
+        const bufferStats = buffer.stats
+        stats.capacityBytes += bufferStats.capacityBytes
+        stats.resizeCount += bufferStats.resizeCount
+        return stats
+      },
+      { capacityBytes: 0, resizeCount: 0 },
+    )
+  }
+
+  destroy(): void {
+    for (const buffer of this.buffers) buffer.destroy()
+  }
 }
 
 function assertReductionMode(mode: WebGpuKzgMsmReductionMode): WebGpuKzgMsmReductionMode {
@@ -295,15 +452,60 @@ async function readAdapterInfo(adapter: WebGpuAdapter): Promise<WebGpuAdapterInf
   return null
 }
 
-function defaultReductionModeForAdapter(info: WebGpuAdapterInfo | null): WebGpuKzgMsmReductionMode {
+export function createWebGpuKzgMsmAdapterCacheKey(info: WebGpuAdapterInfo | null, version = 'webgpu-msm-v1'): string {
+  const normalize = (value: unknown) => String(value ?? 'unknown').trim().toLowerCase() || 'unknown'
+  return [
+    version,
+    normalize(info?.vendor),
+    normalize(info?.architecture),
+    normalize(info?.device),
+    normalize(info?.description),
+    normalize(info?.isFallbackAdapter),
+  ].join('|')
+}
+
+export function defaultWebGpuKzgMsmAdapterCalibration(
+  info: WebGpuAdapterInfo | null,
+): WebGpuKzgMsmAdapterCalibration {
   const vendor = info?.vendor?.toLowerCase() ?? ''
   const architecture = info?.architecture?.toLowerCase() ?? ''
-  if (vendor.includes('apple') || architecture.includes('metal')) return 'parallel16'
-  return WEBGPU_KZG_MSM_REDUCTION_MODE
+  const isAppleMetal = vendor.includes('apple') || architecture.includes('metal')
+  const reductionMode = isAppleMetal ? 'parallel16' : WEBGPU_KZG_MSM_REDUCTION_MODE
+  return {
+    cacheKey: createWebGpuKzgMsmAdapterCacheKey(info),
+    bucketWidth: WEBGPU_KZG_MSM_BUCKET_WIDTH,
+    reductionMode,
+    minBlobs: 1,
+    minBytes: WEBGPU_KZG_MSM_BLOB_SIZE,
+    source: 'default-adapter-rule',
+    reason: isAppleMetal
+      ? 'Apple/Metal diagnostics favor parallel16 for the final per-window reduction'
+      : 'NVIDIA/Vulkan and unknown native adapters default to the stable serial reduction',
+  }
+}
+
+export class WebGpuKzgMsmCalibrationCache {
+  private readonly entries = new Map<string, WebGpuKzgMsmAdapterCalibration>()
+
+  get(info: WebGpuAdapterInfo | null): WebGpuKzgMsmAdapterCalibration | null {
+    return this.entries.get(createWebGpuKzgMsmAdapterCacheKey(info)) ?? null
+  }
+
+  set(info: WebGpuAdapterInfo | null, calibration: WebGpuKzgMsmAdapterCalibration): void {
+    this.entries.set(createWebGpuKzgMsmAdapterCacheKey(info), calibration)
+  }
+
+  invalidate(info?: WebGpuAdapterInfo | null): void {
+    if (typeof info === 'undefined') {
+      this.entries.clear()
+      return
+    }
+    this.entries.delete(createWebGpuKzgMsmAdapterCacheKey(info))
+  }
 }
 
 export function selectWebGpuKzgMsmReductionMode(info: WebGpuAdapterInfo | null): WebGpuKzgMsmReductionMode {
-  return defaultReductionModeForAdapter(info)
+  return defaultWebGpuKzgMsmAdapterCalibration(info).reductionMode
 }
 
 function reductionWorkgroupSize(mode: WebGpuKzgMsmReductionMode): 16 | 32 | 64 {
@@ -337,26 +539,26 @@ function buildParallelSubsumShader(workgroupSize: 16 | 32 | 64): string {
     win_sums_ph2_g1[window_id] = store_g1(sum);`)
 }
 
-async function readBuffer(device: GPUDevice, source: GPUBuffer, size: number): Promise<Uint8Array> {
-  const usage = gpuBufferUsage()
-  const readback = device.createBuffer({
-    label: 'polystore-kzg-msm-readback',
-    size,
-    usage: usage.COPY_DST | usage.MAP_READ,
-  })
+async function readIntoScratchBuffer(
+  device: GPUDevice,
+  readbackScratch: ReusableGpuBuffer,
+  source: GPUBuffer,
+  size: number,
+): Promise<Uint8Array> {
+  const readback = readbackScratch.ensure(size)
   const encoder = device.createCommandEncoder({ label: 'polystore-kzg-msm-readback-encoder' })
   encoder.copyBufferToBuffer(source, 0, readback, 0, size)
   device.queue.submit([encoder.finish()])
   await readback.mapAsync(gpuMapMode().READ)
   const mapped = readback.getMappedRange()
-  const out = new Uint8Array(mapped.slice(0))
+  const out = new Uint8Array(mapped.slice(0, size))
   readback.unmap()
-  readback.destroy()
   return out
 }
 
 export class WebGpuKzgMsmCommitter {
   private readonly srsBuffer: GPUBuffer
+  private readonly scratch: WebGpuKzgMsmScratch
   private readonly aggregatePipeline: GPUComputePipeline
   private readonly montgomeryPipeline: GPUComputePipeline
   private readonly weightPipeline: GPUComputePipeline
@@ -381,6 +583,7 @@ export class WebGpuKzgMsmCommitter {
       throw new Error('WebGPU KZG MSM SRS export is smaller than one blob domain')
     }
     this.srsBuffer = createStorageBuffer(device, 'polystore-kzg-msm-g1-srs', srs)
+    this.scratch = new WebGpuKzgMsmScratch(device)
 
     const aggregateModule = device.createShaderModule({
       label: 'polystore-kzg-msm-g1-aggregate',
@@ -484,6 +687,7 @@ export class WebGpuKzgMsmCommitter {
 
   destroy(): void {
     this.srsBuffer.destroy()
+    this.scratch.destroy()
   }
 
   async getDeviceLostInfo(timeoutMs = 0): Promise<WebGpuKzgMsmDeviceLostInfo | null> {
@@ -508,6 +712,18 @@ export class WebGpuKzgMsmCommitter {
     const reductionMode = assertReductionMode(this.options.reductionMode ?? WEBGPU_KZG_MSM_REDUCTION_MODE)
     const commitments = new Uint8Array(blobs * 48)
     let debug: WebGpuKzgMsmResult['debug']
+    const scratchStatsAtStart = this.scratch.stats()
+    const debugTotals = {
+      bucketCount: 0,
+      baseIndexCount: 0,
+      maxBucketSize: 0,
+      uploadBytes: 0,
+      readbackBytes: 0,
+      windowSumNonZeroBytes: 0,
+      processedBlobs: 0,
+      commandSubmissions: 0,
+      readbackCount: 0,
+    }
     const timings: WebGpuKzgMsmTimings = {
       scalarPrepMs: 0,
       bucketBuildMs: 0,
@@ -528,34 +744,36 @@ export class WebGpuKzgMsmCommitter {
       const bucketStart = nowMs()
       const bucketData = buildWebGpuKzgMsmBucketData(blob, bucketWidth)
       timings.bucketBuildMs += nowMs() - bucketStart
+      debugTotals.bucketCount += bucketData.bucketValues.length
+      debugTotals.baseIndexCount += bucketData.baseIndices.length
+      debugTotals.maxBucketSize = Math.max(debugTotals.maxBucketSize, bucketData.maxBucketSize)
+      debugTotals.processedBlobs += 1
 
       const uploadStart = nowMs()
-      const baseIndices = createStorageBuffer(this.device, 'polystore-kzg-msm-base-indices', bucketData.baseIndices)
-      const bucketPointers = createStorageBuffer(this.device, 'polystore-kzg-msm-bucket-pointers', bucketData.bucketPointers)
-      const bucketSizes = createStorageBuffer(this.device, 'polystore-kzg-msm-bucket-sizes', bucketData.bucketSizes)
-      const bucketValues = createStorageBuffer(this.device, 'polystore-kzg-msm-bucket-values', bucketData.bucketValues)
-      const windowStarts = createStorageBuffer(this.device, 'polystore-kzg-msm-window-starts', bucketData.windowStarts)
-      const windowCounts = createStorageBuffer(this.device, 'polystore-kzg-msm-window-counts', bucketData.windowCounts)
-      const aggregatedBuckets = createEmptyStorageBuffer(
-        this.device,
-        'polystore-kzg-msm-aggregated-buckets',
+      const baseIndices = this.scratch.baseIndices.write(bucketData.baseIndices)
+      const bucketPointers = this.scratch.bucketPointers.write(bucketData.bucketPointers)
+      const bucketSizes = this.scratch.bucketSizes.write(bucketData.bucketSizes)
+      const bucketValues = this.scratch.bucketValues.write(bucketData.bucketValues)
+      const windowStarts = this.scratch.windowStarts.write(bucketData.windowStarts)
+      const windowCounts = this.scratch.windowCounts.write(bucketData.windowCounts)
+      const aggregatedBuckets = this.scratch.aggregatedBuckets.ensure(
         Math.max(1, bucketData.bucketValues.length) * WEBGPU_KZG_MSM_POINT_BYTES,
       )
-      const windowSums = createEmptyStorageBuffer(
-        this.device,
-        'polystore-kzg-msm-window-sums',
-        Math.max(1, bucketData.numWindows) * WEBGPU_KZG_MSM_POINT_BYTES,
-      )
+      const windowSums = this.scratch.windowSums.ensure(Math.max(1, bucketData.numWindows) * WEBGPU_KZG_MSM_POINT_BYTES)
       const partialWindowSums =
         reductionMode === 'serial'
           ? null
-          : createEmptyStorageBuffer(
-              this.device,
-              `polystore-kzg-msm-${reductionMode}-partial-window-sums`,
-              Math.max(1, bucketData.numWindows) *
-                reductionWorkgroupSize(reductionMode) *
-                WEBGPU_KZG_MSM_POINT_BYTES,
+          : this.scratch.partialWindowSums.ensure(
+              Math.max(1, bucketData.numWindows) * reductionWorkgroupSize(reductionMode) * WEBGPU_KZG_MSM_POINT_BYTES,
             )
+      const uploadBytes =
+        bucketData.baseIndices.byteLength +
+        bucketData.bucketPointers.byteLength +
+        bucketData.bucketSizes.byteLength +
+        bucketData.bucketValues.byteLength +
+        bucketData.windowStarts.byteLength +
+        bucketData.windowCounts.byteLength
+      debugTotals.uploadBytes += uploadBytes
       timings.uploadMs += nowMs() - uploadStart
 
       const dispatchStart = nowMs()
@@ -644,35 +862,39 @@ export class WebGpuKzgMsmCommitter {
       }
       pass.end()
       this.device.queue.submit([encoder.finish()])
+      debugTotals.commandSubmissions += 1
       const validationError = await this.device.popErrorScope?.()
       if (validationError) {
         throw new Error(`WebGPU KZG MSM validation failed: ${validationError.message ?? String(validationError)}`)
       }
 
-      const windowSumBytes = await readBuffer(
+      const readbackBytes = Math.max(1, bucketData.numWindows) * WEBGPU_KZG_MSM_POINT_BYTES
+      const windowSumBytes = await readIntoScratchBuffer(
         this.device,
+        this.scratch.readback,
         windowSums,
-        Math.max(1, bucketData.numWindows) * WEBGPU_KZG_MSM_POINT_BYTES,
+        readbackBytes,
       )
-      debug ??= {
+      const scratchStatsAfter = this.scratch.stats()
+      debugTotals.readbackBytes += readbackBytes
+      debugTotals.readbackCount += 1
+      debugTotals.windowSumNonZeroBytes += windowSumBytes.reduce((count, byte) => count + (byte === 0 ? 0 : 1), 0)
+      debug = {
         bucketWidth,
         reductionMode,
-        bucketCount: bucketData.bucketValues.length,
-        baseIndexCount: bucketData.baseIndices.length,
+        bucketCount: debugTotals.bucketCount,
+        baseIndexCount: debugTotals.baseIndexCount,
         numWindows: bucketData.numWindows,
-        maxBucketSize: bucketData.maxBucketSize,
-        meanBucketSize: bucketData.bucketValues.length
-          ? bucketData.baseIndices.length / bucketData.bucketValues.length
-          : 0,
-        uploadBytes:
-          bucketData.baseIndices.byteLength +
-          bucketData.bucketPointers.byteLength +
-          bucketData.bucketSizes.byteLength +
-          bucketData.bucketValues.byteLength +
-          bucketData.windowStarts.byteLength +
-          bucketData.windowCounts.byteLength,
-        readbackBytes: Math.max(1, bucketData.numWindows) * WEBGPU_KZG_MSM_POINT_BYTES,
-        windowSumNonZeroBytes: windowSumBytes.reduce((count, byte) => count + (byte === 0 ? 0 : 1), 0),
+        maxBucketSize: debugTotals.maxBucketSize,
+        meanBucketSize: debugTotals.bucketCount ? debugTotals.baseIndexCount / debugTotals.bucketCount : 0,
+        uploadBytes: debugTotals.uploadBytes,
+        readbackBytes: debugTotals.readbackBytes,
+        windowSumNonZeroBytes: debugTotals.windowSumNonZeroBytes,
+        processedBlobs: debugTotals.processedBlobs,
+        commandSubmissions: debugTotals.commandSubmissions,
+        readbackCount: debugTotals.readbackCount,
+        scratchCapacityBytes: scratchStatsAfter.capacityBytes,
+        scratchResizeCount: scratchStatsAfter.resizeCount - scratchStatsAtStart.resizeCount,
       }
       timings.dispatchReadbackMs += nowMs() - dispatchStart
 
@@ -680,20 +902,6 @@ export class WebGpuKzgMsmCommitter {
       const commitment = this.wasm.webgpu_fold_g1_window_sums(windowSumBytes, bucketWidth)
       timings.foldMs += nowMs() - foldStart
       commitments.set(commitment, i * 48)
-
-      for (const buffer of [
-        baseIndices,
-        bucketPointers,
-        bucketSizes,
-        bucketValues,
-        windowStarts,
-        windowCounts,
-        aggregatedBuckets,
-        windowSums,
-        partialWindowSums,
-      ]) {
-        buffer?.destroy()
-      }
     }
 
     timings.totalMs = nowMs() - started
@@ -716,7 +924,8 @@ export async function createWebGpuKzgMsmCommitter(
   }
   const resolvedOptions: WebGpuKzgMsmOptions = {
     ...options,
-    reductionMode: options.reductionMode ?? defaultReductionModeForAdapter(adapterInfo),
+    bucketWidth: options.bucketWidth ?? defaultWebGpuKzgMsmAdapterCalibration(adapterInfo).bucketWidth,
+    reductionMode: options.reductionMode ?? defaultWebGpuKzgMsmAdapterCalibration(adapterInfo).reductionMode,
   }
   const device = await adapter.requestDevice()
   return new WebGpuKzgMsmCommitter(device, wasm, resolvedOptions)


### PR DESCRIPTION
## Summary

Closes #179. PR #182 has merged, and this branch is now based on `main`.

- replaces the allocation-heavy WebGPU MSM bucket builder with typed-array count/prefix/fill passes
- reuses WebGPU scratch/readback buffers across blobs and commit calls, with geometric growth and aggregate capacity/resize diagnostics
- upgrades the diagnostic benchmark into a matrix runner for blob counts, bucket widths, reduction modes, medians/min/p95, per-stage timings, throughput, timing-source metadata, and threshold recommendation JSON
- codifies adapter defaults and cache helpers: Apple/Metal uses `parallel16`; NVIDIA/Vulkan and unknown native adapters use `serial`; fallback/software adapters remain rejected by default
- updates optimization notes with the #179 scope, evidence, and the deliberate exclusion of unproven true batched shader/reduction rewrites

## Design Decision

`commitBlobs` still executes one blob per GPU command plan, but now with retained scratch buffers and aggregate diagnostics. The deeper true-batch shader work is not landed here because prior reduction/batched variants were browser-unstable or pathological on native adapters. The completed path resolves #179 by making the measured throughput path lower-allocation, adapter-aware, benchmarkable, and evidence-backed without introducing an unproven shader pipeline.

## Validation

- `npx tsx --test src/lib/webgpuKzgMsm.test.ts src/lib/kzgCommitBackend.test.ts`
- `npx tsc --noEmit --pretty false`
- `npm run lint`
- `npm run build`
- `POLYSTORE_WEBGPU_MSM_DIAGNOSTIC=1 POLYSTORE_WEBGPU_MSM_BLOBS_LIST=1,4 POLYSTORE_WEBGPU_MSM_BUCKET_WIDTHS=10 POLYSTORE_WEBGPU_MSM_REDUCTIONS=auto,serial POLYSTORE_WEBGPU_MSM_RUNS=1 npm run diagnose:kzg-webgpu-msm`
  - local Headless Chrome 148 exposed SwiftShader (`vendor: google`, `architecture: swiftshader`, `isFallbackAdapter: true`) and the committer rejected the fallback adapter as expected.

Native NVIDIA final matrix on clean commit `6fbb4868c8e6349423e8db5d668f5fa770b4afff`:

```sh
POLYSTORE_WEBGPU_HEADLESS=0 \
POLYSTORE_WEBGPU_CHROME_ARGS='--use-vulkan=native --force_high_performance_gpu' \
POLYSTORE_WEBGPU_MSM_BLOBS_LIST=1,4,16,64 \
POLYSTORE_WEBGPU_MSM_BUCKET_WIDTHS=10 \
POLYSTORE_WEBGPU_MSM_REDUCTIONS=auto \
POLYSTORE_WEBGPU_MSM_RUNS=3 \
npm run diagnose:kzg-webgpu-msm
```

Adapter: Chrome 148, Ubuntu/Linux x64, `vendor: nvidia`, `architecture: ampere`, `isFallbackAdapter: false`, timing source `cpu-wall-clock`, timestamp-query available, default `serial` reduction.

| blobs | WebGPU median | WASM median | WebGPU throughput | parity | scratch / submissions |
| ---: | ---: | ---: | ---: | --- | --- |
| 1 | 97.56 ms | 328.63 ms | 10.25 blobs/s | true | 4,849,920 B / 1 submit |
| 4 | 405.26 ms | 1219.67 ms | 9.87 blobs/s | true | 4,849,920 B / 4 submits |
| 16 | 1783.85 ms | 5196.76 ms | 8.97 blobs/s | true | 4,849,920 B / 16 submits |
| 64 | 6592.98 ms | 20249.81 ms | 9.71 blobs/s | true | 4,849,920 B / 64 submits |

Matrix recommendation: WebGPU recommended at `min_blobs: 1`, `min_mib: 0.125`, `bucket_width: 10`, `reduction_mode: serial` for this adapter.

Native Apple M3 evidence from https://github.com/Polynomialstore/polystore/pull/183#issuecomment-4568280326:

| blobs | WebGPU total | WASM total | WebGPU throughput | parity | adapter |
| ---: | ---: | ---: | ---: | --- | --- |
| 1 | ~152.19 ms | ~235.20 ms | ~6.57 blobs/s | true | Chrome 143, `vendor: apple`, `architecture: metal-3`, `parallel16` |

## Merge Notes

Ready for human review. Do not merge automatically; repo policy still requires human approval.
