### PR TITLE
fix(chain): clear restored provider bond health

### DIFF
--- a/polystore_gateway/proof_helper.go
+++ b/polystore_gateway/proof_helper.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -244,19 +243,9 @@ func generateProofHeaderJSON(ctx context.Context, dealID uint64, epoch uint64, m
 		return nil, "", fmt.Errorf("leaf_count must be > 0")
 	}
 	commitmentSpan := leafCount * commitmentBytes
-	startOffset := userOrdinal * commitmentSpan
-
-	witnessReader, err := newPolyfsDecodedReader(dealDir, 1, startOffset, commitmentSpan, startOffset, commitmentSpan)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to open witness reader: %w", err)
-	}
-	witnessRaw, err := io.ReadAll(witnessReader)
-	_ = witnessReader.Close()
+	witnessRaw, err := readWitnessCommitmentsForUserMdu(dealDir, userOrdinal, commitmentSpan)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to read witness commitments: %w", err)
-	}
-	if uint64(len(witnessRaw)) != commitmentSpan {
-		return nil, "", fmt.Errorf("invalid witness commitments length: got %d want %d", len(witnessRaw), commitmentSpan)
 	}
 
 	if uint64(leafIndex) >= leafCount {

--- a/polystore_gateway/system_liveness.go
+++ b/polystore_gateway/system_liveness.go
@@ -978,19 +978,10 @@ func generateSystemChainedProof(ctx context.Context, epochSeed [32]byte, dealID 
 
 	const commitmentBytes = 48
 	commitmentSpan := leafCount * commitmentBytes
-	startOffset := userOrdinal * commitmentSpan
 
-	witnessReader, err := newPolyfsDecodedReader(dealDir, 1, startOffset, commitmentSpan, startOffset, commitmentSpan)
+	witnessRaw, err := readWitnessCommitmentsForUserMdu(dealDir, userOrdinal, commitmentSpan)
 	if err != nil {
 		return nil, err
-	}
-	witnessRaw, err := io.ReadAll(witnessReader)
-	_ = witnessReader.Close()
-	if err != nil {
-		return nil, err
-	}
-	if uint64(len(witnessRaw)) != commitmentSpan {
-		return nil, fmt.Errorf("invalid witness commitments length: got %d want %d", len(witnessRaw), commitmentSpan)
 	}
 
 	commitmentOffset := int(blobIndex) * commitmentBytes

--- a/polystore_gateway/system_liveness_mode2_test.go
+++ b/polystore_gateway/system_liveness_mode2_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"polystorechain/x/crypto_ffi"
@@ -77,6 +79,195 @@ func TestSystemLivenessGeneratesProofFromMode2SlotShard(t *testing.T) {
 	}
 	if !ok {
 		t.Fatalf("generated system liveness proof did not verify")
+	}
+}
+
+func TestSystemLivenessGeneratesProofForEveryMode2Slot(t *testing.T) {
+	useTempUploadDir(t)
+	if err := crypto_ffi.Init(trustedSetup); err != nil {
+		t.Fatalf("crypto_ffi.Init failed: %v", err)
+	}
+
+	payloadPath := filepath.Join(t.TempDir(), "payload.bin")
+	payload := bytes.Repeat([]byte("mode2 slot-major proof fixture"), 16<<10)
+	if err := os.WriteFile(payloadPath, payload, 0o644); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+
+	const dealID = uint64(1)
+	const serviceHint = "General:rs=2+1"
+	result, _, err := mode2BuildArtifacts(context.Background(), payloadPath, dealID, serviceHint, "payload.bin", 0)
+	if err != nil {
+		t.Fatalf("mode2BuildArtifacts failed: %v", err)
+	}
+
+	stripe, err := stripeParamsFromHint(serviceHint)
+	if err != nil {
+		t.Fatalf("stripeParamsFromHint failed: %v", err)
+	}
+	mduIndex := uint64(1) + result.witnessMdus
+	dealDir := dealScopedDir(dealID, result.manifestRoot)
+	manifestPath := filepath.Join(dealDir, "manifest.bin")
+
+	var seed [32]byte
+	for slot := uint64(0); slot < stripe.slotCount; slot++ {
+		blobIndex := uint32(slot * stripe.rows)
+		proof, err := generateSystemChainedProof(context.Background(), seed, dealID, dealDir, manifestPath, stripe, mduIndex, blobIndex)
+		if err != nil {
+			t.Fatalf("generateSystemChainedProof slot %d failed: %v", slot, err)
+		}
+
+		flatMerklePath := make([]byte, 0, len(proof.MerklePath)*32)
+		for _, node := range proof.MerklePath {
+			flatMerklePath = append(flatMerklePath, node...)
+		}
+		ok, err := crypto_ffi.VerifyChainedProof(
+			result.manifestRoot.Bytes[:],
+			proof.MduIndex,
+			proof.ManifestOpening,
+			proof.MduRootFr,
+			proof.BlobCommitment,
+			uint64(proof.BlobIndex),
+			stripe.leafCount,
+			flatMerklePath,
+			proof.ZValue,
+			proof.YValue,
+			proof.KzgOpeningProof,
+		)
+		if err != nil {
+			t.Fatalf("VerifyChainedProof slot %d failed: %v", slot, err)
+		}
+		if !ok {
+			t.Fatalf("generated system liveness proof did not verify for slot %d", slot)
+		}
+	}
+}
+
+func TestSystemLivenessGeneratesProofAfterMode2Append(t *testing.T) {
+	useTempUploadDir(t)
+	if err := crypto_ffi.Init(trustedSetup); err != nil {
+		t.Fatalf("crypto_ffi.Init failed: %v", err)
+	}
+
+	dir := t.TempDir()
+	firstPath := filepath.Join(dir, "first.bin")
+	secondPath := filepath.Join(dir, "second.bin")
+	if err := os.WriteFile(firstPath, bytes.Repeat([]byte("first append proof fixture"), 16<<10), 0o644); err != nil {
+		t.Fatalf("write first payload: %v", err)
+	}
+	if err := os.WriteFile(secondPath, bytes.Repeat([]byte("second append proof fixture"), 16<<10), 0o644); err != nil {
+		t.Fatalf("write second payload: %v", err)
+	}
+
+	const dealID = uint64(1)
+	const serviceHint = "General:rs=2+1"
+	initial, _, err := mode2BuildArtifacts(context.Background(), firstPath, dealID, serviceHint, "first.bin", 0)
+	if err != nil {
+		t.Fatalf("mode2BuildArtifacts failed: %v", err)
+	}
+	appended, finalDir, err := mode2BuildArtifactsAppend(context.Background(), secondPath, dealID, serviceHint, initial.manifestRoot.Canonical, "second.bin", 0)
+	if err != nil {
+		t.Fatalf("mode2BuildArtifactsAppend failed: %v", err)
+	}
+
+	stripe, err := stripeParamsFromHint(serviceHint)
+	if err != nil {
+		t.Fatalf("stripeParamsFromHint failed: %v", err)
+	}
+	manifestPath := filepath.Join(finalDir, "manifest.bin")
+
+	var seed [32]byte
+	for userOrdinal := uint64(0); userOrdinal < appended.userMdus; userOrdinal++ {
+		mduIndex := uint64(1) + appended.witnessMdus + userOrdinal
+		for slot := uint64(0); slot < stripe.slotCount; slot++ {
+			blobIndex := uint32(slot * stripe.rows)
+			proof, err := generateSystemChainedProof(context.Background(), seed, dealID, finalDir, manifestPath, stripe, mduIndex, blobIndex)
+			if err != nil {
+				t.Fatalf("generateSystemChainedProof user_mdu=%d slot=%d failed: %v", userOrdinal, slot, err)
+			}
+
+			flatMerklePath := make([]byte, 0, len(proof.MerklePath)*32)
+			for _, node := range proof.MerklePath {
+				flatMerklePath = append(flatMerklePath, node...)
+			}
+			ok, err := crypto_ffi.VerifyChainedProof(
+				appended.manifestRoot.Bytes[:],
+				proof.MduIndex,
+				proof.ManifestOpening,
+				proof.MduRootFr,
+				proof.BlobCommitment,
+				uint64(proof.BlobIndex),
+				stripe.leafCount,
+				flatMerklePath,
+				proof.ZValue,
+				proof.YValue,
+				proof.KzgOpeningProof,
+			)
+			if err != nil {
+				t.Fatalf("VerifyChainedProof user_mdu=%d slot=%d failed: %v", userOrdinal, slot, err)
+			}
+			if !ok {
+				t.Fatalf("generated appended system liveness proof did not verify for user_mdu=%d slot=%d", userOrdinal, slot)
+			}
+		}
+	}
+}
+
+func TestSystemLivenessLiveArtifactProofs(t *testing.T) {
+	dealDir := os.Getenv("POLYSTORE_TEST_LIVE_DEAL_DIR")
+	if dealDir == "" {
+		t.Skip("set POLYSTORE_TEST_LIVE_DEAL_DIR to verify a live provider artifact directory")
+	}
+	if err := crypto_ffi.Init(trustedSetup); err != nil {
+		t.Fatalf("crypto_ffi.Init failed: %v", err)
+	}
+
+	manifestRoot, err := parseManifestRoot("0x" + filepath.Base(dealDir))
+	if err != nil {
+		t.Fatalf("parse manifest root from deal dir: %v", err)
+	}
+	stripe, err := stripeParamsFromHint(envDefault("POLYSTORE_TEST_LIVE_SERVICE_HINT", "General:rs=2+1"))
+	if err != nil {
+		t.Fatalf("stripeParamsFromHint failed: %v", err)
+	}
+	dealID := uint64(0)
+	manifestPath := filepath.Join(dealDir, "manifest.bin")
+
+	var seed [32]byte
+	for slot := uint64(0); slot < stripe.slotCount; slot++ {
+		shardPath := filepath.Join(dealDir, "mdu_2_slot_"+strconv.FormatUint(slot, 10)+".bin")
+		if _, err := os.Stat(shardPath); err != nil {
+			continue
+		}
+		blobIndex := uint32(slot * stripe.rows)
+		proof, err := generateSystemChainedProof(context.Background(), seed, dealID, dealDir, manifestPath, stripe, 2, blobIndex)
+		if err != nil {
+			t.Fatalf("generateSystemChainedProof slot %d failed: %v", slot, err)
+		}
+
+		flatMerklePath := make([]byte, 0, len(proof.MerklePath)*32)
+		for _, node := range proof.MerklePath {
+			flatMerklePath = append(flatMerklePath, node...)
+		}
+		ok, err := crypto_ffi.VerifyChainedProof(
+			manifestRoot.Bytes[:],
+			proof.MduIndex,
+			proof.ManifestOpening,
+			proof.MduRootFr,
+			proof.BlobCommitment,
+			uint64(proof.BlobIndex),
+			stripe.leafCount,
+			flatMerklePath,
+			proof.ZValue,
+			proof.YValue,
+			proof.KzgOpeningProof,
+		)
+		if err != nil {
+			t.Fatalf("VerifyChainedProof slot %d failed: %v", slot, err)
+		}
+		if !ok {
+			t.Fatalf("generated system liveness proof did not verify for slot %d", slot)
+		}
 	}
 }
 

--- a/polystore_gateway/witness_commitments.go
+++ b/polystore_gateway/witness_commitments.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"io"
+)
+
+func readWitnessCommitmentsForUserMdu(dealDir string, userOrdinal uint64, commitmentSpan uint64) ([]byte, error) {
+	if commitmentSpan == 0 {
+		return nil, fmt.Errorf("commitment span must be > 0")
+	}
+	startOffset := userOrdinal * commitmentSpan
+	totalWitnessLen := commitmentSpan
+	if meta, err := readSlabMetadataFile(dealDir); err == nil && meta.UserMdus > 0 {
+		if userOrdinal >= meta.UserMdus {
+			return nil, fmt.Errorf("user mdu ordinal %d out of range (user_mdus=%d)", userOrdinal, meta.UserMdus)
+		}
+		totalWitnessLen = meta.UserMdus * commitmentSpan
+	}
+
+	reader, err := newPolyfsDecodedReader(dealDir, 1, 0, totalWitnessLen, startOffset, commitmentSpan)
+	if err != nil {
+		return nil, err
+	}
+	witnessRaw, err := io.ReadAll(reader)
+	_ = reader.Close()
+	if err != nil {
+		return nil, err
+	}
+	if uint64(len(witnessRaw)) != commitmentSpan {
+		return nil, fmt.Errorf("invalid witness commitments length: got %d want %d", len(witnessRaw), commitmentSpan)
+	}
+	return witnessRaw, nil
+}

