### PR TITLE
Route user MDU KZG through browser WebGPU backend

### DIFF
--- a/polystore-website/src/components/FileSharder.tsx
+++ b/polystore-website/src/components/FileSharder.tsx
@@ -3585,6 +3585,7 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
             const wasmMs = performance.now() - wasmStart
             const workerTotalMs = Number(result.perf?.totalMs ?? 0)
             const workerExpandMs = Number(result.perf?.expandMs ?? 0)
+            const workerCommitMs = Number(result.perf?.commitMs ?? result.perf?.rustCommitMs ?? 0)
             const workerRootMs = Number(result.perf?.rootMs ?? 0)
             const workerQueueMs = Math.max(0, wasmMs - workerTotalMs)
             const workerRustEncodeMs = Number(result.perf?.rustEncodeMs ?? 0)
@@ -3657,7 +3658,7 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
               workerTotalMs,
               workerQueueMs,
               workerExpandMs,
-              workerCommitMs: 0,
+              workerCommitMs,
               workerRootMs,
               workerRustEncodeMs,
               workerRustRsMs,

--- a/polystore-website/src/lib/upload/userMduBrowserKzg.test.ts
+++ b/polystore-website/src/lib/upload/userMduBrowserKzg.test.ts
@@ -1,0 +1,369 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs/promises'
+import test from 'node:test'
+
+import init, { PolyStoreWasm } from '../../../public/wasm/polystore_core.js'
+import { createWasmBlstKzgCommitBackend, KZG_BLOB_SIZE, type KzgCommitBackend, type KzgCommitBackendStatus } from '../kzgCommitBackend'
+import {
+  expandUserMduRsWithBrowserKzg,
+  toUserMduUint8Array,
+  type UserMduBrowserKzgWasm,
+} from './userMduBrowserKzg'
+
+function bytes(length: number, seed = 1): Uint8Array {
+  const out = new Uint8Array(length)
+  for (let i = 0; i < out.length; i += 1) out[i] = (seed + i * 17) & 0xff
+  return out
+}
+
+function rootFromWitness(witness: Uint8Array): Uint8Array {
+  const root = new Uint8Array(32)
+  root[0] = witness.byteLength & 0xff
+  root[1] = witness[0] ?? 0
+  root[2] = witness[witness.length - 1] ?? 0
+  return root
+}
+
+function makeCommitments(blobs: number, seed = 11): Uint8Array {
+  const out = new Uint8Array(blobs * 48)
+  for (let i = 0; i < out.length; i += 1) out[i] = (seed + i * 13) & 0xff
+  return out
+}
+
+function makeCommittedResult(shardsFlat: Uint8Array, shardLen: number, witnessFlat = makeCommitments(shardsFlat.byteLength / KZG_BLOB_SIZE)) {
+  return {
+    shards_flat: shardsFlat,
+    shard_len: shardLen,
+    witness_flat: witnessFlat,
+    mdu_root: rootFromWitness(witnessFlat),
+    perf: {
+      encode_ms: 3,
+      rs_ms: 4,
+      commit_decode_ms: 5,
+      commit_transform_ms: 6,
+      commit_msm_scalar_prep_ms: 7,
+      commit_msm_bucket_fill_ms: 8,
+      commit_msm_reduce_ms: 9,
+      commit_msm_double_ms: 10,
+      commit_msm_ms: 11,
+      commit_compress_ms: 12,
+      commit_ms: 13,
+      total_ms: 20,
+      rows: 1,
+      shards_total: shardsFlat.byteLength / shardLen,
+      shard_len: shardLen,
+    },
+  }
+}
+
+function makeWasm(options?: { committedWitness?: Uint8Array; committedRoot?: Uint8Array }) {
+  const calls = {
+    mduUncommitted: 0,
+    payloadUncommitted: 0,
+    mduCommitted: 0,
+    payloadCommitted: 0,
+    computeRoot: 0,
+  }
+  const shardLen = KZG_BLOB_SIZE
+  const mduShards = bytes(KZG_BLOB_SIZE * 2, 31)
+  const payloadShards = bytes(KZG_BLOB_SIZE * 3, 47)
+  const wasm: UserMduBrowserKzgWasm = {
+    expand_mdu_rs_flat_uncommitted: () => {
+      calls.mduUncommitted += 1
+      return { shards_flat: mduShards, shard_len: shardLen, perf: { encode_ms: 1, rs_ms: 2, total_ms: 3, rows: 1, shards_total: 2, shard_len: shardLen } }
+    },
+    expand_payload_rs_flat_uncommitted: () => {
+      calls.payloadUncommitted += 1
+      return { shards_flat: payloadShards, shard_len: shardLen, perf: { encode_ms: 2, rs_ms: 3, total_ms: 5, rows: 1, shards_total: 3, shard_len: shardLen } }
+    },
+    expand_mdu_rs_flat_committed: () => {
+      calls.mduCommitted += 1
+      return makeCommittedResult(mduShards, shardLen, options?.committedWitness)
+    },
+    expand_payload_rs_flat_committed: () => {
+      calls.payloadCommitted += 1
+      return makeCommittedResult(payloadShards, shardLen, options?.committedWitness)
+    },
+    expand_mdu_rs_flat_committed_profiled: () => {
+      calls.mduCommitted += 1
+      return makeCommittedResult(mduShards, shardLen, options?.committedWitness)
+    },
+    expand_payload_rs_flat_committed_profiled: () => {
+      calls.payloadCommitted += 1
+      return makeCommittedResult(payloadShards, shardLen, options?.committedWitness)
+    },
+    compute_mdu_root: (witnessFlat: Uint8Array) => {
+      calls.computeRoot += 1
+      return options?.committedRoot ?? rootFromWitness(witnessFlat)
+    },
+  }
+  return { wasm, calls, mduShards, payloadShards, shardLen }
+}
+
+function makeBackend(options?: { selectedBackend?: 'webgpu' | 'wasm-blst'; throwCommit?: boolean; witnessSeed?: number; malformedWitness?: boolean }) {
+  const calls = { commitProfiled: 0 }
+  const backend: KzgCommitBackend = {
+    kind: options?.selectedBackend === 'webgpu' ? 'webgpu-scheduler' : 'wasm-blst',
+    getStatus(): KzgCommitBackendStatus {
+      return {
+        kind: this.kind,
+        initialized: true,
+        label: options?.selectedBackend === 'webgpu' ? 'WebGPU KZG MSM' : 'WASM blst',
+        selectedBackend: options?.selectedBackend,
+        webgpu: options?.selectedBackend === 'webgpu'
+          ? {
+              supported: true,
+              available: true,
+              deviceLost: false,
+              fallbackActive: false,
+              reductionMode: 'parallel32',
+              scheduler: {
+                mode: 'auto',
+                probeStatus: 'passed',
+                probeTimeoutMs: 1500,
+                commitTimeoutMs: 3000,
+                minBlobs: 1,
+                circuitOpen: false,
+              },
+            }
+          : undefined,
+      }
+    },
+    commitBlobs: (blobsFlat: Uint8Array) => makeCommitments(blobsFlat.byteLength / KZG_BLOB_SIZE, options?.witnessSeed),
+    commitBlobsProfiled: (blobsFlat: Uint8Array) => {
+      calls.commitProfiled += 1
+      if (options?.throwCommit) throw new Error('synthetic backend failure')
+      return {
+        witnessFlat: options?.malformedWitness ? new Uint8Array(1) : makeCommitments(blobsFlat.byteLength / KZG_BLOB_SIZE, options?.witnessSeed),
+        perf: {
+          decodeMs: 21,
+          transformMs: 22,
+          msmScalarPrepMs: 23,
+          msmBucketFillMs: 24,
+          msmReduceMs: 25,
+          msmDoubleMs: 26,
+          msmMs: 27,
+          compressMs: 28,
+          totalMs: 29,
+          blobs: blobsFlat.byteLength / KZG_BLOB_SIZE,
+        },
+      }
+    },
+  }
+  return { backend, calls }
+}
+
+test('user MDU expansion routes commitments through the browser KZG backend', async () => {
+  const { wasm, calls, mduShards, shardLen } = makeWasm()
+  const { backend, calls: backendCalls } = makeBackend({ selectedBackend: 'webgpu', witnessSeed: 19 })
+
+  const result = await expandUserMduRsWithBrowserKzg({
+    kind: 'mdu',
+    data: bytes(64),
+    k: 2,
+    m: 1,
+    wasm,
+    kzgCommitBackend: backend,
+    now: () => 100,
+  })
+
+  assert.equal(calls.mduUncommitted, 1)
+  assert.equal(calls.mduCommitted, 0)
+  assert.equal(backendCalls.commitProfiled, 1)
+  assert.deepEqual(result.shards_flat, mduShards)
+  assert.equal(result.shard_len, shardLen)
+  assert.deepEqual(result.mdu_root, rootFromWitness(result.witness_flat))
+  assert.equal(result.perf.rustCommitBackend, 'webgpu-msm')
+  assert.equal(result.perf.kzgCommitBackend, 'webgpu')
+  assert.equal(result.perf.kzgWebGpuProbeStatus, 'passed')
+  assert.equal(result.perf.kzgWebGpuReductionMode, 'parallel32')
+  assert.equal(result.perf.rustCommitMs, 29)
+  assert.equal(result.perf.rustEncodeMs, 1)
+  assert.equal(result.perf.rustRsMs, 2)
+})
+
+test('partial payload expansion uses the same browser KZG route and preserves shape', async () => {
+  const { wasm, calls, payloadShards, shardLen } = makeWasm()
+  const { backend, calls: backendCalls } = makeBackend({ selectedBackend: 'webgpu', witnessSeed: 23 })
+
+  const result = await expandUserMduRsWithBrowserKzg({
+    kind: 'payload',
+    data: bytes(1000),
+    k: 2,
+    m: 1,
+    wasm,
+    kzgCommitBackend: backend,
+  })
+
+  assert.equal(calls.payloadUncommitted, 1)
+  assert.equal(calls.payloadCommitted, 0)
+  assert.equal(backendCalls.commitProfiled, 1)
+  assert.equal(result.witness_flat.byteLength, 3 * 48)
+  assert.deepEqual(result.shards_flat, payloadShards)
+  assert.equal(result.shard_len, shardLen)
+  assert.deepEqual(result.mdu_root, rootFromWitness(result.witness_flat))
+  assert.equal(result.perf.shardCount, 3)
+  assert.equal(result.perf.rows, 1)
+  assert.equal(result.perf.shardsTotal, 3)
+})
+
+test('browser KZG failure falls back to the existing committed WASM path', async () => {
+  const committedWitness = makeCommitments(2, 101)
+  const { wasm, calls } = makeWasm({ committedWitness })
+  const { backend, calls: backendCalls } = makeBackend({ throwCommit: true })
+
+  const result = await expandUserMduRsWithBrowserKzg({
+    kind: 'mdu',
+    data: bytes(64),
+    k: 2,
+    m: 1,
+    wasm,
+    kzgCommitBackend: backend,
+  })
+
+  assert.equal(calls.mduUncommitted, 1)
+  assert.equal(calls.mduCommitted, 1)
+  assert.equal(backendCalls.commitProfiled, 1)
+  assert.deepEqual(result.witness_flat, committedWitness)
+  assert.deepEqual(result.mdu_root, rootFromWitness(committedWitness))
+  assert.equal(result.perf.rustCommitBackend, 'blst')
+  assert.match(result.perf.browserKzgCommitFallbackReason ?? '', /synthetic backend failure/)
+  assert.match(result.perf.kzgWebGpuFallbackReason, /synthetic backend failure/)
+})
+
+test('browser KZG validation failure falls back to the existing committed WASM path', async () => {
+  const committedWitness = makeCommitments(2, 111)
+  const { wasm, calls } = makeWasm({ committedWitness })
+  const { backend, calls: backendCalls } = makeBackend({ selectedBackend: 'webgpu', malformedWitness: true })
+
+  const result = await expandUserMduRsWithBrowserKzg({
+    kind: 'mdu',
+    data: bytes(64),
+    k: 2,
+    m: 1,
+    wasm,
+    kzgCommitBackend: backend,
+  })
+
+  assert.equal(calls.mduUncommitted, 1)
+  assert.equal(calls.mduCommitted, 1)
+  assert.equal(backendCalls.commitProfiled, 1)
+  assert.deepEqual(result.witness_flat, committedWitness)
+  assert.deepEqual(result.mdu_root, rootFromWitness(committedWitness))
+  assert.equal(result.perf.rustCommitBackend, 'blst')
+  assert.match(result.perf.browserKzgCommitFallbackReason ?? '', /failed validation/)
+})
+
+test('split browser route can be parity-checked against committed WASM outputs', async () => {
+  const parityWitness = makeCommitments(3, 77)
+  const parityRoot = rootFromWitness(parityWitness)
+  const { wasm } = makeWasm({ committedWitness: parityWitness, committedRoot: parityRoot })
+  const { backend } = makeBackend({ selectedBackend: 'webgpu', witnessSeed: 77 })
+
+  const split = await expandUserMduRsWithBrowserKzg({
+    kind: 'payload',
+    data: bytes(1000),
+    k: 2,
+    m: 1,
+    wasm,
+    kzgCommitBackend: backend,
+  })
+  const committed = wasm.expand_payload_rs_flat_committed_profiled(bytes(1000), 2, 1) as {
+    witness_flat: Uint8Array
+    mdu_root: Uint8Array
+  }
+
+  assert.deepEqual(split.witness_flat, committed.witness_flat)
+  assert.deepEqual(split.mdu_root, committed.mdu_root)
+})
+
+const MDU_SIZE_BYTES = 8 * 1024 * 1024
+const SCALAR_BYTES = 32
+const SCALAR_PAYLOAD_BYTES = 31
+const RAW_MDU_CAPACITY = Math.floor(MDU_SIZE_BYTES / SCALAR_BYTES) * SCALAR_PAYLOAD_BYTES
+
+let realWasmReady: Promise<unknown> | null = null
+
+async function loadRealPolyStoreWasm(): Promise<PolyStoreWasm> {
+  if (!realWasmReady) {
+    realWasmReady = init({
+      module_or_path: await fs.readFile(new URL('../../../public/wasm/polystore_core_bg.wasm', import.meta.url)),
+    })
+  }
+  await realWasmReady
+  const trustedSetup = new Uint8Array(await fs.readFile(new URL('../../../public/trusted_setup.txt', import.meta.url)))
+  return new PolyStoreWasm(trustedSetup)
+}
+
+function encodeToMdu(rawData: Uint8Array): Uint8Array {
+  const mdu = new Uint8Array(MDU_SIZE_BYTES)
+  let readOffset = 0
+  let writeOffset = 0
+  while (readOffset < rawData.length && writeOffset < MDU_SIZE_BYTES) {
+    const chunkLen = Math.min(SCALAR_PAYLOAD_BYTES, rawData.length - readOffset)
+    const pad = SCALAR_BYTES - chunkLen
+    mdu.set(rawData.subarray(readOffset, readOffset + chunkLen), writeOffset + pad)
+    readOffset += chunkLen
+    writeOffset += SCALAR_BYTES
+  }
+  return mdu
+}
+
+function parseRealCommitted(raw: unknown): { witness_flat: Uint8Array; mdu_root: Uint8Array; shards_flat: Uint8Array; shard_len: number } {
+  const parsed = typeof raw === 'string' ? JSON.parse(raw) as Record<string, unknown> : raw as Record<string, unknown>
+  return {
+    witness_flat: toUserMduUint8Array(parsed.witness_flat),
+    mdu_root: toUserMduUint8Array(parsed.mdu_root),
+    shards_flat: toUserMduUint8Array(parsed.shards_flat),
+    shard_len: Number(parsed.shard_len ?? 0),
+  }
+}
+
+async function assertRealWasmParity(kind: 'mdu' | 'payload', data: Uint8Array): Promise<void> {
+  const wasm = await loadRealPolyStoreWasm()
+  const k = 64
+  const m = 1
+  const committedRaw = kind === 'mdu'
+    ? wasm.expand_mdu_rs_flat_committed_profiled(data, k, m)
+    : wasm.expand_payload_rs_flat_committed_profiled(data, k, m)
+  const committed = parseRealCommitted(committedRaw)
+  const split = await expandUserMduRsWithBrowserKzg({
+    kind,
+    data,
+    k,
+    m,
+    wasm,
+    kzgCommitBackend: createWasmBlstKzgCommitBackend(wasm),
+  })
+
+  assert.deepEqual(split.witness_flat, committed.witness_flat)
+  assert.deepEqual(split.mdu_root, committed.mdu_root)
+  assert.deepEqual(split.shards_flat, committed.shards_flat)
+  assert.equal(split.shard_len, committed.shard_len)
+  assert.equal(split.perf.kzgCommitBackend, 'wasm-blst')
+  assert.equal(split.perf.rustCommitBackend, 'blst')
+}
+
+test('real WASM parity covers a full encoded MDU and a partial payload', { timeout: 180_000 }, async () => {
+  await assertRealWasmParity('mdu', encodeToMdu(bytes(RAW_MDU_CAPACITY, 89)))
+  await assertRealWasmParity('payload', bytes(4096, 97))
+})
+
+test('invalid uncommitted shard contracts fail before commitment', async () => {
+  const { wasm } = makeWasm()
+  const { backend, calls } = makeBackend({ selectedBackend: 'webgpu' })
+  wasm.expand_mdu_rs_flat_uncommitted = () => ({ shards_flat: bytes(7), shard_len: 0, perf: {} })
+
+  await assert.rejects(
+    expandUserMduRsWithBrowserKzg({
+      kind: 'mdu',
+      data: bytes(64),
+      k: 2,
+      m: 1,
+      wasm,
+      kzgCommitBackend: backend,
+    }),
+    /invalid shard length/,
+  )
+  assert.equal(calls.commitProfiled, 0)
+})

