### PR TITLE
Bundle Mode 2 provider artifact uploads

### DIFF
--- a/polystore-website/package.json
+++ b/polystore-website/package.json
@@ -27,6 +27,7 @@
     "perf:user-stage-concurrency": "tsx scripts/benchmark_user_stage_concurrency.ts",
     "perf:browser-kzg-baseline": "tsx scripts/benchmark_browser_kzg_baseline.ts",
     "perf:upload-pipeline": "tsx scripts/benchmark_upload_pipelining.ts",
+    "perf:upload-bundle": "tsx scripts/benchmark_bundle_upload_shape.ts",
     "perf:msm-windows": "tsx scripts/benchmark_pippenger_windows.ts",
     "perf:kzg-compare": "tsx scripts/benchmark_kzg_commit_compare.ts",
     "perf:kzg-browser": "tsx scripts/benchmark_browser_kzg_commit.ts",

--- a/polystore-website/scripts/benchmark_bundle_upload_shape.ts
+++ b/polystore-website/scripts/benchmark_bundle_upload_shape.ts
@@ -1,0 +1,163 @@
+import { performance } from 'node:perf_hooks'
+
+import { createUploadEngine, type UploadTransportRequest } from '../src/lib/upload/engine'
+
+const MDU_SIZE = 8 * 1024 * 1024
+const BLOB_SIZE = 128 * 1024
+
+const userMdus = Number(process.env.BUNDLE_BENCH_USER_MDUS || 13)
+const witnessMdus = Number(process.env.BUNDLE_BENCH_WITNESS_MDUS || 1)
+const k = Number(process.env.BUNDLE_BENCH_K || 8)
+const m = Number(process.env.BUNDLE_BENCH_M || 4)
+const latencyMs = Number(process.env.BUNDLE_BENCH_LATENCY_MS || 25)
+const unsupportedProviderIndex = Number(process.env.BUNDLE_BENCH_UNSUPPORTED_PROVIDER || -1)
+
+const providerCount = k + m
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function target(index: number, bundled: boolean) {
+  return {
+    baseUrl: `http://provider-${index}.test`,
+    mduPath: '/sp/upload_mdu',
+    manifestPath: '/sp/upload_manifest',
+    shardPath: '/sp/upload_shard',
+    bundlePath: bundled ? '/sp/upload_bundle' : undefined,
+    label: `provider-${index}`,
+  }
+}
+
+function requestBytes(request: UploadTransportRequest): number {
+  return Math.max(0, request.artifact.bytes.byteLength)
+}
+
+function makeUnsupportedError(): Error {
+  const err = new Error('bundle upload unsupported')
+  err.name = 'BundleUnsupportedUploadError'
+  return err
+}
+
+async function runScenario(name: string, options: { bundled: boolean; unsupportedIndex?: number }) {
+  let artifactRequests = 0
+  let bundleRequests = 0
+  let bytesSent = 0
+  let active = 0
+  let peakActiveUploads = 0
+  const bundleSizes: number[] = []
+
+  const transport = {
+    async sendArtifact(request: UploadTransportRequest) {
+      artifactRequests += 1
+      bytesSent += requestBytes(request)
+      active += 1
+      peakActiveUploads = Math.max(peakActiveUploads, active)
+      await sleep(latencyMs)
+      active -= 1
+    },
+    async sendBundle(requests: UploadTransportRequest[]) {
+      const label = String(requests[0]?.target.label || '')
+      const maybeIndex = Number(label.replace(/^provider-/, ''))
+      if (options.unsupportedIndex === maybeIndex) {
+        throw makeUnsupportedError()
+      }
+      const size = requests.reduce((sum, request) => sum + requestBytes(request), 0)
+      bundleRequests += 1
+      bundleSizes.push(size)
+      bytesSent += size
+      active += 1
+      peakActiveUploads = Math.max(peakActiveUploads, active)
+      await sleep(latencyMs)
+      active -= 1
+    },
+  }
+
+  const engine = createUploadEngine({
+    transport: options.bundled ? transport : { sendArtifact: transport.sendArtifact },
+    parallelism: { stripedMetadata: 6, stripedShards: 6 },
+  })
+
+  const metadataMdus = Array.from({ length: 1 + witnessMdus }, (_, index) => ({
+    index,
+    data: new Uint8Array([index + 1]),
+    fullSize: MDU_SIZE,
+  }))
+  const shardSets = Array.from({ length: userMdus }, (_, userIndex) => ({
+    index: 1 + witnessMdus + userIndex,
+    shards: Array.from({ length: providerCount }, (_, slot) => ({
+      data: new Uint8Array([slot + 1]),
+      fullSize: MDU_SIZE / k,
+    })),
+  }))
+  const targets = Array.from({ length: providerCount }, (_, index) => target(index, options.bundled))
+
+  const started = performance.now()
+  const result = await engine.uploadStriped({
+    dealId: '198',
+    manifestRoot: '0x' + 'ab'.repeat(48),
+    previousManifestRoot: '',
+    manifestBlob: new Uint8Array([9]),
+    manifestBlobFullSize: BLOB_SIZE,
+    metadataMdus,
+    shardSets,
+    metadataTargets: targets,
+    shardTargets: targets,
+  })
+  const wallMs = performance.now() - started
+  if (!result.ok) {
+    throw new Error(`${name} failed: ${result.error || 'unknown error'}`)
+  }
+
+  const stats = result.transportStats
+  return {
+    name,
+    wallMs: Math.round(wallMs * 10) / 10,
+    latencyMs,
+    providerCount,
+    rsProfile: `${k}+${m}`,
+    userMdus,
+    witnessMdus,
+    logicalArtifacts: stats?.artifactCount ?? metadataMdus.length * providerCount + userMdus * providerCount + providerCount,
+    requestCount: stats?.requestCount ?? artifactRequests + bundleRequests,
+    artifactRequests,
+    bundleRequests,
+    fallbackCount: stats?.fallbackCount ?? 0,
+    fallbackReason: stats?.fallbackReason ?? null,
+    bytesSentPayload: stats?.bytesSent ?? bytesSent,
+    bundleSizes,
+    peakActiveUploads: Math.max(peakActiveUploads, stats?.peakActiveUploads ?? 0),
+  }
+}
+
+const perArtifact = await runScenario('per-artifact', { bundled: false })
+const bundled = await runScenario('bundled', { bundled: true })
+const fallback = unsupportedProviderIndex >= 0
+  ? await runScenario('bundled-with-one-unsupported-provider', { bundled: true, unsupportedIndex: unsupportedProviderIndex })
+  : null
+
+const rows = fallback ? [perArtifact, bundled, fallback] : [perArtifact, bundled]
+console.table(rows.map((row) => ({
+  scenario: row.name,
+  requests: row.requestCount,
+  bundles: row.bundleRequests,
+  artifactRequests: row.artifactRequests,
+  wallMs: row.wallMs,
+  bytesSentPayload: row.bytesSentPayload,
+  fallbackCount: row.fallbackCount,
+  peakActiveUploads: row.peakActiveUploads,
+})))
+console.log(JSON.stringify({
+  shape: {
+    file: '100MiB-equivalent sparse Mode 2 RS upload shape',
+    rsProfile: `${k}+${m}`,
+    providerCount,
+    userMdus,
+    witnessMdus,
+    metadataMduReplicaUploads: providerCount * (1 + witnessMdus),
+    userShardUploads: providerCount * userMdus,
+    manifestUploads: providerCount,
+    baselineArtifactRequests: providerCount * (1 + witnessMdus) + providerCount * userMdus + providerCount,
+  },
+  rows,
+}, null, 2))

--- a/polystore-website/src/components/FileSharder.tsx
+++ b/polystore-website/src/components/FileSharder.tsx
@@ -583,6 +583,42 @@ const dealSetupPollIntervalMs = 1_000
 const dealSetupMaxAttempts = 30
 const MDU_SIZE_BYTES = 8 * 1024 * 1024
 const MANIFEST_BLOB_SIZE_BYTES = 128 * 1024
