### PR TITLE
Expose browser upload KZG status and timing

### DIFF
--- a/polystore-website/package-lock.json
+++ b/polystore-website/package-lock.json
@@ -77,6 +77,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -1312,6 +1313,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -1331,6 +1333,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1338,12 +1341,14 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -2336,6 +2341,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -2348,6 +2354,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -2356,6 +2363,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -5763,13 +5771,13 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "18.3.27",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -7733,7 +7741,8 @@
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true
     },
     "node_modules/any-signal": {
       "version": "4.2.0",
@@ -7759,7 +7768,8 @@
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -7856,6 +7866,7 @@
       "version": "0.26.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
       "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dev": true,
       "dependencies": {
         "follow-redirects": "^1.14.8"
       }
@@ -7937,6 +7948,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -7995,6 +8007,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -8149,6 +8162,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -8237,6 +8251,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -8260,6 +8275,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -8339,6 +8355,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -8785,7 +8802,8 @@
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
-      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true
     },
     "node_modules/dijkstrajs": {
       "version": "1.0.3",
@@ -8808,7 +8826,8 @@
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true
     },
     "node_modules/dns-packet": {
       "version": "5.6.1",
@@ -9837,6 +9856,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -9852,6 +9872,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -9896,6 +9917,7 @@
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
       "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -9916,6 +9938,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -10097,6 +10120,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -10224,6 +10248,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -10545,6 +10570,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -10574,6 +10600,7 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -10593,6 +10620,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10629,6 +10657,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -10656,6 +10685,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -10974,6 +11004,7 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -11164,6 +11195,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
       "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -11171,7 +11203,8 @@
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
     },
     "node_modules/lit": {
       "version": "3.3.0",
@@ -11308,6 +11341,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -11322,6 +11356,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -11481,6 +11516,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
       "dependencies": {
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
@@ -11491,6 +11527,7 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11641,6 +11678,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11649,6 +11687,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -11906,7 +11945,8 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -11937,6 +11977,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11983,6 +12024,7 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -12062,6 +12104,7 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -12089,6 +12132,7 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
         "read-cache": "^1.0.0",
@@ -12105,6 +12149,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
       "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -12129,6 +12174,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
       "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -12163,6 +12209,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
       "engines": {
         "node": ">=14"
       },
@@ -12174,6 +12221,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -12198,6 +12246,7 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -12209,7 +12258,8 @@
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true
     },
     "node_modules/preact": {
       "version": "10.24.2",
@@ -12337,6 +12387,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -12410,12 +12461,6 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
-    },
-    "node_modules/react-is": {
-      "version": "19.2.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.1.tgz",
-      "integrity": "sha512-L7BnWgRbMwzMAubQcS7sXdPdNLmKlucPlopgAzx7FtYbksWZgEWiuYM5x9T6UqS2Ne0rsgQTq5kY2SGqpzUkYA==",
-      "peer": true
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
@@ -12557,6 +12602,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
       "dependencies": {
         "pify": "^2.3.0"
       }
@@ -12579,6 +12625,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -12661,6 +12708,7 @@
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
       "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
       "dependencies": {
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
@@ -12704,6 +12752,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -12802,6 +12851,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13004,6 +13054,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13106,6 +13157,7 @@
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
       "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
         "commander": "^4.0.0",
@@ -13148,6 +13200,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -13177,6 +13230,7 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.1.tgz",
       "integrity": "sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==",
+      "dev": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -13247,6 +13301,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
       "dependencies": {
         "any-promise": "^1.0.0"
       }
@@ -13255,6 +13310,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
       },
@@ -13280,6 +13336,7 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
       "dependencies": {
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3"
@@ -13295,6 +13352,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "engines": {
         "node": ">=12.0.0"
       },
@@ -13311,6 +13369,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -13336,6 +13395,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -13364,7 +13424,8 @@
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -13489,6 +13550,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14084,6 +14146,7 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "dev": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/polystore-website/package-lock.json
+++ b/polystore-website/package-lock.json
@@ -77,7 +77,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -1313,7 +1312,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -1333,7 +1331,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1341,14 +1338,12 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -2341,7 +2336,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -2354,7 +2348,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -2363,7 +2356,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -5771,13 +5763,13 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.3.27",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -7741,8 +7733,7 @@
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "dev": true
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
     },
     "node_modules/any-signal": {
       "version": "4.2.0",
@@ -7768,8 +7759,7 @@
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -7866,7 +7856,6 @@
       "version": "0.26.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
       "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-      "dev": true,
       "dependencies": {
         "follow-redirects": "^1.14.8"
       }
@@ -7948,7 +7937,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -8007,7 +7995,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -8162,7 +8149,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -8251,7 +8237,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -8275,7 +8260,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -8355,7 +8339,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -8802,8 +8785,7 @@
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
-      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-      "dev": true
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
     },
     "node_modules/dijkstrajs": {
       "version": "1.0.3",
@@ -8826,8 +8808,7 @@
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
     },
     "node_modules/dns-packet": {
       "version": "5.6.1",
@@ -9856,7 +9837,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -9872,7 +9852,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -9917,7 +9896,6 @@
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
       "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
-      "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -9938,7 +9916,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -10120,7 +10097,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -10248,7 +10224,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -10570,7 +10545,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -10600,7 +10574,6 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "dev": true,
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -10620,7 +10593,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10657,7 +10629,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -10685,7 +10656,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -11004,7 +10974,6 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "dev": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -11195,7 +11164,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
       "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -11203,8 +11171,7 @@
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/lit": {
       "version": "3.3.0",
@@ -11341,7 +11308,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -11356,7 +11322,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -11516,7 +11481,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
       "dependencies": {
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
@@ -11527,7 +11491,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11678,7 +11641,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11687,7 +11649,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -11945,8 +11906,7 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -11977,7 +11937,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12024,7 +11983,6 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -12104,7 +12062,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -12132,7 +12089,6 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
         "read-cache": "^1.0.0",
@@ -12149,7 +12105,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
       "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -12174,7 +12129,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
       "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -12209,7 +12163,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
       "engines": {
         "node": ">=14"
       },
@@ -12221,7 +12174,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -12246,7 +12198,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -12258,8 +12209,7 @@
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "node_modules/preact": {
       "version": "10.24.2",
@@ -12387,7 +12337,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -12461,6 +12410,12 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
+    },
+    "node_modules/react-is": {
+      "version": "19.2.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.1.tgz",
+      "integrity": "sha512-L7BnWgRbMwzMAubQcS7sXdPdNLmKlucPlopgAzx7FtYbksWZgEWiuYM5x9T6UqS2Ne0rsgQTq5kY2SGqpzUkYA==",
+      "peer": true
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
@@ -12602,7 +12557,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
       "dependencies": {
         "pify": "^2.3.0"
       }
@@ -12625,7 +12579,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -12708,7 +12661,6 @@
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
       "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
-      "dev": true,
       "dependencies": {
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
@@ -12752,7 +12704,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -12851,7 +12802,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13054,7 +13004,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13157,7 +13106,6 @@
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
       "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
         "commander": "^4.0.0",
@@ -13200,7 +13148,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -13230,7 +13177,6 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.1.tgz",
       "integrity": "sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==",
-      "dev": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -13301,7 +13247,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dev": true,
       "dependencies": {
         "any-promise": "^1.0.0"
       }
@@ -13310,7 +13255,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dev": true,
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
       },
@@ -13336,7 +13280,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "dependencies": {
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3"
@@ -13352,7 +13295,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "engines": {
         "node": ">=12.0.0"
       },
@@ -13369,7 +13311,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -13395,7 +13336,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -13424,8 +13364,7 @@
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "dev": true
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -13550,7 +13489,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14146,7 +14084,6 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/polystore-website/src/components/FileSharder.tsx
+++ b/polystore-website/src/components/FileSharder.tsx
@@ -977,6 +977,18 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
     uploadStatusRef.current = null
     uploadArtifactCountsRef.current = { queued: 0, uploaded: 0 }
     setUploadStatus(null)
+    if (typeof window !== 'undefined') {
+      const statusWindow = window as typeof window & {
+        __polyStoreUploadStatus?: UploadPipelineStatus | null
+        __polyStoreKzgStatus?: UploadPipelineStatus['kzg'] | null
+        __polyStorePerfBundle?: PolyStoreBrowserPerfBundle
+      }
+      statusWindow.__polyStoreUploadStatus = null
+      statusWindow.__polyStoreKzgStatus = null
+      if (statusWindow.__polyStorePerfBundle) {
+        statusWindow.__polyStorePerfBundle.uploadStatus = null
+      }
+    }
     if (fileInputRef.current) {
       fileInputRef.current.value = ''
     }

--- a/polystore-website/src/components/FileSharder.tsx
+++ b/polystore-website/src/components/FileSharder.tsx
@@ -3675,9 +3675,9 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
                   ? Math.floor(toU8(result.shards_flat).byteLength / Math.max(1, Number(result.shard_len)))
                   : (result.shards ?? []).length,
             }
-              perfSamples.user.push(perfSample)
-              updateUploadKzgStatus(result.perf, 'kzg:user_mdu')
-              console.log('[perf] user mdu (mode2)', {
+            perfSamples.user.push(perfSample)
+            updateUploadKzgStatus(result.perf, 'kzg:user_mdu')
+            console.log('[perf] user mdu (mode2)', {
               ...perfSample,
             })
             prevCommitMsPerMdu = opMs
@@ -3851,9 +3851,9 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
                 totalMs: opMs,
                 batchBlobs,
               };
-                perfSamples.user.push(perfSample);
-                updateUploadKzgStatus(result.perf, 'kzg:user_mdu')
-                console.log('[perf] user mdu', {
+              perfSamples.user.push(perfSample);
+              updateUploadKzgStatus(result.perf, 'kzg:user_mdu')
+              console.log('[perf] user mdu', {
                 ...perfSample,
               });
               prevCommitMsPerMdu = opMs;
@@ -4018,9 +4018,9 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
               workerCommitWorkerCount,
               totalMs: opMs,
             };
-              perfSamples.witness.push(perfSample);
-              updateUploadKzgStatus(result.perf, 'kzg:witness_mdu')
-              console.log('[perf] witness mdu', {
+            perfSamples.witness.push(perfSample);
+            updateUploadKzgStatus(result.perf, 'kzg:witness_mdu')
+            console.log('[perf] witness mdu', {
               ...perfSample,
             });
             prevCommitMsPerMdu = opMs;
@@ -4145,9 +4145,9 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
           workerRustCommitMsmSubphasesAvailable,
           totalMs: opMs,
         }
-          perfSamples.meta.push(metaPerfSample)
-          updateUploadKzgStatus(mdu0PrepareResult.perf, 'kzg:mdu0')
-          console.log('[perf] meta mdu0', {
+        perfSamples.meta.push(metaPerfSample)
+        updateUploadKzgStatus(mdu0PrepareResult.perf, 'kzg:mdu0')
+        console.log('[perf] meta mdu0', {
           prepareBuilderMs: Number(mdu0PrepareResult.perf?.prepareBuilderMs ?? 0),
           ...metaPerfSample,
         });
@@ -4195,18 +4195,18 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
           currentMduIndex: null,
         }));
         const manifestStart = performance.now();
-          const manifest = await workerClient.computeManifest(allRoots);
-          const manifestMs = performance.now() - manifestStart;
-          updateUploadStatus(
-            {
-              phase: 'manifest',
-              phaseLabel: 'Manifest root computed',
-              tone: 'active',
-              timing: { phases: { manifest: roundPerfMs(manifestMs) ?? manifestMs } },
-            },
-            'manifest:computed',
-          )
-          console.log('[perf] manifest aggregation', { ms: manifestMs, roots: allRoots.length / 32 });
+        const manifest = await workerClient.computeManifest(allRoots);
+        const manifestMs = performance.now() - manifestStart;
+        updateUploadStatus(
+          {
+            phase: 'manifest',
+            phaseLabel: 'Manifest root computed',
+            tone: 'active',
+            timing: { phases: { manifest: roundPerfMs(manifestMs) ?? manifestMs } },
+          },
+          'manifest:computed',
+        )
+        console.log('[perf] manifest aggregation', { ms: manifestMs, roots: allRoots.length / 32 });
         
         const finalMdus = [
           makePreparedMdu(0, mdu0Bytes),
@@ -4459,7 +4459,7 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
           note: 'max* fields are closest to wall-clock critical path; sum* fields are parallel worker totals',
         });
         console.log('[perf] prepare profile', prepareProfile);
-          browserPerfEndPhase('prepare', {
+        browserPerfEndPhase('prepare', {
           ok: true,
           totalMs: roundPerfMs(elapsedMs),
           fileBytes: bytes.length,
@@ -4489,25 +4489,25 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
           slowestUserMduIndex: prepareProfile.summary.slowestUserMduIndex,
           slowestWitnessMduIndex: prepareProfile.summary.slowestWitnessMduIndex,
           manifestMs: roundPerfMs(manifestMs),
-          })
-          updateUploadStatus(
-            {
-              phase: 'done',
-              phaseLabel: 'Client-side expansion complete',
-              tone: 'success',
-              storage: { stage: 'upload_queue', queuedArtifacts: finalMdus.length + 1 },
-              totals: {
-                userMdus: totalUserChunks,
-                witnessMdus: witnessMduCount,
-                totalMdus: finalMdus.length,
-                bytesDone: bytes.length,
-                bytesTotal: bytes.length,
-                workDone: workTotal,
-                workTotal,
-              },
+        })
+        updateUploadStatus(
+          {
+            phase: 'done',
+            phaseLabel: 'Client-side expansion complete',
+            tone: 'success',
+            storage: { stage: 'upload_queue', queuedArtifacts: finalMdus.length + 1 },
+            totals: {
+              userMdus: totalUserChunks,
+              witnessMdus: witnessMduCount,
+              totalMdus: finalMdus.length,
+              bytesDone: bytes.length,
+              bytesTotal: bytes.length,
+              workDone: workTotal,
+              workTotal,
             },
-            'prepare:complete',
-          )
+          },
+          'prepare:complete',
+        )
 
         const mib = logicalSizeBytes / (1024 * 1024);
         const seconds = elapsedMs / 1000;
@@ -4524,19 +4524,19 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
     } catch (e: unknown) {
         console.error(e);
         const msg = e instanceof Error ? e.message : String(e);
-          browserPerfLog('run:error', {
+        browserPerfLog('run:error', {
+          error: msg,
+        })
+        updateUploadStatus(
+          {
+            phase: 'error',
+            phaseLabel: msg,
+            tone: 'error',
             error: msg,
-          })
-          updateUploadStatus(
-            {
-              phase: 'error',
-              phaseLabel: msg,
-              tone: 'error',
-              error: msg,
-              transport: { lastError: msg },
-            },
-            'run:error',
-          )
+            transport: { lastError: msg },
+          },
+          'run:error',
+        )
         addLog(`Error: ${msg}`);
         setShardProgress((p) => ({
           ...p,

--- a/polystore-website/src/components/FileSharder.tsx
+++ b/polystore-website/src/components/FileSharder.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, useCallback, useEffect, useRef } from 'react';
 import { useAccount, usePublicClient, useWalletClient } from 'wagmi';
-import { CheckCircle2, FileJson, LoaderCircle, UploadCloud, Wallet } from 'lucide-react';
+import { CheckCircle2, ClipboardCopy, Cpu, Database, FileJson, LoaderCircle, Network, UploadCloud, Wallet } from 'lucide-react';
 import { useConnectModal } from '@rainbow-me/rainbowkit';
 import { pickExpansionWorkerCount } from '../lib/expansionWorkers';
 import { workerClient } from '../lib/worker-client';
@@ -55,6 +55,17 @@ import { isMissingGatewayAppendStateError, recoverGatewayAppendState } from '../
 import { collectMode2SlotFailures } from '../lib/upload/mode2Recovery';
 import { classifyPolyfsCommitError } from '../lib/polyfsCommitError';
 import { waitForTransactionReceipt } from '../lib/evmRpc';
+import {
+  createUploadPipelineStatus,
+  normalizeKzgBackendStatus,
+  patchUploadPipelineStatus,
+  sanitizeUploadPipelineStatus,
+  type DeepPartialUploadPipelineStatus,
+  type KzgDiagnosticsInput,
+  type UploadPipelinePhase,
+  type UploadPipelineStatus,
+  type UploadStatusTone,
+} from '../lib/uploadStatus';
 import {
   decodeComputeRetrievalSessionIdsResult,
   encodeComputeRetrievalSessionIdsData,
@@ -306,6 +317,7 @@ type PolyStoreBrowserPerfBundle = {
   browserPerfLast: Record<string, unknown> | null
   prepareSummary: PolyStorePrepareSummary | null
   prepareProfile: PreparePerfProfile | null
+  uploadStatus?: UploadPipelineStatus | null
 }
 
 type PolyStorePrepareSummary = PreparePerfProfile['summary'] & {
@@ -361,6 +373,100 @@ function formatDuration(ms: number) {
   if (!Number.isFinite(ms) || ms < 0) return '—';
   if (ms < 1000) return `${ms.toFixed(0)}ms`;
   return `${(ms / 1000).toFixed(2)}s`;
+}
+
+function uploadToneForPhase(phase: UploadPipelinePhase): UploadStatusTone {
+  if (phase === 'done') return 'success'
+  if (phase === 'error') return 'error'
+  if (phase === 'idle') return 'idle'
+  return 'active'
+}
+
+function browserPerfPhaseToUploadPhase(phase: string): UploadPipelinePhase {
+  switch (phase) {
+    case 'read_file':
+      return 'read_file'
+    case 'gateway_ingest':
+      return 'gateway_ingest'
+    case 'prepare':
+      return 'prepare'
+    case 'append_bootstrap':
+      return 'append_bootstrap'
+    case 'plan_upload':
+      return 'plan_upload'
+    case 'persist_local':
+      return 'opfs_staging'
+    case 'upload':
+      return 'upload_transport'
+    case 'commit':
+      return 'chain_handoff'
+    default:
+      return 'prepare'
+  }
+}
+
+function labelUploadPhase(phase: UploadPipelinePhase): string {
+  switch (phase) {
+    case 'read_file':
+      return 'Reading file into browser memory'
+    case 'gateway_ingest':
+      return 'Gateway ingest'
+    case 'prepare':
+      return 'Preparing slab'
+    case 'append_bootstrap':
+      return 'Resolving append base'
+    case 'plan_upload':
+      return 'Planning slab layout'
+    case 'browser_memory':
+      return 'Bytes staged in browser memory'
+    case 'opfs_staging':
+      return 'Saving slab artifacts to browser storage'
+    case 'expand_user':
+      return 'Expanding user MDUs'
+    case 'expand_witness':
+      return 'Committing witness MDUs'
+    case 'mdu0_builder':
+      return 'Building MDU0'
+    case 'manifest':
+      return 'Computing manifest'
+    case 'upload_transport':
+      return 'Uploading artifacts'
+    case 'chain_handoff':
+      return 'Committing manifest root'
+    case 'done':
+      return 'Upload pipeline complete'
+    case 'error':
+      return 'Upload pipeline error'
+    default:
+      return 'Idle'
+  }
+}
+
+function uploadStatusPhaseFromShardPhase(phase: ShardPhase): UploadPipelinePhase {
+  switch (phase) {
+    case 'reading':
+      return 'read_file'
+    case 'gateway_receiving':
+    case 'gateway_encoding':
+    case 'gateway_uploading':
+      return 'gateway_ingest'
+    case 'planning':
+      return 'plan_upload'
+    case 'shard_user':
+      return 'expand_user'
+    case 'shard_witness':
+      return 'expand_witness'
+    case 'finalize_mdu0':
+      return 'mdu0_builder'
+    case 'compute_manifest':
+      return 'manifest'
+    case 'done':
+      return 'done'
+    case 'error':
+      return 'error'
+    default:
+      return 'idle'
+  }
 }
 
 function alternateLoopbackBase(baseUrl: string): string | null {
@@ -555,6 +661,9 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
   const lastStaleCommitMessageRef = useRef<string | null>(null)
   const browserPerfRunRef = useRef<BrowserPerfRun | null>(null)
   const browserPerfSeqRef = useRef(1)
+  const uploadArtifactCountsRef = useRef({ queued: 0, uploaded: 0 })
+  const [uploadStatus, setUploadStatus] = useState<UploadPipelineStatus | null>(null)
+  const uploadStatusRef = useRef<UploadPipelineStatus | null>(null)
   const dealSetupAttemptRef = useRef(0)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
   const gatewayUploadProgressRef = useRef<{ phase: string; workDone: number; workTotal: number }>({
@@ -591,6 +700,60 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
   )
 
   const addLog = useCallback((msg: string) => setLogs(prev => [...prev, msg]), []);
+
+  const publishUploadStatus = useCallback((next: UploadPipelineStatus) => {
+    const sanitized = sanitizeUploadPipelineStatus(next)
+    uploadStatusRef.current = sanitized
+    setUploadStatus(sanitized)
+    if (typeof window !== 'undefined') {
+      const statusWindow = window as typeof window & {
+        __polyStoreUploadStatus?: UploadPipelineStatus
+        __polyStoreKzgStatus?: UploadPipelineStatus['kzg']
+        __polyStorePerfBundle?: PolyStoreBrowserPerfBundle
+        __nilBrowserPerfLog?: Array<Record<string, unknown>>
+        __nilBrowserPerfLast?: Record<string, unknown>
+      }
+      statusWindow.__polyStoreUploadStatus = sanitized
+      statusWindow.__polyStoreKzgStatus = sanitized.kzg
+      statusWindow.__polyStorePerfBundle = {
+        browserPerfLog: statusWindow.__nilBrowserPerfLog ?? statusWindow.__polyStorePerfBundle?.browserPerfLog ?? [],
+        browserPerfLast: statusWindow.__nilBrowserPerfLast ?? statusWindow.__polyStorePerfBundle?.browserPerfLast ?? null,
+        prepareSummary: statusWindow.__polyStorePerfBundle?.prepareSummary ?? null,
+        prepareProfile: statusWindow.__polyStorePerfBundle?.prepareProfile ?? null,
+        uploadStatus: sanitized,
+      }
+    }
+  }, [])
+
+  const updateUploadStatus = useCallback(
+    (patch: DeepPartialUploadPipelineStatus, event?: string) => {
+      const now = typeof performance !== 'undefined' ? performance.now() : Date.now()
+      const next = patchUploadPipelineStatus(
+        uploadStatusRef.current,
+        {
+          ...patch,
+          latestEvent: event ?? patch.latestEvent ?? uploadStatusRef.current?.latestEvent ?? null,
+        },
+        now,
+      )
+      publishUploadStatus(next)
+      return next
+    },
+    [publishUploadStatus],
+  )
+
+  const updateUploadKzgStatus = useCallback(
+    (diagnostics: KzgDiagnosticsInput | null | undefined, event = 'kzg:status') => {
+      if (!diagnostics) return
+      updateUploadStatus(
+        {
+          kzg: normalizeKzgBackendStatus(diagnostics),
+        },
+        event,
+      )
+    },
+    [updateUploadStatus],
+  )
 
   const browserPerfLog = useCallback(
     (event: string, extra: Record<string, unknown> = {}) => {
@@ -643,6 +806,7 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
           browserPerfLast: perfWindow.__nilBrowserPerfLast ?? null,
           prepareSummary: perfWindow.__polyStorePerfBundle?.prepareSummary ?? null,
           prepareProfile: perfWindow.__polyStorePerfBundle?.prepareProfile ?? null,
+          uploadStatus: uploadStatusRef.current,
         }
       }
       if (import.meta.env.DEV) {
@@ -661,6 +825,15 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
         startedAtMs: performance.now(),
         phaseStarts: {},
       }
+      publishUploadStatus(
+        createUploadPipelineStatus({
+          dealId,
+          runId: browserPerfRunRef.current.id,
+          fileName: file.name,
+          fileBytes: file.size,
+          nowMs: browserPerfRunRef.current.startedAtMs,
+        }),
+      )
       browserPerfLog('run:start', {
         hardwareConcurrency:
           typeof navigator !== 'undefined' && Number.isFinite(navigator.hardwareConcurrency)
@@ -668,7 +841,7 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
             : null,
       })
     },
-    [browserPerfLog],
+    [browserPerfLog, dealId, publishUploadStatus],
   )
 
   const browserPerfStartPhase = useCallback(
@@ -676,9 +849,35 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
       const run = browserPerfRunRef.current
       if (!run) return
       run.phaseStarts[phase] = performance.now()
+      if (phase === 'upload') {
+        uploadArtifactCountsRef.current = { queued: 0, uploaded: 0 }
+      }
       browserPerfLog(`${phase}:start`, extra)
+      const uploadPhase = browserPerfPhaseToUploadPhase(phase)
+      updateUploadStatus(
+        {
+          phase: uploadPhase,
+          phaseLabel: labelUploadPhase(uploadPhase),
+          tone: uploadToneForPhase(uploadPhase),
+          storage:
+            uploadPhase === 'read_file' || uploadPhase === 'prepare' || uploadPhase === 'plan_upload'
+              ? { stage: 'browser_memory' }
+              : uploadPhase === 'opfs_staging'
+                ? { stage: 'opfs' }
+                : undefined,
+          transport:
+            uploadPhase === 'gateway_ingest'
+              ? { mode: 'gateway' }
+              : uploadPhase === 'upload_transport'
+                ? { mode: 'striped-provider' }
+                : uploadPhase === 'chain_handoff'
+                  ? { mode: 'none' }
+                  : undefined,
+        },
+        `${phase}:start`,
+      )
     },
-    [browserPerfLog],
+    [browserPerfLog, updateUploadStatus],
   )
 
   const browserPerfEndPhase = useCallback(
@@ -694,12 +893,26 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
         durationMs,
         ...extra,
       })
+      if (durationMs !== null) {
+        updateUploadStatus(
+          {
+            timing: { phases: { [phase]: durationMs } },
+          },
+          `${phase}:end`,
+        )
+      }
     },
-    [browserPerfLog],
+    [browserPerfLog, updateUploadStatus],
   )
 
   const browserPerfUploadTaskEvent = useCallback(
     (event: UploadTaskEvent) => {
+      const uploadArtifactCounts = uploadArtifactCountsRef.current
+      if (event.phase === 'start') {
+        uploadArtifactCounts.queued += 1
+      } else if (event.phase === 'end' && event.ok !== false) {
+        uploadArtifactCounts.uploaded += 1
+      }
       browserPerfLog(`upload_task:${event.phase}`, {
         artifactKind: event.kind,
         target: event.target,
@@ -711,9 +924,33 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
         ok: event.ok ?? null,
         error: event.error ?? null,
       })
+      updateUploadStatus(
+        {
+          phase: 'upload_transport',
+          phaseLabel: event.phase === 'start' ? 'Uploading artifact' : event.ok === false ? 'Artifact upload failed' : 'Uploaded artifact',
+          tone: event.ok === false ? 'error' : 'active',
+          storage: {
+            stage: event.phase === 'end' && event.ok !== false ? 'provider' : 'upload_queue',
+            queuedArtifacts: uploadArtifactCounts.queued,
+            uploadedArtifacts: uploadArtifactCounts.uploaded,
+          },
+          transport: {
+            mode: event.kind === 'shard' ? 'striped-provider' : 'direct-provider',
+            target: event.target,
+            lastError: event.error ?? null,
+          },
+          totals: {
+            bytesDone: event.phase === 'end' && event.ok !== false ? event.bytes : undefined,
+            bytesTotal: event.fullSize ?? event.bytes,
+          },
+          error: event.error ?? null,
+        },
+        `upload_task:${event.phase}`,
+      )
     },
-    [browserPerfLog],
+    [browserPerfLog, updateUploadStatus],
   )
+
   const resetUploadPanel = useCallback(() => {
     setProcessing(false)
     setShards([])
@@ -737,6 +974,9 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
       workDone: 0,
       workTotal: 0,
     }
+    uploadStatusRef.current = null
+    uploadArtifactCountsRef.current = { queued: 0, uploaded: 0 }
+    setUploadStatus(null)
     if (fileInputRef.current) {
       fileInputRef.current.value = ''
     }
@@ -822,6 +1062,41 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
   const isUploadComplete = isMode2
     ? mode2UploadComplete
     : uploadProgress.length > 0 && uploadProgress.every(p => p.status === 'complete');
+
+  useEffect(() => {
+    if (!uploadStatusRef.current) return
+    const phase = uploadStatusPhaseFromShardPhase(shardProgress.phase)
+    const isGateway = shardProgress.phase.startsWith('gateway_')
+    updateUploadStatus(
+      {
+        phase,
+        phaseLabel: shardProgress.label || labelUploadPhase(phase),
+        tone: uploadToneForPhase(phase),
+        totals: {
+          userMdus: shardProgress.totalUserMdus || null,
+          witnessMdus: shardProgress.totalWitnessMdus || null,
+          totalMdus: shardProgress.totalMdus || null,
+          bytesDone: shardProgress.userBytesDone || null,
+          bytesTotal: shardProgress.fileBytesTotal || null,
+          workDone: shardProgress.workDone || null,
+          workTotal: shardProgress.workTotal || null,
+        },
+        storage:
+          phase === 'read_file' ||
+          phase === 'plan_upload' ||
+          phase === 'expand_user' ||
+          phase === 'expand_witness' ||
+          phase === 'mdu0_builder' ||
+          phase === 'manifest'
+            ? { stage: 'browser_memory', browserMemoryBytes: shardProgress.fileBytesTotal || null }
+            : phase === 'done'
+              ? { stage: mode2UploadComplete || isUploadComplete ? 'provider' : 'upload_queue' }
+              : undefined,
+        transport: isGateway ? { mode: 'gateway' } : undefined,
+      },
+      `phase:${shardProgress.phase}`,
+    )
+  }, [isUploadComplete, mode2UploadComplete, shardProgress, updateUploadStatus])
 
   const applyDealSetupSnapshot = useCallback((snapshot: DealSetupSnapshot) => {
     setBaseManifestRoot(snapshot.baseManifestRoot)
@@ -2956,6 +3231,22 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
         ok: true,
         bufferBytes: buffer.byteLength,
       })
+      updateUploadStatus(
+        {
+          phase: 'browser_memory',
+          phaseLabel: 'File bytes staged in browser memory',
+          tone: 'active',
+          storage: {
+            stage: 'browser_memory',
+            browserMemoryBytes: buffer.byteLength,
+          },
+          totals: {
+            bytesDone: buffer.byteLength,
+            bytesTotal: buffer.byteLength,
+          },
+        },
+        'browser_memory:ready',
+      )
       console.log(`[Debug] Buffer byteLength: ${buffer.byteLength}`)
       let bytes: Uint8Array = new Uint8Array(buffer)
       let logicalSizeBytes = file.size
@@ -3124,6 +3415,21 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
       blobsTotal: uploadPlan.blobsTotal,
       workTotal: uploadPlan.workTotal,
     })
+    updateUploadStatus(
+      {
+        phase: 'plan_upload',
+        phaseLabel: 'Slab plan ready',
+        tone: 'active',
+        totals: {
+          userMdus: uploadPlan.totalUserMdus,
+          witnessMdus: uploadPlan.witnessMduCount,
+          totalMdus: uploadPlan.totalMdus,
+          bytesTotal: totalFileBytes,
+          workTotal: uploadPlan.workTotal,
+        },
+      },
+      'plan_upload:ready',
+    )
     addLog(`DEBUG: File bytes: ${bytes.length}, RawMduCapacity: ${RawMduCapacity}, TotalUserMdus: ${totalUserChunks}`);
     console.log('[perf] sharding start', {
       file: file.name,
@@ -3369,8 +3675,9 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
                   ? Math.floor(toU8(result.shards_flat).byteLength / Math.max(1, Number(result.shard_len)))
                   : (result.shards ?? []).length,
             }
-            perfSamples.user.push(perfSample)
-            console.log('[perf] user mdu (mode2)', {
+              perfSamples.user.push(perfSample)
+              updateUploadKzgStatus(result.perf, 'kzg:user_mdu')
+              console.log('[perf] user mdu (mode2)', {
               ...perfSample,
             })
             prevCommitMsPerMdu = opMs
@@ -3544,8 +3851,9 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
                 totalMs: opMs,
                 batchBlobs,
               };
-              perfSamples.user.push(perfSample);
-              console.log('[perf] user mdu', {
+                perfSamples.user.push(perfSample);
+                updateUploadKzgStatus(result.perf, 'kzg:user_mdu')
+                console.log('[perf] user mdu', {
                 ...perfSample,
               });
               prevCommitMsPerMdu = opMs;
@@ -3710,8 +4018,9 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
               workerCommitWorkerCount,
               totalMs: opMs,
             };
-            perfSamples.witness.push(perfSample);
-            console.log('[perf] witness mdu', {
+              perfSamples.witness.push(perfSample);
+              updateUploadKzgStatus(result.perf, 'kzg:witness_mdu')
+              console.log('[perf] witness mdu', {
               ...perfSample,
             });
             prevCommitMsPerMdu = opMs;
@@ -3836,8 +4145,9 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
           workerRustCommitMsmSubphasesAvailable,
           totalMs: opMs,
         }
-        perfSamples.meta.push(metaPerfSample)
-        console.log('[perf] meta mdu0', {
+          perfSamples.meta.push(metaPerfSample)
+          updateUploadKzgStatus(mdu0PrepareResult.perf, 'kzg:mdu0')
+          console.log('[perf] meta mdu0', {
           prepareBuilderMs: Number(mdu0PrepareResult.perf?.prepareBuilderMs ?? 0),
           ...metaPerfSample,
         });
@@ -3885,9 +4195,18 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
           currentMduIndex: null,
         }));
         const manifestStart = performance.now();
-        const manifest = await workerClient.computeManifest(allRoots);
-        const manifestMs = performance.now() - manifestStart;
-        console.log('[perf] manifest aggregation', { ms: manifestMs, roots: allRoots.length / 32 });
+          const manifest = await workerClient.computeManifest(allRoots);
+          const manifestMs = performance.now() - manifestStart;
+          updateUploadStatus(
+            {
+              phase: 'manifest',
+              phaseLabel: 'Manifest root computed',
+              tone: 'active',
+              timing: { phases: { manifest: roundPerfMs(manifestMs) ?? manifestMs } },
+            },
+            'manifest:computed',
+          )
+          console.log('[perf] manifest aggregation', { ms: manifestMs, roots: allRoots.length / 32 });
         
         const finalMdus = [
           makePreparedMdu(0, mdu0Bytes),
@@ -4074,7 +4393,7 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
               __nilBrowserPerfLog?: Array<Record<string, unknown>>
               __nilBrowserPerfLast?: Record<string, unknown>
             }
-          ).__polyStorePerfBundle = {
+            ).__polyStorePerfBundle = {
             browserPerfLog:
               (
                 window as typeof window & {
@@ -4087,10 +4406,11 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
                   __nilBrowserPerfLast?: Record<string, unknown>
                 }
               ).__nilBrowserPerfLast ?? null,
-            prepareSummary,
-            prepareProfile,
+              prepareSummary,
+              prepareProfile,
+              uploadStatus: uploadStatusRef.current,
+            }
           }
-        }
         console.log('[perf] sharding totals', {
           totalMs: elapsedMs,
           fileBytes: bytes.length,
@@ -4139,7 +4459,7 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
           note: 'max* fields are closest to wall-clock critical path; sum* fields are parallel worker totals',
         });
         console.log('[perf] prepare profile', prepareProfile);
-        browserPerfEndPhase('prepare', {
+          browserPerfEndPhase('prepare', {
           ok: true,
           totalMs: roundPerfMs(elapsedMs),
           fileBytes: bytes.length,
@@ -4169,7 +4489,25 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
           slowestUserMduIndex: prepareProfile.summary.slowestUserMduIndex,
           slowestWitnessMduIndex: prepareProfile.summary.slowestWitnessMduIndex,
           manifestMs: roundPerfMs(manifestMs),
-        })
+          })
+          updateUploadStatus(
+            {
+              phase: 'done',
+              phaseLabel: 'Client-side expansion complete',
+              tone: 'success',
+              storage: { stage: 'upload_queue', queuedArtifacts: finalMdus.length + 1 },
+              totals: {
+                userMdus: totalUserChunks,
+                witnessMdus: witnessMduCount,
+                totalMdus: finalMdus.length,
+                bytesDone: bytes.length,
+                bytesTotal: bytes.length,
+                workDone: workTotal,
+                workTotal,
+              },
+            },
+            'prepare:complete',
+          )
 
         const mib = logicalSizeBytes / (1024 * 1024);
         const seconds = elapsedMs / 1000;
@@ -4186,9 +4524,19 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
     } catch (e: unknown) {
         console.error(e);
         const msg = e instanceof Error ? e.message : String(e);
-        browserPerfLog('run:error', {
-          error: msg,
-        })
+          browserPerfLog('run:error', {
+            error: msg,
+          })
+          updateUploadStatus(
+            {
+              phase: 'error',
+              phaseLabel: msg,
+              tone: 'error',
+              error: msg,
+              transport: { lastError: msg },
+            },
+            'run:error',
+          )
         addLog(`Error: ${msg}`);
         setShardProgress((p) => ({
           ...p,
@@ -4202,7 +4550,7 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
     } finally {
         setProcessing(false);
     }
-  }, [addLog, baseManifestRoot, bootstrapMode2AppendBaseFromNetwork, browserPerfEndPhase, browserPerfLog, browserPerfStartPhase, browserPerfStartRun, compressUploads, dealId, dealSetupStatus, ensureWasmReady, gatewayMode2Enabled, isConnected, localGateway.status, localGateway.url, rehydrateGatewayFromOpfs, resetUpload, stripeParams, stripeParamsLoaded]);
+  }, [addLog, baseManifestRoot, bootstrapMode2AppendBaseFromNetwork, browserPerfEndPhase, browserPerfLog, browserPerfStartPhase, browserPerfStartRun, compressUploads, dealId, dealSetupStatus, ensureWasmReady, gatewayMode2Enabled, isConnected, localGateway.status, localGateway.url, rehydrateGatewayFromOpfs, resetUpload, stripeParams, stripeParamsLoaded, updateUploadKzgStatus, updateUploadStatus]);
 
   // Helper for encoding (matches polystore_core/coding.rs encode_to_mdu)
   function encodeToMdu(rawData: Uint8Array): Uint8Array {
@@ -4311,6 +4659,69 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
         ? 'text-success'
         : 'text-muted-foreground'
 
+  const uploadStatusRows = useMemo(() => {
+    if (!uploadStatus) return []
+    const timingPhases = uploadStatus.timing.phases
+    const uploaded = uploadStatus.storage.uploadedArtifacts
+    const queued = uploadStatus.storage.queuedArtifacts
+    return [
+      { label: 'phase', value: uploadStatus.phaseLabel },
+      { label: 'kzg', value: uploadStatus.kzg.label },
+      {
+        label: 'adapter',
+        value:
+          uploadStatus.kzg.webGpuAvailable === null
+            ? 'pending'
+            : uploadStatus.kzg.webGpuAvailable
+              ? 'native WebGPU'
+              : 'not available',
+      },
+      { label: 'probe', value: uploadStatus.kzg.probeStatus || 'pending' },
+      { label: 'storage', value: uploadStatus.storage.stage.replace(/_/g, ' ') },
+      { label: 'transport', value: uploadStatus.transport.mode.replace(/-/g, ' ') },
+      {
+        label: 'elapsed',
+        value: uploadStatus.timing.elapsedMs === null ? '—' : formatDuration(uploadStatus.timing.elapsedMs),
+      },
+      {
+        label: 'prepare',
+        value: timingPhases.prepare === undefined ? '—' : formatDuration(timingPhases.prepare),
+      },
+      {
+        label: 'upload',
+        value: timingPhases.upload === undefined ? '—' : formatDuration(timingPhases.upload),
+      },
+      {
+        label: 'artifacts',
+        value:
+          queued === null && uploaded === null
+            ? '—'
+            : `${String(uploaded ?? 0)} uploaded / ${String(queued ?? 0)} queued`,
+      },
+    ]
+  }, [uploadStatus])
+
+  const uploadStatusToneClass =
+    uploadStatus?.tone === 'error'
+      ? 'border-destructive/40 bg-destructive/5 text-destructive'
+      : uploadStatus?.tone === 'success'
+        ? 'border-success/30 bg-success/10 text-success'
+        : uploadStatus?.kzg.display === 'webgpu-msm'
+          ? 'border-primary/30 bg-primary/5 text-primary'
+          : uploadStatus?.kzg.display === 'fallback' || uploadStatus?.kzg.display === 'unavailable'
+            ? 'border-amber-500/40 bg-amber-500/5 text-amber-600 dark:text-amber-300'
+            : 'border-border/70 bg-background/40 text-muted-foreground'
+
+  const copyUploadStatus = useCallback(() => {
+    if (!uploadStatus) return
+    const text = JSON.stringify(uploadStatus, null, 2)
+    if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+      void navigator.clipboard.writeText(text)
+      return
+    }
+    console.log('[polyStoreUploadStatus]', uploadStatus)
+  }, [uploadStatus])
+
   const startPreparedUpload = useCallback(
     async (trigger: 'auto' | 'manual' = 'manual') => {
       if (!currentManifestRoot) return false
@@ -4334,6 +4745,16 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
         mode: isMode2 ? 'mode2' : 'mode1',
       })
       if (ok) {
+        updateUploadStatus(
+          {
+            phase: 'chain_handoff',
+            phaseLabel: 'Provider upload complete; chain commit pending',
+            tone: 'active',
+            storage: { stage: 'provider' },
+            transport: { mode: isMode2 ? 'striped-provider' : 'direct-provider' },
+          },
+          'upload:complete',
+        )
         void mirrorSlabToGateway()
       }
       return ok
@@ -4352,6 +4773,7 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
       processing,
       uploadMdus,
       uploadMode2,
+      updateUploadStatus,
     ],
   )
 
@@ -4690,6 +5112,15 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
           ok: true,
           manifestRoot: currentManifestRoot,
         })