--- a/polystore-website/src/lib/upload/userMduBrowserKzg.ts
+++ b/polystore-website/src/lib/upload/userMduBrowserKzg.ts
@@ -1,0 +1,341 @@
+import {
+  KZG_BLOB_SIZE,
+  KZG_COMMITMENT_SIZE,
+  type KzgCommitBackend,
+  type KzgCommitPerf,
+  type KzgCommitProfiledResult,
+} from '../kzgCommitBackend'
+
+export type UserMduExpansionKind = 'mdu' | 'payload'
+
+export type UserMduBrowserKzgWasm = {
+  expand_mdu_rs_flat_uncommitted(data: Uint8Array, k: number, m: number): unknown
+  expand_payload_rs_flat_uncommitted(data: Uint8Array, k: number, m: number): unknown
+  expand_mdu_rs_flat_committed(data: Uint8Array, k: number, m: number): unknown
+  expand_payload_rs_flat_committed(data: Uint8Array, k: number, m: number): unknown
+  expand_mdu_rs_flat_committed_profiled(data: Uint8Array, k: number, m: number): unknown
+  expand_payload_rs_flat_committed_profiled(data: Uint8Array, k: number, m: number): unknown
+  compute_mdu_root(witnessFlat: Uint8Array): unknown
+}
+
+export type UserMduBrowserKzgPerf = ReturnType<typeof kzgCommitDiagnosticsForBackend> & {
+  expandMs: number
+  commitMs: number
+  rootMs: number
+  totalMs: number
+  shardCount: number
+  shardLen: number
+  rustEncodeMs: number
+  rustRsMs: number
+  rustCommitDecodeMs: number
+  rustCommitTransformMs: number
+  rustCommitMsmScalarPrepMs: number
+  rustCommitMsmBucketFillMs: number
+  rustCommitMsmReduceMs: number
+  rustCommitMsmDoubleMs: number
+  rustCommitMsmMs: number
+  rustCommitCompressMs: number
+  rustCommitMs: number
+  rustTotalMs: number
+  rustCommitBackend: string
+  rustCommitMsmSubphasesAvailable: boolean
+  rows: number
+  shardsTotal: number
+  browserKzgCommitFallbackReason?: string
+}
+
+export type UserMduBrowserKzgResult = {
+  witness_flat: Uint8Array
+  mdu_root: Uint8Array
+  shards_flat: Uint8Array
+  shard_len: number
+  perf: UserMduBrowserKzgPerf
+}
+
+type SplitExpansionPerf = {
+  encode_ms?: unknown
+  rs_ms?: unknown
+  total_ms?: unknown
+  rows?: unknown
+  shards_total?: unknown
+  shard_len?: unknown
+}
+
+type CommittedExpansionPerf = SplitExpansionPerf & {
+  commit_decode_ms?: unknown
+  commit_transform_ms?: unknown
+  commit_msm_scalar_prep_ms?: unknown
+  commit_msm_bucket_fill_ms?: unknown
+  commit_msm_reduce_ms?: unknown
+  commit_msm_double_ms?: unknown
+  commit_msm_ms?: unknown
+  commit_compress_ms?: unknown
+  commit_ms?: unknown
+}
+
+type ParsedUncommittedExpansion = {
+  shardsFlat: Uint8Array
+  shardLen: number
+  perf: SplitExpansionPerf
+}
+
+type ParsedCommittedExpansion = ParsedUncommittedExpansion & {
+  witnessFlat: Uint8Array
+  mduRoot: Uint8Array
+  perf: CommittedExpansionPerf
+}
+
+type ExpandWithBrowserKzgOptions = {
+  kind: UserMduExpansionKind
+  data: Uint8Array
+  k: number
+  m: number
+  profile?: boolean
+  wasm: UserMduBrowserKzgWasm
+  kzgCommitBackend: KzgCommitBackend
+  now?: () => number
+}
+
+function defaultNow(): number {
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') return performance.now()
+  return Date.now()
+}
+
+function numberField(value: unknown): number {
+  const parsed = Number(value ?? 0)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+export function toUserMduUint8Array(value: unknown): Uint8Array {
+  if (value instanceof Uint8Array) return value
+  if (Array.isArray(value)) return Uint8Array.from(value)
+  if (ArrayBuffer.isView(value)) {
+    const view = value as ArrayBufferView
+    return new Uint8Array(view.buffer, view.byteOffset, view.byteLength)
+  }
+  return new Uint8Array(value as ArrayBufferLike)
+}
+
+function parseMaybeJson(value: unknown): Record<string, unknown> {
+  if (typeof value === 'string') return JSON.parse(value) as Record<string, unknown>
+  if (!value || typeof value !== 'object') throw new Error('WASM expansion returned a non-object result')
+  return value as Record<string, unknown>
+}
+
+function parseUncommittedExpansion(raw: unknown, label: string): ParsedUncommittedExpansion {
+  const parsed = parseMaybeJson(raw)
+  const shardLen = Number(parsed.shard_len ?? 0)
+  if (!Number.isInteger(shardLen) || shardLen <= 0) {
+    throw new Error(`${label} returned an invalid shard length`)
+  }
+  const shardsFlat = toUserMduUint8Array(parsed.shards_flat)
+  if (shardsFlat.byteLength === 0 || shardsFlat.byteLength % shardLen !== 0) {
+    throw new Error(`${label} returned misaligned shard bytes`)
+  }
+  if (shardsFlat.byteLength % KZG_BLOB_SIZE !== 0) {
+    throw new Error(`${label} returned shard bytes that are not 128 KiB aligned`)
+  }
+  return {
+    shardsFlat,
+    shardLen,
+    perf: (parsed.perf ?? {}) as SplitExpansionPerf,
+  }
+}
+
+function parseCommittedExpansion(raw: unknown, label: string): ParsedCommittedExpansion {
+  const parsed = parseMaybeJson(raw)
+  const base = parseUncommittedExpansion(parsed, label)
+  const witnessFlat = toUserMduUint8Array(parsed.witness_flat)
+  const mduRoot = toUserMduUint8Array(parsed.mdu_root)
+  const expectedWitnessBytes = (base.shardsFlat.byteLength / KZG_BLOB_SIZE) * KZG_COMMITMENT_SIZE
+  if (witnessFlat.byteLength !== expectedWitnessBytes) {
+    throw new Error(`${label} returned ${witnessFlat.byteLength} witness bytes, expected ${expectedWitnessBytes}`)
+  }
+  if (mduRoot.byteLength !== 32) {
+    throw new Error(`${label} returned ${mduRoot.byteLength} MDU root bytes, expected 32`)
+  }
+  return {
+    ...base,
+    witnessFlat,
+    mduRoot,
+    perf: (parsed.perf ?? {}) as CommittedExpansionPerf,
+  }
+}
+
+export function kzgCommitDiagnosticsForBackend(kzgCommitBackend: KzgCommitBackend | null | undefined) {
+  const status = kzgCommitBackend?.getStatus()
+  const scheduler = status?.webgpu?.scheduler
+  return {
+    rustCommitBackend: status?.selectedBackend === 'webgpu' ? 'webgpu-msm' : 'blst',
+    kzgCommitBackend: status?.selectedBackend ?? status?.kind ?? 'unknown',
+    kzgWebGpuAvailable: Boolean(status?.webgpu?.available),
+    kzgWebGpuFallbackReason: status?.fallbackReason ?? '',
+    kzgWebGpuProbeStatus: scheduler?.probeStatus ?? '',
+    kzgWebGpuCircuitOpen: Boolean(scheduler?.circuitOpen),
+    kzgWebGpuProbeTimeoutMs: scheduler?.probeTimeoutMs ?? 0,
+    kzgWebGpuCommitTimeoutMs: scheduler?.commitTimeoutMs ?? 0,
+    kzgWebGpuMinBlobs: scheduler?.minBlobs ?? 0,
+    kzgWebGpuReductionMode: status?.webgpu?.reductionMode ?? '',
+  }
+}
+
+function perfFromSplitAndCommit(
+  splitPerf: SplitExpansionPerf,
+  commitPerf: KzgCommitPerf,
+  commitMs: number,
+  rootMs: number,
+  totalMs: number,
+  shardsFlat: Uint8Array,
+  shardLen: number,
+  diagnostics: ReturnType<typeof kzgCommitDiagnosticsForBackend>,
+  fallbackReason?: string,
+): UserMduBrowserKzgPerf {
+  const expandMs = numberField(splitPerf.encode_ms) + numberField(splitPerf.rs_ms)
+  const rustCommitMs = commitPerf.totalMs || commitMs
+  const fallbackFields = fallbackReason
+    ? {
+        browserKzgCommitFallbackReason: fallbackReason,
+        kzgWebGpuFallbackReason: diagnostics.kzgWebGpuFallbackReason || fallbackReason,
+      }
+    : {}
+  return {
+    expandMs,
+    commitMs,
+    rootMs,
+    totalMs,
+    shardCount: Math.floor(shardsFlat.byteLength / shardLen),
+    shardLen,
+    rustEncodeMs: numberField(splitPerf.encode_ms),
+    rustRsMs: numberField(splitPerf.rs_ms),
+    rustCommitDecodeMs: commitPerf.decodeMs,
+    rustCommitTransformMs: commitPerf.transformMs,
+    rustCommitMsmScalarPrepMs: commitPerf.msmScalarPrepMs,
+    rustCommitMsmBucketFillMs: commitPerf.msmBucketFillMs,
+    rustCommitMsmReduceMs: commitPerf.msmReduceMs,
+    rustCommitMsmDoubleMs: commitPerf.msmDoubleMs,
+    rustCommitMsmMs: commitPerf.msmMs,
+    rustCommitCompressMs: commitPerf.compressMs,
+    rustCommitMs,
+    rustTotalMs: numberField(splitPerf.total_ms) + rustCommitMs + rootMs,
+    rustCommitMsmSubphasesAvailable: false,
+    rows: numberField(splitPerf.rows),
+    shardsTotal: numberField(splitPerf.shards_total),
+    ...diagnostics,
+    ...fallbackFields,
+  }
+}
+
+function committedPerfToKzgCommitPerf(perf: CommittedExpansionPerf): KzgCommitPerf {
+  return {
+    decodeMs: numberField(perf.commit_decode_ms),
+    transformMs: numberField(perf.commit_transform_ms),
+    msmScalarPrepMs: numberField(perf.commit_msm_scalar_prep_ms),
+    msmBucketFillMs: numberField(perf.commit_msm_bucket_fill_ms),
+    msmReduceMs: numberField(perf.commit_msm_reduce_ms),
+    msmDoubleMs: numberField(perf.commit_msm_double_ms),
+    msmMs: numberField(perf.commit_msm_ms),
+    compressMs: numberField(perf.commit_compress_ms),
+    totalMs: numberField(perf.commit_ms),
+    blobs: numberField(perf.shards_total) * numberField(perf.rows),
+  }
+}
+
+function committedFallback(
+  options: ExpandWithBrowserKzgOptions,
+  now: () => number,
+  totalStart: number,
+  fallbackReason?: string,
+): UserMduBrowserKzgResult {
+  const { kind, data, k, m, profile = true, wasm, kzgCommitBackend } = options
+  const committedRaw = kind === 'mdu'
+    ? profile
+      ? wasm.expand_mdu_rs_flat_committed_profiled(data, k, m)
+      : wasm.expand_mdu_rs_flat_committed(data, k, m)
+    : profile
+      ? wasm.expand_payload_rs_flat_committed_profiled(data, k, m)
+      : wasm.expand_payload_rs_flat_committed(data, k, m)
+  const parsed = parseCommittedExpansion(committedRaw, kind === 'mdu' ? 'expandMduRs fallback' : 'expandPayloadRs fallback')
+  const diagnostics = {
+    ...kzgCommitDiagnosticsForBackend(kzgCommitBackend),
+    rustCommitBackend: 'blst',
+  }
+  const rootMs = 0
+  const commitPerf = committedPerfToKzgCommitPerf(parsed.perf)
+  return {
+    witness_flat: parsed.witnessFlat,
+    mdu_root: parsed.mduRoot,
+    shards_flat: parsed.shardsFlat,
+    shard_len: parsed.shardLen,
+    perf: perfFromSplitAndCommit(
+      parsed.perf,
+      commitPerf,
+      numberField(parsed.perf.commit_ms),
+      rootMs,
+      now() - totalStart,
+      parsed.shardsFlat,
+      parsed.shardLen,
+      diagnostics,
+      fallbackReason,
+    ),
+  }
+}
+
+export async function expandUserMduRsWithBrowserKzg(
+  options: ExpandWithBrowserKzgOptions,
+): Promise<UserMduBrowserKzgResult> {
+  const { kind, data, k, m, wasm, kzgCommitBackend } = options
+  if (!(data instanceof Uint8Array)) throw new Error('data must be a Uint8Array')
+  const now = options.now ?? defaultNow
+  const totalStart = now()
+
+  const uncommittedRaw = kind === 'mdu'
+    ? wasm.expand_mdu_rs_flat_uncommitted(data, k, m)
+    : wasm.expand_payload_rs_flat_uncommitted(data, k, m)
+  const expanded = parseUncommittedExpansion(uncommittedRaw, kind === 'mdu' ? 'expandMduRs' : 'expandPayloadRs')
+
+  let committedRaw: KzgCommitProfiledResult
+  let commitMs = 0
+  let witnessFlat: Uint8Array
+  let rootMs = 0
+  let rootBytes: Uint8Array
+  try {
+    const commitStart = now()
+    committedRaw = await kzgCommitBackend.commitBlobsProfiled(expanded.shardsFlat)
+    commitMs = now() - commitStart
+    witnessFlat = committedRaw.witnessFlat
+    const expectedWitnessBytes = (expanded.shardsFlat.byteLength / KZG_BLOB_SIZE) * KZG_COMMITMENT_SIZE
+    if (witnessFlat.byteLength !== expectedWitnessBytes) {
+      throw new Error(`browser KZG returned ${witnessFlat.byteLength} witness bytes, expected ${expectedWitnessBytes}`)
+    }
+
+    const rootStart = now()
+    const root = wasm.compute_mdu_root(witnessFlat) as unknown
+    rootMs = now() - rootStart
+    rootBytes = toUserMduUint8Array(root)
+    if (rootBytes.byteLength !== 32) {
+      throw new Error(`compute_mdu_root returned ${rootBytes.byteLength} bytes, expected 32`)
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return committedFallback(options, now, totalStart, `browser KZG commit failed validation; used committed WASM fallback: ${message}`)
+  }
+
+  const diagnostics = kzgCommitDiagnosticsForBackend(kzgCommitBackend)
+  const totalMs = now() - totalStart
+  return {
+    witness_flat: witnessFlat,
+    mdu_root: rootBytes,
+    shards_flat: expanded.shardsFlat,
+    shard_len: expanded.shardLen,
+    perf: perfFromSplitAndCommit(
+      expanded.perf,
+      committedRaw.perf,
+      commitMs,
+      rootMs,
+      totalMs,
+      expanded.shardsFlat,
+      expanded.shardLen,
+      diagnostics,
+    ),
+  }
+}

--- a/polystore-website/src/lib/worker-client.ts
+++ b/polystore-website/src/lib/worker-client.ts
@@ -234,6 +234,7 @@ export interface ExpandedStripe {
     shard_len?: number;
     perf?: KzgCommitDiagnostics & {
       expandMs?: number;
+      commitMs?: number;
       rootMs?: number;
       totalMs?: number;
       shardCount?: number;
@@ -254,6 +255,7 @@ export interface ExpandedStripe {
       rustCommitMsmSubphasesAvailable?: boolean;
       rows?: number;
       shardsTotal?: number;
+      browserKzgCommitFallbackReason?: string;
     };
 }
 

--- a/polystore-website/src/workers/expand.worker.ts
+++ b/polystore-website/src/workers/expand.worker.ts
@@ -1,11 +1,25 @@
 import init, { PolyStoreWasm } from '../lib/polystoreCoreRuntime.js'
 import { createBrowserKzgCommitBackend, type KzgCommitBackend } from '../lib/kzgCommitBackend'
+import {
+  expandUserMduRsWithBrowserKzg,
+  kzgCommitDiagnosticsForBackend,
+} from '../lib/upload/userMduBrowserKzg'
 
 let wasmInitialized = false
 let wasmInitPromise: Promise<void> | null = null
 let wasmInitError: unknown = null
 let polyStoreWasmInstance: PolyStoreWasm | null = null
 let kzgCommitBackend: KzgCommitBackend | null = null
+
+// User MDU batches are large (default Mode 2 RS 8+4 commits 96 blobs), so
+// do not let a one-blob probe reject WebGPU for the dominant upload stage.
+// Validation failures still fall back through expandUserMduRsWithBrowserKzg.
+const USER_UPLOAD_KZG_OPTIONS = {
+  preferWebGpu: true,
+  webGpuMode: 'force' as const,
+  webGpuProbeTimeoutMs: 15_000,
+  webGpuCommitTimeoutMs: 60_000,
+}
 
 function initializeWasm(): Promise<void> {
   if (wasmInitialized) return Promise.resolve()
@@ -27,20 +41,7 @@ function initializeWasm(): Promise<void> {
 void initializeWasm()
 
 function kzgCommitDiagnostics() {
-  const status = kzgCommitBackend?.getStatus()
-  const scheduler = status?.webgpu?.scheduler
-  return {
-    rustCommitBackend: status?.selectedBackend === 'webgpu' ? 'webgpu-msm' : 'blst',
-    kzgCommitBackend: status?.selectedBackend ?? status?.kind ?? 'unknown',
-    kzgWebGpuAvailable: Boolean(status?.webgpu?.available),
-    kzgWebGpuFallbackReason: status?.fallbackReason ?? '',
-    kzgWebGpuProbeStatus: scheduler?.probeStatus ?? '',
-    kzgWebGpuCircuitOpen: Boolean(scheduler?.circuitOpen),
-    kzgWebGpuProbeTimeoutMs: scheduler?.probeTimeoutMs ?? 0,
-    kzgWebGpuCommitTimeoutMs: scheduler?.commitTimeoutMs ?? 0,
-    kzgWebGpuMinBlobs: scheduler?.minBlobs ?? 0,
-    kzgWebGpuReductionMode: status?.webgpu?.reductionMode ?? '',
-  }
+  return kzgCommitDiagnosticsForBackend(kzgCommitBackend)
 }
 
 self.onmessage = async (event) => {
@@ -58,7 +59,7 @@ self.onmessage = async (event) => {
         const { trustedSetupBytes } = payload as { trustedSetupBytes: Uint8Array }
         if (!trustedSetupBytes) throw new Error('Trusted setup bytes required')
         polyStoreWasmInstance = new PolyStoreWasm(trustedSetupBytes)
-        kzgCommitBackend = await createBrowserKzgCommitBackend(polyStoreWasmInstance, trustedSetupBytes, { preferWebGpu: true })
+        kzgCommitBackend = await createBrowserKzgCommitBackend(polyStoreWasmInstance, trustedSetupBytes, USER_UPLOAD_KZG_OPTIONS)
         ;(self as unknown as Worker).postMessage({ id, type: 'result', payload: 'ok' })
         return
       }
@@ -66,83 +67,28 @@ self.onmessage = async (event) => {
         if (!polyStoreWasmInstance || !kzgCommitBackend) throw new Error('PolyStoreWasm not initialized')
         const { data, k, m, profile = true } = payload as { data: Uint8Array; k: number; m: number; profile?: boolean }
         if (!(data instanceof Uint8Array)) throw new Error('data must be Uint8Array')
-        const opStart = performance.now()
-        const expanded = (
-          profile
-            ? polyStoreWasmInstance.expand_mdu_rs_flat_committed_profiled(data, Number(k), Number(m))
-            : polyStoreWasmInstance.expand_mdu_rs_flat_committed(data, Number(k), Number(m))
-        ) as unknown
-        const parsed = typeof expanded === 'string' ? JSON.parse(expanded) : expanded
-        const witnessRaw = (parsed as { witness_flat?: unknown }).witness_flat
-        const rootRaw = (parsed as { mdu_root?: unknown }).mdu_root
-        const shardsRaw = (parsed as { shards_flat?: unknown }).shards_flat
-        const shardLen = Number((parsed as { shard_len?: unknown }).shard_len ?? 0)
-        const rustPerf = (parsed as {
-          perf?: {
-            encode_ms?: unknown
-            rs_ms?: unknown
-            commit_decode_ms?: unknown
-            commit_transform_ms?: unknown
-            commit_msm_scalar_prep_ms?: unknown
-            commit_msm_bucket_fill_ms?: unknown
-            commit_msm_reduce_ms?: unknown
-            commit_msm_double_ms?: unknown
-            commit_msm_ms?: unknown
-            commit_compress_ms?: unknown
-            commit_ms?: unknown
-            total_ms?: unknown
-            rows?: unknown
-            shards_total?: unknown
-          }
-        }).perf
-        if (!Number.isInteger(shardLen) || shardLen <= 0) {
-          throw new Error('expandMduRs returned an invalid shard length')
-        }
-
-        const witnessFlat = witnessRaw instanceof Uint8Array ? witnessRaw : new Uint8Array(witnessRaw as ArrayBufferLike)
-        const rootBytes = rootRaw instanceof Uint8Array ? rootRaw : new Uint8Array(rootRaw as ArrayBufferLike)
-        const shardsFlat = shardsRaw instanceof Uint8Array ? shardsRaw : new Uint8Array(shardsRaw as ArrayBufferLike)
-        const transferables: Transferable[] = [witnessFlat.buffer, rootBytes.buffer, shardsFlat.buffer]
+        const result = await expandUserMduRsWithBrowserKzg({
+          kind: 'mdu',
+          data,
+          k: Number(k),
+          m: Number(m),
+          profile,
+          wasm: polyStoreWasmInstance,
+          kzgCommitBackend,
+        })
+        const transferables: Transferable[] = [result.witness_flat.buffer, result.mdu_root.buffer, result.shards_flat.buffer]
         ;(self as unknown as Worker).postMessage(
           {
             id,
             type: 'result',
-            payload: {
-              witness_flat: witnessFlat,
-              mdu_root: rootBytes,
-              shards_flat: shardsFlat,
-              shard_len: shardLen,
-              perf: {
-                expandMs: Number(rustPerf?.encode_ms ?? 0) + Number(rustPerf?.rs_ms ?? 0),
-                rootMs: 0,
-                totalMs: performance.now() - opStart,
-                shardCount: Math.floor(shardsFlat.byteLength / shardLen),
-                shardLen,
-                rustEncodeMs: Number(rustPerf?.encode_ms ?? 0),
-                rustRsMs: Number(rustPerf?.rs_ms ?? 0),
-                rustCommitDecodeMs: Number(rustPerf?.commit_decode_ms ?? 0),
-                rustCommitTransformMs: Number(rustPerf?.commit_transform_ms ?? 0),
-                rustCommitMsmScalarPrepMs: Number(rustPerf?.commit_msm_scalar_prep_ms ?? 0),
-                rustCommitMsmBucketFillMs: Number(rustPerf?.commit_msm_bucket_fill_ms ?? 0),
-                rustCommitMsmReduceMs: Number(rustPerf?.commit_msm_reduce_ms ?? 0),
-                rustCommitMsmDoubleMs: Number(rustPerf?.commit_msm_double_ms ?? 0),
-                rustCommitMsmMs: Number(rustPerf?.commit_msm_ms ?? 0),
-                rustCommitCompressMs: Number(rustPerf?.commit_compress_ms ?? 0),
-                rustCommitMs: Number(rustPerf?.commit_ms ?? 0),
-                rustTotalMs: Number(rustPerf?.total_ms ?? 0),
-                rustCommitBackend: 'blst',
-                rustCommitMsmSubphasesAvailable: false,
-                rows: Number(rustPerf?.rows ?? 0),
-                shardsTotal: Number(rustPerf?.shards_total ?? 0),
-              },
-            },
+            payload: result,
           },
           transferables,
         )
         return
       }
       case 'expandPayloadRs': {
-        if (!polyStoreWasmInstance) throw new Error('PolyStoreWasm not initialized')
+        if (!polyStoreWasmInstance || !kzgCommitBackend) throw new Error('PolyStoreWasm not initialized')
         const { data, k, m, profile = true } = payload as {
           data: Uint8Array
           k: number
@@ -151,82 +97,22 @@ self.onmessage = async (event) => {
         }
         if (!(data instanceof Uint8Array)) throw new Error('data must be Uint8Array')
 
-        const opStart = performance.now()
-        const expanded = (
-          profile
-            ? polyStoreWasmInstance.expand_payload_rs_flat_committed_profiled(data, Number(k), Number(m))
-            : polyStoreWasmInstance.expand_payload_rs_flat_committed(data, Number(k), Number(m))
-        ) as unknown
-        const parsed = typeof expanded === 'string' ? JSON.parse(expanded) : expanded
-        const shardsRaw = (parsed as { shards_flat?: unknown }).shards_flat
-        const witnessRaw = (parsed as { witness_flat?: unknown }).witness_flat
-        const rootRaw = (parsed as { mdu_root?: unknown }).mdu_root
-        const shardLen = Number((parsed as { shard_len?: unknown }).shard_len ?? 0)
-        const rustPerf = (parsed as {
-          perf?: {
-            encode_ms?: unknown
-            rs_ms?: unknown
-            commit_decode_ms?: unknown
-            commit_transform_ms?: unknown
-            commit_msm_scalar_prep_ms?: unknown
-            commit_msm_bucket_fill_ms?: unknown
-            commit_msm_reduce_ms?: unknown
-            commit_msm_double_ms?: unknown
-            commit_msm_ms?: unknown
-            commit_compress_ms?: unknown
-            commit_ms?: unknown
-            total_ms?: unknown
-            rows?: unknown
-            shards_total?: unknown
-          }
-        }).perf
-        if (!Number.isInteger(shardLen) || shardLen <= 0) {
-          throw new Error('expandPayloadRs returned an invalid shard length')
-        }
-
-        const shardsFlat = shardsRaw instanceof Uint8Array ? shardsRaw : new Uint8Array(shardsRaw as ArrayBufferLike)
-        if (shardsFlat.byteLength % shardLen !== 0) {
-          throw new Error('expandPayloadRs returned misaligned shard bytes')
-        }
-        const witnessFlat =
-          witnessRaw instanceof Uint8Array ? witnessRaw : new Uint8Array(witnessRaw as ArrayBufferLike)
-        const rootBytes = rootRaw instanceof Uint8Array ? rootRaw : new Uint8Array(rootRaw as ArrayBufferLike)
+        const result = await expandUserMduRsWithBrowserKzg({
+          kind: 'payload',
+          data,
+          k: Number(k),
+          m: Number(m),
+          profile,
+          wasm: polyStoreWasmInstance,
+          kzgCommitBackend,
+        })
         ;(self as unknown as Worker).postMessage(
           {
             id,
             type: 'result',
-            payload: {
-              witness_flat: witnessFlat,
-              mdu_root: rootBytes,
-              shards_flat: shardsFlat,
-              shard_len: shardLen,
-              perf: {
-                expandMs: Number(rustPerf?.encode_ms ?? 0) + Number(rustPerf?.rs_ms ?? 0),
-                commitMs: Number(rustPerf?.commit_ms ?? 0),
-                rootMs: 0,
-                totalMs: performance.now() - opStart,
-                shardCount: shardsFlat.byteLength / shardLen,
-                shardLen,
-                rustEncodeMs: Number(rustPerf?.encode_ms ?? 0),
-                rustRsMs: Number(rustPerf?.rs_ms ?? 0),
-                rustCommitDecodeMs: Number(rustPerf?.commit_decode_ms ?? 0),
-                rustCommitTransformMs: Number(rustPerf?.commit_transform_ms ?? 0),
-                rustCommitMsmScalarPrepMs: Number(rustPerf?.commit_msm_scalar_prep_ms ?? 0),
-                rustCommitMsmBucketFillMs: Number(rustPerf?.commit_msm_bucket_fill_ms ?? 0),
-                rustCommitMsmReduceMs: Number(rustPerf?.commit_msm_reduce_ms ?? 0),
-                rustCommitMsmDoubleMs: Number(rustPerf?.commit_msm_double_ms ?? 0),
-                rustCommitMsmMs: Number(rustPerf?.commit_msm_ms ?? 0),
-                rustCommitCompressMs: Number(rustPerf?.commit_compress_ms ?? 0),
-                rustCommitMs: Number(rustPerf?.commit_ms ?? 0),
-                rustTotalMs: Number(rustPerf?.total_ms ?? 0),
-                rustCommitBackend: 'blst',
-                rustCommitMsmSubphasesAvailable: false,
-                rows: Number(rustPerf?.rows ?? 0),
-                shardsTotal: Number(rustPerf?.shards_total ?? 0),
-              },
-            },
+            payload: result,
           },
-          [witnessFlat.buffer, rootBytes.buffer, shardsFlat.buffer],
+          [result.witness_flat.buffer, result.mdu_root.buffer, result.shards_flat.buffer],
         )
         return
       }

--- a/polystore-website/src/workers/gateway.worker.ts
+++ b/polystore-website/src/workers/gateway.worker.ts
@@ -7,6 +7,10 @@
 // The `Mdu0Builder` and `PolyStoreWasm` classes are exposed by wasm-bindgen.
 import init, { WasmMdu0Builder, PolyStoreWasm } from '../lib/polystoreCoreRuntime.js';
 import { createBrowserKzgCommitBackend, type KzgCommitBackend } from '../lib/kzgCommitBackend';
+import {
+    expandUserMduRsWithBrowserKzg,
+    kzgCommitDiagnosticsForBackend,
+} from '../lib/upload/userMduBrowserKzg';
 
 let wasmInitialized = false;
 let wasmInitPromise: Promise<void> | null = null;
@@ -14,6 +18,16 @@ let wasmInitError: unknown = null;
 let mdu0BuilderInstance: WasmMdu0Builder | null = null;
 let polyStoreWasmInstance: PolyStoreWasm | null = null;
 let kzgCommitBackend: KzgCommitBackend | null = null;
+
+// User MDU batches are large (default Mode 2 RS 8+4 commits 96 blobs), so
+// do not let a one-blob probe reject WebGPU for the dominant upload stage.
+// Validation failures still fall back through expandUserMduRsWithBrowserKzg.
+const USER_UPLOAD_KZG_OPTIONS = {
+    preferWebGpu: true,
+    webGpuMode: 'force' as const,
+    webGpuProbeTimeoutMs: 15_000,
+    webGpuCommitTimeoutMs: 60_000,
+};
 
 type CommitWorkerPending = {
     resolve: (value: unknown) => void;
@@ -150,20 +164,7 @@ function commitBlobsWithPool(data: Uint8Array): Promise<Uint8Array> {
 }
 
 function kzgCommitDiagnostics() {
-    const status = kzgCommitBackend?.getStatus();
-    const scheduler = status?.webgpu?.scheduler;
-    return {
-        rustCommitBackend: status?.selectedBackend === 'webgpu' ? 'webgpu-msm' : 'blst',
-        kzgCommitBackend: status?.selectedBackend ?? status?.kind ?? 'unknown',
-        kzgWebGpuAvailable: Boolean(status?.webgpu?.available),
-        kzgWebGpuFallbackReason: status?.fallbackReason ?? '',
-        kzgWebGpuProbeStatus: scheduler?.probeStatus ?? '',
-        kzgWebGpuCircuitOpen: Boolean(scheduler?.circuitOpen),
-        kzgWebGpuProbeTimeoutMs: scheduler?.probeTimeoutMs ?? 0,
-        kzgWebGpuCommitTimeoutMs: scheduler?.commitTimeoutMs ?? 0,
-        kzgWebGpuMinBlobs: scheduler?.minBlobs ?? 0,
-        kzgWebGpuReductionMode: status?.webgpu?.reductionMode ?? '',
-    };
+    return kzgCommitDiagnosticsForBackend(kzgCommitBackend);
 }
 
 // Start fetching + compiling the WASM as soon as the worker loads so the first
@@ -212,7 +213,7 @@ self.onmessage = async (event) => {
                 }
                 if (!trustedSetupBytes) throw new Error('Trusted setup bytes required for PolyStoreWasm initialization');
                 polyStoreWasmInstance = new PolyStoreWasm(trustedSetupBytes);
-                kzgCommitBackend = await createBrowserKzgCommitBackend(polyStoreWasmInstance, trustedSetupBytes, { preferWebGpu: true });
+                kzgCommitBackend = await createBrowserKzgCommitBackend(polyStoreWasmInstance, trustedSetupBytes, USER_UPLOAD_KZG_OPTIONS);
                 // Initialize the blob-commit compute pool (best-effort).
                 try {
                     await initializeCommitPool(trustedSetupBytes);
@@ -604,164 +605,42 @@ self.onmessage = async (event) => {
             }
             case 'expandMduRs': {
                 if (!polyStoreWasmInstance) throw new Error('PolyStoreWasm not initialized. Call initPolyStoreWasm first.');
+                if (!kzgCommitBackend) throw new Error('PolyStoreWasm not initialized. Call initPolyStoreWasm first.');
                 const { data, k, m, profile = true } = payload as {
                     data: Uint8Array;
                     k: number;
                     m: number;
                     profile?: boolean;
                 };
-                if (!(data instanceof Uint8Array)) throw new Error('data must be a Uint8Array');
-                const expanded = (
-                    profile
-                        ? polyStoreWasmInstance.expand_mdu_rs_flat_committed_profiled(data, Number(k), Number(m))
-                        : polyStoreWasmInstance.expand_mdu_rs_flat_committed(data, Number(k), Number(m))
-                ) as unknown;
-                const parsed = typeof expanded === 'string' ? JSON.parse(expanded) : expanded;
-                const witnessRaw = (parsed as { witness_flat?: unknown }).witness_flat;
-                const rootRaw = (parsed as { mdu_root?: unknown }).mdu_root;
-                const shardsRaw = (parsed as { shards_flat?: unknown }).shards_flat;
-                const shardLen = Number((parsed as { shard_len?: unknown }).shard_len ?? 0);
-                const rustPerf = (parsed as {
-                    perf?: {
-                        encode_ms?: unknown;
-                        rs_ms?: unknown;
-                        commit_decode_ms?: unknown;
-                        commit_transform_ms?: unknown;
-                        commit_msm_scalar_prep_ms?: unknown;
-                        commit_msm_bucket_fill_ms?: unknown;
-                        commit_msm_reduce_ms?: unknown;
-                        commit_msm_double_ms?: unknown;
-                        commit_msm_ms?: unknown;
-                        commit_compress_ms?: unknown;
-                        commit_ms?: unknown;
-                        total_ms?: unknown;
-                        rows?: unknown;
-                        shards_total?: unknown;
-                    };
-                }).perf;
-                if (!Number.isInteger(shardLen) || shardLen <= 0) {
-                    throw new Error('expandMduRs returned an invalid shard length');
-                }
-
-                const witnessFlat =
-                    witnessRaw instanceof Uint8Array ? witnessRaw : new Uint8Array(witnessRaw as ArrayBufferLike);
-                const rootBytes =
-                    rootRaw instanceof Uint8Array ? rootRaw : new Uint8Array(rootRaw as ArrayBufferLike);
-                const shardsFlat =
-                    shardsRaw instanceof Uint8Array ? shardsRaw : new Uint8Array(shardsRaw as ArrayBufferLike);
-
-                result = {
-                    witness_flat: witnessFlat,
-                    mdu_root: rootBytes,
-                    shards_flat: shardsFlat,
-                    shard_len: shardLen,
-                    perf: {
-                        expandMs: Number(rustPerf?.encode_ms ?? 0) + Number(rustPerf?.rs_ms ?? 0),
-                        rootMs: 0,
-                        totalMs: Number(rustPerf?.total_ms ?? 0),
-                        shardCount: Math.floor(shardsFlat.byteLength / shardLen),
-                        shardLen,
-                        rustEncodeMs: Number(rustPerf?.encode_ms ?? 0),
-                        rustRsMs: Number(rustPerf?.rs_ms ?? 0),
-                        rustCommitDecodeMs: Number(rustPerf?.commit_decode_ms ?? 0),
-                        rustCommitTransformMs: Number(rustPerf?.commit_transform_ms ?? 0),
-                        rustCommitMsmScalarPrepMs: Number(rustPerf?.commit_msm_scalar_prep_ms ?? 0),
-                        rustCommitMsmBucketFillMs: Number(rustPerf?.commit_msm_bucket_fill_ms ?? 0),
-                        rustCommitMsmReduceMs: Number(rustPerf?.commit_msm_reduce_ms ?? 0),
-                        rustCommitMsmDoubleMs: Number(rustPerf?.commit_msm_double_ms ?? 0),
-                        rustCommitMsmMs: Number(rustPerf?.commit_msm_ms ?? 0),
-                        rustCommitCompressMs: Number(rustPerf?.commit_compress_ms ?? 0),
-                        rustCommitMs: Number(rustPerf?.commit_ms ?? 0),
-                        rustTotalMs: Number(rustPerf?.total_ms ?? 0),
-                        rustCommitBackend: 'blst',
-                        rustCommitMsmSubphasesAvailable: false,
-                        rows: Number(rustPerf?.rows ?? 0),
-                        shardsTotal: Number(rustPerf?.shards_total ?? 0),
-                    },
-                };
+                result = await expandUserMduRsWithBrowserKzg({
+                    kind: 'mdu',
+                    data,
+                    k: Number(k),
+                    m: Number(m),
+                    profile,
+                    wasm: polyStoreWasmInstance,
+                    kzgCommitBackend,
+                });
                 break;
             }
             case 'expandPayloadRs': {
                 if (!polyStoreWasmInstance) throw new Error('PolyStoreWasm not initialized. Call initPolyStoreWasm first.');
+                if (!kzgCommitBackend) throw new Error('PolyStoreWasm not initialized. Call initPolyStoreWasm first.');
                 const { data, k, m, profile = true } = payload as {
                     data: Uint8Array;
                     k: number;
                     m: number;
                     profile?: boolean;
                 };
-                if (!(data instanceof Uint8Array)) throw new Error('data must be a Uint8Array');
-
-                const expanded = (
-                    profile
-                        ? polyStoreWasmInstance.expand_payload_rs_flat_committed_profiled(data, Number(k), Number(m))
-                        : polyStoreWasmInstance.expand_payload_rs_flat_committed(data, Number(k), Number(m))
-                ) as unknown;
-                const parsed = typeof expanded === 'string' ? JSON.parse(expanded) : expanded;
-                const shardsRaw = (parsed as { shards_flat?: unknown }).shards_flat;
-                const witnessRaw = (parsed as { witness_flat?: unknown }).witness_flat;
-                const rootRaw = (parsed as { mdu_root?: unknown }).mdu_root;
-                const shardLen = Number((parsed as { shard_len?: unknown }).shard_len ?? 0);
-                const rustPerf = (parsed as {
-                    perf?: {
-                        encode_ms?: unknown;
-                        rs_ms?: unknown;
-                        commit_decode_ms?: unknown;
-                        commit_transform_ms?: unknown;
-                        commit_msm_scalar_prep_ms?: unknown;
-                        commit_msm_bucket_fill_ms?: unknown;
-                        commit_msm_reduce_ms?: unknown;
-                        commit_msm_double_ms?: unknown;
-                        commit_msm_ms?: unknown;
-                        commit_compress_ms?: unknown;
-                        commit_ms?: unknown;
-                        total_ms?: unknown;
-                        rows?: unknown;
-                        shards_total?: unknown;
-                    };
-                }).perf;
-                if (!Number.isInteger(shardLen) || shardLen <= 0) {
-                    throw new Error('expandPayloadRs returned an invalid shard length');
-                }
-
-                const shardsFlat = shardsRaw instanceof Uint8Array ? shardsRaw : new Uint8Array(shardsRaw as ArrayBufferLike);
-                if (shardsFlat.byteLength % shardLen !== 0) {
-                    throw new Error('expandPayloadRs returned misaligned shard bytes');
-                }
-                const witnessFlat =
-                    witnessRaw instanceof Uint8Array ? witnessRaw : new Uint8Array(witnessRaw as ArrayBufferLike);
-                const rootBytes =
-                    rootRaw instanceof Uint8Array ? rootRaw : new Uint8Array(rootRaw as ArrayBufferLike);
-
-                result = {
-                    witness_flat: witnessFlat,
-                    mdu_root: rootBytes,
-                    shards_flat: shardsFlat,
-                    shard_len: shardLen,
-                    perf: {
-                        expandMs: Number(rustPerf?.encode_ms ?? 0) + Number(rustPerf?.rs_ms ?? 0),
-                        commitMs: Number(rustPerf?.commit_ms ?? 0),
-                        rootMs: 0,
-                        totalMs: Number(rustPerf?.total_ms ?? 0),
-                        shardCount: shardsFlat.byteLength / shardLen,
-                        shardLen,
-                        rustEncodeMs: Number(rustPerf?.encode_ms ?? 0),
-                        rustRsMs: Number(rustPerf?.rs_ms ?? 0),
-                        rustCommitDecodeMs: Number(rustPerf?.commit_decode_ms ?? 0),
-                        rustCommitTransformMs: Number(rustPerf?.commit_transform_ms ?? 0),
-                        rustCommitMsmScalarPrepMs: Number(rustPerf?.commit_msm_scalar_prep_ms ?? 0),
-                        rustCommitMsmBucketFillMs: Number(rustPerf?.commit_msm_bucket_fill_ms ?? 0),
-                        rustCommitMsmReduceMs: Number(rustPerf?.commit_msm_reduce_ms ?? 0),
-                        rustCommitMsmDoubleMs: Number(rustPerf?.commit_msm_double_ms ?? 0),
-                        rustCommitMsmMs: Number(rustPerf?.commit_msm_ms ?? 0),
-                        rustCommitCompressMs: Number(rustPerf?.commit_compress_ms ?? 0),
-                        rustCommitMs: Number(rustPerf?.commit_ms ?? 0),
-                        rustTotalMs: Number(rustPerf?.total_ms ?? 0),
-                        rustCommitBackend: 'blst',
-                        rustCommitMsmSubphasesAvailable: false,
-                        rows: Number(rustPerf?.rows ?? 0),
-                        shardsTotal: Number(rustPerf?.shards_total ?? 0),
-                    },
-                };
+                result = await expandUserMduRsWithBrowserKzg({
+                    kind: 'payload',
+                    data,
+                    k: Number(k),
+                    m: Number(m),
+                    profile,
+                    wasm: polyStoreWasmInstance,
+                    kzgCommitBackend,
+                });
                 break;
             }
             case 'computeManifest': {


### PR DESCRIPTION
## Summary

Closes #189.

- Routes Mode 2 user MDU RS expansion through the browser KZG backend: uncommitted Rust/WASM expansion now feeds `kzgCommitBackend.commitBlobsProfiled(...)`, then computes the MDU root from the returned commitments.
- Applies the route consistently in both browser worker entrypoints (`expand.worker.ts` and `gateway.worker.ts`) for full encoded MDUs and payload/final user MDUs.
- Keeps the committed Rust/WASM path as a fail-safe when browser KZG commit output fails or fails validation.
- Extends user-stage perf/status accounting so user MDU samples include commit timing and backend diagnostics (`webgpu` / `webgpu-msm` or WASM fallback).

## Old split backend path vs new route

Before this PR, user MDUs used `expand_*_flat_committed[_profiled]`, so expansion and KZG commitments happened inside Rust/WASM and reported `rustCommitBackend: "blst"`. Witness/meta MDUs used `createBrowserKzgCommitBackend(...).commitBlobsProfiled(...)`, which can select WebGPU/MSM.

Now user MDUs use:

1. `expand_mdu_rs_flat_uncommitted(...)` or `expand_payload_rs_flat_uncommitted(...)` for RS/shard bytes only.
2. `kzgCommitBackend.commitBlobsProfiled(shardsFlat)` for the dominant KZG work.
3. `compute_mdu_root(witnessFlat)` from those backend-produced commitments.

The browser upload KZG backend is initialized in force mode with bounded timeouts for upload workers because default Mode 2 RS 8+4 user MDUs commit 96 blobs; a one-blob probe should not reject WebGPU for the dominant large-batch stage. WebGPU validation/timeout failures still fall back through the committed WASM path.

## Correctness tests

- `cd polystore-website && npm run test:unit`
  - 260/260 passing.
  - Includes focused tests for backend selection, fallback, validation-failure fallback, contract shape, mocked parity, and real WASM parity for:
    - one full encoded 8 MiB MDU (`kind: "mdu"`), and
    - one partial/final payload (`kind: "payload"`).
- `cd polystore-website && npm run lint`
- `cd polystore-website && npm run build:app`

## Browser performance evidence

Ad-hoc headed Chrome/WebGPU A/B on the same Linux/NVIDIA Ampere machine, same fixture, RS profile, browser, and trusted setup:

| Field | Value |
| --- | ---: |
| Browser | Chrome 148 on Linux x64 |
| GPU | NVIDIA Ampere WebGPU adapter |
| File bytes | 8,126,464 |
| RS profile | 8+4 |
| User MDU KZG commitments | 96 |
| Legacy committed WASM wall | 28,544.75 ms |
| Legacy committed WASM commit | 28,081 ms |
| Split browser route wall | 9,108.23 ms |
| Split browser route commit | 8,726.12 ms |
| Split selected backend | `webgpu` / `webgpu-msm` |
| Probe status | `passed` |
| Commit timeout | 60,000 ms |
| Parity | root=true, witness=true, shards=true |

A separate headless diagnostic saw SwiftShader and correctly rejected the fallback/software adapter; the headed run above exercised the real hardware adapter.

## CI / review status

- Latest head: `bbb7e382`.
- GitHub latest-head CI: all checks green.
- Local validation: green (commands above).
- Internal Pi review: passed after fixes; no remaining blocking findings.
- Copilot review: completed, no comments.
- Codex review: requested; unavailable (`chatgpt-codex-connector` asks for account connection).
- CodeRabbit review: requested; no response/review surfaced on this PR.
- Review threads: none.

## Caveats / deferrals

- No upload protocol, provider-daemon, RS layout, witness format, manifest format, or deal semantic changes.
- Broader WebGPU reduction-mode tuning remains deferred as scoped in #189.