--- a/polystorechain/x/polystorechain/keeper/msg_provider_bond.go
+++ b/polystorechain/x/polystorechain/keeper/msg_provider_bond.go
@@ -110,6 +110,9 @@ func (k msgServer) AddProviderBond(goCtx context.Context, msg *types.MsgAddProvi
 	if err := k.Providers.Set(ctx, providerAddr, provider); err != nil {
 		return nil, fmt.Errorf("failed to update provider bond: %w", err)
 	}
+	if err := k.clearResolvedProviderUnderbondedHealth(ctx, provider); err != nil {
+		return nil, fmt.Errorf("failed to clear resolved provider underbonded health: %w", err)
+	}
 
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(

--- a/polystorechain/x/polystorechain/keeper/provider_bond.go
+++ b/polystorechain/x/polystorechain/keeper/provider_bond.go
@@ -1,9 +1,11 @@
 package keeper
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
+	"cosmossdk.io/collections"
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -240,4 +242,37 @@ func overlayProviderBondHealth(health types.ProviderHealthState, provider types.
 	health.UpdatedHeight = height
 	health.ConsequenceCeiling = reason
 	return health
+}
+
+func (k Keeper) clearResolvedProviderUnderbondedHealth(ctx sdk.Context, provider types.Provider) error {
+	providerAddr := strings.TrimSpace(provider.Address)
+	if providerAddr == "" {
+		return nil
+	}
+	health, err := k.ProviderHealthStates.Get(ctx, providerAddr)
+	if err != nil {
+		if errors.Is(err, collections.ErrNotFound) {
+			return nil
+		}
+		return err
+	}
+	if health.Reason != providerUnderbondedReason ||
+		health.LifecycleStatus != types.ProviderLifecycleStatus_PROVIDER_LIFECYCLE_STATUS_DELINQUENT {
+		return nil
+	}
+	reason, err := k.providerAssignmentCollateralIneligibility(ctx, provider, 0)
+	if err != nil {
+		return err
+	}
+	if reason != "" {
+		return nil
+	}
+
+	health.LifecycleStatus = types.ProviderLifecycleStatus_PROVIDER_LIFECYCLE_STATUS_ACTIVE
+	health.Reason = "provider_bond_restored"
+	health.EvidenceClass = types.EvidenceClass_EVIDENCE_CLASS_OPERATIONAL
+	health.Severity = types.EvidenceSeverity_EVIDENCE_SEVERITY_INFO
+	health.UpdatedHeight = ctx.BlockHeight()
+	health.ConsequenceCeiling = "provider bond now satisfies collateral requirements"
+	return k.ProviderHealthStates.Set(ctx, providerAddr, health)
 }

--- a/polystorechain/x/polystorechain/keeper/provider_bond_test.go
+++ b/polystorechain/x/polystorechain/keeper/provider_bond_test.go
@@ -344,6 +344,69 @@ func TestAddProviderBondRestoresAssignmentCollateralHeadroom(t *testing.T) {
 	require.True(t, after.Collateral.EligibleForNewAssignment)
 }
 
+func TestAddProviderBondClearsResolvedUnderbondedHealth(t *testing.T) {
+	bank := newTrackingBankKeeper()
+	f := initFixtureWithBankKeeper(t, bank)
+	msgServer := keeper.NewMsgServerImpl(f.keeper)
+	queryServer := keeper.NewQueryServerImpl(f.keeper)
+	ctx := sdk.UnwrapSDKContext(f.ctx).WithBlockHeight(10)
+
+	params := types.DefaultParams()
+	params.MinProviderBond = sdk.NewInt64Coin(sdk.DefaultBondDenom, 150)
+	params.AssignmentCollateralPerSlot = sdk.NewInt64Coin(sdk.DefaultBondDenom, 5)
+	require.NoError(t, f.keeper.Params.Set(ctx, params))
+
+	provider := makePolicyTestAddr(t, f, 0xA1)
+	providerAddr, err := sdk.AccAddressFromBech32(provider)
+	require.NoError(t, err)
+	bank.setAccountBalance(providerAddr, sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 250)))
+
+	_, err = msgServer.RegisterProvider(ctx, &types.MsgRegisterProvider{
+		Creator:      provider,
+		Capabilities: "General",
+		TotalStorage: 1_000_000_000,
+		Endpoints:    testProviderEndpoints,
+		Bond:         sdk.NewInt64Coin(sdk.DefaultBondDenom, 150),
+	})
+	require.NoError(t, err)
+
+	record, err := f.keeper.Providers.Get(ctx, provider)
+	require.NoError(t, err)
+	record.Bond = sdk.NewInt64Coin(sdk.DefaultBondDenom, 100)
+	require.NoError(t, f.keeper.Providers.Set(ctx, provider, record))
+	require.NoError(t, f.keeper.ProviderHealthStates.Set(ctx, provider, types.ProviderHealthState{
+		Provider:           provider,
+		LifecycleStatus:    types.ProviderLifecycleStatus_PROVIDER_LIFECYCLE_STATUS_DELINQUENT,
+		Reason:             "provider_underbonded",
+		EvidenceClass:      types.EvidenceClass_EVIDENCE_CLASS_OPERATIONAL,
+		Severity:           types.EvidenceSeverity_EVIDENCE_SEVERITY_DELINQUENT,
+		UpdatedHeight:      9,
+		ConsequenceCeiling: "provider bond 100stake is below minimum 150stake",
+	}))
+
+	before, err := queryServer.GetProviderCollateral(ctx, &types.QueryGetProviderCollateralRequest{Address: provider})
+	require.NoError(t, err)
+	require.False(t, before.Collateral.EligibleForNewAssignment)
+	require.Contains(t, before.Collateral.IneligibilityReason, "below required collateral")
+
+	_, err = msgServer.AddProviderBond(ctx, &types.MsgAddProviderBond{
+		Creator:  provider,
+		Provider: provider,
+		Bond:     sdk.NewInt64Coin(sdk.DefaultBondDenom, 75),
+	})
+	require.NoError(t, err)
+
+	health, err := queryServer.GetProviderHealth(ctx, &types.QueryGetProviderHealthRequest{Address: provider})
+	require.NoError(t, err)
+	require.Equal(t, types.ProviderLifecycleStatus_PROVIDER_LIFECYCLE_STATUS_ACTIVE, health.Health.LifecycleStatus)
+	require.Equal(t, "provider_bond_restored", health.Health.Reason)
+
+	after, err := queryServer.GetProviderCollateral(ctx, &types.QueryGetProviderCollateralRequest{Address: provider})
+	require.NoError(t, err)
+	require.True(t, after.Collateral.EligibleForNewAssignment)
+	require.Empty(t, after.Collateral.IneligibilityReason)
+}
+
 func TestWithdrawProviderBondRetainsLockAwareAssignmentCollateral(t *testing.T) {
 	bank := newTrackingBankKeeper()
 	f := initFixtureWithBankKeeper(t, bank)


### PR DESCRIPTION
## Summary
- Clear stale provider-underbonded health when a restored bond satisfies collateral requirements.
- Fix gateway proof generation for appended Mode 2 witness metadata by decoding witness commitments as one continuous PolyFS payload.
- Add regression coverage for Mode 2 2+1 all-slot system proofs and appended-deal system proofs.

## Local validation
- cd polystorechain && LD_LIBRARY_PATH=/opt/polystore/polystore_core/target/release go test ./x/polystorechain/keeper -run 'TestAddProviderBond(RestoresAssignmentCollateralHeadroom|ClearsResolvedUnderbondedHealth)$'
- cd polystorechain && LD_LIBRARY_PATH=/opt/polystore/polystore_core/target/release go test ./x/polystorechain/keeper
- cd polystore_gateway && LD_LIBRARY_PATH=/opt/polystore/polystore_core/target/release go test . -run 'TestSystemLivenessGeneratesProof(ForEveryMode2Slot|AfterMode2Append|FromMode2SlotShard)$' -count=1 -v
- cd polystore_gateway && LD_LIBRARY_PATH=/opt/polystore/polystore_core/target/release go test . -run 'TestSystemLiveness|TestBuildRetrievalProof|TestRetrieval|TestMode2' -count=1
- Live artifact verification passed for current provider1/provider2/provider3 appended deal artifacts with POLYSTORE_TEST_LIVE_DEAL_DIR.

## Devnet note
- No chain reset after the later user instruction.
- System-liveness has been disabled on local provider daemons while the fix is deployed, to avoid re-jailing from pre-fix proof generation.
- SP1/SP2 bonds were topped back up; they remain temporarily jailed until the configured jail window expires on-chain.