+        updateUploadStatus(
+          {
+            phase: 'done',
+            phaseLabel: 'Manifest root committed on-chain',
+            tone: 'success',
+            storage: { stage: 'chain' },
+          },
+          'commit:complete',
+        )
         return true
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : String(e)
@@ -4699,6 +5130,16 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
           error: msg,
         })
         addLog(`Commit failed: ${msg}`)
+        updateUploadStatus(
+          {
+            phase: 'error',
+            phaseLabel: `Commit failed: ${msg}`,
+            tone: 'error',
+            error: msg,
+            transport: { lastError: msg },
+          },
+          'commit:error',
+        )
         return false
       }
     },
@@ -4719,6 +5160,7 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
       shardProgress.totalUserMdus,
       shardProgress.totalWitnessMdus,
       uploadEngine,
+      updateUploadStatus,
     ],
   )
 
@@ -5113,11 +5555,61 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
                     ) : null}
                   </div>
                 )
-              })}
-            </div>
+                })}
+              </div>
 
-            {hasError ? (
-              <div className="nil-tab-panel border-destructive/40 bg-destructive/10 px-3 py-2 text-[11px] font-mono-data text-destructive">
+            {uploadStatus ? (
+              <div
+                className={`nil-tab-panel px-4 py-3 ${uploadStatusToneClass}`}
+                data-testid="upload-pipeline-status"
+                data-upload-kzg={uploadStatus.kzg.display}
+                data-upload-storage={uploadStatus.storage.stage}
+              >
+                <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                  <div className="min-w-0 space-y-2">
+                    <div className="flex flex-wrap items-center gap-2 text-[10px] font-bold uppercase tracking-[0.18em] font-mono-data">
+                      <Cpu className="h-3.5 w-3.5" />
+                      <span>{uploadStatus.kzg.label}</span>
+                      <span className="text-muted-foreground">/</span>
+                      <span>{uploadStatus.phaseLabel}</span>
+                    </div>
+                    {uploadStatus.kzg.fallbackReason || uploadStatus.error ? (
+                      <div className="text-[10px] font-mono-data leading-relaxed text-muted-foreground">
+                        {uploadStatus.error || uploadStatus.kzg.fallbackReason}
+                      </div>
+                    ) : null}
+                  </div>
+                  <button
+                    type="button"
+                    onClick={copyUploadStatus}
+                    className="inline-flex shrink-0 items-center justify-center gap-2 border border-border/70 px-3 py-2 text-[10px] font-bold uppercase tracking-[0.18em] font-mono-data text-foreground transition-colors hover:border-primary/60 hover:text-primary"
+                    data-testid="copy-upload-status"
+                  >
+                    <ClipboardCopy className="h-3.5 w-3.5" />
+                    Copy JSON
+                  </button>
+                </div>
+
+                <div className="mt-3 grid grid-cols-2 gap-2 text-[10px] font-mono-data sm:grid-cols-5">
+                  {uploadStatusRows.map((row) => (
+                    <div key={row.label} className="nil-tab-inset min-w-0 px-2 py-2">
+                      <div className="flex items-center gap-1 uppercase tracking-[0.18em] text-muted-foreground">
+                        {row.label === 'storage' ? (
+                          <Database className="h-3 w-3" />
+                        ) : row.label === 'transport' ? (
+                          <Network className="h-3 w-3" />
+                        ) : null}
+                        <span>{row.label}</span>
+                      </div>
+                      <div className="mt-1 truncate text-foreground">{row.value}</div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
+              {hasError ? (
+                <div className="nil-tab-panel border-destructive/40 bg-destructive/10 px-3 py-2 text-[11px] font-mono-data text-destructive">
                 {commitDisplayError ? `Commit failed: ${commitDisplayError.message}` : null}
                 {commitDisplayError && mode2UploadError ? <span className="mx-2 text-border">|</span> : null}
                 {mode2UploadError ? `Upload failed: ${mode2UploadError}` : null}

--- a/polystore-website/src/lib/uploadStatus.test.ts
+++ b/polystore-website/src/lib/uploadStatus.test.ts
@@ -36,6 +36,22 @@ test('normalizeKzgBackendStatus reports WASM fallback reason', () => {
   assert.equal(status.fallbackReason, 'WebGPU fallback adapter rejected')
 })
 
+test('normalizeKzgBackendStatus ignores zero-valued scheduler defaults', () => {
+  const status = normalizeKzgBackendStatus({
+    rustCommitBackend: 'blst',
+    kzgCommitBackend: 'wasm-blst',
+    kzgWebGpuProbeTimeoutMs: 0,
+    kzgWebGpuCommitTimeoutMs: 0,
+    kzgWebGpuMinBlobs: 0,
+    commitWorkerCount: 0,
+  })
+
+  assert.equal(status.probeTimeoutMs, null)
+  assert.equal(status.commitTimeoutMs, null)
+  assert.equal(status.minBlobs, null)
+  assert.equal(status.commitWorkerCount, null)
+})
+
 test('patchUploadPipelineStatus preserves nested state and records elapsed time', () => {
   const initial = createUploadPipelineStatus({
     dealId: '42',
@@ -65,12 +81,14 @@ test('patchUploadPipelineStatus preserves nested state and records elapsed time'
 
 test('sanitizeUploadPipelineStatus truncates user-controlled text', () => {
   const status = createUploadPipelineStatus({
-    dealId: '42',
+    dealId: 'd'.repeat(300),
     fileName: 'x'.repeat(300),
     nowMs: 0,
   })
   const sanitized = sanitizeUploadPipelineStatus({
     ...status,
+    phaseLabel: 'p'.repeat(800),
+    latestEvent: 'l'.repeat(800),
     error: 'e'.repeat(800),
     kzg: {
       ...status.kzg,
@@ -78,6 +96,9 @@ test('sanitizeUploadPipelineStatus truncates user-controlled text', () => {
     },
   })
 
+  assert.equal(sanitized.dealId.length, 160)
+  assert.equal(sanitized.phaseLabel.length, 240)
+  assert.equal(sanitized.latestEvent?.length, 160)
   assert.equal(sanitized.file.name?.length, 160)
   assert.equal(sanitized.error?.length, 500)
   assert.equal(sanitized.kzg.fallbackReason?.length, 500)

--- a/polystore-website/src/lib/uploadStatus.test.ts
+++ b/polystore-website/src/lib/uploadStatus.test.ts
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  createUploadPipelineStatus,
+  normalizeKzgBackendStatus,
+  patchUploadPipelineStatus,
+  sanitizeUploadPipelineStatus,
+} from './uploadStatus'
+
+test('normalizeKzgBackendStatus names WebGPU MSM with reduction mode', () => {
+  const status = normalizeKzgBackendStatus({
+    rustCommitBackend: 'webgpu-msm',
+    kzgCommitBackend: 'webgpu',
+    kzgWebGpuAvailable: true,
+    kzgWebGpuProbeStatus: 'passed',
+    kzgWebGpuReductionMode: 'serial',
+  })
+
+  assert.equal(status.display, 'webgpu-msm')
+  assert.equal(status.label, 'WebGPU MSM (serial)')
+  assert.equal(status.webGpuAvailable, true)
+  assert.equal(status.probeStatus, 'passed')
+})
+
+test('normalizeKzgBackendStatus reports WASM fallback reason', () => {
+  const status = normalizeKzgBackendStatus({
+    rustCommitBackend: 'blst',
+    kzgCommitBackend: 'webgpu-wasm-fallback',
+    kzgWebGpuAvailable: false,
+    kzgWebGpuFallbackReason: 'WebGPU fallback adapter rejected',
+  })
+
+  assert.equal(status.display, 'fallback')
+  assert.equal(status.label, 'WASM blst fallback')
+  assert.equal(status.fallbackReason, 'WebGPU fallback adapter rejected')
+})
+
+test('patchUploadPipelineStatus preserves nested state and records elapsed time', () => {
+  const initial = createUploadPipelineStatus({
+    dealId: '42',
+    runId: 7,
+    fileName: 'upload.bin',
+    fileBytes: 1024,
+    nowMs: 100,
+  })
+  const next = patchUploadPipelineStatus(
+    initial,
+    {
+      phase: 'plan_upload',
+      phaseLabel: 'Planning slab layout',
+      totals: { totalMdus: 3, workDone: 1 },
+      storage: { stage: 'browser_memory', browserMemoryBytes: 1024 },
+    },
+    250,
+  )
+
+  assert.equal(next.file.name, 'upload.bin')
+  assert.equal(next.totals.bytesTotal, 1024)
+  assert.equal(next.totals.totalMdus, 3)
+  assert.equal(next.totals.workDone, 1)
+  assert.equal(next.storage.stage, 'browser_memory')
+  assert.equal(next.timing.elapsedMs, 150)
+})
+
+test('sanitizeUploadPipelineStatus truncates user-controlled text', () => {
+  const status = createUploadPipelineStatus({
+    dealId: '42',
+    fileName: 'x'.repeat(300),
+    nowMs: 0,
+  })
+  const sanitized = sanitizeUploadPipelineStatus({
+    ...status,
+    error: 'e'.repeat(800),
+    kzg: {
+      ...status.kzg,
+      fallbackReason: 'f'.repeat(800),
+    },
+  })
+
+  assert.equal(sanitized.file.name?.length, 160)
+  assert.equal(sanitized.error?.length, 500)
+  assert.equal(sanitized.kzg.fallbackReason?.length, 500)
+})

--- a/polystore-website/src/lib/uploadStatus.ts
+++ b/polystore-website/src/lib/uploadStatus.ts
@@ -158,7 +158,7 @@ function firstString(...values: unknown[]): string | null {
 function firstNumber(...values: unknown[]): number | null {
   for (const value of values) {
     if (typeof value !== 'number') continue
-    if (Number.isFinite(value)) return value
+    if (Number.isFinite(value) && value > 0) return value
   }
   return null
 }
@@ -300,21 +300,25 @@ export function patchUploadPipelineStatus(
 }
 
 export function sanitizeUploadPipelineStatus(status: UploadPipelineStatus): UploadPipelineStatus {
+  const truncate = (value: string | null, maxLength: number) => (value ? value.slice(0, maxLength) : null)
   return {
     ...status,
+    dealId: status.dealId.slice(0, 160),
+    phaseLabel: status.phaseLabel.slice(0, 240),
     file: {
       ...status.file,
-      name: status.file.name ? status.file.name.slice(0, 160) : null,
+      name: truncate(status.file.name, 160),
     },
-    error: status.error ? status.error.slice(0, 500) : null,
+    latestEvent: truncate(status.latestEvent, 160),
+    error: truncate(status.error, 500),
     transport: {
       ...status.transport,
-      target: status.transport.target ? status.transport.target.slice(0, 240) : null,
-      lastError: status.transport.lastError ? status.transport.lastError.slice(0, 500) : null,
+      target: truncate(status.transport.target, 240),
+      lastError: truncate(status.transport.lastError, 500),
     },
     kzg: {
       ...status.kzg,
-      fallbackReason: status.kzg.fallbackReason ? status.kzg.fallbackReason.slice(0, 500) : null,
+      fallbackReason: truncate(status.kzg.fallbackReason, 500),
     },
   }
 }

--- a/polystore-website/src/lib/uploadStatus.ts
+++ b/polystore-website/src/lib/uploadStatus.ts
@@ -1,0 +1,320 @@
+export type UploadPipelinePhase =
+  | 'idle'
+  | 'read_file'
+  | 'gateway_ingest'
+  | 'prepare'
+  | 'append_bootstrap'
+  | 'plan_upload'
+  | 'browser_memory'
+  | 'opfs_staging'
+  | 'expand_user'
+  | 'expand_witness'
+  | 'mdu0_builder'
+  | 'manifest'
+  | 'upload_transport'
+  | 'chain_handoff'
+  | 'done'
+  | 'error'
+
+export type UploadPipelineStorageStage =
+  | 'none'
+  | 'browser_memory'
+  | 'opfs'
+  | 'upload_queue'
+  | 'provider'
+  | 'chain'
+
+export type KzgBackendDisplay = 'pending' | 'webgpu-msm' | 'wasm-blst' | 'fallback' | 'unavailable' | 'unknown'
+
+export type UploadStatusTone = 'idle' | 'active' | 'success' | 'warning' | 'error'
+
+export type KzgBackendStatus = {
+  display: KzgBackendDisplay
+  label: string
+  backend: string
+  rustBackend: string
+  webGpuAvailable: boolean | null
+  fallbackReason: string | null
+  probeStatus: string | null
+  circuitOpen: boolean | null
+  reductionMode: string | null
+  probeTimeoutMs: number | null
+  commitTimeoutMs: number | null
+  minBlobs: number | null
+  commitWorkerCount: number | null
+}
+
+export type UploadPipelineTiming = {
+  startedAtMs: number | null
+  updatedAtMs: number
+  elapsedMs: number | null
+  phases: Record<string, number>
+}
+
+export type UploadPipelineStatus = {
+  version: 1
+  runId: number | null
+  dealId: string
+  phase: UploadPipelinePhase
+  phaseLabel: string
+  tone: UploadStatusTone
+  file: {
+    name: string | null
+    bytes: number | null
+    logicalBytes: number | null
+  }
+  totals: {
+    userMdus: number | null
+    witnessMdus: number | null
+    totalMdus: number | null
+    bytesDone: number | null
+    bytesTotal: number | null
+    workDone: number | null
+    workTotal: number | null
+  }
+  storage: {
+    stage: UploadPipelineStorageStage
+    browserMemoryBytes: number | null
+    opfsBytes: number | null
+    queuedArtifacts: number | null
+    uploadedArtifacts: number | null
+  }
+  transport: {
+    mode: 'gateway' | 'direct-provider' | 'striped-provider' | 'none' | 'unknown'
+    target: string | null
+    retries: number
+    lastError: string | null
+  }
+  kzg: KzgBackendStatus
+  timing: UploadPipelineTiming
+  latestEvent: string | null
+  error: string | null
+}
+
+export type KzgDiagnosticsInput = {
+  rustCommitBackend?: string
+  workerRustCommitBackend?: string
+  kzgCommitBackend?: string
+  workerKzgCommitBackend?: string
+  kzgWebGpuAvailable?: boolean
+  workerKzgWebGpuAvailable?: boolean
+  kzgWebGpuFallbackReason?: string
+  workerKzgWebGpuFallbackReason?: string
+  kzgWebGpuProbeStatus?: string
+  workerKzgWebGpuProbeStatus?: string
+  kzgWebGpuCircuitOpen?: boolean
+  workerKzgWebGpuCircuitOpen?: boolean
+  kzgWebGpuReductionMode?: string
+  workerKzgWebGpuReductionMode?: string
+  kzgWebGpuProbeTimeoutMs?: number
+  workerKzgWebGpuProbeTimeoutMs?: number
+  kzgWebGpuCommitTimeoutMs?: number
+  workerKzgWebGpuCommitTimeoutMs?: number
+  kzgWebGpuMinBlobs?: number
+  workerKzgWebGpuMinBlobs?: number
+  commitWorkerCount?: number
+  workerCommitWorkerCount?: number
+}
+
+export type DeepPartialUploadPipelineStatus = Omit<
+  Partial<UploadPipelineStatus>,
+  'file' | 'totals' | 'storage' | 'transport' | 'kzg' | 'timing'
+> & {
+  file?: Partial<UploadPipelineStatus['file']>
+  totals?: Partial<UploadPipelineStatus['totals']>
+  storage?: Partial<UploadPipelineStatus['storage']>
+  transport?: Partial<UploadPipelineStatus['transport']>
+  kzg?: Partial<UploadPipelineStatus['kzg']>
+  timing?: Partial<UploadPipelineStatus['timing']> & {
+    phases?: Record<string, number>
+  }
+}
+
+export const PENDING_KZG_BACKEND_STATUS: KzgBackendStatus = {
+  display: 'pending',
+  label: 'KZG backend pending',
+  backend: 'pending',
+  rustBackend: 'pending',
+  webGpuAvailable: null,
+  fallbackReason: null,
+  probeStatus: null,
+  circuitOpen: null,
+  reductionMode: null,
+  probeTimeoutMs: null,
+  commitTimeoutMs: null,
+  minBlobs: null,
+  commitWorkerCount: null,
+}
+
+function firstString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value !== 'string') continue
+    const trimmed = value.trim()
+    if (trimmed) return trimmed
+  }
+  return null
+}
+
+function firstNumber(...values: unknown[]): number | null {
+  for (const value of values) {
+    if (typeof value !== 'number') continue
+    if (Number.isFinite(value)) return value
+  }
+  return null
+}
+
+function firstBoolean(...values: unknown[]): boolean | null {
+  for (const value of values) {
+    if (typeof value === 'boolean') return value
+  }
+  return null
+}
+
+export function normalizeKzgBackendStatus(input?: KzgDiagnosticsInput | null): KzgBackendStatus {
+  if (!input) return { ...PENDING_KZG_BACKEND_STATUS }
+
+  const backend = firstString(input.kzgCommitBackend, input.workerKzgCommitBackend) ?? 'unknown'
+  const rustBackend = firstString(input.rustCommitBackend, input.workerRustCommitBackend) ?? 'unknown'
+  const fallbackReason = firstString(input.kzgWebGpuFallbackReason, input.workerKzgWebGpuFallbackReason)
+  const probeStatus = firstString(input.kzgWebGpuProbeStatus, input.workerKzgWebGpuProbeStatus)
+  const circuitOpen = firstBoolean(input.kzgWebGpuCircuitOpen, input.workerKzgWebGpuCircuitOpen)
+  const webGpuAvailable = firstBoolean(input.kzgWebGpuAvailable, input.workerKzgWebGpuAvailable)
+  const reductionMode = firstString(input.kzgWebGpuReductionMode, input.workerKzgWebGpuReductionMode)
+
+  let display: KzgBackendDisplay = 'unknown'
+  let label = 'KZG backend unknown'
+  if (backend === 'webgpu' || rustBackend === 'webgpu-msm') {
+    display = 'webgpu-msm'
+    label = reductionMode ? `WebGPU MSM (${reductionMode})` : 'WebGPU MSM'
+  } else if (backend === 'wasm-blst' || backend === 'webgpu-wasm-fallback' || rustBackend === 'blst') {
+    display = fallbackReason ? 'fallback' : 'wasm-blst'
+    label = fallbackReason ? 'WASM blst fallback' : 'WASM blst'
+  } else if (webGpuAvailable === false || fallbackReason) {
+    display = webGpuAvailable === false ? 'unavailable' : 'fallback'
+    label = webGpuAvailable === false ? 'WebGPU unavailable' : 'WebGPU fallback'
+  }
+
+  return {
+    display,
+    label,
+    backend,
+    rustBackend,
+    webGpuAvailable,
+    fallbackReason,
+    probeStatus,
+    circuitOpen,
+    reductionMode,
+    probeTimeoutMs: firstNumber(input.kzgWebGpuProbeTimeoutMs, input.workerKzgWebGpuProbeTimeoutMs),
+    commitTimeoutMs: firstNumber(input.kzgWebGpuCommitTimeoutMs, input.workerKzgWebGpuCommitTimeoutMs),
+    minBlobs: firstNumber(input.kzgWebGpuMinBlobs, input.workerKzgWebGpuMinBlobs),
+    commitWorkerCount: firstNumber(input.commitWorkerCount, input.workerCommitWorkerCount),
+  }
+}
+
+export function createUploadPipelineStatus(input: {
+  dealId: string
+  runId?: number | null
+  fileName?: string | null
+  fileBytes?: number | null
+  nowMs?: number
+}): UploadPipelineStatus {
+  const now = input.nowMs ?? 0
+  return {
+    version: 1,
+    runId: input.runId ?? null,
+    dealId: input.dealId,
+    phase: 'idle',
+    phaseLabel: 'Idle',
+    tone: 'idle',
+    file: {
+      name: input.fileName ?? null,
+      bytes: input.fileBytes ?? null,
+      logicalBytes: input.fileBytes ?? null,
+    },
+    totals: {
+      userMdus: null,
+      witnessMdus: null,
+      totalMdus: null,
+      bytesDone: null,
+      bytesTotal: input.fileBytes ?? null,
+      workDone: null,
+      workTotal: null,
+    },
+    storage: {
+      stage: 'none',
+      browserMemoryBytes: null,
+      opfsBytes: null,
+      queuedArtifacts: null,
+      uploadedArtifacts: null,
+    },
+    transport: {
+      mode: 'none',
+      target: null,
+      retries: 0,
+      lastError: null,
+    },
+    kzg: { ...PENDING_KZG_BACKEND_STATUS },
+    timing: {
+      startedAtMs: now,
+      updatedAtMs: now,
+      elapsedMs: null,
+      phases: {},
+    },
+    latestEvent: null,
+    error: null,
+  }
+}
+
+export function patchUploadPipelineStatus(
+  current: UploadPipelineStatus | null,
+  patch: DeepPartialUploadPipelineStatus,
+  nowMs: number,
+): UploadPipelineStatus {
+  const base =
+    current ??
+    createUploadPipelineStatus({
+      dealId: typeof patch.dealId === 'string' ? patch.dealId : '',
+      nowMs,
+    })
+  const startedAtMs = patch.timing?.startedAtMs ?? base.timing.startedAtMs
+  return {
+    ...base,
+    ...patch,
+    file: { ...base.file, ...(patch.file ?? {}) },
+    totals: { ...base.totals, ...(patch.totals ?? {}) },
+    storage: { ...base.storage, ...(patch.storage ?? {}) },
+    transport: { ...base.transport, ...(patch.transport ?? {}) },
+    kzg: { ...base.kzg, ...(patch.kzg ?? {}) },
+    timing: {
+      ...base.timing,
+      ...(patch.timing ?? {}),
+      startedAtMs,
+      updatedAtMs: nowMs,
+      elapsedMs: startedAtMs === null ? null : nowMs - startedAtMs,
+      phases: {
+        ...base.timing.phases,
+        ...(patch.timing?.phases ?? {}),
+      },
+    },
+  }
+}
+
+export function sanitizeUploadPipelineStatus(status: UploadPipelineStatus): UploadPipelineStatus {
+  return {
+    ...status,
+    file: {
+      ...status.file,
+      name: status.file.name ? status.file.name.slice(0, 160) : null,
+    },
+    error: status.error ? status.error.slice(0, 500) : null,
+    transport: {
+      ...status.transport,
+      target: status.transport.target ? status.transport.target.slice(0, 240) : null,
+      lastError: status.transport.lastError ? status.transport.lastError.slice(0, 500) : null,
+    },
+    kzg: {
+      ...status.kzg,
+      fallbackReason: status.kzg.fallbackReason ? status.kzg.fallbackReason.slice(0, 500) : null,
+    },
+  }
+}


### PR DESCRIPTION
## Summary

Closes #186.
Follows #179 and #183; #183 is now merged, so this PR targets `main` directly.

This adds a browser upload observability surface so an upload no longer has to wait for `window.__polyStorePerfBundle.prepareProfile` before exposing useful status. During upload, the app now publishes:

- `window.__polyStoreUploadStatus`
- `window.__polyStoreKzgStatus`
- `window.__polyStorePerfBundle.uploadStatus`

The upload UI also shows a compact KZG/status panel with phase, backend, adapter/probe state, storage/transport stage, elapsed timing, prepare/upload timing, and artifact upload counters. The panel includes copyable sanitized JSON for support/debugging.

## Upload Lifecycle Coverage

Covered stages:

- file read and browser-memory staging
- gateway ingest vs browser/direct processing
- append bootstrap and slab/MDU planning
- user MDU expansion and KZG status updates
- witness MDU commitment status
- MDU0 commitment status
- manifest generation timing
- local/OPFS staging and upload queue state
- provider upload transport and artifact counters
- chain handoff/commit completion or error

The new shared `UploadPipelineStatus` and `KzgBackendStatus` helpers normalize WebGPU MSM, WASM blst, fallback, unavailable, probe, circuit, timeout, reduction-mode, and worker-count fields. Sanitization truncates user-controlled text and avoids including private file contents or shard bytes.

## Notes On The prepareProfile Null Case

`window.__polyStorePerfBundle` can exist while `prepareProfile` is still `null` because generic browser perf logging initializes the bundle before the prepare/sharding path has completed. This PR makes the live status explicit instead of requiring callers to infer readiness from `prepareProfile`.

## Tests

Run locally from `polystore-website` on the rebased head:

```sh
npx tsx --test src/lib/uploadStatus.test.ts src/lib/webgpuKzgMsm.test.ts src/lib/kzgCommitBackend.test.ts
npm run lint
npm run build
```

Results:

- focused status/WebGPU/KZG tests: 27 passed
- lint: passed
- production build: passed

Build warnings observed are existing Vite/browser-data/zstd externalization/Rollup annotation/large chunk warnings; no build failure.

## Performance / Risk

No KZG algorithm, commitment bytes, manifest format, MDU layout, or deal protocol changes. The new work is phase-bound UI/status publication and normalized status copying. It should not affect the measured KZG hot path except for small React/window status updates around existing phase/progress events.

Native browser upload smoke on real WebGPU hardware was not run in this agent environment. CI and reviewer feedback should be used as the latest-head merge gate.
