### PR TITLE
Autotune WebGPU MSM settings for browser KZG uploads

### DIFF
--- a/notes/kzg_webgpu_msm_optimization.md
+++ b/notes/kzg_webgpu_msm_optimization.md
@@ -245,3 +245,44 @@ not JavaScript allocation churn. The PR therefore closes #179 by making the
 measured throughput path reproducible, adapter-aware, lower-allocation, and
 guarded by benchmark evidence rather than by landing a new unproven batched
 shader pipeline.
+
+## #193 Runtime Autotune Contract
+
+Issue #193 turns the benchmark-matrix output into a runtime calibration
+contract for browser uploads. The stable contract exposed by
+`webgpuKzgMsm.ts`/`kzgCommitBackend.ts` is:
+
+- cache key: `webgpu-msm-calibration-v2|vendor|architecture|device|description|isFallbackAdapter`
+- cached schema fields: `version`, `cacheKey`, `bucketWidth`, `reductionMode`,
+  `minBlobs`, `minBytes`, `source`, `reason`, `score`, `measuredFixture`, and
+  `measuredAtMs`
+- runtime diagnostics: `bucketWidth`, `reductionMode`, `calibration.status`,
+  `calibration.source`, `calibration.cacheKey`, scheduler probe state, and the
+  existing fallback/circuit-breaker fields
+- bounded runtime calibration: auto mode only calibrates once a real batch is at
+  least 64 blobs, using a small deterministic 4-blob fixture and the WASM/blst
+  oracle for parity; small uploads keep the adapter default and do not pay the
+  calibration matrix cost
+- fallback rules: stale cache version, adapter-key mismatch, calibration
+  timeout, parity failure, or device loss invalidates the cached entry and falls
+  back to WASM/blst rather than accepting non-identical commitments
+
+The PR-grade native GPU matrix command for #193 and follow-up tickets is:
+
+```sh
+cd polystore-website
+npm run perf:kzg-webgpu-msm:matrix
+```
+
+That script expands to the required 64/96/256 blob matrix across bucket widths
+`10,12,13` and reduction modes `serial,parallel16`. For environments where CI
+or headless Chrome resolves to SwiftShader, use diagnostic mode to capture the
+skip/fallback reason without failing the run:
+
+```sh
+POLYSTORE_WEBGPU_MSM_BLOBS_LIST=1 \
+POLYSTORE_WEBGPU_MSM_BUCKET_WIDTHS=10 \
+POLYSTORE_WEBGPU_MSM_REDUCTIONS=serial \
+POLYSTORE_WEBGPU_MSM_RUNS=1 \
+npm run diagnose:kzg-webgpu-msm
+```

--- a/polystore-website/package.json
+++ b/polystore-website/package.json
@@ -32,6 +32,7 @@
     "perf:kzg-browser": "tsx scripts/benchmark_browser_kzg_commit.ts",
     "perf:kzg-webgpu-lifecycle": "tsx scripts/benchmark_browser_kzg_webgpu_lifecycle.ts",
     "perf:kzg-webgpu-msm": "tsx scripts/benchmark_browser_kzg_webgpu_msm.ts",
+    "perf:kzg-webgpu-msm:matrix": "POLYSTORE_WEBGPU_MSM_BLOBS_LIST=64,96,256 POLYSTORE_WEBGPU_MSM_BUCKET_WIDTHS=10,12,13 POLYSTORE_WEBGPU_MSM_REDUCTIONS=serial,parallel16 POLYSTORE_WEBGPU_MSM_RUNS=1 tsx scripts/benchmark_browser_kzg_webgpu_msm.ts",
     "diagnose:kzg-webgpu-msm": "POLYSTORE_WEBGPU_MSM_DIAGNOSTIC=1 tsx scripts/benchmark_browser_kzg_webgpu_msm.ts",
     "preflight:webgpu": "tsx scripts/preflight_webgpu_chrome.ts",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",