+
+interface UploadTransportCounters {
+  queued: number
+  uploaded: number
+  artifactCount: number
+  perArtifactCount: number
+  bundledArtifactCount: number
+  bundleCount: number
+  requestCount: number
+  bytesSent: number
+  fallbackCount: number
+  fallbackReason: string | null
+  activeUploads: number
+  peakActiveUploads: number
+  startedBundles: Set<string>
+  finishedBundles: Set<string>
+}
+
+function createUploadTransportCounters(): UploadTransportCounters {
+  return {
+    queued: 0,
+    uploaded: 0,
+    artifactCount: 0,
+    perArtifactCount: 0,
+    bundledArtifactCount: 0,
+    bundleCount: 0,
+    requestCount: 0,
+    bytesSent: 0,
+    fallbackCount: 0,
+    fallbackReason: null,
+    activeUploads: 0,
+    peakActiveUploads: 0,
+    startedBundles: new Set<string>(),
+    finishedBundles: new Set<string>(),
+  }
+}
 function makePreparedMdu(index: number, data: Uint8Array, fullSize = MDU_SIZE_BYTES): PreparedBrowserMdu {
   const sparse = makeSparseArtifact({ kind: 'mdu', index, bytes: data, fullSize })
   return { index, data: sparse.bytes, fullSize: sparse.fullSize }
@@ -661,7 +697,7 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
   const lastStaleCommitMessageRef = useRef<string | null>(null)
   const browserPerfRunRef = useRef<BrowserPerfRun | null>(null)
   const browserPerfSeqRef = useRef(1)
-  const uploadArtifactCountsRef = useRef({ queued: 0, uploaded: 0 })
+  const uploadTransportCountersRef = useRef<UploadTransportCounters>(createUploadTransportCounters())
   const [uploadStatus, setUploadStatus] = useState<UploadPipelineStatus | null>(null)
   const uploadStatusRef = useRef<UploadPipelineStatus | null>(null)
   const dealSetupAttemptRef = useRef(0)
@@ -850,7 +886,7 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
       if (!run) return
       run.phaseStarts[phase] = performance.now()
       if (phase === 'upload') {
-        uploadArtifactCountsRef.current = { queued: 0, uploaded: 0 }
+        uploadTransportCountersRef.current = createUploadTransportCounters()
       }
       browserPerfLog(`${phase}:start`, extra)
       const uploadPhase = browserPerfPhaseToUploadPhase(phase)
@@ -907,12 +943,54 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
 
   const browserPerfUploadTaskEvent = useCallback(
     (event: UploadTaskEvent) => {
-      const uploadArtifactCounts = uploadArtifactCountsRef.current
+      const counters = uploadTransportCountersRef.current
+      const bundleId = event.bundleId || ''
+      const bundleArtifactCount = Math.max(0, Number(event.bundleArtifactCount) || 0)
+      const bundleBytes = Math.max(0, Number(event.bundleBytes) || 0)
+
       if (event.phase === 'start') {
-        uploadArtifactCounts.queued += 1
-      } else if (event.phase === 'end' && event.ok !== false) {
-        uploadArtifactCounts.uploaded += 1
+        counters.queued += 1
+        counters.artifactCount += 1
+        if (event.transportKind === 'bundle' && bundleId) {
+          if (!counters.startedBundles.has(bundleId)) {
+            counters.startedBundles.add(bundleId)
+            counters.bundleCount += 1
+            counters.bundledArtifactCount += bundleArtifactCount || 1
+            counters.requestCount += 1
+            counters.bytesSent += bundleBytes || event.bytes
+            counters.activeUploads += 1
+            counters.peakActiveUploads = Math.max(counters.peakActiveUploads, counters.activeUploads)
+          }
+        } else {
+          counters.perArtifactCount += 1
+          counters.requestCount += 1
+          counters.bytesSent += event.bytes
+          counters.activeUploads += 1
+          counters.peakActiveUploads = Math.max(counters.peakActiveUploads, counters.activeUploads)
+        }
+      } else if (event.phase === 'fallback') {
+        counters.fallbackCount += 1
+        counters.fallbackReason = event.fallbackReason || event.error || counters.fallbackReason
+        const fallbackArtifacts = Math.max(0, Number(event.fallbackArtifactCount) || bundleArtifactCount || 0)
+        counters.perArtifactCount += fallbackArtifacts
+        counters.requestCount += fallbackArtifacts
+        counters.bytesSent += event.bytes
+        if (bundleId && !counters.finishedBundles.has(bundleId)) {
+          counters.finishedBundles.add(bundleId)
+          counters.activeUploads = Math.max(0, counters.activeUploads - 1)
+        }
+      } else if (event.phase === 'end') {
+        if (event.ok !== false) counters.uploaded += 1
+        if (event.transportKind === 'bundle' && bundleId) {
+          if (!counters.finishedBundles.has(bundleId)) {
+            counters.finishedBundles.add(bundleId)
+            counters.activeUploads = Math.max(0, counters.activeUploads - 1)
+          }
+        } else if (!event.fallbackReason) {
+          counters.activeUploads = Math.max(0, counters.activeUploads - 1)
+        }
       }
+
       browserPerfLog(`upload_task:${event.phase}`, {
         artifactKind: event.kind,
         target: event.target,
@@ -923,21 +1001,48 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
         durationMs: event.durationMs !== undefined ? roundPerfMs(event.durationMs) : null,
         ok: event.ok ?? null,
         error: event.error ?? null,
+        transportKind: event.transportKind ?? null,
+        bundleId: event.bundleId ?? null,
+        bundleArtifactCount: event.bundleArtifactCount ?? null,
+        bundleBytes: event.bundleBytes ?? null,
+        fallbackArtifactCount: event.fallbackArtifactCount ?? null,
+        fallbackReason: event.fallbackReason ?? null,
+        requestCount: counters.requestCount,
+        bytesSent: counters.bytesSent,
+        peakActiveUploads: counters.peakActiveUploads,
       })
+      const isFallback = event.phase === 'fallback'
       updateUploadStatus(
         {
           phase: 'upload_transport',
-          phaseLabel: event.phase === 'start' ? 'Uploading artifact' : event.ok === false ? 'Artifact upload failed' : 'Uploaded artifact',
-          tone: event.ok === false ? 'error' : 'active',
+          phaseLabel: isFallback
+            ? 'Bundle unsupported; using per-artifact fallback'
+            : event.phase === 'start'
+              ? event.transportKind === 'bundle'
+                ? 'Uploading provider bundle'
+                : 'Uploading artifact'
+              : event.ok === false
+                ? 'Artifact upload failed'
+                : 'Uploaded artifact',
+          tone: event.ok === false ? 'error' : isFallback ? 'warning' : 'active',
           storage: {
             stage: event.phase === 'end' && event.ok !== false ? 'provider' : 'upload_queue',
-            queuedArtifacts: uploadArtifactCounts.queued,
-            uploadedArtifacts: uploadArtifactCounts.uploaded,
+            queuedArtifacts: counters.queued,
+            uploadedArtifacts: counters.uploaded,
           },
           transport: {
             mode: event.kind === 'shard' ? 'striped-provider' : 'direct-provider',
             target: event.target,
             lastError: event.error ?? null,
+            artifactCount: counters.artifactCount,
+            perArtifactCount: counters.perArtifactCount,
+            bundledArtifactCount: counters.bundledArtifactCount,
+            bundleCount: counters.bundleCount,
+            requestCount: counters.requestCount,
+            bytesSent: counters.bytesSent,
+            fallbackCount: counters.fallbackCount,
+            fallbackReason: counters.fallbackReason,
+            peakActiveUploads: counters.peakActiveUploads,
           },
           totals: {
             bytesDone: event.phase === 'end' && event.ok !== false ? event.bytes : undefined,
@@ -975,7 +1080,7 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
       workTotal: 0,
     }
     uploadStatusRef.current = null
-    uploadArtifactCountsRef.current = { queued: 0, uploaded: 0 }
+    uploadTransportCountersRef.current = createUploadTransportCounters()
     setUploadStatus(null)
     if (typeof window !== 'undefined') {
       const statusWindow = window as typeof window & {
@@ -4677,6 +4782,10 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
     const timingPhases = uploadStatus.timing.phases
     const uploaded = uploadStatus.storage.uploadedArtifacts
     const queued = uploadStatus.storage.queuedArtifacts
+    const requestCount = uploadStatus.transport.requestCount
+    const bundleCount = uploadStatus.transport.bundleCount
+    const bytesSent = uploadStatus.transport.bytesSent
+    const fallbackCount = uploadStatus.transport.fallbackCount
     return [
       { label: 'phase', value: uploadStatus.phaseLabel },
       { label: 'kzg', value: uploadStatus.kzg.label },
@@ -4711,6 +4820,20 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
             ? '—'
             : `${String(uploaded ?? 0)} uploaded / ${String(queued ?? 0)} queued`,
       },
+      {
+        label: 'requests',
+        value:
+          requestCount === null
+            ? '—'
+            : `${requestCount} reqs${bundleCount && bundleCount > 0 ? ` (${bundleCount} bundles)` : ''}`,
+      },
+      {
+        label: 'sent',
+        value: bytesSent === null ? '—' : formatBytes(bytesSent),
+      },
+      ...(fallbackCount && fallbackCount > 0
+        ? [{ label: 'fallback', value: uploadStatus.transport.fallbackReason || `${fallbackCount} bundle fallback(s)` }]
+        : []),
     ]
   }, [uploadStatus])
 
@@ -4753,9 +4876,19 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
       }
 
       const ok = isMode2 ? await uploadMode2() : await uploadMdus(collectedMdus)
+      const transportSummary = uploadStatusRef.current?.transport
       browserPerfEndPhase('upload', {
         ok,
         mode: isMode2 ? 'mode2' : 'mode1',
+        requestCount: transportSummary?.requestCount ?? null,
+        bundleCount: transportSummary?.bundleCount ?? null,
+        artifactCount: transportSummary?.artifactCount ?? null,
+        perArtifactCount: transportSummary?.perArtifactCount ?? null,
+        bundledArtifactCount: transportSummary?.bundledArtifactCount ?? null,
+        bytesSent: transportSummary?.bytesSent ?? null,
+        fallbackCount: transportSummary?.fallbackCount ?? null,
+        fallbackReason: transportSummary?.fallbackReason ?? null,
+        peakActiveUploads: transportSummary?.peakActiveUploads ?? null,
       })
       if (ok) {
         updateUploadStatus(

--- a/polystore-website/src/lib/upload/engine.test.ts
+++ b/polystore-website/src/lib/upload/engine.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { buildCommitRequest, createUploadEngine, type UploadTransportRequest } from './engine'
+import { buildCommitRequest, createUploadEngine, type UploadTaskEvent, type UploadTransportRequest } from './engine'
 
 function makeRecordingTransport(failAt?: (request: UploadTransportRequest) => string | null) {
   const calls: UploadTransportRequest[] = []
@@ -510,6 +510,104 @@ test('upload engine: striped upload bundles requests per target when transport s
       'provider-b:manifest:manifest:-',
     ],
   ])
+  assert.equal(result.transportStats?.bundleCount, 2)
+  assert.equal(result.transportStats?.requestCount, 2)
+  assert.equal(result.transportStats?.bundledArtifactCount, 8)
+})
+
+test('upload engine: bundle unsupported falls back per target without replaying successful bundles', async () => {
+  const bundleCalls: string[] = []
+  const artifactCalls: string[] = []
+  const events: UploadTaskEvent[] = []
+  const transport = {
+    async sendArtifact(request: UploadTransportRequest) {
+      artifactCalls.push(`${request.target.label}:${request.artifact.kind}:${request.artifact.index ?? 'manifest'}:${request.artifact.slot ?? '-'}`)
+    },
+    async sendBundle(requests: UploadTransportRequest[]) {
+      const label = requests[0]?.target.label || 'unknown'
+      bundleCalls.push(label)
+      if (label === 'provider-b') {
+        const err = new Error('bundle upload unsupported')
+        err.name = 'BundleUnsupportedUploadError'
+        throw err
+      }
+    },
+  }
+
+  const engine = createUploadEngine({ transport })
+  const result = await engine.uploadStriped({
+    dealId: '18',
+    manifestRoot: '0xbundle',
+    previousManifestRoot: '0xprev',
+    manifestBlob: new Uint8Array([5, 4, 3]),
+    manifestBlobFullSize: 128 * 1024,
+    metadataMdus: [{ index: 0, data: new Uint8Array([1]), fullSize: 8 * 1024 * 1024 }],
+    shardSets: [
+      {
+        index: 2,
+        shards: [
+          { data: new Uint8Array([7]), fullSize: 1024 },
+          { data: new Uint8Array([8]), fullSize: 1024 },
+        ],
+      },
+    ],
+    metadataTargets: [
+      {
+        baseUrl: 'http://provider-a',
+        mduPath: '/sp/upload_mdu',
+        manifestPath: '/sp/upload_manifest',
+        shardPath: '/sp/upload_shard',
+        bundlePath: '/sp/upload_bundle',
+        label: 'provider-a',
+      },
+      {
+        baseUrl: 'http://provider-b',
+        mduPath: '/sp/upload_mdu',
+        manifestPath: '/sp/upload_manifest',
+        shardPath: '/sp/upload_shard',
+        bundlePath: '/sp/upload_bundle',
+        label: 'provider-b',
+      },
+    ],
+    shardTargets: [
+      {
+        baseUrl: 'http://provider-a',
+        mduPath: '/sp/upload_mdu',
+        manifestPath: '/sp/upload_manifest',
+        shardPath: '/sp/upload_shard',
+        bundlePath: '/sp/upload_bundle',
+        label: 'provider-a',
+      },
+      {
+        baseUrl: 'http://provider-b',
+        mduPath: '/sp/upload_mdu',
+        manifestPath: '/sp/upload_manifest',
+        shardPath: '/sp/upload_shard',
+        bundlePath: '/sp/upload_bundle',
+        label: 'provider-b',
+      },
+    ],
+    onTaskEvent(event) {
+      events.push(event)
+    },
+  })
+
+  assert.equal(result.ok, true)
+  assert.deepEqual(bundleCalls.sort(), ['provider-a', 'provider-b'])
+  assert.deepEqual(artifactCalls, [
+    'provider-b:mdu:0:-',
+    'provider-b:shard:2:1',
+    'provider-b:manifest:manifest:-',
+  ])
+  assert.equal(result.transportStats?.bundleCount, 2)
+  assert.equal(result.transportStats?.perArtifactCount, 3)
+  assert.equal(result.transportStats?.fallbackCount, 1)
+  assert.match(result.transportStats?.fallbackReason || '', /unsupported/)
+  assert.equal(events.some((event) => event.phase === 'fallback' && event.fallbackArtifactCount === 3), true)
+  assert.equal(
+    events.some((event) => event.phase === 'end' && event.ok === false && event.error?.includes('unsupported')),
+    false,
+  )
 })
 
 test('buildCommitRequest: mode2 derives total mdus from witness + user counts', () => {

--- a/polystore-website/src/lib/upload/engine.ts
+++ b/polystore-website/src/lib/upload/engine.ts
@@ -37,7 +37,7 @@ export interface UploadProgressStep {
 }
 
 export interface UploadTaskEvent {
-  phase: 'start' | 'end'
+  phase: 'start' | 'end' | 'fallback'
   kind: SparseArtifactKind
   target: string
   index?: number
@@ -47,6 +47,24 @@ export interface UploadTaskEvent {
   durationMs?: number
   ok?: boolean
   error?: string
+  transportKind?: 'artifact' | 'bundle'
+  bundleId?: string
+  bundleArtifactCount?: number
+  bundleBytes?: number
+  fallbackArtifactCount?: number
+  fallbackReason?: string
+}
+
+export interface UploadTransportStats {
+  artifactCount: number
+  perArtifactCount: number
+  bundledArtifactCount: number
+  bundleCount: number
+  requestCount: number
+  bytesSent: number
+  fallbackCount: number
+  fallbackReason?: string
+  peakActiveUploads: number
 }
 
 export interface UploadTransportRequest {
@@ -95,6 +113,7 @@ export interface UploadEngineResult {
   ok: boolean
   steps: UploadProgressStep[]
   error?: string
+  transportStats?: UploadTransportStats
 }
 
 export interface DirectUploadInput {
@@ -324,6 +343,46 @@ const DEFAULT_DIRECT_UPLOAD_CONCURRENCY = 4
 const DEFAULT_STRIPED_METADATA_UPLOAD_CONCURRENCY = 6
 const DEFAULT_STRIPED_SHARD_UPLOAD_CONCURRENCY = 6
 
+function createUploadTransportStats(): UploadTransportStats {
+  return {
+    artifactCount: 0,
+    perArtifactCount: 0,
+    bundledArtifactCount: 0,
+    bundleCount: 0,
+    requestCount: 0,
+    bytesSent: 0,
+    fallbackCount: 0,
+    fallbackReason: undefined,
+    peakActiveUploads: 0,
+  }
+}
+
+function artifactPayloadBytes(task: UploadTask): number {
+  return Math.max(0, task.request.artifact.bytes.byteLength)
+}
+
+function bundlePayloadBytes(bundle: UploadTaskBundle): number {
+  return bundle.tasks.reduce((sum, task) => sum + artifactPayloadBytes(task), 0)
+}
+
+function mergeUploadTransportStats(...statsList: Array<UploadTransportStats | undefined>): UploadTransportStats | undefined {
+  const filtered = statsList.filter((stats): stats is UploadTransportStats => Boolean(stats))
+  if (filtered.length === 0) return undefined
+  const merged = createUploadTransportStats()
+  for (const stats of filtered) {
+    merged.artifactCount += stats.artifactCount
+    merged.perArtifactCount += stats.perArtifactCount
+    merged.bundledArtifactCount += stats.bundledArtifactCount
+    merged.bundleCount += stats.bundleCount
+    merged.requestCount += stats.requestCount
+    merged.bytesSent += stats.bytesSent
+    merged.fallbackCount += stats.fallbackCount
+    merged.peakActiveUploads = Math.max(merged.peakActiveUploads, stats.peakActiveUploads)
+    if (!merged.fallbackReason && stats.fallbackReason) merged.fallbackReason = stats.fallbackReason
+  }
+  return merged
+}
+
 function normalizeConcurrency(value: number | undefined, fallback: number): number {
   const normalized = Number(value)
   if (!Number.isFinite(normalized) || normalized <= 0) return fallback
@@ -346,15 +405,17 @@ async function runUploadTasks(
   let nextIndex = 0
   let active = 0
   let firstError: string | null = null
+  const stats = createUploadTransportStats()
+  stats.artifactCount = tasks.length
 
   return await new Promise<UploadEngineResult>((resolve) => {
     const settleIfDone = () => {
       if (active !== 0) return
       if (nextIndex < tasks.length && (!firstError || continueOnError)) return
       if (firstError) {
-        resolve({ ok: false, steps, error: firstError })
+        resolve({ ok: false, steps, error: firstError, transportStats: stats })
       } else {
-        resolve({ ok: true, steps })
+        resolve({ ok: true, steps, transportStats: stats })
       }
     }
 
@@ -363,6 +424,10 @@ async function runUploadTasks(
         const task = tasks[nextIndex]
         nextIndex += 1
         active += 1
+        stats.perArtifactCount += 1
+        stats.requestCount += 1
+        stats.bytesSent += artifactPayloadBytes(task)
+        stats.peakActiveUploads = Math.max(stats.peakActiveUploads, active)
         const startedAt = trackTaskEvents ? (typeof performance !== 'undefined' ? performance.now() : Date.now()) : 0
         const target = trackTaskEvents ? task.request.target.label || task.request.target.baseUrl : ''
         const index = trackTaskEvents && 'index' in task.request.artifact ? task.request.artifact.index : undefined
@@ -378,6 +443,7 @@ async function runUploadTasks(
             slot,
             bytes,
             fullSize,
+            transportKind: 'artifact',
           })
         }
 
@@ -400,6 +466,7 @@ async function runUploadTasks(
                 fullSize,
                 durationMs: finishedAt - startedAt,
                 ok: true,
+                transportKind: 'artifact',
               })
             }
             if (trackProgress) {
@@ -422,6 +489,7 @@ async function runUploadTasks(
                 durationMs: finishedAt - startedAt,
                 ok: false,
                 error: message,
+                transportKind: 'artifact',
               })
             }
             if (trackProgress) {
@@ -450,6 +518,7 @@ async function runPipelinedUploadTaskProducer(
   const trackTaskEvents = Boolean(input.onTaskEvent)
   let producerDone = false
   let firstError: string | null = null
+  const stats = createUploadTransportStats()
   const queue: PipelinedUploadArtifact[] = []
   const waiters: Array<() => void> = []
 
@@ -475,6 +544,10 @@ async function runPipelinedUploadTaskProducer(
       target: item.target,
       artifact: item.artifact,
     }
+    stats.artifactCount += 1
+    stats.perArtifactCount += 1
+    stats.requestCount += 1
+    stats.bytesSent += Math.max(0, request.artifact.bytes.byteLength)
     const startedAt = trackTaskEvents ? (typeof performance !== 'undefined' ? performance.now() : Date.now()) : 0
     const target = trackTaskEvents ? request.target.label || request.target.baseUrl : ''
     const index = trackTaskEvents && 'index' in request.artifact ? request.artifact.index : undefined
@@ -490,6 +563,7 @@ async function runPipelinedUploadTaskProducer(
         slot,
         bytes,
         fullSize,
+        transportKind: 'artifact',
       })
     }
     try {
@@ -506,6 +580,7 @@ async function runPipelinedUploadTaskProducer(
           fullSize,
           durationMs: finishedAt - startedAt,
           ok: true,
+          transportKind: 'artifact',
         })
       }
     } catch (error: unknown) {
@@ -523,6 +598,7 @@ async function runPipelinedUploadTaskProducer(
           durationMs: finishedAt - startedAt,
           ok: false,
           error: message,
+          transportKind: 'artifact',
         })
       }
       throw new Error(message)
@@ -561,7 +637,7 @@ async function runPipelinedUploadTaskProducer(
   }
 
   await Promise.all([produce(), ...Array.from({ length: Math.max(1, concurrency) }, () => worker())])
-  return firstError ? { ok: false, steps: [], error: firstError } : { ok: true, steps: [] }
+  return firstError ? { ok: false, steps: [], error: firstError, transportStats: stats } : { ok: true, steps: [], transportStats: stats }
 }
 
 function groupUploadTasksByTarget(tasks: UploadTask[]): UploadTaskBundle[] {
@@ -592,7 +668,7 @@ async function runUploadTaskBundles(
   concurrency: number,
   transport: UploadTransportPort & Required<Pick<UploadTransportPort, 'sendBundle'>>,
   options?: { continueOnError?: boolean },
-): Promise<UploadEngineResult & { bundleUnsupported?: boolean }> {
+): Promise<UploadEngineResult> {
   const trackProgress = Boolean(onProgress) && initialSteps.length > 0
   const trackTaskEvents = Boolean(onTaskEvent)
   const continueOnError = Boolean(options?.continueOnError)
@@ -600,27 +676,30 @@ async function runUploadTaskBundles(
   let nextIndex = 0
   let active = 0
   let firstError: string | null = null
-  let bundleUnsupported = false
+  const stats = createUploadTransportStats()
+  stats.artifactCount = bundles.reduce((sum, bundle) => sum + bundle.tasks.length, 0)
 
-  return await new Promise<UploadEngineResult & { bundleUnsupported?: boolean }>((resolve) => {
+  return await new Promise<UploadEngineResult>((resolve) => {
     const settleIfDone = () => {
       if (active !== 0) return
-      if (nextIndex < bundles.length && (!firstError || continueOnError) && !bundleUnsupported) return
-      if (bundleUnsupported) {
-        resolve({ ok: false, steps, error: 'bundle upload unsupported', bundleUnsupported: true })
-      } else if (firstError) {
-        resolve({ ok: false, steps, error: firstError })
+      if (nextIndex < bundles.length && (!firstError || continueOnError)) return
+      if (firstError) {
+        resolve({ ok: false, steps, error: firstError, transportStats: stats })
       } else {
-        resolve({ ok: true, steps })
+        resolve({ ok: true, steps, transportStats: stats })
       }
     }
 
     const launchNext = () => {
-      while ((continueOnError || !firstError) && !bundleUnsupported && active < concurrency && nextIndex < bundles.length) {
+      while ((continueOnError || !firstError) && active < concurrency && nextIndex < bundles.length) {
         const bundle = bundles[nextIndex]
+        const bundleIndex = nextIndex
         nextIndex += 1
         active += 1
+        stats.peakActiveUploads = Math.max(stats.peakActiveUploads, active)
         const startedAt = typeof performance !== 'undefined' ? performance.now() : Date.now()
+        const bundleId = `${bundle.target}#${bundleIndex}`
+        const bundleBytes = bundlePayloadBytes(bundle)
         const events = trackTaskEvents
           ? bundle.tasks.map((task) => ({
               request: task.request,
@@ -632,6 +711,11 @@ async function runUploadTaskBundles(
             }))
           : []
 
+        stats.bundleCount += 1
+        stats.bundledArtifactCount += bundle.tasks.length
+        stats.requestCount += 1
+        stats.bytesSent += bundleBytes
+
         if (trackTaskEvents) {
           for (const event of events) {
             onTaskEvent?.({
@@ -642,6 +726,10 @@ async function runUploadTaskBundles(
               slot: event.slot,
               bytes: event.bytes,
               fullSize: event.fullSize,
+              transportKind: 'bundle',
+              bundleId,
+              bundleArtifactCount: bundle.tasks.length,
+              bundleBytes,
             })
           }
         }
@@ -653,12 +741,66 @@ async function runUploadTaskBundles(
           steps = emitProgress(steps, onProgress)
         }
 
-        void transport
-          .sendBundle(bundle.tasks.map((task) => task.request))
-          .then(() => {
-            const finishedAt = typeof performance !== 'undefined' ? performance.now() : Date.now()
-            if (trackTaskEvents) {
-              for (const event of events) {
+        const completeBundle = (ok: boolean, message?: string) => {
+          const finishedAt = typeof performance !== 'undefined' ? performance.now() : Date.now()
+          if (trackTaskEvents) {
+            for (const event of events) {
+              onTaskEvent?.({
+                phase: 'end',
+                kind: event.request.artifact.kind,
+                target: event.target,
+                index: event.index,
+                slot: event.slot,
+                bytes: event.bytes,
+                fullSize: event.fullSize,
+                durationMs: finishedAt - startedAt,
+                ok,
+                error: message,
+                transportKind: 'bundle',
+                bundleId,
+                bundleArtifactCount: bundle.tasks.length,
+                bundleBytes,
+              })
+            }
+          }
+          if (trackProgress) {
+            for (const task of bundle.tasks) {
+              steps = updateStep(steps, task.stepIndex, ok ? { status: 'complete' } : { status: 'error', error: message })
+            }
+            steps = emitProgress(steps, onProgress)
+          }
+        }
+
+        const fallbackToArtifacts = async (reason: string): Promise<void> => {
+          stats.fallbackCount += 1
+          if (!stats.fallbackReason) stats.fallbackReason = reason
+          if (trackTaskEvents && events.length > 0) {
+            const first = events[0]
+            onTaskEvent?.({
+              phase: 'fallback',
+              kind: first.request.artifact.kind,
+              target: first.target,
+              bytes: bundleBytes,
+              fullSize: bundleBytes,
+              transportKind: 'artifact',
+              bundleId,
+              bundleArtifactCount: bundle.tasks.length,
+              bundleBytes,
+              fallbackArtifactCount: bundle.tasks.length,
+              fallbackReason: reason,
+            })
+          }
+
+          for (let i = 0; i < bundle.tasks.length; i += 1) {
+            const task = bundle.tasks[i]
+            const event = events[i]
+            stats.perArtifactCount += 1
+            stats.requestCount += 1
+            stats.bytesSent += artifactPayloadBytes(task)
+            try {
+              await transport.sendArtifact(task.request)
+              if (trackTaskEvents && event) {
+                const finishedAt = typeof performance !== 'undefined' ? performance.now() : Date.now()
                 onTaskEvent?.({
                   phase: 'end',
                   kind: event.request.artifact.kind,
@@ -669,26 +811,21 @@ async function runUploadTaskBundles(
                   fullSize: event.fullSize,
                   durationMs: finishedAt - startedAt,
                   ok: true,
+                  transportKind: 'artifact',
+                  bundleId,
+                  bundleArtifactCount: bundle.tasks.length,
+                  bundleBytes,
+                  fallbackReason: reason,
                 })
               }
-            }
-            if (trackProgress) {
-              for (const task of bundle.tasks) {
-                steps = updateStep(steps, task.stepIndex, { status: 'complete' })
+              if (trackProgress) {
+                steps = emitProgress(updateStep(steps, task.stepIndex, { status: 'complete' }), onProgress)
               }
-              steps = emitProgress(steps, onProgress)
-            }
-          })
-          .catch((error: unknown) => {
-            if (isBundleUnsupportedError(error)) {
-              bundleUnsupported = true
-              return
-            }
-            const message = error instanceof Error ? error.message : String(error)
-            if (!firstError) firstError = message
-            const finishedAt = typeof performance !== 'undefined' ? performance.now() : Date.now()
-            if (trackTaskEvents) {
-              for (const event of events) {
+            } catch (error: unknown) {
+              const message = error instanceof Error ? error.message : String(error)
+              if (!firstError) firstError = message
+              if (trackTaskEvents && event) {
+                const finishedAt = typeof performance !== 'undefined' ? performance.now() : Date.now()
                 onTaskEvent?.({
                   phase: 'end',
                   kind: event.request.artifact.kind,
@@ -700,21 +837,39 @@ async function runUploadTaskBundles(
                   durationMs: finishedAt - startedAt,
                   ok: false,
                   error: message,
+                  transportKind: 'artifact',
+                  bundleId,
+                  bundleArtifactCount: bundle.tasks.length,
+                  bundleBytes,
+                  fallbackReason: reason,
                 })
               }
-            }
-            if (trackProgress) {
-              for (const task of bundle.tasks) {
-                steps = updateStep(steps, task.stepIndex, { status: 'error', error: message })
+              if (trackProgress) {
+                steps = emitProgress(updateStep(steps, task.stepIndex, { status: 'error', error: message }), onProgress)
               }
-              steps = emitProgress(steps, onProgress)
+              if (!continueOnError) return
             }
-          })
-          .finally(() => {
+          }
+        }
+
+        void (async () => {
+          try {
+            await transport.sendBundle(bundle.tasks.map((task) => task.request))
+            completeBundle(true)
+          } catch (error: unknown) {
+            const message = error instanceof Error ? error.message : String(error)
+            if (isBundleUnsupportedError(error)) {
+              await fallbackToArtifacts(message || 'bundle upload unsupported')
+              return
+            }
+            if (!firstError) firstError = message
+            completeBundle(false, message)
+          } finally {
             active -= 1
             launchNext()
             settleIfDone()
-          })
+          }
+        })()
       }
 
       settleIfDone()
@@ -814,10 +969,7 @@ export function createUploadEngine(options: UploadEngineOptions) {
           1,
           ports.transport as UploadTransportPort & Required<Pick<UploadTransportPort, 'sendBundle'>>,
         )
-        if (!bundleResult.bundleUnsupported) {
-          return bundleResult
-        }
-        steps = trackSteps ? emitProgress(buildDirectUploadSteps(input), input.onProgress) : []
+        return bundleResult
       }
 
       return runUploadTasks(tasks, steps, input.onProgress, input.onTaskEvent, directConcurrency, ports.transport)
@@ -930,10 +1082,7 @@ export function createUploadEngine(options: UploadEngineOptions) {
           ports.transport as UploadTransportPort & Required<Pick<UploadTransportPort, 'sendBundle'>>,
           { continueOnError: true },
         )
-        if (!bundleResult.bundleUnsupported) {
-          return bundleResult
-        }
-        steps = trackSteps ? emitProgress(buildStripedUploadSteps(input), input.onProgress) : []
+        return bundleResult
       }
 
       return runUploadTasks(
@@ -1022,10 +1171,7 @@ export function createUploadEngine(options: UploadEngineOptions) {
           1,
           ports.transport as UploadTransportPort & Required<Pick<UploadTransportPort, 'sendBundle'>>,
         )
-        if (!bundleResult.bundleUnsupported) {
-          return bundleResult
-        }
-        steps = trackSteps ? emitProgress(buildStripedSlotUploadSteps(input), input.onProgress) : []
+        return bundleResult
       }
 
       const slotConcurrency = Math.max(1, Math.min(tasks.length, stripedMetadataConcurrency + stripedShardConcurrency))
@@ -1049,7 +1195,11 @@ export function createUploadEngine(options: UploadEngineOptions) {
           artifact: { kind: 'manifest', bytes: manifest.manifestBlob, fullSize: manifest.manifestBlobFullSize } as const,
         },
       }))
-      return runUploadTasks(manifestTasks, [], undefined, input.onTaskEvent, directConcurrency, ports.transport)
+      const manifestResult = await runUploadTasks(manifestTasks, [], undefined, input.onTaskEvent, directConcurrency, ports.transport)
+      return {
+        ...manifestResult,
+        transportStats: mergeUploadTransportStats(artifactResult.transportStats, manifestResult.transportStats),
+      }
     },
 
     async commitPreparedContent(input: PreparedCommitInput): Promise<ChainCommitRequest> {

--- a/polystore-website/src/lib/upload/httpTransport.test.ts
+++ b/polystore-website/src/lib/upload/httpTransport.test.ts
@@ -146,6 +146,7 @@ test('http transport bundles target artifacts into one binary bundle request', a
         dealId: '42',
         manifestRoot: '0xnext',
         previousManifestRoot: '0xprev',
+        uploadGeneration: 'browser-run-7',
         target: {
           baseUrl: 'http://provider.test/',
           mduPath: '/sp/upload_mdu',
@@ -164,6 +165,7 @@ test('http transport bundles target artifacts into one binary bundle request', a
         dealId: '42',
         manifestRoot: '0xnext',
         previousManifestRoot: '0xprev',
+        uploadGeneration: 'browser-run-7',
         target: {
           baseUrl: 'http://provider.test/',
           mduPath: '/sp/upload_mdu',
@@ -184,10 +186,65 @@ test('http transport bundles target artifacts into one binary bundle request', a
 
   assert.equal(receivedUrl, 'http://provider.test/sp/upload_bundle')
   assert.equal(receivedContentType, 'application/x.polystore-bundle-v2')
-  assert.match(receivedMeta, /"deal_id":42/)
-  assert.match(receivedMeta, /"kind":"mdu"/)
-  assert.match(receivedMeta, /"kind":"manifest"/)
+  const meta = JSON.parse(receivedMeta) as {
+    deal_id: number
+    manifest_root: string
+    previous_manifest_root: string
+    upload_generation: string
+    artifacts: Array<{ part: string; kind: string; full_size: number; send_size: number; mdu_index?: number }>
+  }
+  assert.equal(meta.deal_id, 42)
+  assert.equal(meta.manifest_root, '0xnext')
+  assert.equal(meta.previous_manifest_root, '0xprev')
+  assert.equal(meta.upload_generation, 'browser-run-7')
+  assert.deepStrictEqual(meta.artifacts, [
+    { part: 'artifact_00', kind: 'mdu', mdu_index: 0, full_size: 8, send_size: 3 },
+    { part: 'artifact_01', kind: 'manifest', full_size: 16, send_size: 1 },
+  ])
   assert.deepStrictEqual(Array.from(receivedBytes.slice(-4)), [1, 2, 3, 9])
+})
+
+test('http transport rejects mixed bundle targets before sending', async () => {
+  const originalFetch = globalThis.fetch
+  let calls = 0
+  globalThis.fetch = (async () => {
+    calls += 1
+    return new Response('OK', { status: 200 })
+  }) as typeof fetch
+  try {
+    const transport = createSparseHttpTransportPort()
+    await assert.rejects(
+      () =>
+        transport.sendBundle?.([
+          {
+            dealId: '42',
+            manifestRoot: '0xnext',
+            target: {
+              baseUrl: 'http://provider-a.test',
+              mduPath: '/sp/upload_mdu',
+              manifestPath: '/sp/upload_manifest',
+              bundlePath: '/sp/upload_bundle',
+            },
+            artifact: { kind: 'manifest', bytes: new Uint8Array([1]) },
+          },
+          {
+            dealId: '42',
+            manifestRoot: '0xnext',
+            target: {
+              baseUrl: 'http://provider-b.test',
+              mduPath: '/sp/upload_mdu',
+              manifestPath: '/sp/upload_manifest',
+              bundlePath: '/sp/upload_bundle',
+            },
+            artifact: { kind: 'manifest', bytes: new Uint8Array([2]) },
+          },
+        ]) ?? Promise.resolve(),
+      /single provider bundle endpoint/,
+    )
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+  assert.equal(calls, 0)
 })
 
 test('http transport marks bundle upload unsupported on 404', async () => {

--- a/polystore-website/src/lib/upload/httpTransport.ts
+++ b/polystore-website/src/lib/upload/httpTransport.ts
@@ -76,10 +76,9 @@ function isBundleCompatibilityError(status: number, body: string): boolean {
   const normalized = body.toLowerCase()
   if (normalized.trim() === '') return true
   return (
-    normalized.includes('invalid bundle') ||
+    normalized.includes('bundle') ||
     normalized.includes('invalid multipart') ||
     normalized.includes('unsupported media') ||
-    normalized.includes('bundle upload unsupported') ||
     normalized.includes('invalid artifact')
   )
 }
@@ -149,6 +148,26 @@ export function createSparseHttpTransportPort(): UploadTransportPort {
       if (!Number.isInteger(parsedDealId) || parsedDealId < 0) {
         throw new Error(`invalid deal id for bundle upload: ${first.dealId}`)
       }
+      const firstManifestRoot = String(first.manifestRoot || '').trim()
+      const firstPreviousManifestRoot = String(first.previousManifestRoot || '').trim()
+      const firstUploadGeneration = String(first.uploadGeneration || '').trim()
+      for (const request of requests) {
+        if (targetUrls(request.target).bundle !== bundleUrl) {
+          throw new Error('bundle requests must target a single provider bundle endpoint')
+        }
+        if (String(request.dealId) !== String(first.dealId)) {
+          throw new Error('bundle requests must use a single deal_id')
+        }
+        if (String(request.manifestRoot || '').trim() !== firstManifestRoot) {
+          throw new Error('bundle requests must use a single manifest_root')
+        }
+        if (String(request.previousManifestRoot || '').trim() !== firstPreviousManifestRoot) {
+          throw new Error('bundle requests must use a single previous_manifest_root')
+        }
+        if (String(request.uploadGeneration || '').trim() !== firstUploadGeneration) {
+          throw new Error('bundle requests must use a single upload_generation')
+        }
+      }
 
       const artifacts = requests.map((request, index) => {
         const sparseArtifact = makeSparseArtifact(request.artifact)
@@ -157,9 +176,9 @@ export function createSparseHttpTransportPort(): UploadTransportPort {
       })
       const metaJson = JSON.stringify({
         deal_id: parsedDealId,
-        manifest_root: first.manifestRoot,
-        previous_manifest_root: String(first.previousManifestRoot || '').trim(),
-        upload_generation: String(first.uploadGeneration || '').trim(),
+        manifest_root: firstManifestRoot,
+        previous_manifest_root: firstPreviousManifestRoot,
+        upload_generation: firstUploadGeneration,
         artifacts: artifacts.map(({ request, sparseArtifact, part }) => ({
           part,
           kind: request.artifact.kind,

--- a/polystore-website/src/lib/uploadStatus.test.ts
+++ b/polystore-website/src/lib/uploadStatus.test.ts
@@ -90,6 +90,10 @@ test('sanitizeUploadPipelineStatus truncates user-controlled text', () => {
     phaseLabel: 'p'.repeat(800),
     latestEvent: 'l'.repeat(800),
     error: 'e'.repeat(800),
+    transport: {
+      ...status.transport,
+      fallbackReason: 't'.repeat(800),
+    },
     kzg: {
       ...status.kzg,
       fallbackReason: 'f'.repeat(800),
@@ -101,5 +105,6 @@ test('sanitizeUploadPipelineStatus truncates user-controlled text', () => {
   assert.equal(sanitized.latestEvent?.length, 160)
   assert.equal(sanitized.file.name?.length, 160)
   assert.equal(sanitized.error?.length, 500)
+  assert.equal(sanitized.transport.fallbackReason?.length, 500)
   assert.equal(sanitized.kzg.fallbackReason?.length, 500)
 })

--- a/polystore-website/src/lib/uploadStatus.ts
+++ b/polystore-website/src/lib/uploadStatus.ts
@@ -84,6 +84,15 @@ export type UploadPipelineStatus = {
     target: string | null
     retries: number
     lastError: string | null
+    artifactCount: number | null
+    perArtifactCount: number | null
+    bundledArtifactCount: number | null
+    bundleCount: number | null
+    requestCount: number | null
+    bytesSent: number | null
+    fallbackCount: number | null
+    fallbackReason: string | null
+    peakActiveUploads: number | null
   }
   kzg: KzgBackendStatus
   timing: UploadPipelineTiming
@@ -252,6 +261,15 @@ export function createUploadPipelineStatus(input: {
       target: null,
       retries: 0,
       lastError: null,
+      artifactCount: null,
+      perArtifactCount: null,
+      bundledArtifactCount: null,
+      bundleCount: null,
+      requestCount: null,
+      bytesSent: null,
+      fallbackCount: null,
+      fallbackReason: null,
+      peakActiveUploads: null,
     },
     kzg: { ...PENDING_KZG_BACKEND_STATUS },
     timing: {
@@ -315,6 +333,7 @@ export function sanitizeUploadPipelineStatus(status: UploadPipelineStatus): Uplo
       ...status.transport,
       target: truncate(status.transport.target, 240),
       lastError: truncate(status.transport.lastError, 500),
+      fallbackReason: truncate(status.transport.fallbackReason, 500),
     },
     kzg: {
       ...status.kzg,

--- a/polystore-website/tests/direct-upload-sparse.spec.ts
+++ b/polystore-website/tests/direct-upload-sparse.spec.ts
@@ -10,6 +10,7 @@ const uploadSizeBytes = Number(process.env.SPARSE_FILE_SIZE_BYTES || 192 * 1024)
 const largeUploadTimeoutMs = uploadSizeBytes > 32 * 1024 * 1024 ? 900_000 : 120_000
 const capturePreparePerf = process.env.CAPTURE_PREPARE_PERF === '1'
 const stopAfterPreparePerf = process.env.STOP_AFTER_PREPARE_PERF === '1'
+const bundleUploadsEnabled = process.env.SPARSE_BUNDLE_UPLOADS === '1'
 
 function ethToPolystoreAddress(ethAddress: string): string {
   const data = Buffer.from(ethAddress.replace(/^0x/, ''), 'hex')
@@ -26,9 +27,11 @@ test('Thick Client: no-gateway Mode 2 browser upload sends sparse MDU, manifest,
   const chainIdHex = `0x${chainId.toString(16)}`
   const polystoreAddress = ethToPolystoreAddress(account.address)
 
-  const mduUploads: Array<{ bodyLen: number; fullSize: number | null; mduIndex: string }> = []
-  const manifestUploads: Array<{ bodyLen: number; fullSize: number | null }> = []
-  const shardUploads: Array<{ bodyLen: number; fullSize: number | null; mduIndex: string; slot: string }> = []
+  const mduUploads: Array<{ bodyLen: number; fullSize: number | null; mduIndex: string; viaBundle?: boolean }> = []
+  const manifestUploads: Array<{ bodyLen: number; fullSize: number | null; viaBundle?: boolean }> = []
+  const shardUploads: Array<{ bodyLen: number; fullSize: number | null; mduIndex: string; slot: string; viaBundle?: boolean }> = []
+  const bundleUploads: Array<{ artifactCount: number; bodyLen: number; target: string }> = []
+  let perArtifactPostRequests = 0
   let gatewayUploadAttempts = 0
   let gatewayProbeAttempts = 0
   let activeUploads = 0
@@ -83,9 +86,67 @@ test('Thick Client: no-gateway Mode 2 browser upload sends sparse MDU, manifest,
     await route.fulfill({ status: 599, body: 'gateway disabled in sparse e2e' })
   })
 
-  // Force per-artifact sparse uploads in this test; the bundle path is covered elsewhere.
   await page.route('**/sp/upload_bundle*', async (route) => {
-    await route.fulfill({ status: 404, body: 'bundle disabled in sparse e2e' })
+    if (!bundleUploadsEnabled) {
+      await route.fulfill({ status: 404, body: 'bundle disabled in sparse e2e' })
+      return
+    }
+    if (route.request().method() === 'OPTIONS') {
+      await route.fulfill({
+        status: 204,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Methods': 'POST, OPTIONS',
+          'Access-Control-Allow-Headers': 'content-type,x-polystore-deal-id,x-polystore-manifest-root,x-polystore-previous-manifest-root,x-polystore-upload-generation',
+        },
+      })
+      return
+    }
+
+    const body = route.request().postDataBuffer() || Buffer.alloc(0)
+    expect(body.subarray(0, 4).toString('utf8')).toBe('NLB2')
+    const metaLen = body.readUInt32LE(4)
+    const meta = JSON.parse(body.subarray(8, 8 + metaLen).toString('utf8')) as {
+      manifest_root: string
+      artifacts: Array<{ kind: 'mdu' | 'manifest' | 'shard'; mdu_index?: number; slot?: number; full_size: number; send_size: number }>
+    }
+    let offset = 8 + metaLen
+    for (const artifact of meta.artifacts) {
+      const sendSize = Number(artifact.send_size || artifact.full_size || 0)
+      const part = body.subarray(offset, offset + sendSize)
+      offset += sendSize
+      if (artifact.kind === 'mdu') {
+        mduUploads.push({
+          bodyLen: part.length,
+          fullSize: Number(artifact.full_size),
+          mduIndex: String(artifact.mdu_index ?? ''),
+          viaBundle: true,
+        })
+      } else if (artifact.kind === 'manifest') {
+        manifestUploads.push({
+          bodyLen: part.length,
+          fullSize: Number(artifact.full_size),
+          viaBundle: true,
+        })
+      } else {
+        shardUploads.push({
+          bodyLen: part.length,
+          fullSize: Number(artifact.full_size),
+          mduIndex: String(artifact.mdu_index ?? ''),
+          slot: String(artifact.slot ?? ''),
+          viaBundle: true,
+        })
+      }
+    }
+    expect(offset).toBe(body.length)
+    bundleUploads.push({ artifactCount: meta.artifacts.length, bodyLen: body.length, target: route.request().url() })
+    return recordConcurrentUpload(() =>
+      route.fulfill({
+        status: 200,
+        headers: { 'Access-Control-Allow-Origin': '*' },
+        body: 'OK',
+      }),
+    )
   })
 
   const failGatewayProbe = async (route: import('@playwright/test').Route) => {
@@ -99,6 +160,7 @@ test('Thick Client: no-gateway Mode 2 browser upload sends sparse MDU, manifest,
   await page.route('http://localhost:8080/health', failGatewayProbe)
 
   await page.route('**/sp/upload_mdu', async (route) => {
+    perArtifactPostRequests += 1
     const headers = route.request().headers()
     const body = route.request().postDataBuffer() || Buffer.alloc(0)
     const fullSizeHeader = headers['x-polystore-full-size']
@@ -111,6 +173,7 @@ test('Thick Client: no-gateway Mode 2 browser upload sends sparse MDU, manifest,
   })
 
   await page.route('**/sp/upload_manifest', async (route) => {
+    perArtifactPostRequests += 1
     const headers = route.request().headers()
     const body = route.request().postDataBuffer() || Buffer.alloc(0)
     const fullSizeHeader = headers['x-polystore-full-size']
@@ -122,6 +185,7 @@ test('Thick Client: no-gateway Mode 2 browser upload sends sparse MDU, manifest,
   })
 
   await page.route('**/sp/upload_shard', async (route) => {
+    perArtifactPostRequests += 1
     const headers = route.request().headers()
     const body = route.request().postDataBuffer() || Buffer.alloc(0)
     const fullSizeHeader = headers['x-polystore-full-size']
@@ -327,15 +391,50 @@ test('Thick Client: no-gateway Mode 2 browser upload sends sparse MDU, manifest,
   const sparseManifestUploads = manifestUploads.filter((upload) => upload.fullSize != null && upload.bodyLen < upload.fullSize)
   const sparseShardUploads = shardUploads.filter((upload) => upload.fullSize != null && upload.bodyLen < upload.fullSize)
 
+  const uploadStatus = await page.evaluate(() => {
+    return (window as Window & { __polyStoreUploadStatus?: unknown }).__polyStoreUploadStatus ?? null
+  }) as {
+    transport?: {
+      requestCount?: number | null
+      bundleCount?: number | null
+      artifactCount?: number | null
+      bytesSent?: number | null
+      fallbackCount?: number | null
+      fallbackReason?: string | null
+      peakActiveUploads?: number | null
+    }
+  } | null
+  const logicalArtifactCount = mduUploads.length + manifestUploads.length + shardUploads.length
+  const providerRequestCount = bundleUploads.length + perArtifactPostRequests
+
   console.log('[direct sparse upload evidence]', {
     uploadSizeBytes,
+    bundleUploadsEnabled,
     gatewayProbeAttempts,
     mduUploads,
     manifestUploads,
     shardUploads,
+    bundleUploads,
+    perArtifactPostRequests,
+    providerRequestCount,
+    logicalArtifactCount,
+    uploadStatus,
     peakActiveUploads,
     perf,
   })
+
+  if (bundleUploadsEnabled) {
+    expect(bundleUploads.length).toBeGreaterThan(0)
+    expect(perArtifactPostRequests).toBe(0)
+    expect(providerRequestCount).toBeLessThan(logicalArtifactCount)
+    expect(uploadStatus?.transport?.bundleCount ?? 0).toBeGreaterThan(0)
+    expect(uploadStatus?.transport?.fallbackCount ?? 0).toBe(0)
+  } else {
+    expect(bundleUploads.length).toBe(0)
+    expect(perArtifactPostRequests).toBe(logicalArtifactCount)
+    expect(uploadStatus?.transport?.fallbackCount ?? 0).toBeGreaterThanOrEqual(1)
+    expect(uploadStatus?.transport?.fallbackReason || '').toMatch(/bundle/i)
+  }
 
   expect(sparseMduUploads.length).toBeGreaterThan(0)
   expect(sparseManifestUploads.length).toBeGreaterThan(0)

--- a/polystore_gateway/polystore-gateway-spec.md
+++ b/polystore_gateway/polystore-gateway-spec.md
@@ -84,6 +84,15 @@ These endpoints support the `polystore-website` "Thin Client" flow.
         *   **Provider is a dumb pipe:** the server does not need to understand layout variants beyond writing/serving bytes addressed by the headers.
         *   Metadata MDUs (MDU #0 + Witness) remain replicated to all slots via `/sp/upload_mdu`.
 
+*   **`POST /sp/upload_bundle`** *(Optional provider bundle API)*
+    *   **Role:** Reduces browser direct-upload round trips by sending all Mode 2 artifacts for one provider in a single request. Support is optional; browsers MUST fall back to `/sp/upload_mdu`, `/sp/upload_shard`, and `/sp/upload_manifest` if the endpoint returns unsupported/invalid-bundle responses.
+    *   **Content-Type:** `application/x.polystore-bundle-v2`.
+    *   **Binary format:** `"NLB2"` magic (4 bytes), little-endian `uint32` metadata JSON length, metadata JSON, then artifact bodies concatenated in metadata order.
+    *   **Metadata JSON:** `{ "deal_id": uint64, "manifest_root": "0x...", "previous_manifest_root": "0x...", "upload_generation": "optional-devnet-id", "artifacts": [{ "part": "artifact_00", "kind": "mdu|shard|manifest", "mdu_index": uint64?, "slot": uint64?, "full_size": int64, "send_size": int64 }] }`.
+    *   **Sparse artifacts:** `send_size` MAY be smaller than `full_size`; providers write the prefix bytes and zero-extend/truncate the stored file to `full_size`, matching per-artifact `X-PolyStore-Full-Size` semantics.
+    *   **Validation:** All artifacts in a bundle share the same deal/root/generation scope. Providers reject missing/invalid roots, too many artifacts, duplicate target filenames, malformed generation IDs, body length mismatches, and unexpected trailing bytes without committing partial files.
+    *   **CORS:** Providers answer `OPTIONS /sp/upload_bundle` and allow `Content-Type` plus `X-PolyStore-*` headers so browser-only uploads remain gateway-optional.
+
 *   **`POST /gateway/mirror_mdu` / `/gateway/mirror_manifest` / `/gateway/mirror_shard`** *(Gateway mirror helpers)*
     *   **Input:** Same headers/payloads as `/sp/upload_mdu`, `/sp/upload_manifest`, `/sp/upload_shard`.
     *   **Role:** Optional browser-side mirroring into a local user-gateway cache (used when the user-gateway is running in proxy mode and `/sp/*` endpoints are not exposed on that process).

--- a/polystore_gateway/sp_upload_bundle.go
+++ b/polystore_gateway/sp_upload_bundle.go
@@ -17,17 +17,20 @@ import (
 )
 
 const (
-	spUploadBundleKindMDU      = "mdu"
-	spUploadBundleKindShard    = "shard"
-	spUploadBundleKindManifest = "manifest"
-	spUploadBundleV2Magic      = "NLB2"
-	spUploadBundleV2MediaType  = "application/x.polystore-bundle-v2"
+	spUploadBundleKindMDU       = "mdu"
+	spUploadBundleKindShard     = "shard"
+	spUploadBundleKindManifest  = "manifest"
+	spUploadBundleV2Magic       = "NLB2"
+	spUploadBundleV2MediaType   = "application/x.polystore-bundle-v2"
+	spUploadBundleMaxArtifacts  = 4096
+	spUploadBundleMaxGeneration = 128
 )
 
 type spUploadBundleRequest struct {
 	DealID               *uint64                  `json:"deal_id"`
 	ManifestRoot         string                   `json:"manifest_root"`
 	PreviousManifestRoot string                   `json:"previous_manifest_root,omitempty"`
+	UploadGeneration     string                   `json:"upload_generation,omitempty"`
 	Artifacts            []spUploadBundleArtifact `json:"artifacts"`
 }
 
@@ -46,6 +49,43 @@ type spUploadBundleResolvedArtifact struct {
 	fullSize   int64
 	sendSize   int64
 	maxBodyLen int64
+}
+
+type spUploadBundleBodyError struct {
+	err error
+}
+
+func (e spUploadBundleBodyError) Error() string {
+	return e.err.Error()
+}
+
+func (e spUploadBundleBodyError) Unwrap() error {
+	return e.err
+}
+
+func newSpUploadBundleBodyError(format string, args ...interface{}) error {
+	return spUploadBundleBodyError{err: fmt.Errorf(format, args...)}
+}
+
+func isSpUploadBundleBodyError(err error) bool {
+	_, ok := err.(spUploadBundleBodyError)
+	return ok
+}
+
+func validateSpUploadBundleGenerationID(generation string) error {
+	generation = strings.TrimSpace(generation)
+	if generation == "" {
+		return nil
+	}
+	if len(generation) > spUploadBundleMaxGeneration {
+		return fmt.Errorf("upload_generation is too long")
+	}
+	for _, r := range generation {
+		if r < 0x20 || r == 0x7f || r == '/' || r == '\\' {
+			return fmt.Errorf("upload_generation contains invalid characters")
+		}
+	}
+	return nil
 }
 
 func (a spUploadBundleArtifact) resolve() (spUploadBundleResolvedArtifact, error) {
@@ -119,9 +159,9 @@ func copyBundleArtifactBody(tmp *os.File, src io.Reader, resolved spUploadBundle
 	}
 	if n != resolved.sendSize {
 		if n > resolved.sendSize {
-			return n, fmt.Errorf("artifact %s exceeded declared send_size", resolved.meta.Part)
+			return n, newSpUploadBundleBodyError("artifact %s exceeded declared send_size", resolved.meta.Part)
 		}
-		return n, fmt.Errorf("artifact %s shorter than declared send_size", resolved.meta.Part)
+		return n, newSpUploadBundleBodyError("artifact %s shorter than declared send_size", resolved.meta.Part)
 	}
 	return n, nil
 }
@@ -157,7 +197,7 @@ func storeBundleArtifact(rootDir string, resolved spUploadBundleResolvedArtifact
 			return fmt.Errorf("failed to discard existing artifact body: %w", discardErr)
 		}
 		if n != resolved.sendSize {
-			return fmt.Errorf("bundle artifact size mismatch")
+			return newSpUploadBundleBodyError("bundle artifact size mismatch")
 		}
 		profile.addCount("received_body_bytes", uint64(n))
 		profile.addCount("stored_size_bytes", uint64(info.Size()))
@@ -228,7 +268,7 @@ func SpUploadBundle(w http.ResponseWriter, r *http.Request) {
 		releaseMode2UploadProfile(profile)
 	}()
 
-	setCORS(w)
+	setCORSForRequest(w, r)
 	if r.Method == http.MethodOptions {
 		statusCode = http.StatusNoContent
 		w.WriteHeader(http.StatusNoContent)
@@ -316,6 +356,18 @@ func SpUploadBundle(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "bundle artifacts are required", http.StatusBadRequest)
 		return
 	}
+	if len(req.Artifacts) > spUploadBundleMaxArtifacts {
+		statusCode = http.StatusBadRequest
+		outcome = "too_many_artifacts"
+		http.Error(w, "bundle contains too many artifacts", http.StatusBadRequest)
+		return
+	}
+	if err := validateSpUploadBundleGenerationID(req.UploadGeneration); err != nil {
+		statusCode = http.StatusBadRequest
+		outcome = "invalid_upload_generation"
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 	profile.setCount("artifact_count", uint64(len(req.Artifacts)))
 
 	parsed, err := parseManifestRoot(clientManifestRoot)
@@ -400,6 +452,12 @@ func SpUploadBundle(w http.ResponseWriter, r *http.Request) {
 			resolved := artifactsByPart[artifact.Part]
 			if err := storeBundleArtifact(rootDir, resolved, io.LimitReader(r.Body, resolved.sendSize), profile); err != nil {
 				log.Printf("SpUploadBundle: failed to store binary artifact part=%s target=%s: %v", artifact.Part, resolved.filename, err)
+				if isSpUploadBundleBodyError(err) {
+					statusCode = http.StatusBadRequest
+					outcome = "invalid_bundle_body"
+					http.Error(w, "invalid bundle body", http.StatusBadRequest)
+					return
+				}
 				statusCode = http.StatusInternalServerError
 				outcome = "artifact_store_failed"
 				http.Error(w, "failed to store bundle artifact", http.StatusInternalServerError)
@@ -453,6 +511,12 @@ func SpUploadBundle(w http.ResponseWriter, r *http.Request) {
 			if err := storeBundleArtifact(rootDir, resolved, part, profile); err != nil {
 				log.Printf("SpUploadBundle: failed to store multipart artifact part=%s target=%s: %v", partName, resolved.filename, err)
 				_ = part.Close()
+				if isSpUploadBundleBodyError(err) {
+					statusCode = http.StatusBadRequest
+					outcome = "invalid_bundle_body"
+					http.Error(w, "invalid bundle body", http.StatusBadRequest)
+					return
+				}
 				statusCode = http.StatusInternalServerError
 				outcome = "artifact_store_failed"
 				http.Error(w, "failed to store bundle artifact", http.StatusInternalServerError)

--- a/polystore_gateway/sp_upload_bundle_test.go
+++ b/polystore_gateway/sp_upload_bundle_test.go
@@ -262,6 +262,192 @@ func TestSpUploadBundle_AcceptsBinaryBundleV2(t *testing.T) {
 	}
 }
 
+func TestSpUploadBundle_RejectsShortBinaryBundleAsBadRequest(t *testing.T) {
+	useTempUploadDir(t)
+	resetPolyfsCASStatusCountersForTest()
+	resetPolyfsUploadRootPreflightCacheForTest()
+
+	manifestRoot := mustTestManifestRoot(t, "sp-upload-bundle-short")
+	dealID := uint64(3)
+
+	srv := dynamicMockDealServer(map[uint64]struct {
+		Owner string
+		CID   string
+	}{
+		dealID: {Owner: "nil1owner", CID: ""},
+	})
+	defer srv.Close()
+	oldLCD := lcdBase
+	lcdBase = srv.URL
+	t.Cleanup(func() { lcdBase = oldLCD })
+
+	reqMeta := spUploadBundleRequest{
+		DealID:               ptrUint64(dealID),
+		ManifestRoot:         manifestRoot.Canonical,
+		PreviousManifestRoot: "",
+		UploadGeneration:     "browser-run-7",
+		Artifacts: []spUploadBundleArtifact{
+			{
+				Part:     "artifact_00",
+				Kind:     spUploadBundleKindMDU,
+				MduIndex: ptrUint64(0),
+				FullSize: int64(types.MDU_SIZE),
+				SendSize: 8,
+			},
+		},
+	}
+	metaBytes, err := json.Marshal(reqMeta)
+	if err != nil {
+		t.Fatalf("marshal meta: %v", err)
+	}
+
+	var body bytes.Buffer
+	var header [8]byte
+	copy(header[:4], []byte(spUploadBundleV2Magic))
+	binary.LittleEndian.PutUint32(header[4:], uint32(len(metaBytes)))
+	body.Write(header[:])
+	body.Write(metaBytes)
+	body.Write([]byte{0xA1, 0xA2, 0xA3, 0xA4})
+
+	req := httptest.NewRequest(http.MethodPost, "/sp/upload_bundle", &body)
+	req.Header.Set("Content-Type", spUploadBundleV2MediaType)
+	req.Header.Set("Content-Length", strconv.Itoa(body.Len()))
+
+	w := httptest.NewRecorder()
+	testRouter().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	if !bytes.Contains(w.Body.Bytes(), []byte("invalid bundle body")) {
+		t.Fatalf("expected invalid bundle body response, got %q", w.Body.String())
+	}
+
+	rootDir := filepath.Join(uploadDir, "deals", "3", manifestRoot.Key)
+	if _, err := os.Stat(filepath.Join(rootDir, "mdu_0.bin")); !os.IsNotExist(err) {
+		t.Fatalf("expected partial mdu not to be committed, stat err=%v", err)
+	}
+}
+
+func TestSpUploadBundle_OptionsCORS(t *testing.T) {
+	req := httptest.NewRequest(http.MethodOptions, "/sp/upload_bundle", nil)
+	req.Header.Set("Origin", "https://web.polynomialstore.com")
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+	req.Header.Set("Access-Control-Request-Headers", "content-type,x-polystore-upload-generation")
+
+	w := httptest.NewRecorder()
+	testRouter().ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "https://web.polynomialstore.com" {
+		t.Fatalf("expected origin echo, got %q", got)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Private-Network"); got != "true" {
+		t.Fatalf("expected private network CORS header, got %q", got)
+	}
+	allowHeaders := w.Header().Get("Access-Control-Allow-Headers")
+	for _, want := range []string{"content-type", "x-polystore-upload-generation"} {
+		if !csvHeaderContains(allowHeaders, want) {
+			t.Fatalf("expected allow headers to include %q, got %q", want, allowHeaders)
+		}
+	}
+}
+
+func TestSpUploadBundle_RejectsTooManyArtifacts(t *testing.T) {
+	manifestRoot := mustTestManifestRoot(t, "sp-upload-bundle-too-many")
+	artifacts := make([]spUploadBundleArtifact, spUploadBundleMaxArtifacts+1)
+	for i := range artifacts {
+		artifacts[i] = spUploadBundleArtifact{
+			Part:     "artifact_" + strconv.Itoa(i),
+			Kind:     spUploadBundleKindManifest,
+			FullSize: int64(types.BLOB_SIZE),
+			SendSize: 1,
+		}
+	}
+	metaBytes, err := json.Marshal(spUploadBundleRequest{
+		DealID:       ptrUint64(5),
+		ManifestRoot: manifestRoot.Canonical,
+		Artifacts:    artifacts,
+	})
+	if err != nil {
+		t.Fatalf("marshal meta: %v", err)
+	}
+
+	var body bytes.Buffer
+	var header [8]byte
+	copy(header[:4], []byte(spUploadBundleV2Magic))
+	binary.LittleEndian.PutUint32(header[4:], uint32(len(metaBytes)))
+	body.Write(header[:])
+	body.Write(metaBytes)
+
+	req := httptest.NewRequest(http.MethodPost, "/sp/upload_bundle", &body)
+	req.Header.Set("Content-Type", spUploadBundleV2MediaType)
+
+	w := httptest.NewRecorder()
+	testRouter().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	if !bytes.Contains(w.Body.Bytes(), []byte("bundle contains too many artifacts")) {
+		t.Fatalf("expected too many artifacts error, got %q", w.Body.String())
+	}
+}
+
+func TestSpUploadBundle_RejectsInvalidGenerationID(t *testing.T) {
+	useTempUploadDir(t)
+	resetPolyfsCASStatusCountersForTest()
+	resetPolyfsUploadRootPreflightCacheForTest()
+
+	manifestRoot := mustTestManifestRoot(t, "sp-upload-bundle-generation")
+	dealID := uint64(4)
+
+	srv := dynamicMockDealServer(map[uint64]struct {
+		Owner string
+		CID   string
+	}{
+		dealID: {Owner: "nil1owner", CID: ""},
+	})
+	defer srv.Close()
+	oldLCD := lcdBase
+	lcdBase = srv.URL
+	t.Cleanup(func() { lcdBase = oldLCD })
+
+	metaBytes, err := json.Marshal(spUploadBundleRequest{
+		DealID:           ptrUint64(dealID),
+		ManifestRoot:     manifestRoot.Canonical,
+		UploadGeneration: "bad/generation",
+		Artifacts: []spUploadBundleArtifact{{
+			Part:     "artifact_00",
+			Kind:     spUploadBundleKindManifest,
+			FullSize: int64(types.BLOB_SIZE),
+			SendSize: 1,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal meta: %v", err)
+	}
+
+	var body bytes.Buffer
+	var header [8]byte
+	copy(header[:4], []byte(spUploadBundleV2Magic))
+	binary.LittleEndian.PutUint32(header[4:], uint32(len(metaBytes)))
+	body.Write(header[:])
+	body.Write(metaBytes)
+	body.WriteByte(0)
+
+	req := httptest.NewRequest(http.MethodPost, "/sp/upload_bundle", &body)
+	req.Header.Set("Content-Type", spUploadBundleV2MediaType)
+
+	w := httptest.NewRecorder()
+	testRouter().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	if !bytes.Contains(w.Body.Bytes(), []byte("upload_generation contains invalid characters")) {
+		t.Fatalf("expected generation validation error, got %q", w.Body.String())
+	}
+}
+
 func ptrUint64(v uint64) *uint64 {
 	return &v
 }

--- a/scripts/e2e_sparse_browser_upload_bundle.sh
+++ b/scripts/e2e_sparse_browser_upload_bundle.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Browser sparse upload smoke with provider bundle uploads enabled.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+export SPARSE_BUNDLE_UPLOADS=1
+export SPARSE_FILE_SIZE_BYTES="${SPARSE_FILE_SIZE_BYTES:-196608}"
+
+"$ROOT_DIR/scripts/e2e_browser_smoke_no_gateway.sh"


### PR DESCRIPTION
## Summary

Closes #198. Part of #192.

- enables target-scoped Mode 2 browser bundle uploads via `sendBundle` / `/sp/upload_bundle`, with per-provider fallback to per-artifact uploads when bundle support is missing/invalid
- adds upload transport stats/events and UI/perf counters for request count, bundle count, artifact count, payload bytes, fallback count/reason, and peak active uploads
- hardens provider bundle validation/CORS for sparse binary bundles, generation IDs, artifact-count limits, malformed bodies, and partial-write cleanup
- documents the `application/x.polystore-bundle-v2` binary bundle contract and adds a fast 100 MiB-equivalent sparse RS 8+4 benchmark harness

## Scope / non-goals

- Browser remains fully functional without a local gateway.
- Browser wallet signing remains in-browser; no gateway signing authority added.
- Bundle support is optional; unsupported providers fall back cleanly.
- No artifact byte, root, KZG, RS, or on-chain protocol semantics changed.
- Did not implement #193, #194, #195, #196, #197, or #199.

## Test plan and outcomes

- `cd polystore-website && npx tsx --test src/lib/upload/httpTransport.test.ts src/lib/upload/engine.test.ts src/lib/uploadStatus.test.ts` — pass (27 tests)
- `cd polystore-website && npm run test:unit -- src/lib/upload/engine.test.ts src/lib/upload/httpTransport.test.ts src/lib/uploadStatus.test.ts` — pass (262 tests; repo script expands all src/lib+src/api tests before extra args)
- `cd polystore-website && npm run lint` — pass
- `cd polystore-website && npm run build:app` — pass
- `cd polystore_core && cargo build --release` — pass (needed for gateway CGO tests)
- `cd polystore_gateway && LD_LIBRARY_PATH=../polystore_core/target/release go test ./... -run 'SpUploadBundle|IsBundleUnsupported'` — pass
- `cd polystore_gateway && LD_LIBRARY_PATH=../polystore_core/target/release go test ./...` — pass
- Targeted browser smoke with Vite dev server, gateway routes disabled/stubbed:
  - `VITE_E2E=1 CHAIN_ID=20260211 E2E_BASE_URL=http://127.0.0.1:5173 npm run test:e2e -- tests/direct-upload-sparse.spec.ts` — pass; unsupported bundle fallback path exercised
  - `SPARSE_BUNDLE_UPLOADS=1 VITE_E2E=1 CHAIN_ID=20260211 E2E_BASE_URL=http://127.0.0.1:5173 npm run test:e2e -- tests/direct-upload-sparse.spec.ts` — pass; bundle path exercised

## Benchmark evidence

Command: `cd polystore-website && npm run perf:upload-bundle`

Shape: 100 MiB-equivalent sparse Mode 2 RS 8+4, 13 user MDUs, 1 witness MDU, 12 providers, fixed 25ms artificial latency per provider request. Measures upload transport only (request scheduling + mocked latency), excluding KZG/RS preparation and chain commit.

| Scenario | Requests | Bundle requests | Per-artifact requests | Wall | Payload bytes | Fallbacks | Peak active uploads |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Per-artifact baseline | 192 | 0 | 192 | 410.9ms | 192 | 0 | 12 |
| Bundled | 12 | 12 | 0 | 28.8ms | 192 | 0 | 12 |

Command: `cd polystore-website && BUNDLE_BENCH_UNSUPPORTED_PROVIDER=0 npm run perf:upload-bundle`

| Scenario | Requests | Bundle requests | Per-artifact requests | Wall | Payload bytes | Fallbacks | Peak active uploads |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Per-artifact baseline | 192 | 0 | 192 | 405.1ms | 192 | 0 | 12 |
| Bundled | 12 | 12 | 0 | 26.2ms | 192 | 0 | 12 |
| One unsupported provider | 28 | 11 successful bundles + 1 unsupported attempt | 16 | 401.9ms | 208 | 1 | 12 |

Notes: payload bytes are sparse payload bytes (not HTTP headers). The unsupported-provider case intentionally double-sends that provider's sparse payload after fallback.

## Browser smoke evidence

- Unsupported fallback (default sparse spec): 12 logical artifacts, 12 per-artifact provider requests, 3 bundle fallback attempts, `fallbackReason="bundle disabled in sparse e2e"`.
- Bundle enabled (`SPARSE_BUNDLE_UPLOADS=1`): 12 logical artifacts, 3 provider bundle requests, 0 per-artifact provider requests, 0 fallbacks.

## AI review status

Requested @copilot and @coderabbitai. @codex was requested, but the repo connector replied that Codex is unavailable until a Codex account is connected to GitHub.

## Risks / follow-ups

- Fallback is per-provider and correctness-first; one unsupported provider still pays per-artifact latency for that provider.
- `upload_generation` is validated and carried in bundle metadata, but this PR does not implement upload pipelining (#197) or provisional generation promotion semantics.