--- a/polystore-website/src/components/FileSharder.tsx
+++ b/polystore-website/src/components/FileSharder.tsx
@@ -196,7 +196,11 @@ type PreparePerfSample = {
   workerKzgWebGpuFallbackReason?: string
   workerKzgWebGpuProbeStatus?: string
   workerKzgWebGpuCircuitOpen?: boolean
+  workerKzgWebGpuBucketWidth?: number
   workerKzgWebGpuReductionMode?: string
+  workerKzgWebGpuCalibrationStatus?: string
+  workerKzgWebGpuCalibrationSource?: string
+  workerKzgWebGpuCalibrationCacheKey?: string
   workerKzgWebGpuProbeTimeoutMs?: number
   workerKzgWebGpuCommitTimeoutMs?: number
   workerKzgWebGpuMinBlobs?: number
@@ -286,7 +290,11 @@ type PreparePerfProfile = {
     kzgWebGpuFallbackReason?: string
     kzgWebGpuProbeStatus?: string
     kzgWebGpuCircuitOpen?: boolean
+    kzgWebGpuBucketWidth?: number
     kzgWebGpuReductionMode?: string
+    kzgWebGpuCalibrationStatus?: string
+    kzgWebGpuCalibrationSource?: string
+    kzgWebGpuCalibrationCacheKey?: string
     kzgWebGpuProbeTimeoutMs?: number
     kzgWebGpuCommitTimeoutMs?: number
     kzgWebGpuMinBlobs?: number
@@ -3613,8 +3621,21 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
               typeof result.perf?.kzgWebGpuProbeStatus === 'string' ? result.perf.kzgWebGpuProbeStatus : undefined
             const workerKzgWebGpuCircuitOpen =
               typeof result.perf?.kzgWebGpuCircuitOpen === 'boolean' ? result.perf.kzgWebGpuCircuitOpen : undefined
+            const workerKzgWebGpuBucketWidth = Number(result.perf?.kzgWebGpuBucketWidth ?? 0) || undefined
             const workerKzgWebGpuReductionMode =
               typeof result.perf?.kzgWebGpuReductionMode === 'string' ? result.perf.kzgWebGpuReductionMode : undefined
+            const workerKzgWebGpuCalibrationStatus =
+              typeof result.perf?.kzgWebGpuCalibrationStatus === 'string'
+                ? result.perf.kzgWebGpuCalibrationStatus
+                : undefined
+            const workerKzgWebGpuCalibrationSource =
+              typeof result.perf?.kzgWebGpuCalibrationSource === 'string'
+                ? result.perf.kzgWebGpuCalibrationSource
+                : undefined
+            const workerKzgWebGpuCalibrationCacheKey =
+              typeof result.perf?.kzgWebGpuCalibrationCacheKey === 'string'
+                ? result.perf.kzgWebGpuCalibrationCacheKey
+                : undefined
             const workerKzgWebGpuProbeTimeoutMs = Number(result.perf?.kzgWebGpuProbeTimeoutMs ?? 0)
             const workerKzgWebGpuCommitTimeoutMs = Number(result.perf?.kzgWebGpuCommitTimeoutMs ?? 0)
             const workerKzgWebGpuMinBlobs = Number(result.perf?.kzgWebGpuMinBlobs ?? 0)
@@ -3677,7 +3698,11 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
               workerKzgWebGpuFallbackReason,
               workerKzgWebGpuProbeStatus,
               workerKzgWebGpuCircuitOpen,
+              workerKzgWebGpuBucketWidth,
               workerKzgWebGpuReductionMode,
+              workerKzgWebGpuCalibrationStatus,
+              workerKzgWebGpuCalibrationSource,
+              workerKzgWebGpuCalibrationCacheKey,
               workerKzgWebGpuProbeTimeoutMs,
               workerKzgWebGpuCommitTimeoutMs,
               workerKzgWebGpuMinBlobs,
@@ -3982,8 +4007,21 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
               typeof result.perf?.kzgWebGpuProbeStatus === 'string' ? result.perf.kzgWebGpuProbeStatus : undefined
             const workerKzgWebGpuCircuitOpen =
               typeof result.perf?.kzgWebGpuCircuitOpen === 'boolean' ? result.perf.kzgWebGpuCircuitOpen : undefined
+            const workerKzgWebGpuBucketWidth = Number(result.perf?.kzgWebGpuBucketWidth ?? 0) || undefined
             const workerKzgWebGpuReductionMode =
               typeof result.perf?.kzgWebGpuReductionMode === 'string' ? result.perf.kzgWebGpuReductionMode : undefined
+            const workerKzgWebGpuCalibrationStatus =
+              typeof result.perf?.kzgWebGpuCalibrationStatus === 'string'
+                ? result.perf.kzgWebGpuCalibrationStatus
+                : undefined
+            const workerKzgWebGpuCalibrationSource =
+              typeof result.perf?.kzgWebGpuCalibrationSource === 'string'
+                ? result.perf.kzgWebGpuCalibrationSource
+                : undefined
+            const workerKzgWebGpuCalibrationCacheKey =
+              typeof result.perf?.kzgWebGpuCalibrationCacheKey === 'string'
+                ? result.perf.kzgWebGpuCalibrationCacheKey
+                : undefined
             const workerKzgWebGpuProbeTimeoutMs = Number(result.perf?.kzgWebGpuProbeTimeoutMs ?? 0)
             const workerKzgWebGpuCommitTimeoutMs = Number(result.perf?.kzgWebGpuCommitTimeoutMs ?? 0)
             const workerKzgWebGpuMinBlobs = Number(result.perf?.kzgWebGpuMinBlobs ?? 0)
@@ -4024,7 +4062,11 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
               workerKzgWebGpuFallbackReason,
               workerKzgWebGpuProbeStatus,
               workerKzgWebGpuCircuitOpen,
+              workerKzgWebGpuBucketWidth,
               workerKzgWebGpuReductionMode,
+              workerKzgWebGpuCalibrationStatus,
+              workerKzgWebGpuCalibrationSource,
+              workerKzgWebGpuCalibrationCacheKey,
               workerKzgWebGpuProbeTimeoutMs,
               workerKzgWebGpuCommitTimeoutMs,
               workerKzgWebGpuMinBlobs,
@@ -4352,7 +4394,11 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
             kzgWebGpuFallbackReason: kzgDiagnosticSample?.workerKzgWebGpuFallbackReason,
             kzgWebGpuProbeStatus: kzgDiagnosticSample?.workerKzgWebGpuProbeStatus,
             kzgWebGpuCircuitOpen: kzgDiagnosticSample?.workerKzgWebGpuCircuitOpen,
+            kzgWebGpuBucketWidth: kzgDiagnosticSample?.workerKzgWebGpuBucketWidth,
             kzgWebGpuReductionMode: kzgDiagnosticSample?.workerKzgWebGpuReductionMode,
+            kzgWebGpuCalibrationStatus: kzgDiagnosticSample?.workerKzgWebGpuCalibrationStatus,
+            kzgWebGpuCalibrationSource: kzgDiagnosticSample?.workerKzgWebGpuCalibrationSource,
+            kzgWebGpuCalibrationCacheKey: kzgDiagnosticSample?.workerKzgWebGpuCalibrationCacheKey,
             kzgWebGpuProbeTimeoutMs: kzgDiagnosticSample?.workerKzgWebGpuProbeTimeoutMs,
             kzgWebGpuCommitTimeoutMs: kzgDiagnosticSample?.workerKzgWebGpuCommitTimeoutMs,
             kzgWebGpuMinBlobs: kzgDiagnosticSample?.workerKzgWebGpuMinBlobs,
@@ -4690,6 +4736,12 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
               : 'not available',
       },
       { label: 'probe', value: uploadStatus.kzg.probeStatus || 'pending' },
+      {
+        label: 'calibration',
+        value: [uploadStatus.kzg.calibrationStatus, uploadStatus.kzg.calibrationSource]
+          .filter(Boolean)
+          .join(' / ') || 'default',
+      },
       { label: 'storage', value: uploadStatus.storage.stage.replace(/_/g, ' ') },
       { label: 'transport', value: uploadStatus.transport.mode.replace(/-/g, ' ') },
       {

--- a/polystore-website/src/lib/kzgCommitBackend.test.ts
+++ b/polystore-website/src/lib/kzgCommitBackend.test.ts
@@ -14,6 +14,11 @@ import {
   parseTrustedSetupG1Srs,
   parseKzgCommitProfiledResult,
 } from './kzgCommitBackend'
+import {
+  WebGpuKzgMsmCalibrationCache,
+  defaultWebGpuKzgMsmAdapterCalibration,
+  type WebGpuKzgMsmOptions,
+} from './webgpuKzgMsm'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -102,6 +107,7 @@ function fakeCommitter(options: {
   totalMs?: number
   delayMs?: number
   commitmentsSeed?: number
+  bucketWidth?: number
   reductionMode?: 'serial' | 'parallel16' | 'parallel32' | 'parallel64'
 }) {
   const destroyed = { value: false }
@@ -130,7 +136,7 @@ function fakeCommitter(options: {
           },
           blobs,
           debug: {
-            bucketWidth: 10,
+            bucketWidth: options.bucketWidth ?? 10,
             reductionMode: options.reductionMode ?? 'serial',
             bucketCount: 1,
             baseIndexCount: 1,
@@ -353,6 +359,93 @@ test('browser backend selects WebGPU after bounded parity probe', async () => {
   assert.equal(status.webgpu?.fallbackActive, false)
   assert.equal(status.webgpu?.scheduler?.probeStatus, 'passed')
   assert.equal(status.webgpu?.reductionMode, 'serial')
+})
+
+test('browser backend applies bounded calibration winner and reports diagnostics', async () => {
+  const calls: Array<WebGpuKzgMsmOptions | undefined> = []
+  const backend = await createBrowserKzgCommitBackend(dynamicMockWasm(), await loadTrustedSetupBytes(), {
+    preferWebGpu: true,
+    webGpuMode: 'force',
+    webGpuCalibrationMode: 'force',
+    webGpuCalibrationBlobCount: 1,
+    webGpuCalibrationRuns: 1,
+    webGpuCalibrationTimeoutMs: 1000,
+    webGpuCalibrationCache: new WebGpuKzgMsmCalibrationCache({ storage: null }),
+    navigatorLike: fakeNavigator({ vendor: 'nvidia', architecture: 'ampere', isFallbackAdapter: false }),
+    webGpuCommitterFactory: async (options) => {
+      calls.push(options)
+      const totalMs = options?.bucketWidth === 12 && options.reductionMode === 'parallel16' ? 5 : 20
+      return fakeCommitter({ totalMs, bucketWidth: options?.bucketWidth, reductionMode: options?.reductionMode }).committer as never
+    },
+  })
+
+  assert.deepEqual(await backend.commitBlobs(blobBatch(2)), commitments(2))
+  const status = backend.getStatus()
+  assert.equal(status.selectedBackend, 'webgpu')
+  assert.equal(status.webgpu?.bucketWidth, 12)
+  assert.equal(status.webgpu?.reductionMode, 'parallel16')
+  assert.equal(status.webgpu?.calibration?.status, 'passed')
+  assert.equal(status.webgpu?.calibration?.source, 'benchmark-matrix')
+  assert.equal(status.webgpu?.scheduler?.bucketWidth, 12)
+  assert.ok(calls.some((call) => call?.bucketWidth === 10 && call.reductionMode === 'serial'))
+  assert.ok(calls.some((call) => call?.bucketWidth === 12 && call.reductionMode === 'parallel16'))
+})
+
+test('browser backend uses cached calibration instead of default adapter rule', async () => {
+  const info = { vendor: 'nvidia', architecture: 'ampere', device: 'rtx-3060-ti', isFallbackAdapter: false }
+  const cache = new WebGpuKzgMsmCalibrationCache({ storage: null })
+  cache.set(info, {
+    ...defaultWebGpuKzgMsmAdapterCalibration(info),
+    bucketWidth: 12,
+    reductionMode: 'parallel16',
+    source: 'benchmark-matrix',
+    reason: 'cached winner',
+    score: 4.58,
+    measuredFixture: { blobs: 96, bytes: 96 * KZG_BLOB_SIZE, runs: 1, candidates: 2, metric: 'median-total-ms', wasmMs: 28.3 },
+    measuredAtMs: 123,
+  })
+  const calls: Array<WebGpuKzgMsmOptions | undefined> = []
+  const backend = await createBrowserKzgCommitBackend(dynamicMockWasm(), await loadTrustedSetupBytes(), {
+    preferWebGpu: true,
+    webGpuMode: 'force',
+    webGpuCalibrationCache: cache,
+    navigatorLike: fakeNavigator(info),
+    webGpuCommitterFactory: async (options) => {
+      calls.push(options)
+      return fakeCommitter({ totalMs: 5, bucketWidth: options?.bucketWidth, reductionMode: options?.reductionMode }).committer as never
+    },
+  })
+
+  assert.deepEqual(await backend.commitBlobs(blobBatch(1)), commitments(1))
+  assert.equal(backend.getStatus().webgpu?.calibration?.status, 'cached')
+  assert.equal(backend.getStatus().webgpu?.bucketWidth, 12)
+  assert.equal(calls[0]?.bucketWidth, 12)
+  assert.equal(calls[0]?.reductionMode, 'parallel16')
+})
+
+test('browser backend opens circuit when calibration parity fails', async () => {
+  const backend = await createBrowserKzgCommitBackend(dynamicMockWasm(), await loadTrustedSetupBytes(), {
+    preferWebGpu: true,
+    webGpuMode: 'force',
+    webGpuCalibrationMode: 'force',
+    webGpuCalibrationBlobCount: 1,
+    webGpuCalibrationCache: new WebGpuKzgMsmCalibrationCache({ storage: null }),
+    navigatorLike: fakeNavigator({ vendor: 'nvidia', architecture: 'ampere', isFallbackAdapter: false }),
+    webGpuCommitterFactory: async (options) =>
+      fakeCommitter({
+        totalMs: 5,
+        commitmentsSeed: 99,
+        bucketWidth: options?.bucketWidth,
+        reductionMode: options?.reductionMode,
+      }).committer as never,
+  })
+
+  assert.deepEqual(await backend.commitBlobs(blobBatch(1)), commitments(1))
+  const status = backend.getStatus()
+  assert.equal(status.selectedBackend, 'wasm-blst')
+  assert.equal(status.webgpu?.scheduler?.circuitOpen, true)
+  assert.equal(status.webgpu?.calibration?.status, 'failed')
+  assert.match(status.fallbackReason || '', /calibration failed/)
 })
 
 test('browser backend falls back when auto probe is slower than WASM', async () => {

--- a/polystore-website/src/lib/kzgCommitBackend.ts
+++ b/polystore-website/src/lib/kzgCommitBackend.ts
@@ -1,6 +1,14 @@
 import {
+  calibrateWebGpuKzgMsmAdapter,
   createWebGpuKzgMsmCommitter,
+  defaultWebGpuKzgMsmAdapterCalibration,
+  defaultWebGpuKzgMsmCalibrationCache,
+  type WebGpuKzgMsmAdapterCalibration,
+  type WebGpuKzgMsmCalibrationCandidate,
+  type WebGpuKzgMsmCalibrationCache,
+  type WebGpuKzgMsmCalibrationSource,
   type WebGpuKzgMsmCommitter,
+  type WebGpuKzgMsmOptions,
   type WebGpuKzgMsmReductionMode,
   type WebGpuKzgMsmResult,
 } from './webgpuKzgMsm'
@@ -12,10 +20,16 @@ export const POLYSTORE_TRUSTED_SETUP_SHA256 = 'd39b9f2d047cc9dca2de58f264b6a0944
 const DEFAULT_WEBGPU_PROBE_TIMEOUT_MS = 1500
 const DEFAULT_WEBGPU_COMMIT_TIMEOUT_MS = 3000
 const DEFAULT_WEBGPU_MIN_BLOBS = 1
+const DEFAULT_WEBGPU_CALIBRATION_MIN_BLOBS = 64
+const DEFAULT_WEBGPU_CALIBRATION_BLOBS = 4
+const DEFAULT_WEBGPU_CALIBRATION_RUNS = 1
+const DEFAULT_WEBGPU_CALIBRATION_TIMEOUT_MS = 12_000
 
 export type KzgCommitBackendKind = 'wasm-blst' | 'webgpu-scheduler' | 'webgpu-wasm-fallback'
 export type KzgCommitBackendChoice = 'wasm-blst' | 'webgpu'
 export type WebGpuKzgMode = 'auto' | 'force' | 'off'
+export type WebGpuKzgCalibrationMode = 'auto' | 'force' | 'off'
+export type WebGpuKzgCalibrationRunStatus = 'default' | 'cached' | 'running' | 'passed' | 'failed' | 'disabled'
 
 export type PolyStoreCommitApi = {
   commit_blobs(blobBytes: Uint8Array): Uint8Array | ArrayBufferLike
@@ -111,6 +125,22 @@ export type WebGpuSrsMetadata = {
   basis: 'lagrange-or-monomial-g1-compressed'
 }
 
+export type WebGpuKzgCalibrationStatus = {
+  status: WebGpuKzgCalibrationRunStatus
+  mode: WebGpuKzgCalibrationMode
+  cacheKey?: string
+  version?: string
+  source?: WebGpuKzgMsmCalibrationSource
+  bucketWidth?: number
+  reductionMode?: WebGpuKzgMsmReductionMode
+  minBlobs?: number
+  minBytes?: number
+  score?: number | null
+  measuredAtMs?: number | null
+  measuredFixture?: WebGpuKzgMsmAdapterCalibration['measuredFixture']
+  reason?: string
+}
+
 export type WebGpuKzgStatus = {
   supported: boolean
   available: boolean
@@ -119,7 +149,9 @@ export type WebGpuKzgStatus = {
   reason?: string
   adapter?: WebGpuKzgAdapterInfo | null
   selectedBackend?: KzgCommitBackendChoice
+  bucketWidth?: number
   reductionMode?: WebGpuKzgMsmReductionMode
+  calibration?: WebGpuKzgCalibrationStatus
   scheduler?: WebGpuKzgSchedulerStatus
   srs?: WebGpuSrsMetadata
   timings?: WebGpuKzgInitTimings
@@ -139,6 +171,10 @@ export type WebGpuKzgSchedulerStatus = {
   probeTimeoutMs: number
   commitTimeoutMs: number
   minBlobs: number
+  bucketWidth?: number
+  reductionMode?: WebGpuKzgMsmReductionMode
+  calibrationStatus?: WebGpuKzgCalibrationRunStatus
+  calibrationSource?: WebGpuKzgMsmCalibrationSource
   circuitOpen: boolean
   circuitReason?: string
   lastProbeMs?: number
@@ -154,7 +190,14 @@ export type CreateKzgCommitBackendOptions = {
   webGpuCommitTimeoutMs?: number
   webGpuMinBlobs?: number
   allowFallbackAdapter?: boolean
-  webGpuCommitterFactory?: () => Promise<WebGpuKzgMsmCommitter>
+  webGpuCalibrationMode?: WebGpuKzgCalibrationMode
+  webGpuCalibrationMinBlobs?: number
+  webGpuCalibrationBlobCount?: number
+  webGpuCalibrationRuns?: number
+  webGpuCalibrationTimeoutMs?: number
+  webGpuCalibrationCandidates?: WebGpuKzgMsmCalibrationCandidate[]
+  webGpuCalibrationCache?: WebGpuKzgMsmCalibrationCache | null
+  webGpuCommitterFactory?: (options?: WebGpuKzgMsmOptions) => Promise<WebGpuKzgMsmCommitter>
   navigatorLike?: WebGpuNavigator
   bufferUsage?: WebGpuBufferUsageLike
   now?: () => number
@@ -443,6 +486,14 @@ export class ScheduledWebGpuKzgCommitBackend implements KzgCommitBackend {
   private readonly probeTimeoutMs: number
   private readonly commitTimeoutMs: number
   private readonly minBlobs: number
+  private readonly calibrationMode: WebGpuKzgCalibrationMode
+  private readonly calibrationMinBlobs: number
+  private readonly calibrationBlobCount: number
+  private readonly calibrationRuns: number
+  private readonly calibrationTimeoutMs: number
+  private readonly calibrationCache: WebGpuKzgMsmCalibrationCache | null
+  private selectedCalibration: WebGpuKzgMsmAdapterCalibration
+  private calibrationPromise: Promise<boolean> | null = null
 
   constructor(
     private readonly wasmFallback: KzgCommitBackend,
@@ -455,16 +506,32 @@ export class ScheduledWebGpuKzgCommitBackend implements KzgCommitBackend {
     this.probeTimeoutMs = normalizeTimeout(options.webGpuProbeTimeoutMs, DEFAULT_WEBGPU_PROBE_TIMEOUT_MS)
     this.commitTimeoutMs = normalizeTimeout(options.webGpuCommitTimeoutMs, DEFAULT_WEBGPU_COMMIT_TIMEOUT_MS)
     this.minBlobs = normalizeMinBlobs(options.webGpuMinBlobs)
+    this.calibrationMode = options.webGpuCalibrationMode ?? 'auto'
+    this.calibrationMinBlobs = normalizeTimeout(options.webGpuCalibrationMinBlobs, DEFAULT_WEBGPU_CALIBRATION_MIN_BLOBS)
+    this.calibrationBlobCount = normalizeTimeout(options.webGpuCalibrationBlobCount, DEFAULT_WEBGPU_CALIBRATION_BLOBS)
+    this.calibrationRuns = normalizeTimeout(options.webGpuCalibrationRuns, DEFAULT_WEBGPU_CALIBRATION_RUNS)
+    this.calibrationTimeoutMs = normalizeTimeout(options.webGpuCalibrationTimeoutMs, DEFAULT_WEBGPU_CALIBRATION_TIMEOUT_MS)
+    this.calibrationCache = options.webGpuCalibrationCache === undefined ? defaultWebGpuKzgMsmCalibrationCache : options.webGpuCalibrationCache
+    const adapterInfo = initialStatus.adapter ?? null
+    const cachedCalibration = this.calibrationCache?.get(adapterInfo) ?? null
+    this.selectedCalibration = cachedCalibration ?? defaultWebGpuKzgMsmAdapterCalibration(adapterInfo)
     this.status = {
       ...initialStatus,
       fallbackActive: true,
       selectedBackend: 'wasm-blst',
+      bucketWidth: this.selectedCalibration.bucketWidth,
+      reductionMode: this.selectedCalibration.reductionMode,
+      calibration: this.calibrationStatus(cachedCalibration ? 'cached' : this.calibrationMode === 'off' ? 'disabled' : 'default'),
       scheduler: {
         mode: this.mode,
         probeStatus: this.mode === 'off' ? 'disabled' : 'not-run',
         probeTimeoutMs: this.probeTimeoutMs,
         commitTimeoutMs: this.commitTimeoutMs,
         minBlobs: this.minBlobs,
+        bucketWidth: this.selectedCalibration.bucketWidth,
+        reductionMode: this.selectedCalibration.reductionMode,
+        calibrationStatus: cachedCalibration ? 'cached' : this.calibrationMode === 'off' ? 'disabled' : 'default',
+        calibrationSource: this.selectedCalibration.source,
         circuitOpen: false,
       },
     }
@@ -481,6 +548,54 @@ export class ScheduledWebGpuKzgCommitBackend implements KzgCommitBackend {
     }
   }
 
+  private calibrationStatus(
+    status: WebGpuKzgCalibrationRunStatus,
+    reason = this.selectedCalibration.reason,
+  ): WebGpuKzgCalibrationStatus {
+    return {
+      status,
+      mode: this.calibrationMode,
+      cacheKey: this.selectedCalibration.cacheKey,
+      version: this.selectedCalibration.version,
+      source: this.selectedCalibration.source,
+      bucketWidth: this.selectedCalibration.bucketWidth,
+      reductionMode: this.selectedCalibration.reductionMode,
+      minBlobs: this.selectedCalibration.minBlobs,
+      minBytes: this.selectedCalibration.minBytes,
+      score: this.selectedCalibration.score,
+      measuredAtMs: this.selectedCalibration.measuredAtMs,
+      measuredFixture: this.selectedCalibration.measuredFixture,
+      reason,
+    }
+  }
+
+  private updateSelectedCalibration(
+    calibration: WebGpuKzgMsmAdapterCalibration,
+    status: WebGpuKzgCalibrationRunStatus,
+    reason = calibration.reason,
+  ): void {
+    const changed =
+      this.selectedCalibration.bucketWidth !== calibration.bucketWidth ||
+      this.selectedCalibration.reductionMode !== calibration.reductionMode
+    if (changed) {
+      this.committer?.destroy()
+      this.committer = null
+    }
+    this.selectedCalibration = calibration
+    this.status = {
+      ...this.status,
+      bucketWidth: calibration.bucketWidth,
+      reductionMode: calibration.reductionMode,
+      calibration: this.calibrationStatus(status, reason),
+    }
+    this.updateScheduler({
+      bucketWidth: calibration.bucketWidth,
+      reductionMode: calibration.reductionMode,
+      calibrationStatus: status,
+      calibrationSource: calibration.source,
+    })
+  }
+
   private updateScheduler(update: Partial<WebGpuKzgSchedulerStatus>): void {
     const scheduler = this.status.scheduler ?? {
       mode: this.mode,
@@ -488,6 +603,10 @@ export class ScheduledWebGpuKzgCommitBackend implements KzgCommitBackend {
       probeTimeoutMs: this.probeTimeoutMs,
       commitTimeoutMs: this.commitTimeoutMs,
       minBlobs: this.minBlobs,
+      bucketWidth: this.selectedCalibration.bucketWidth,
+      reductionMode: this.selectedCalibration.reductionMode,
+      calibrationStatus: this.status.calibration?.status ?? 'default',
+      calibrationSource: this.selectedCalibration.source,
       circuitOpen: false,
     }
     this.status = {
@@ -510,6 +629,7 @@ export class ScheduledWebGpuKzgCommitBackend implements KzgCommitBackend {
   private openCircuit(reason: string): void {
     this.committer?.destroy()
     this.committer = null
+    this.calibrationCache?.invalidate(this.status.adapter ?? null)
     this.status = {
       ...this.status,
       available: false,
@@ -526,12 +646,18 @@ export class ScheduledWebGpuKzgCommitBackend implements KzgCommitBackend {
 
   private async initCommitter(): Promise<WebGpuKzgMsmCommitter> {
     if (this.committer) return this.committer
+    const committerOptions: WebGpuKzgMsmOptions = {
+      allowFallbackAdapter: this.options.allowFallbackAdapter ?? false,
+      bucketWidth: this.selectedCalibration.bucketWidth,
+      reductionMode: this.selectedCalibration.reductionMode,
+      calibration: this.selectedCalibration,
+    }
     const committer = this.options.webGpuCommitterFactory
-      ? await this.options.webGpuCommitterFactory()
+      ? await this.options.webGpuCommitterFactory(committerOptions)
       : await createWebGpuKzgMsmCommitter(
           this.wasmInterop as unknown as Parameters<typeof createWebGpuKzgMsmCommitter>[0],
           this.navigatorLike as unknown as Parameters<typeof createWebGpuKzgMsmCommitter>[1],
-          { allowFallbackAdapter: this.options.allowFallbackAdapter ?? false },
+          committerOptions,
         )
     this.committer = committer
     this.status = {
@@ -550,12 +676,80 @@ export class ScheduledWebGpuKzgCommitBackend implements KzgCommitBackend {
     return committer
   }
 
-  private async probe(): Promise<boolean> {
+  private async ensureCalibration(realBatchBlobs: number): Promise<boolean> {
+    if (this.calibrationMode === 'off') {
+      this.updateSelectedCalibration(this.selectedCalibration, 'disabled', 'WebGPU MSM calibration disabled')
+      return true
+    }
+
+    const cached = this.calibrationCache?.get(this.status.adapter ?? null) ?? null
+    if (cached) {
+      this.updateSelectedCalibration(cached, 'cached', 'loaded WebGPU MSM calibration from cache')
+      return true
+    }
+
+    if (this.calibrationMode === 'auto' && realBatchBlobs < this.calibrationMinBlobs) {
+      this.updateSelectedCalibration(
+        this.selectedCalibration,
+        'default',
+        `batch below calibration threshold: ${realBatchBlobs} < ${this.calibrationMinBlobs}`,
+      )
+      return true
+    }
+
+    if (this.calibrationPromise) return this.calibrationPromise
+    this.status = { ...this.status, calibration: this.calibrationStatus('running', 'running bounded calibration') }
+    this.updateScheduler({ calibrationStatus: 'running' })
+    this.calibrationPromise = this.runCalibration().finally(() => {
+      this.calibrationPromise = null
+    })
+    return this.calibrationPromise
+  }
+
+  private async runCalibration(): Promise<boolean> {
+    try {
+      const calibration = await calibrateWebGpuKzgMsmAdapter({
+        adapterInfo: this.status.adapter ?? null,
+        candidates: this.options.webGpuCalibrationCandidates,
+        blobCount: this.calibrationBlobCount,
+        runsPerCandidate: this.calibrationRuns,
+        timeoutMs: this.calibrationTimeoutMs,
+        now: this.options.now,
+        oracleCommitBlobs: (blobsFlat) => this.wasmFallback.commitBlobs(blobsFlat),
+        createCommitter: (candidate) => {
+          const committerOptions: WebGpuKzgMsmOptions = {
+            allowFallbackAdapter: this.options.allowFallbackAdapter ?? false,
+            bucketWidth: candidate.bucketWidth,
+            reductionMode: candidate.reductionMode,
+          }
+          return this.options.webGpuCommitterFactory
+            ? this.options.webGpuCommitterFactory(committerOptions)
+            : createWebGpuKzgMsmCommitter(
+                this.wasmInterop as unknown as Parameters<typeof createWebGpuKzgMsmCommitter>[0],
+                this.navigatorLike as unknown as Parameters<typeof createWebGpuKzgMsmCommitter>[1],
+                committerOptions,
+              )
+        },
+      })
+      this.calibrationCache?.set(this.status.adapter ?? null, calibration)
+      this.updateSelectedCalibration(calibration, 'passed')
+      return true
+    } catch (error) {
+      const reason = `WebGPU MSM calibration failed: ${error instanceof Error ? error.message : String(error)}`
+      this.openCircuit(reason)
+      this.status = { ...this.status, calibration: this.calibrationStatus('failed', reason) }
+      this.updateScheduler({ calibrationStatus: 'failed' })
+      return false
+    }
+  }
+
+  private async probe(realBatchBlobs: number): Promise<boolean> {
     if (this.mode === 'off') {
       this.fallBack('WebGPU KZG scheduler disabled')
       return false
     }
     if (this.status.scheduler?.circuitOpen) return false
+    if (!(await this.ensureCalibration(realBatchBlobs))) return false
     if (this.status.scheduler?.probeStatus === 'passed') return true
     if (this.probePromise) return this.probePromise
 
@@ -606,10 +800,16 @@ export class ScheduledWebGpuKzgCommitBackend implements KzgCommitBackend {
         available: true,
         fallbackActive: false,
         selectedBackend: 'webgpu',
-        reductionMode: gpu.debug?.reductionMode,
+        bucketWidth: gpu.debug?.bucketWidth ?? this.selectedCalibration.bucketWidth,
+        reductionMode: gpu.debug?.reductionMode ?? this.selectedCalibration.reductionMode,
         reason: undefined,
       }
-      this.updateScheduler({ probeStatus: 'passed', lastFallbackReason: undefined })
+      this.updateScheduler({
+        probeStatus: 'passed',
+        bucketWidth: gpu.debug?.bucketWidth ?? this.selectedCalibration.bucketWidth,
+        reductionMode: gpu.debug?.reductionMode ?? this.selectedCalibration.reductionMode,
+        lastFallbackReason: undefined,
+      })
       return true
     } catch (error) {
       const reason = error instanceof Error ? error.message : String(error)
@@ -625,7 +825,7 @@ export class ScheduledWebGpuKzgCommitBackend implements KzgCommitBackend {
       this.fallBack(`batch below WebGPU threshold: ${blobs} < ${this.minBlobs}`)
       return this.wasmFallback.commitBlobs(blobsFlat)
     }
-    if (!(await this.probe()) || !this.committer) {
+    if (!(await this.probe(blobs)) || !this.committer) {
       return this.wasmFallback.commitBlobs(blobsFlat)
     }
 
@@ -641,9 +841,15 @@ export class ScheduledWebGpuKzgCommitBackend implements KzgCommitBackend {
       ...this.status,
       fallbackActive: false,
       selectedBackend: 'webgpu',
+      bucketWidth: timed.value.debug?.bucketWidth ?? this.status.bucketWidth,
       reductionMode: timed.value.debug?.reductionMode ?? this.status.reductionMode,
     }
-    this.updateScheduler({ lastWebGpuMs: timed.value.timings.totalMs, lastFallbackReason: undefined })
+    this.updateScheduler({
+      bucketWidth: timed.value.debug?.bucketWidth ?? this.status.bucketWidth,
+      reductionMode: timed.value.debug?.reductionMode ?? this.status.reductionMode,
+      lastWebGpuMs: timed.value.timings.totalMs,
+      lastFallbackReason: undefined,
+    })
     return timed.value.commitments
   }
 
@@ -653,7 +859,7 @@ export class ScheduledWebGpuKzgCommitBackend implements KzgCommitBackend {
       this.fallBack(`batch below WebGPU threshold: ${blobs} < ${this.minBlobs}`)
       return this.wasmFallback.commitBlobsProfiled(blobsFlat)
     }
-    if (!(await this.probe()) || !this.committer) {
+    if (!(await this.probe(blobs)) || !this.committer) {
       return this.wasmFallback.commitBlobsProfiled(blobsFlat)
     }
 
@@ -669,9 +875,15 @@ export class ScheduledWebGpuKzgCommitBackend implements KzgCommitBackend {
       ...this.status,
       fallbackActive: false,
       selectedBackend: 'webgpu',
+      bucketWidth: timed.value.debug?.bucketWidth ?? this.status.bucketWidth,
       reductionMode: timed.value.debug?.reductionMode ?? this.status.reductionMode,
     }
-    this.updateScheduler({ lastWebGpuMs: timed.value.timings.totalMs, lastFallbackReason: undefined })
+    this.updateScheduler({
+      bucketWidth: timed.value.debug?.bucketWidth ?? this.status.bucketWidth,
+      reductionMode: timed.value.debug?.reductionMode ?? this.status.reductionMode,
+      lastWebGpuMs: timed.value.timings.totalMs,
+      lastFallbackReason: undefined,
+    })
     return {
       witnessFlat: timed.value.commitments,
       perf: profileFromWebGpuResult(timed.value),

--- a/polystore-website/src/lib/upload/userMduBrowserKzg.ts
+++ b/polystore-website/src/lib/upload/userMduBrowserKzg.ts
@@ -175,7 +175,11 @@ export function kzgCommitDiagnosticsForBackend(kzgCommitBackend: KzgCommitBacken
     kzgWebGpuProbeTimeoutMs: scheduler?.probeTimeoutMs ?? 0,
     kzgWebGpuCommitTimeoutMs: scheduler?.commitTimeoutMs ?? 0,
     kzgWebGpuMinBlobs: scheduler?.minBlobs ?? 0,
-    kzgWebGpuReductionMode: status?.webgpu?.reductionMode ?? '',
+    kzgWebGpuBucketWidth: status?.webgpu?.bucketWidth ?? scheduler?.bucketWidth ?? 0,
+    kzgWebGpuReductionMode: status?.webgpu?.reductionMode ?? scheduler?.reductionMode ?? '',
+    kzgWebGpuCalibrationStatus: status?.webgpu?.calibration?.status ?? scheduler?.calibrationStatus ?? '',
+    kzgWebGpuCalibrationSource: status?.webgpu?.calibration?.source ?? scheduler?.calibrationSource ?? '',
+    kzgWebGpuCalibrationCacheKey: status?.webgpu?.calibration?.cacheKey ?? '',
   }
 }
 

--- a/polystore-website/src/lib/uploadStatus.test.ts
+++ b/polystore-website/src/lib/uploadStatus.test.ts
@@ -14,13 +14,19 @@ test('normalizeKzgBackendStatus names WebGPU MSM with reduction mode', () => {
     kzgCommitBackend: 'webgpu',
     kzgWebGpuAvailable: true,
     kzgWebGpuProbeStatus: 'passed',
+    kzgWebGpuBucketWidth: 12,
     kzgWebGpuReductionMode: 'serial',
+    kzgWebGpuCalibrationSource: 'benchmark-matrix',
+    kzgWebGpuCalibrationStatus: 'passed',
   })
 
   assert.equal(status.display, 'webgpu-msm')
-  assert.equal(status.label, 'WebGPU MSM (serial)')
+  assert.equal(status.label, 'WebGPU MSM (serial, bucket 12, benchmark-matrix)')
   assert.equal(status.webGpuAvailable, true)
   assert.equal(status.probeStatus, 'passed')
+  assert.equal(status.bucketWidth, 12)
+  assert.equal(status.calibrationStatus, 'passed')
+  assert.equal(status.calibrationSource, 'benchmark-matrix')
 })
 
 test('normalizeKzgBackendStatus reports WASM fallback reason', () => {

--- a/polystore-website/src/lib/uploadStatus.ts
+++ b/polystore-website/src/lib/uploadStatus.ts
@@ -37,7 +37,11 @@ export type KzgBackendStatus = {
   fallbackReason: string | null
   probeStatus: string | null
   circuitOpen: boolean | null
+  bucketWidth: number | null
   reductionMode: string | null
+  calibrationStatus: string | null
+  calibrationSource: string | null
+  calibrationCacheKey: string | null
   probeTimeoutMs: number | null
   commitTimeoutMs: number | null
   minBlobs: number | null
@@ -104,8 +108,16 @@ export type KzgDiagnosticsInput = {
   workerKzgWebGpuProbeStatus?: string
   kzgWebGpuCircuitOpen?: boolean
   workerKzgWebGpuCircuitOpen?: boolean
+  kzgWebGpuBucketWidth?: number
+  workerKzgWebGpuBucketWidth?: number
   kzgWebGpuReductionMode?: string
   workerKzgWebGpuReductionMode?: string
+  kzgWebGpuCalibrationStatus?: string
+  workerKzgWebGpuCalibrationStatus?: string
+  kzgWebGpuCalibrationSource?: string
+  workerKzgWebGpuCalibrationSource?: string
+  kzgWebGpuCalibrationCacheKey?: string
+  workerKzgWebGpuCalibrationCacheKey?: string
   kzgWebGpuProbeTimeoutMs?: number
   workerKzgWebGpuProbeTimeoutMs?: number
   kzgWebGpuCommitTimeoutMs?: number
@@ -139,7 +151,11 @@ export const PENDING_KZG_BACKEND_STATUS: KzgBackendStatus = {
   fallbackReason: null,
   probeStatus: null,
   circuitOpen: null,
+  bucketWidth: null,
   reductionMode: null,
+  calibrationStatus: null,
+  calibrationSource: null,
+  calibrationCacheKey: null,
   probeTimeoutMs: null,
   commitTimeoutMs: null,
   minBlobs: null,
@@ -179,13 +195,18 @@ export function normalizeKzgBackendStatus(input?: KzgDiagnosticsInput | null): K
   const probeStatus = firstString(input.kzgWebGpuProbeStatus, input.workerKzgWebGpuProbeStatus)
   const circuitOpen = firstBoolean(input.kzgWebGpuCircuitOpen, input.workerKzgWebGpuCircuitOpen)
   const webGpuAvailable = firstBoolean(input.kzgWebGpuAvailable, input.workerKzgWebGpuAvailable)
+  const bucketWidth = firstNumber(input.kzgWebGpuBucketWidth, input.workerKzgWebGpuBucketWidth)
   const reductionMode = firstString(input.kzgWebGpuReductionMode, input.workerKzgWebGpuReductionMode)
+  const calibrationStatus = firstString(input.kzgWebGpuCalibrationStatus, input.workerKzgWebGpuCalibrationStatus)
+  const calibrationSource = firstString(input.kzgWebGpuCalibrationSource, input.workerKzgWebGpuCalibrationSource)
+  const calibrationCacheKey = firstString(input.kzgWebGpuCalibrationCacheKey, input.workerKzgWebGpuCalibrationCacheKey)
+  const settingParts = [reductionMode, bucketWidth ? `bucket ${bucketWidth}` : null, calibrationSource].filter(Boolean)
 
   let display: KzgBackendDisplay = 'unknown'
   let label = 'KZG backend unknown'
   if (backend === 'webgpu' || rustBackend === 'webgpu-msm') {
     display = 'webgpu-msm'
-    label = reductionMode ? `WebGPU MSM (${reductionMode})` : 'WebGPU MSM'
+    label = settingParts.length ? `WebGPU MSM (${settingParts.join(', ')})` : 'WebGPU MSM'
   } else if (backend === 'wasm-blst' || backend === 'webgpu-wasm-fallback' || rustBackend === 'blst') {
     display = fallbackReason ? 'fallback' : 'wasm-blst'
     label = fallbackReason ? 'WASM blst fallback' : 'WASM blst'
@@ -203,7 +224,11 @@ export function normalizeKzgBackendStatus(input?: KzgDiagnosticsInput | null): K
     fallbackReason,
     probeStatus,
     circuitOpen,
+    bucketWidth,
     reductionMode,
+    calibrationStatus,
+    calibrationSource,
+    calibrationCacheKey,
     probeTimeoutMs: firstNumber(input.kzgWebGpuProbeTimeoutMs, input.workerKzgWebGpuProbeTimeoutMs),
     commitTimeoutMs: firstNumber(input.kzgWebGpuCommitTimeoutMs, input.workerKzgWebGpuCommitTimeoutMs),
     minBlobs: firstNumber(input.kzgWebGpuMinBlobs, input.workerKzgWebGpuMinBlobs),
@@ -319,6 +344,7 @@ export function sanitizeUploadPipelineStatus(status: UploadPipelineStatus): Uplo
     kzg: {
       ...status.kzg,
       fallbackReason: truncate(status.kzg.fallbackReason, 500),
+      calibrationCacheKey: truncate(status.kzg.calibrationCacheKey, 240),
     },
   }
 }

--- a/polystore-website/src/lib/webgpuKzgMsm.test.ts
+++ b/polystore-website/src/lib/webgpuKzgMsm.test.ts
@@ -3,12 +3,18 @@ import assert from 'node:assert/strict'
 
 import {
   WEBGPU_KZG_MSM_BLOB_SIZE,
+  WEBGPU_KZG_MSM_CALIBRATION_VERSION,
   WEBGPU_KZG_MSM_SIGN_BIT,
+  calibrateWebGpuKzgMsmAdapter,
   buildWebGpuKzgMsmBucketData,
   createWebGpuKzgMsmAdapterCacheKey,
   defaultWebGpuKzgMsmAdapterCalibration,
+  makeWebGpuKzgMsmCalibrationBlobBatch,
+  selectWebGpuKzgMsmAdapterCalibration,
   selectWebGpuKzgMsmReductionMode,
   WebGpuKzgMsmCalibrationCache,
+  type WebGpuKzgMsmCalibrationCandidate,
+  type WebGpuKzgMsmOptions,
 } from './webgpuKzgMsm'
 
 function blobWithCell(index: number, value: bigint): Uint8Array {
@@ -19,6 +25,55 @@ function blobWithCell(index: number, value: bigint): Uint8Array {
     remaining >>= 8n
   }
   return blob
+}
+
+function commitmentsFor(blobs: Uint8Array, seed = 1): Uint8Array {
+  const out = new Uint8Array((blobs.byteLength / WEBGPU_KZG_MSM_BLOB_SIZE) * 48)
+  for (let i = 0; i < out.length; i += 1) out[i] = (seed + i) & 0xff
+  return out
+}
+
+function fakeCommitter(options: {
+  totalMs: number
+  seed?: number
+  candidate: WebGpuKzgMsmCalibrationCandidate
+}) {
+  return {
+    destroyed: false,
+    destroy() {
+      this.destroyed = true
+    },
+    getDeviceLostInfo: async () => null,
+    commitBlobs: async (input: Uint8Array) => ({
+      commitments: commitmentsFor(input, options.seed ?? 1),
+      timings: {
+        scalarPrepMs: 0,
+        bucketBuildMs: 0,
+        uploadMs: 0,
+        dispatchReadbackMs: options.totalMs,
+        foldMs: 0,
+        totalMs: options.totalMs,
+      },
+      blobs: input.byteLength / WEBGPU_KZG_MSM_BLOB_SIZE,
+      debug: {
+        bucketWidth: options.candidate.bucketWidth,
+        reductionMode: options.candidate.reductionMode,
+        bucketCount: 1,
+        baseIndexCount: 1,
+        numWindows: 1,
+        maxBucketSize: 1,
+        meanBucketSize: 1,
+        uploadBytes: 4,
+        readbackBytes: 384,
+        windowSumNonZeroBytes: 1,
+        processedBlobs: input.byteLength / WEBGPU_KZG_MSM_BLOB_SIZE,
+        commandSubmissions: 1,
+        readbackCount: 1,
+        scratchCapacityBytes: 4096,
+        scratchResizeCount: 0,
+      },
+    }),
+  }
 }
 
 test('WebGPU KZG MSM bucket data skips zero scalars', () => {
@@ -76,13 +131,16 @@ test('WebGPU KZG MSM adapter defaults preserve measured Apple and NVIDIA modes',
 })
 
 test('WebGPU KZG MSM calibration cache keys and invalidation are adapter scoped', () => {
-  const cache = new WebGpuKzgMsmCalibrationCache()
+  const cache = new WebGpuKzgMsmCalibrationCache({ storage: null })
   const nvidia = { vendor: 'nvidia', architecture: 'ampere', device: 'rtx-3060-ti', isFallbackAdapter: false }
   const apple = { vendor: 'apple', architecture: 'metal-3', device: 'm3', isFallbackAdapter: false }
   const calibration = {
     ...defaultWebGpuKzgMsmAdapterCalibration(nvidia),
     source: 'benchmark-matrix' as const,
     reason: 'test calibration',
+    score: 4.2,
+    measuredFixture: { blobs: 4, bytes: 4 * WEBGPU_KZG_MSM_BLOB_SIZE, runs: 1, candidates: 2, metric: 'median-total-ms' as const, wasmMs: 12 },
+    measuredAtMs: 123,
   }
 
   cache.set(nvidia, calibration)
@@ -97,4 +155,87 @@ test('WebGPU KZG MSM calibration cache keys and invalidation are adapter scoped'
   cache.set(nvidia, calibration)
   cache.invalidate()
   assert.equal(cache.get(nvidia), null)
+})
+
+test('WebGPU KZG MSM calibration cache rejects stale schema versions', () => {
+  const storage = new Map<string, string>()
+  const cache = new WebGpuKzgMsmCalibrationCache({
+    storage: {
+      getItem: (key) => storage.get(key) ?? null,
+      setItem: (key, value) => storage.set(key, value),
+      removeItem: (key) => storage.delete(key),
+    },
+  })
+  const nvidia = { vendor: 'nvidia', architecture: 'ampere', device: 'rtx-3060-ti', isFallbackAdapter: false }
+  const stale = {
+    ...defaultWebGpuKzgMsmAdapterCalibration(nvidia, 'old-version'),
+    source: 'benchmark-matrix' as const,
+  }
+  storage.set(`polystore:kzg:webgpu-msm-calibration:${createWebGpuKzgMsmAdapterCacheKey(nvidia)}`, JSON.stringify(stale))
+
+  assert.equal(cache.get(nvidia), null)
+})
+
+test('WebGPU KZG MSM selects cached calibration over adapter defaults', () => {
+  const nvidia = { vendor: 'nvidia', architecture: 'ampere', device: 'rtx-3060-ti', isFallbackAdapter: false }
+  const cache = new WebGpuKzgMsmCalibrationCache({ storage: null })
+  cache.set(nvidia, {
+    ...defaultWebGpuKzgMsmAdapterCalibration(nvidia),
+    bucketWidth: 12,
+    reductionMode: 'parallel16',
+    source: 'benchmark-matrix',
+    reason: 'local bench winner',
+    score: 4.58,
+    measuredFixture: { blobs: 96, bytes: 96 * WEBGPU_KZG_MSM_BLOB_SIZE, runs: 1, candidates: 2, metric: 'median-total-ms', wasmMs: 28.3 },
+    measuredAtMs: 456,
+  })
+
+  const selected = selectWebGpuKzgMsmAdapterCalibration(nvidia, cache)
+  assert.equal(selected.bucketWidth, 12)
+  assert.equal(selected.reductionMode, 'parallel16')
+  assert.equal(selected.source, 'benchmark-matrix')
+  assert.equal(selectWebGpuKzgMsmAdapterCalibration(nvidia, null).bucketWidth, 10)
+})
+
+test('WebGPU KZG MSM bounded calibration chooses fastest parity-valid candidate', async () => {
+  const nvidia = { vendor: 'nvidia', architecture: 'ampere', device: 'rtx-3060-ti', isFallbackAdapter: false }
+  const candidates: WebGpuKzgMsmCalibrationCandidate[] = [
+    { bucketWidth: 10, reductionMode: 'serial' },
+    { bucketWidth: 12, reductionMode: 'parallel16' },
+  ]
+  const seen: WebGpuKzgMsmOptions[] = []
+  const calibration = await calibrateWebGpuKzgMsmAdapter({
+    adapterInfo: nvidia,
+    candidates,
+    blobCount: 2,
+    timeoutMs: 1000,
+    oracleCommitBlobs: (input) => commitmentsFor(input),
+    createCommitter: async (candidate) => {
+      seen.push({ bucketWidth: candidate.bucketWidth, reductionMode: candidate.reductionMode })
+      return fakeCommitter({ candidate, totalMs: candidate.bucketWidth === 12 ? 5 : 20 })
+    },
+    now: () => 999,
+  })
+
+  assert.equal(calibration.version, WEBGPU_KZG_MSM_CALIBRATION_VERSION)
+  assert.equal(calibration.bucketWidth, 12)
+  assert.equal(calibration.reductionMode, 'parallel16')
+  assert.equal(calibration.source, 'benchmark-matrix')
+  assert.equal(calibration.score, 5)
+  assert.equal(calibration.measuredFixture?.blobs, 2)
+  assert.equal(seen.length, 2)
+})
+
+test('WebGPU KZG MSM bounded calibration fails closed when all candidates fail parity', async () => {
+  const fixture = makeWebGpuKzgMsmCalibrationBlobBatch(1)
+  await assert.rejects(
+    calibrateWebGpuKzgMsmAdapter({
+      adapterInfo: { vendor: 'nvidia', architecture: 'ampere', isFallbackAdapter: false },
+      candidates: [{ bucketWidth: 12, reductionMode: 'parallel16' }],
+      blobCount: 1,
+      oracleCommitBlobs: () => commitmentsFor(fixture, 1),
+      createCommitter: async (candidate) => fakeCommitter({ candidate, totalMs: 5, seed: 99 }),
+    }),
+    /parity mismatch/,
+  )
 })

--- a/polystore-website/src/lib/webgpuKzgMsm.ts
+++ b/polystore-website/src/lib/webgpuKzgMsm.ts
@@ -50,7 +50,7 @@ type WebGpuAdapter = {
   requestAdapterInfo?: () => Promise<WebGpuAdapterInfo>
   requestDevice: () => Promise<GPUDevice>
 }
-type WebGpuAdapterInfo = {
+export type WebGpuKzgMsmAdapterInfo = {
   vendor?: string
   architecture?: string
   device?: string
@@ -58,8 +58,12 @@ type WebGpuAdapterInfo = {
   isFallbackAdapter?: boolean
 }
 
+type WebGpuAdapterInfo = WebGpuKzgMsmAdapterInfo
+
 export const WEBGPU_KZG_MSM_BUCKET_WIDTH = 10
 export const WEBGPU_KZG_MSM_REDUCTION_MODE: WebGpuKzgMsmReductionMode = 'serial'
+export const WEBGPU_KZG_MSM_CALIBRATION_VERSION = 'webgpu-msm-calibration-v2'
+export const WEBGPU_KZG_MSM_CALIBRATION_STORAGE_PREFIX = 'polystore:kzg:webgpu-msm-calibration:'
 export const WEBGPU_KZG_MSM_POINT_BYTES = 384
 export const WEBGPU_KZG_MSM_SIGN_BIT = 0x80000000
 export const WEBGPU_KZG_MSM_BLOB_SIZE = 128 * 1024
@@ -77,16 +81,56 @@ export type WebGpuKzgMsmOptions = {
   bucketWidth?: number
   reductionMode?: WebGpuKzgMsmReductionMode
   allowFallbackAdapter?: boolean
+  calibration?: WebGpuKzgMsmAdapterCalibration
+}
+
+export type WebGpuKzgMsmCalibrationSource = 'default-adapter-rule' | 'benchmark-matrix'
+
+export type WebGpuKzgMsmCalibrationFixture = {
+  blobs: number
+  bytes: number
+  runs: number
+  candidates: number
+  metric: 'median-total-ms'
+  wasmMs: number | null
 }
 
 export type WebGpuKzgMsmAdapterCalibration = {
+  version: string
   cacheKey: string
   bucketWidth: number
   reductionMode: WebGpuKzgMsmReductionMode
   minBlobs: number
   minBytes: number
-  source: 'default-adapter-rule' | 'benchmark-matrix'
+  source: WebGpuKzgMsmCalibrationSource
   reason: string
+  score: number | null
+  measuredFixture: WebGpuKzgMsmCalibrationFixture | null
+  measuredAtMs: number | null
+}
+
+export type WebGpuKzgMsmCalibrationCandidate = {
+  bucketWidth: number
+  reductionMode: WebGpuKzgMsmReductionMode
+  label?: string
+}
+
+export type WebGpuKzgMsmCalibrationStorage = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>
+
+export type WebGpuKzgMsmCalibrationCommitter = {
+  commitBlobs: (blobsFlat: Uint8Array) => Promise<WebGpuKzgMsmResult>
+  destroy: () => void
+}
+
+export type WebGpuKzgMsmCalibrationOptions = {
+  adapterInfo: WebGpuKzgMsmAdapterInfo | null
+  createCommitter: (candidate: WebGpuKzgMsmCalibrationCandidate) => Promise<WebGpuKzgMsmCalibrationCommitter>
+  oracleCommitBlobs: (blobsFlat: Uint8Array) => Uint8Array | Promise<Uint8Array>
+  candidates?: WebGpuKzgMsmCalibrationCandidate[]
+  blobCount?: number
+  runsPerCandidate?: number
+  timeoutMs?: number
+  now?: () => number
 }
 
 export type WebGpuKzgMsmTimings = {
@@ -442,6 +486,81 @@ function assertReductionMode(mode: WebGpuKzgMsmReductionMode): WebGpuKzgMsmReduc
   throw new Error('WebGPU KZG MSM reduction mode must be serial, parallel16, parallel32, or parallel64')
 }
 
+function normalizePositiveInteger(value: unknown, fallback: number): number {
+  const numberValue = Number(value)
+  if (!Number.isFinite(numberValue) || numberValue < 1) return fallback
+  return Math.floor(numberValue)
+}
+
+function normalizeCalibrationCandidate(candidate: WebGpuKzgMsmCalibrationCandidate): WebGpuKzgMsmCalibrationCandidate {
+  return {
+    bucketWidth: assertBucketWidth(candidate.bucketWidth),
+    reductionMode: assertReductionMode(candidate.reductionMode),
+    label: candidate.label,
+  }
+}
+
+function uniqueCalibrationCandidates(
+  candidates: WebGpuKzgMsmCalibrationCandidate[],
+): WebGpuKzgMsmCalibrationCandidate[] {
+  const seen = new Set<string>()
+  const out: WebGpuKzgMsmCalibrationCandidate[] = []
+  for (const candidate of candidates) {
+    const normalized = normalizeCalibrationCandidate(candidate)
+    const key = `${normalized.bucketWidth}:${normalized.reductionMode}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push(normalized)
+  }
+  return out
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.byteLength !== b.byteLength) return false
+  for (let i = 0; i < a.byteLength; i += 1) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
+}
+
+function median(values: number[]): number {
+  const sorted = values.filter((value) => Number.isFinite(value)).sort((a, b) => a - b)
+  if (sorted.length === 0) return Number.POSITIVE_INFINITY
+  return sorted[Math.floor((sorted.length - 1) / 2)]
+}
+
+function delay<T>(ms: number, value: T): Promise<T> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(value), ms)
+  })
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+): Promise<{ timedOut: false; value: T } | { timedOut: true }> {
+  return Promise.race([
+    promise.then((value) => ({ timedOut: false as const, value })),
+    delay(timeoutMs, { timedOut: true as const }),
+  ])
+}
+
+export function makeWebGpuKzgMsmCalibrationBlobBatch(blobCount = 4): Uint8Array {
+  const blobs = normalizePositiveInteger(blobCount, 4)
+  const out = new Uint8Array(WEBGPU_KZG_MSM_BLOB_SIZE * blobs)
+  for (let blobIndex = 0; blobIndex < blobs; blobIndex += 1) {
+    const seed = 41 + blobIndex * 13
+    for (let cellIndex = 0; cellIndex < WEBGPU_KZG_MSM_CELLS_PER_BLOB; cellIndex += 1) {
+      const offset = blobIndex * WEBGPU_KZG_MSM_BLOB_SIZE + cellIndex * 32
+      out[offset] = 0
+      for (let byteIndex = 1; byteIndex < 32; byteIndex += 1) {
+        out[offset + byteIndex] = (seed + cellIndex * 17 + byteIndex * 29) & 0xff
+      }
+    }
+  }
+  return out
+}
+
 async function readAdapterInfo(adapter: WebGpuAdapter): Promise<WebGpuAdapterInfo | null> {
   try {
     if (adapter.info) return adapter.info
@@ -452,7 +571,10 @@ async function readAdapterInfo(adapter: WebGpuAdapter): Promise<WebGpuAdapterInf
   return null
 }
 
-export function createWebGpuKzgMsmAdapterCacheKey(info: WebGpuAdapterInfo | null, version = 'webgpu-msm-v1'): string {
+export function createWebGpuKzgMsmAdapterCacheKey(
+  info: WebGpuAdapterInfo | null,
+  version = WEBGPU_KZG_MSM_CALIBRATION_VERSION,
+): string {
   const normalize = (value: unknown) => String(value ?? 'unknown').trim().toLowerCase() || 'unknown'
   return [
     version,
@@ -466,13 +588,15 @@ export function createWebGpuKzgMsmAdapterCacheKey(info: WebGpuAdapterInfo | null
 
 export function defaultWebGpuKzgMsmAdapterCalibration(
   info: WebGpuAdapterInfo | null,
+  version = WEBGPU_KZG_MSM_CALIBRATION_VERSION,
 ): WebGpuKzgMsmAdapterCalibration {
   const vendor = info?.vendor?.toLowerCase() ?? ''
   const architecture = info?.architecture?.toLowerCase() ?? ''
   const isAppleMetal = vendor.includes('apple') || architecture.includes('metal')
   const reductionMode = isAppleMetal ? 'parallel16' : WEBGPU_KZG_MSM_REDUCTION_MODE
   return {
-    cacheKey: createWebGpuKzgMsmAdapterCacheKey(info),
+    version,
+    cacheKey: createWebGpuKzgMsmAdapterCacheKey(info, version),
     bucketWidth: WEBGPU_KZG_MSM_BUCKET_WIDTH,
     reductionMode,
     minBlobs: 1,
@@ -481,31 +605,252 @@ export function defaultWebGpuKzgMsmAdapterCalibration(
     reason: isAppleMetal
       ? 'Apple/Metal diagnostics favor parallel16 for the final per-window reduction'
       : 'NVIDIA/Vulkan and unknown native adapters default to the stable serial reduction',
+    score: null,
+    measuredFixture: null,
+    measuredAtMs: null,
+  }
+}
+
+function resolveDefaultCalibrationStorage(): WebGpuKzgMsmCalibrationStorage | null {
+  try {
+    const storage = (globalThis as unknown as { localStorage?: WebGpuKzgMsmCalibrationStorage }).localStorage
+    return storage ?? null
+  } catch {
+    return null
+  }
+}
+
+function normalizeWebGpuKzgMsmCalibration(
+  info: WebGpuAdapterInfo | null,
+  raw: unknown,
+  version = WEBGPU_KZG_MSM_CALIBRATION_VERSION,
+): WebGpuKzgMsmAdapterCalibration | null {
+  const obj = raw as Partial<WebGpuKzgMsmAdapterCalibration> | null | undefined
+  const expectedCacheKey = createWebGpuKzgMsmAdapterCacheKey(info, version)
+  if (!obj || obj.version !== version || obj.cacheKey !== expectedCacheKey) return null
+  if (obj.source !== 'default-adapter-rule' && obj.source !== 'benchmark-matrix') return null
+
+  try {
+    const bucketWidth = assertBucketWidth(Number(obj.bucketWidth))
+    const reductionMode = assertReductionMode(obj.reductionMode as WebGpuKzgMsmReductionMode)
+    const minBlobs = normalizePositiveInteger(obj.minBlobs, 1)
+    const measuredFixture = obj.measuredFixture
+      ? {
+          blobs: normalizePositiveInteger(obj.measuredFixture.blobs, 1),
+          bytes: normalizePositiveInteger(obj.measuredFixture.bytes, WEBGPU_KZG_MSM_BLOB_SIZE),
+          runs: normalizePositiveInteger(obj.measuredFixture.runs, 1),
+          candidates: normalizePositiveInteger(obj.measuredFixture.candidates, 1),
+          metric: 'median-total-ms' as const,
+          wasmMs: Number.isFinite(Number(obj.measuredFixture.wasmMs)) ? Number(obj.measuredFixture.wasmMs) : null,
+        }
+      : null
+    return {
+      version,
+      cacheKey: expectedCacheKey,
+      bucketWidth,
+      reductionMode,
+      minBlobs,
+      minBytes: normalizePositiveInteger(obj.minBytes, minBlobs * WEBGPU_KZG_MSM_BLOB_SIZE),
+      source: obj.source,
+      reason: typeof obj.reason === 'string' && obj.reason.trim() ? obj.reason : 'calibration selected',
+      score: Number.isFinite(Number(obj.score)) ? Number(obj.score) : null,
+      measuredFixture,
+      measuredAtMs: Number.isFinite(Number(obj.measuredAtMs)) ? Number(obj.measuredAtMs) : null,
+    }
+  } catch {
+    return null
   }
 }
 
 export class WebGpuKzgMsmCalibrationCache {
   private readonly entries = new Map<string, WebGpuKzgMsmAdapterCalibration>()
+  private readonly storage: WebGpuKzgMsmCalibrationStorage | null
+  private readonly version: string
+  private readonly storagePrefix: string
+
+  constructor(options: {
+    storage?: WebGpuKzgMsmCalibrationStorage | null
+    version?: string
+    storagePrefix?: string
+  } = {}) {
+    this.storage = options.storage === undefined ? resolveDefaultCalibrationStorage() : options.storage
+    this.version = options.version ?? WEBGPU_KZG_MSM_CALIBRATION_VERSION
+    this.storagePrefix = options.storagePrefix ?? WEBGPU_KZG_MSM_CALIBRATION_STORAGE_PREFIX
+  }
 
   get(info: WebGpuAdapterInfo | null): WebGpuKzgMsmAdapterCalibration | null {
-    return this.entries.get(createWebGpuKzgMsmAdapterCacheKey(info)) ?? null
+    const cacheKey = createWebGpuKzgMsmAdapterCacheKey(info, this.version)
+    const memoryEntry = normalizeWebGpuKzgMsmCalibration(info, this.entries.get(cacheKey), this.version)
+    if (memoryEntry) return memoryEntry
+    this.entries.delete(cacheKey)
+
+    if (!this.storage) return null
+    try {
+      const raw = this.storage.getItem(`${this.storagePrefix}${cacheKey}`)
+      if (!raw) return null
+      const storageEntry = normalizeWebGpuKzgMsmCalibration(info, JSON.parse(raw), this.version)
+      if (!storageEntry) {
+        this.storage.removeItem(`${this.storagePrefix}${cacheKey}`)
+        return null
+      }
+      this.entries.set(cacheKey, storageEntry)
+      return storageEntry
+    } catch {
+      return null
+    }
   }
 
   set(info: WebGpuAdapterInfo | null, calibration: WebGpuKzgMsmAdapterCalibration): void {
-    this.entries.set(createWebGpuKzgMsmAdapterCacheKey(info), calibration)
+    const normalized = normalizeWebGpuKzgMsmCalibration(
+      info,
+      {
+        ...calibration,
+        version: this.version,
+        cacheKey: createWebGpuKzgMsmAdapterCacheKey(info, this.version),
+      },
+      this.version,
+    )
+    if (!normalized) throw new Error('invalid WebGPU KZG MSM calibration result')
+    this.entries.set(normalized.cacheKey, normalized)
+    try {
+      this.storage?.setItem(`${this.storagePrefix}${normalized.cacheKey}`, JSON.stringify(normalized))
+    } catch {
+      // Persistent storage is best effort; the in-memory cache remains valid for this session.
+    }
   }
 
   invalidate(info?: WebGpuAdapterInfo | null): void {
     if (typeof info === 'undefined') {
+      for (const key of this.entries.keys()) {
+        try {
+          this.storage?.removeItem(`${this.storagePrefix}${key}`)
+        } catch {
+          // best effort
+        }
+      }
       this.entries.clear()
       return
     }
-    this.entries.delete(createWebGpuKzgMsmAdapterCacheKey(info))
+    const cacheKey = createWebGpuKzgMsmAdapterCacheKey(info, this.version)
+    this.entries.delete(cacheKey)
+    try {
+      this.storage?.removeItem(`${this.storagePrefix}${cacheKey}`)
+    } catch {
+      // best effort
+    }
   }
 }
 
+export const defaultWebGpuKzgMsmCalibrationCache = new WebGpuKzgMsmCalibrationCache()
+
+export function defaultWebGpuKzgMsmCalibrationCandidates(
+  info: WebGpuAdapterInfo | null,
+  fallback = defaultWebGpuKzgMsmAdapterCalibration(info),
+): WebGpuKzgMsmCalibrationCandidate[] {
+  const vendor = info?.vendor?.toLowerCase() ?? ''
+  const architecture = info?.architecture?.toLowerCase() ?? ''
+  const candidates: WebGpuKzgMsmCalibrationCandidate[] = [
+    { bucketWidth: fallback.bucketWidth, reductionMode: fallback.reductionMode, label: 'adapter-default' },
+  ]
+
+  if (vendor.includes('apple') || architecture.includes('metal')) {
+    candidates.push({ bucketWidth: 10, reductionMode: 'parallel16', label: 'apple-metal-parallel16' })
+  } else {
+    candidates.push({ bucketWidth: 12, reductionMode: 'parallel16', label: 'ampere-parallel16-bucket12' })
+  }
+
+  return uniqueCalibrationCandidates(candidates)
+}
+
+export function selectWebGpuKzgMsmAdapterCalibration(
+  info: WebGpuAdapterInfo | null,
+  cache: WebGpuKzgMsmCalibrationCache | null | undefined = defaultWebGpuKzgMsmCalibrationCache,
+): WebGpuKzgMsmAdapterCalibration {
+  return cache?.get(info) ?? defaultWebGpuKzgMsmAdapterCalibration(info)
+}
+
 export function selectWebGpuKzgMsmReductionMode(info: WebGpuAdapterInfo | null): WebGpuKzgMsmReductionMode {
-  return defaultWebGpuKzgMsmAdapterCalibration(info).reductionMode
+  return selectWebGpuKzgMsmAdapterCalibration(info).reductionMode
+}
+
+export async function calibrateWebGpuKzgMsmAdapter(
+  options: WebGpuKzgMsmCalibrationOptions,
+): Promise<WebGpuKzgMsmAdapterCalibration> {
+  const fallback = defaultWebGpuKzgMsmAdapterCalibration(options.adapterInfo)
+  const candidates = uniqueCalibrationCandidates(options.candidates ?? defaultWebGpuKzgMsmCalibrationCandidates(options.adapterInfo, fallback))
+  const blobCount = normalizePositiveInteger(options.blobCount, 4)
+  const runsPerCandidate = normalizePositiveInteger(options.runsPerCandidate, 1)
+  const timeoutMs = normalizePositiveInteger(options.timeoutMs, 12_000)
+  const fixture = makeWebGpuKzgMsmCalibrationBlobBatch(blobCount)
+  const oracleStart = nowMs()
+  const oracleCommitments = await options.oracleCommitBlobs(fixture)
+  const wasmMs = nowMs() - oracleStart
+  const expectedBytes = blobCount * 48
+  if (oracleCommitments.byteLength !== expectedBytes) {
+    throw new Error(`WebGPU MSM calibration oracle returned ${oracleCommitments.byteLength} bytes, expected ${expectedBytes}`)
+  }
+
+  const scored: Array<{ candidate: WebGpuKzgMsmCalibrationCandidate; score: number }> = []
+  const failures: string[] = []
+  for (const candidate of candidates) {
+    const scores: number[] = []
+    let committer: WebGpuKzgMsmCalibrationCommitter | null = null
+    try {
+      committer = await options.createCommitter(candidate)
+      for (let run = 0; run < runsPerCandidate; run += 1) {
+        const timed = await withTimeout(committer.commitBlobs(fixture), timeoutMs)
+        if (timed.timedOut) {
+          failures.push(`${candidate.bucketWidth}/${candidate.reductionMode}: timeout after ${timeoutMs}ms`)
+          break
+        }
+        if (!bytesEqual(oracleCommitments, timed.value.commitments)) {
+          failures.push(`${candidate.bucketWidth}/${candidate.reductionMode}: parity mismatch`)
+          scores.length = 0
+          break
+        }
+        scores.push(timed.value.timings.totalMs)
+      }
+    } catch (error) {
+      failures.push(
+        `${candidate.bucketWidth}/${candidate.reductionMode}: ${error instanceof Error ? error.message : String(error)}`,
+      )
+    } finally {
+      committer?.destroy()
+    }
+
+    if (scores.length === runsPerCandidate) {
+      scored.push({ candidate, score: median(scores) })
+    }
+  }
+
+  scored.sort((a, b) => a.score - b.score)
+  const winner = scored[0]
+  if (!winner) {
+    throw new Error(
+      `WebGPU MSM calibration failed for ${candidates.length} candidate(s)${failures.length ? `: ${failures.join('; ')}` : ''}`,
+    )
+  }
+
+  return {
+    version: fallback.version,
+    cacheKey: fallback.cacheKey,
+    bucketWidth: winner.candidate.bucketWidth,
+    reductionMode: winner.candidate.reductionMode,
+    minBlobs: Math.max(1, Math.min(blobCount, fallback.minBlobs || blobCount)),
+    minBytes: Math.max(WEBGPU_KZG_MSM_BLOB_SIZE, Math.min(fixture.byteLength, fallback.minBytes || fixture.byteLength)),
+    source: 'benchmark-matrix',
+    reason: `bounded calibration selected bucket ${winner.candidate.bucketWidth} / ${winner.candidate.reductionMode}`,
+    score: winner.score,
+    measuredFixture: {
+      blobs: blobCount,
+      bytes: fixture.byteLength,
+      runs: runsPerCandidate,
+      candidates: candidates.length,
+      metric: 'median-total-ms',
+      wasmMs,
+    },
+    measuredAtMs: options.now ? options.now() : Date.now(),
+  }
 }
 
 function reductionWorkgroupSize(mode: WebGpuKzgMsmReductionMode): 16 | 32 | 64 {
@@ -922,10 +1267,12 @@ export async function createWebGpuKzgMsmCommitter(
   if (!options.allowFallbackAdapter && adapterInfo?.isFallbackAdapter) {
     throw new Error('WebGPU adapter is a fallback/software adapter')
   }
+  const calibration = options.calibration ?? selectWebGpuKzgMsmAdapterCalibration(adapterInfo)
   const resolvedOptions: WebGpuKzgMsmOptions = {
     ...options,
-    bucketWidth: options.bucketWidth ?? defaultWebGpuKzgMsmAdapterCalibration(adapterInfo).bucketWidth,
-    reductionMode: options.reductionMode ?? defaultWebGpuKzgMsmAdapterCalibration(adapterInfo).reductionMode,
+    calibration,
+    bucketWidth: options.bucketWidth ?? calibration.bucketWidth,
+    reductionMode: options.reductionMode ?? calibration.reductionMode,
   }
   const device = await adapter.requestDevice()
   return new WebGpuKzgMsmCommitter(device, wasm, resolvedOptions)

--- a/polystore-website/src/lib/worker-client.ts
+++ b/polystore-website/src/lib/worker-client.ts
@@ -269,7 +269,11 @@ export type KzgCommitDiagnostics = {
   kzgWebGpuProbeTimeoutMs?: number
   kzgWebGpuCommitTimeoutMs?: number
   kzgWebGpuMinBlobs?: number
+  kzgWebGpuBucketWidth?: number
   kzgWebGpuReductionMode?: string
+  kzgWebGpuCalibrationStatus?: string
+  kzgWebGpuCalibrationSource?: string
+  kzgWebGpuCalibrationCacheKey?: string
   commitWorkerCount?: number
 }
 


### PR DESCRIPTION
**Latest validation update (2026-05-30):** Native Apple M3 and NVIDIA/Ampere WebGPU validation is now available in PR comments. Evidence supports the WebGPU MSM autotune performance claim: non-fallback native adapters, parity true, and WebGPU faster than WASM. This supersedes older draft caveats about native WebGPU evidence being unavailable.

---

## Summary

Closes #193 (child of #192).

Implements the WebGPU KZG MSM calibration/settings contract for browser uploads:

- Adds `webgpu-msm-calibration-v2` adapter cache keys and calibration result schema (`bucketWidth`, `reductionMode`, score, fixture, source, timestamp, version).
- Adds bounded runtime calibration for the browser KZG backend with WASM/blst parity validation and cache invalidation/fallback on stale schema, parity failure, timeout, or device loss.
- Applies calibrated `{bucketWidth, reductionMode}` when constructing the WebGPU MSM committer and surfaces bucket width + calibration status/source/cache key in upload diagnostics/status.
- Adds a committed PR-grade matrix command for native WebGPU benchmark evidence: `npm run perf:kzg-webgpu-msm:matrix`.
- Documents the stable contract and local benchmark/diagnostic commands in `notes/kzg_webgpu_msm_optimization.md`.

## Scope boundaries / non-goals

This PR intentionally does **not** implement #194 RS/KZG scheduler split, #195 cross-MDU batching, #196 upload worker autotune, #197 upload pipelining, #198 bundle uploads, or #199 prewarm runtime work.

The browser remains gateway-optional, wallet signing remains in-browser, and WASM/blst remains the correctness oracle/fallback.

## Calibration contract for downstream #194/#195

Stable snapshot for consumers:

- Cache key: `webgpu-msm-calibration-v2|vendor|architecture|device|description|isFallbackAdapter`.
- Result schema: `version`, `cacheKey`, `bucketWidth`, `reductionMode`, `minBlobs`, `minBytes`, `source`, `reason`, `score`, `measuredFixture`, `measuredAtMs`.
- Runtime options: `webGpuCalibrationMode`, `webGpuCalibrationMinBlobs`, `webGpuCalibrationBlobCount`, `webGpuCalibrationRuns`, `webGpuCalibrationTimeoutMs`, `webGpuCalibrationCandidates`, `webGpuCalibrationCache`.
- Status/diagnostics: `webgpu.bucketWidth`, `webgpu.reductionMode`, `webgpu.calibration.{status,source,cacheKey,...}`, and scheduler mirrors for `bucketWidth`, `reductionMode`, `calibrationStatus`, `calibrationSource`.
- Default bounded behavior: auto calibration only starts for real batches `>= 64` blobs; calibration fixture is 4 deterministic blobs; small uploads keep default adapter rules.
- Fallback invariant: any calibration/probe/commit parity failure, timeout, stale cache, or device loss falls back to WASM/blst and invalidates the cached adapter entry.

## Test plan / evidence

Commands run on latest head `15db9074`:

| Command | Outcome |
| --- | --- |
| `cd polystore-website && npm run test:unit` | PASS (267 tests) |
| `cd polystore-website && npm run lint` | PASS |
| `cd polystore-website && npm run build:app` | PASS (`tsc && vite build`; only existing Vite/Rollup/browserlist warnings) |
| `cd polystore-website && POLYSTORE_WEBGPU_MSM_BLOBS_LIST=1 POLYSTORE_WEBGPU_MSM_BUCKET_WIDTHS=10 POLYSTORE_WEBGPU_MSM_REDUCTIONS=serial POLYSTORE_WEBGPU_MSM_RUNS=1 npm run diagnose:kzg-webgpu-msm` | PASS/diagnostic: Chrome WebGPU present but adapter was SwiftShader fallback (`isFallbackAdapter: true`), so native WebGPU run was skipped with `WebGPU adapter is a fallback/software adapter` |

## Benchmark plan for native WebGPU completion evidence

The full before/after native GPU evidence still needs to be collected on a native adapter (e.g. headed Chrome with NVIDIA/Vulkan or Apple/Metal):

```sh
cd polystore-website
npm run perf:kzg-webgpu-msm:matrix
```

This runs the required 64/96/256 blob matrix across bucket widths `10,12,13` and reduction modes `serial,parallel16`. For NVIDIA headed Chrome, use the known native-adapter flags if headless resolves to SwiftShader:

```sh
cd polystore-website
POLYSTORE_WEBGPU_HEADLESS=0 \
POLYSTORE_WEBGPU_CHROME_ARGS='--use-vulkan=native --force_high_performance_gpu' \
npm run perf:kzg-webgpu-msm:matrix
```

100 MiB upload-prep before/after evidence should use the parent tracker fixture: Mode 2 RS 8+4, 13 user MDUs, 96 user-blob commitments per MDU, 1,248 user-MDU KZG commitments total. Baseline/problem statement numbers from #193/#192 remain: total prepare wall 109.7s, user stage 97.3s, aggregate user KZG worker-sum 530.3s; NVIDIA Ampere 96-blob microbench current serial/bucket10 ~9.24s vs parallel16/bucket12 ~4.58s, bucket13 regressed ~20s.

## Risks / caveats

- Draft because native WebGPU performance evidence was unavailable in this headless environment (Chrome selected SwiftShader). Correctness/fallback/unit/build coverage is complete locally.
- The runtime calibration fixture is intentionally bounded (4 blobs) to avoid punishing small uploads; full matrix evidence still decides whether defaults/candidates should be adjusted in a follow-up.

## AI review status

Requested `@codex review`, `@copilot review`, and `@coderabbitai review` after opening the PR. Codex connector replied that a Codex account/GitHub connector is not configured for this repo/user, so Codex review is unavailable. Copilot acknowledged the review trigger with an eyes reaction; CodeRabbit response is pending as of the latest status check.

