### PR TITLE
Split browser RS expansion from KZG scheduling

### DIFF
--- a/polystore-website/src/components/FileSharder.tsx
+++ b/polystore-website/src/components/FileSharder.tsx
@@ -179,6 +179,12 @@ type PreparePerfSample = {
   workerExpandMs: number
   workerCommitMs: number
   workerRootMs: number
+  workerKzgSchedulerQueueWaitMs: number
+  workerKzgSchedulerTotalMs: number
+  workerKzgSchedulerDepthAtEnqueue?: number
+  workerKzgSchedulerActiveAtEnqueue?: number
+  workerKzgSchedulerMaxQueueDepth?: number
+  workerKzgSchedulerFallbackCount?: number
   workerRustEncodeMs: number
   workerRustRsMs: number
   workerRustCommitDecodeMs: number
@@ -247,6 +253,9 @@ type PreparePerfProfile = {
     sumUserCommitMs: number
     sumUserExpandMs: number
     sumUserQueueMs: number
+    maxUserKzgSchedulerQueueWaitMs: number
+    sumUserKzgSchedulerQueueWaitMs: number
+    sumUserKzgSchedulerTotalMs: number
     sumWitnessTotalMs: number
     sumWitnessCommitMs: number
     sumWitnessQueueMs: number
@@ -260,6 +269,8 @@ type PreparePerfProfile = {
     workerExpandMs: number
     workerCommitMs: number
     workerRootMs: number
+    workerKzgSchedulerQueueWaitMs: number
+    workerKzgSchedulerTotalMs: number
     workerRustEncodeMs: number
     workerRustRsMs: number
     workerRustCommitDecodeMs: number
@@ -298,6 +309,8 @@ type PreparePerfProfile = {
     kzgWebGpuProbeTimeoutMs?: number
     kzgWebGpuCommitTimeoutMs?: number
     kzgWebGpuMinBlobs?: number
+    kzgSchedulerMaxQueueDepth?: number
+    kzgSchedulerFallbackCount?: number
     commitWorkerCount?: number
   }
   samples: {
@@ -3596,6 +3609,12 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
             const workerCommitMs = Number(result.perf?.commitMs ?? result.perf?.rustCommitMs ?? 0)
             const workerRootMs = Number(result.perf?.rootMs ?? 0)
             const workerQueueMs = Math.max(0, wasmMs - workerTotalMs)
+            const workerKzgSchedulerQueueWaitMs = Number(result.perf?.kzgSchedulerQueueWaitMs ?? 0)
+            const workerKzgSchedulerTotalMs = Number(result.perf?.kzgSchedulerTotalMs ?? 0)
+            const workerKzgSchedulerDepthAtEnqueue = Number(result.perf?.kzgSchedulerDepthAtEnqueue ?? 0) || undefined
+            const workerKzgSchedulerActiveAtEnqueue = Number(result.perf?.kzgSchedulerActiveAtEnqueue ?? 0) || undefined
+            const workerKzgSchedulerMaxQueueDepth = Number(result.perf?.kzgSchedulerMaxQueueDepth ?? 0) || undefined
+            const workerKzgSchedulerFallbackCount = Number(result.perf?.kzgSchedulerFallbackCount ?? 0) || undefined
             const workerRustEncodeMs = Number(result.perf?.rustEncodeMs ?? 0)
             const workerRustRsMs = Number(result.perf?.rustRsMs ?? 0)
             const workerRustCommitDecodeMs = Number(result.perf?.rustCommitDecodeMs ?? 0)
@@ -3681,6 +3700,12 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
               workerExpandMs,
               workerCommitMs,
               workerRootMs,
+              workerKzgSchedulerQueueWaitMs,
+              workerKzgSchedulerTotalMs,
+              workerKzgSchedulerDepthAtEnqueue,
+              workerKzgSchedulerActiveAtEnqueue,
+              workerKzgSchedulerMaxQueueDepth,
+              workerKzgSchedulerFallbackCount,
               workerRustEncodeMs,
               workerRustRsMs,
               workerRustCommitDecodeMs,
@@ -3875,6 +3900,8 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
                 workerExpandMs: 0,
                 workerCommitMs,
                 workerRootMs,
+                workerKzgSchedulerQueueWaitMs: 0,
+                workerKzgSchedulerTotalMs: 0,
                 workerRustEncodeMs: 0,
                 workerRustRsMs: 0,
                 workerRustCommitDecodeMs: 0,
@@ -3982,6 +4009,12 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
             const workerCommitMs = Number(result.perf?.commitMs ?? 0);
             const workerRootMs = Number(result.perf?.rootMs ?? 0);
             const workerQueueMs = Math.max(0, wasmMs - workerTotalMs);
+            const workerKzgSchedulerQueueWaitMs = Number(result.perf?.kzgSchedulerQueueWaitMs ?? 0)
+            const workerKzgSchedulerTotalMs = Number(result.perf?.kzgSchedulerTotalMs ?? 0)
+            const workerKzgSchedulerDepthAtEnqueue = Number(result.perf?.kzgSchedulerDepthAtEnqueue ?? 0) || undefined
+            const workerKzgSchedulerActiveAtEnqueue = Number(result.perf?.kzgSchedulerActiveAtEnqueue ?? 0) || undefined
+            const workerKzgSchedulerMaxQueueDepth = Number(result.perf?.kzgSchedulerMaxQueueDepth ?? 0) || undefined
+            const workerKzgSchedulerFallbackCount = Number(result.perf?.kzgSchedulerFallbackCount ?? 0) || undefined
             const workerRustCommitDecodeMs = Number(result.perf?.rustCommitDecodeMs ?? 0)
             const workerRustCommitTransformMs = Number(result.perf?.rustCommitTransformMs ?? 0)
             const workerRustCommitMsmScalarPrepMs = Number(result.perf?.rustCommitMsmScalarPrepMs ?? 0)
@@ -4045,6 +4078,12 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
               workerExpandMs: 0,
               workerCommitMs,
               workerRootMs,
+              workerKzgSchedulerQueueWaitMs,
+              workerKzgSchedulerTotalMs,
+              workerKzgSchedulerDepthAtEnqueue,
+              workerKzgSchedulerActiveAtEnqueue,
+              workerKzgSchedulerMaxQueueDepth,
+              workerKzgSchedulerFallbackCount,
               workerRustEncodeMs: 0,
               workerRustRsMs: 0,
               workerRustCommitDecodeMs,
@@ -4185,6 +4224,8 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
           workerExpandMs: 0,
           workerCommitMs,
           workerRootMs,
+          workerKzgSchedulerQueueWaitMs: 0,
+          workerKzgSchedulerTotalMs: 0,
           workerRustEncodeMs: 0,
           workerRustRsMs: 0,
           workerRustCommitDecodeMs,
@@ -4340,6 +4381,9 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
             maxUserCommitMs: maxBy(perfSamples.user, (sample) => sample.workerRustCommitMs),
             maxUserExpandMs: maxBy(perfSamples.user, (sample) => sample.workerExpandMs),
             maxUserQueueMs: maxBy(perfSamples.user, (sample) => sample.workerQueueMs),
+            maxUserKzgSchedulerQueueWaitMs: maxBy(perfSamples.user, (sample) => sample.workerKzgSchedulerQueueWaitMs),
+            sumUserKzgSchedulerQueueWaitMs: sumBy(perfSamples.user, (sample) => sample.workerKzgSchedulerQueueWaitMs),
+            sumUserKzgSchedulerTotalMs: sumBy(perfSamples.user, (sample) => sample.workerKzgSchedulerTotalMs),
             maxWitnessTotalMs: maxBy(perfSamples.witness, (sample) => sample.totalMs),
             maxWitnessCommitMs: maxBy(perfSamples.witness, (sample) => sample.workerCommitMs),
             maxWitnessQueueMs: maxBy(perfSamples.witness, (sample) => sample.workerQueueMs),
@@ -4364,6 +4408,8 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
             workerExpandMs: sumBy(allSamples, (sample) => sample.workerExpandMs),
             workerCommitMs: sumBy(allSamples, (sample) => sample.workerCommitMs),
             workerRootMs: sumBy(allSamples, (sample) => sample.workerRootMs),
+            workerKzgSchedulerQueueWaitMs: sumBy(allSamples, (sample) => sample.workerKzgSchedulerQueueWaitMs),
+            workerKzgSchedulerTotalMs: sumBy(allSamples, (sample) => sample.workerKzgSchedulerTotalMs),
             workerRustEncodeMs: sumBy(allSamples, (sample) => sample.workerRustEncodeMs),
             workerRustRsMs: sumBy(allSamples, (sample) => sample.workerRustRsMs),
             workerRustCommitDecodeMs: sumBy(allSamples, (sample) => sample.workerRustCommitDecodeMs),
@@ -4402,6 +4448,8 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
             kzgWebGpuProbeTimeoutMs: kzgDiagnosticSample?.workerKzgWebGpuProbeTimeoutMs,
             kzgWebGpuCommitTimeoutMs: kzgDiagnosticSample?.workerKzgWebGpuCommitTimeoutMs,
             kzgWebGpuMinBlobs: kzgDiagnosticSample?.workerKzgWebGpuMinBlobs,
+            kzgSchedulerMaxQueueDepth: kzgDiagnosticSample?.workerKzgSchedulerMaxQueueDepth,
+            kzgSchedulerFallbackCount: kzgDiagnosticSample?.workerKzgSchedulerFallbackCount,
             commitWorkerCount: kzgDiagnosticSample?.workerCommitWorkerCount,
           },
           samples: perfSamples,
@@ -4494,12 +4542,15 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
           maxUserCommitMs: roundPerfMs(prepareProfile.summary.maxUserCommitMs),
           maxUserExpandMs: roundPerfMs(prepareProfile.summary.maxUserExpandMs),
           maxUserQueueMs: roundPerfMs(prepareProfile.summary.maxUserQueueMs),
+          maxUserKzgSchedulerQueueWaitMs: roundPerfMs(prepareProfile.summary.maxUserKzgSchedulerQueueWaitMs),
           maxWitnessTotalMs: roundPerfMs(prepareProfile.summary.maxWitnessTotalMs),
           maxWitnessCommitMs: roundPerfMs(prepareProfile.summary.maxWitnessCommitMs),
           maxWitnessQueueMs: roundPerfMs(prepareProfile.summary.maxWitnessQueueMs),
           sumUserCommitMs: roundPerfMs(prepareProfile.summary.sumUserCommitMs),
           sumUserExpandMs: roundPerfMs(prepareProfile.summary.sumUserExpandMs),
           sumUserQueueMs: roundPerfMs(prepareProfile.summary.sumUserQueueMs),
+          sumUserKzgSchedulerQueueWaitMs: roundPerfMs(prepareProfile.summary.sumUserKzgSchedulerQueueWaitMs),
+          sumUserKzgSchedulerTotalMs: roundPerfMs(prepareProfile.summary.sumUserKzgSchedulerTotalMs),
           sumWitnessCommitMs: roundPerfMs(prepareProfile.summary.sumWitnessCommitMs),
           sumWitnessQueueMs: roundPerfMs(prepareProfile.summary.sumWitnessQueueMs),
           rustCommitDecodeMs: roundPerfMs(prepareProfile.phases.workerRustCommitDecodeMs),
@@ -4537,12 +4588,15 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
           maxUserCommitMs: roundPerfMs(prepareProfile.summary.maxUserCommitMs),
           maxUserExpandMs: roundPerfMs(prepareProfile.summary.maxUserExpandMs),
           maxUserQueueMs: roundPerfMs(prepareProfile.summary.maxUserQueueMs),
+          maxUserKzgSchedulerQueueWaitMs: roundPerfMs(prepareProfile.summary.maxUserKzgSchedulerQueueWaitMs),
           maxWitnessTotalMs: roundPerfMs(prepareProfile.summary.maxWitnessTotalMs),
           maxWitnessCommitMs: roundPerfMs(prepareProfile.summary.maxWitnessCommitMs),
           maxWitnessQueueMs: roundPerfMs(prepareProfile.summary.maxWitnessQueueMs),
           sumUserCommitMs: roundPerfMs(prepareProfile.summary.sumUserCommitMs),
           sumUserExpandMs: roundPerfMs(prepareProfile.summary.sumUserExpandMs),
           sumUserQueueMs: roundPerfMs(prepareProfile.summary.sumUserQueueMs),
+          sumUserKzgSchedulerQueueWaitMs: roundPerfMs(prepareProfile.summary.sumUserKzgSchedulerQueueWaitMs),
+          sumUserKzgSchedulerTotalMs: roundPerfMs(prepareProfile.summary.sumUserKzgSchedulerTotalMs),
           sumWitnessCommitMs: roundPerfMs(prepareProfile.summary.sumWitnessCommitMs),
           sumWitnessQueueMs: roundPerfMs(prepareProfile.summary.sumWitnessQueueMs),
           slowestUserMduIndex: prepareProfile.summary.slowestUserMduIndex,

--- a/polystore-website/src/lib/upload/userMduBrowserKzg.test.ts
+++ b/polystore-website/src/lib/upload/userMduBrowserKzg.test.ts
@@ -6,7 +6,9 @@ import init, { PolyStoreWasm } from '../../../public/wasm/polystore_core.js'
 import { createWasmBlstKzgCommitBackend, KZG_BLOB_SIZE, type KzgCommitBackend, type KzgCommitBackendStatus } from '../kzgCommitBackend'
 import {
   expandUserMduRsWithBrowserKzg,
+  parseUserMduUncommittedExpansion,
   toUserMduUint8Array,
+  USER_MDU_UNCOMMITTED_CONTRACT,
   type UserMduBrowserKzgWasm,
 } from './userMduBrowserKzg'
 
@@ -152,6 +154,41 @@ function makeBackend(options?: { selectedBackend?: 'webgpu' | 'wasm-blst'; throw
   }
   return { backend, calls }
 }
+
+test('uncommitted expansion parser stamps the deterministic internal contract', () => {
+  const shardsFlat = bytes(KZG_BLOB_SIZE * 3, 5)
+  const parsed = parseUserMduUncommittedExpansion(
+    {
+      shards_flat: shardsFlat,
+      shard_len: KZG_BLOB_SIZE,
+      perf: { encode_ms: 1, rs_ms: 2, total_ms: 3, rows: 1, shards_total: 3, shard_len: KZG_BLOB_SIZE },
+    },
+    { kind: 'payload', k: 2, m: 1, payloadId: 'fixture', sequence: 12 },
+  )
+
+  assert.equal(parsed.contract, USER_MDU_UNCOMMITTED_CONTRACT)
+  assert.equal(parsed.payloadId, 'fixture')
+  assert.equal(parsed.sequence, 12)
+  assert.equal(parsed.kind, 'payload')
+  assert.equal(parsed.k, 2)
+  assert.equal(parsed.m, 1)
+  assert.equal(parsed.shardLen, KZG_BLOB_SIZE)
+  assert.deepEqual(parsed.shardsFlat, shardsFlat)
+})
+
+test('uncommitted expansion parser rejects shard-count drift before commitment', () => {
+  assert.throws(
+    () => parseUserMduUncommittedExpansion(
+      {
+        shards_flat: bytes(KZG_BLOB_SIZE * 2, 9),
+        shard_len: KZG_BLOB_SIZE,
+        perf: { rows: 1, shards_total: 2 },
+      },
+      { kind: 'payload', k: 2, m: 1, payloadId: 'bad' },
+    ),
+    /returned 2 shards, expected 3/,
+  )
+})
 
 test('user MDU expansion routes commitments through the browser KZG backend', async () => {
   const { wasm, calls, mduShards, shardLen } = makeWasm()

--- a/polystore-website/src/lib/upload/userMduBrowserKzg.ts
+++ b/polystore-website/src/lib/upload/userMduBrowserKzg.ts
@@ -3,7 +3,6 @@ import {
   KZG_COMMITMENT_SIZE,
   type KzgCommitBackend,
   type KzgCommitPerf,
-  type KzgCommitProfiledResult,
 } from '../kzgCommitBackend'
 
 export type UserMduExpansionKind = 'mdu' | 'payload'
@@ -42,6 +41,16 @@ export type UserMduBrowserKzgPerf = ReturnType<typeof kzgCommitDiagnosticsForBac
   rows: number
   shardsTotal: number
   browserKzgCommitFallbackReason?: string
+  kzgSchedulerSequence?: number
+  kzgSchedulerQueueWaitMs?: number
+  kzgSchedulerCommitMs?: number
+  kzgSchedulerTotalMs?: number
+  kzgSchedulerDepthAtEnqueue?: number
+  kzgSchedulerActiveAtEnqueue?: number
+  kzgSchedulerQueueDepthAtStart?: number
+  kzgSchedulerMaxQueueDepth?: number
+  kzgSchedulerFallbackCount?: number
+  kzgSchedulerOwner?: string
 }
 
 export type UserMduBrowserKzgResult = {
@@ -52,7 +61,7 @@ export type UserMduBrowserKzgResult = {
   perf: UserMduBrowserKzgPerf
 }
 
-type SplitExpansionPerf = {
+export type SplitExpansionPerf = {
   encode_ms?: unknown
   rs_ms?: unknown
   total_ms?: unknown
@@ -61,7 +70,7 @@ type SplitExpansionPerf = {
   shard_len?: unknown
 }
 
-type CommittedExpansionPerf = SplitExpansionPerf & {
+export type CommittedExpansionPerf = SplitExpansionPerf & {
   commit_decode_ms?: unknown
   commit_transform_ms?: unknown
   commit_msm_scalar_prep_ms?: unknown
@@ -73,13 +82,26 @@ type CommittedExpansionPerf = SplitExpansionPerf & {
   commit_ms?: unknown
 }
 
-type ParsedUncommittedExpansion = {
+export type ParsedUncommittedExpansion = {
   shardsFlat: Uint8Array
   shardLen: number
   perf: SplitExpansionPerf
 }
 
-type ParsedCommittedExpansion = ParsedUncommittedExpansion & {
+export const USER_MDU_UNCOMMITTED_CONTRACT = 'mode2-user-mdu-uncommitted-v1' as const
+
+export type UserMduUncommittedExpansion = ParsedUncommittedExpansion & {
+  contract: typeof USER_MDU_UNCOMMITTED_CONTRACT
+  kind: UserMduExpansionKind
+  k: number
+  m: number
+  payloadId: string
+  profile: boolean
+  sequence?: number
+  mduIndex?: number
+}
+
+export type ParsedCommittedExpansion = ParsedUncommittedExpansion & {
   witnessFlat: Uint8Array
   mduRoot: Uint8Array
   perf: CommittedExpansionPerf
@@ -122,7 +144,7 @@ function parseMaybeJson(value: unknown): Record<string, unknown> {
   return value as Record<string, unknown>
 }
 
-function parseUncommittedExpansion(raw: unknown, label: string): ParsedUncommittedExpansion {
+export function parseUncommittedExpansion(raw: unknown, label: string): ParsedUncommittedExpansion {
   const parsed = parseMaybeJson(raw)
   const shardLen = Number(parsed.shard_len ?? 0)
   if (!Number.isInteger(shardLen) || shardLen <= 0) {
@@ -142,7 +164,7 @@ function parseUncommittedExpansion(raw: unknown, label: string): ParsedUncommitt
   }
 }
 
-function parseCommittedExpansion(raw: unknown, label: string): ParsedCommittedExpansion {
+export function parseCommittedExpansion(raw: unknown, label: string): ParsedCommittedExpansion {
   const parsed = parseMaybeJson(raw)
   const base = parseUncommittedExpansion(parsed, label)
   const witnessFlat = toUserMduUint8Array(parsed.witness_flat)
@@ -159,6 +181,48 @@ function parseCommittedExpansion(raw: unknown, label: string): ParsedCommittedEx
     witnessFlat,
     mduRoot,
     perf: (parsed.perf ?? {}) as CommittedExpansionPerf,
+  }
+}
+
+export function parseUserMduUncommittedExpansion(
+  raw: unknown,
+  context: {
+    kind: UserMduExpansionKind
+    k: number
+    m: number
+    payloadId?: string
+    profile?: boolean
+    sequence?: number
+    mduIndex?: number
+    label?: string
+  },
+): UserMduUncommittedExpansion {
+  const k = Number(context.k)
+  const m = Number(context.m)
+  if (!Number.isInteger(k) || k <= 0) throw new Error('RS k must be a positive integer')
+  if (!Number.isInteger(m) || m <= 0) throw new Error('RS m must be a positive integer')
+  const parsed = parseUncommittedExpansion(raw, context.label ?? context.kind)
+  const shardCount = parsed.shardsFlat.byteLength / parsed.shardLen
+  if (shardCount !== k + m) {
+    throw new Error(`${context.label ?? context.kind} returned ${shardCount} shards, expected ${k + m}`)
+  }
+  const perfRows = numberField(parsed.perf.rows)
+  const expectedCommitmentCount = parsed.shardsFlat.byteLength / KZG_BLOB_SIZE
+  if (perfRows > 0 && expectedCommitmentCount !== shardCount * perfRows) {
+    throw new Error(
+      `${context.label ?? context.kind} returned ${expectedCommitmentCount} blobs, expected ${shardCount * perfRows}`,
+    )
+  }
+  return {
+    contract: USER_MDU_UNCOMMITTED_CONTRACT,
+    kind: context.kind,
+    k,
+    m,
+    payloadId: context.payloadId ?? `${context.kind}:${context.sequence ?? 'unknown'}`,
+    profile: context.profile !== false,
+    sequence: context.sequence,
+    mduIndex: context.mduIndex,
+    ...parsed,
   }
 }
 
@@ -284,6 +348,83 @@ function committedFallback(
   }
 }
 
+export function committedExpansionToUserMduBrowserKzgResult(
+  parsed: ParsedCommittedExpansion,
+  fallbackReason?: string,
+): UserMduBrowserKzgResult {
+  const diagnostics = {
+    ...kzgCommitDiagnosticsForBackend(undefined),
+    kzgCommitBackend: 'wasm-blst',
+    rustCommitBackend: 'blst',
+  }
+  const rootMs = 0
+  const commitPerf = committedPerfToKzgCommitPerf(parsed.perf)
+  return {
+    witness_flat: parsed.witnessFlat,
+    mdu_root: parsed.mduRoot,
+    shards_flat: parsed.shardsFlat,
+    shard_len: parsed.shardLen,
+    perf: perfFromSplitAndCommit(
+      parsed.perf,
+      commitPerf,
+      numberField(parsed.perf.commit_ms),
+      rootMs,
+      numberField(parsed.perf.total_ms) + numberField(parsed.perf.commit_ms),
+      parsed.shardsFlat,
+      parsed.shardLen,
+      diagnostics,
+      fallbackReason,
+    ),
+  }
+}
+
+export async function commitUserMduUncommittedWithBrowserKzg(options: {
+  expansion: ParsedUncommittedExpansion
+  wasm: Pick<UserMduBrowserKzgWasm, 'compute_mdu_root'>
+  kzgCommitBackend: KzgCommitBackend
+  now?: () => number
+  totalStartMs?: number
+}): Promise<UserMduBrowserKzgResult> {
+  const { expansion, wasm, kzgCommitBackend } = options
+  const now = options.now ?? defaultNow
+  const totalStart = options.totalStartMs
+
+  const commitStart = now()
+  const committedRaw = await kzgCommitBackend.commitBlobsProfiled(expansion.shardsFlat)
+  const commitMs = now() - commitStart
+  const witnessFlat = committedRaw.witnessFlat
+  const expectedWitnessBytes = (expansion.shardsFlat.byteLength / KZG_BLOB_SIZE) * KZG_COMMITMENT_SIZE
+  if (witnessFlat.byteLength !== expectedWitnessBytes) {
+    throw new Error(`browser KZG returned ${witnessFlat.byteLength} witness bytes, expected ${expectedWitnessBytes}`)
+  }
+
+  const rootStart = now()
+  const root = wasm.compute_mdu_root(witnessFlat) as unknown
+  const rootMs = now() - rootStart
+  const rootBytes = toUserMduUint8Array(root)
+  if (rootBytes.byteLength !== 32) {
+    throw new Error(`compute_mdu_root returned ${rootBytes.byteLength} bytes, expected 32`)
+  }
+
+  const diagnostics = kzgCommitDiagnosticsForBackend(kzgCommitBackend)
+  return {
+    witness_flat: witnessFlat,
+    mdu_root: rootBytes,
+    shards_flat: expansion.shardsFlat,
+    shard_len: expansion.shardLen,
+    perf: perfFromSplitAndCommit(
+      expansion.perf,
+      committedRaw.perf,
+      commitMs,
+      rootMs,
+      totalStart === undefined ? numberField(expansion.perf.total_ms) + commitMs + rootMs : now() - totalStart,
+      expansion.shardsFlat,
+      expansion.shardLen,
+      diagnostics,
+    ),
+  }
+}
+
 export async function expandUserMduRsWithBrowserKzg(
   options: ExpandWithBrowserKzgOptions,
 ): Promise<UserMduBrowserKzgResult> {
@@ -297,49 +438,16 @@ export async function expandUserMduRsWithBrowserKzg(
     : wasm.expand_payload_rs_flat_uncommitted(data, k, m)
   const expanded = parseUncommittedExpansion(uncommittedRaw, kind === 'mdu' ? 'expandMduRs' : 'expandPayloadRs')
 
-  let committedRaw: KzgCommitProfiledResult
-  let commitMs = 0
-  let witnessFlat: Uint8Array
-  let rootMs = 0
-  let rootBytes: Uint8Array
   try {
-    const commitStart = now()
-    committedRaw = await kzgCommitBackend.commitBlobsProfiled(expanded.shardsFlat)
-    commitMs = now() - commitStart
-    witnessFlat = committedRaw.witnessFlat
-    const expectedWitnessBytes = (expanded.shardsFlat.byteLength / KZG_BLOB_SIZE) * KZG_COMMITMENT_SIZE
-    if (witnessFlat.byteLength !== expectedWitnessBytes) {
-      throw new Error(`browser KZG returned ${witnessFlat.byteLength} witness bytes, expected ${expectedWitnessBytes}`)
-    }
-
-    const rootStart = now()
-    const root = wasm.compute_mdu_root(witnessFlat) as unknown
-    rootMs = now() - rootStart
-    rootBytes = toUserMduUint8Array(root)
-    if (rootBytes.byteLength !== 32) {
-      throw new Error(`compute_mdu_root returned ${rootBytes.byteLength} bytes, expected 32`)
-    }
+    return await commitUserMduUncommittedWithBrowserKzg({
+      expansion: expanded,
+      wasm,
+      kzgCommitBackend,
+      now,
+      totalStartMs: totalStart,
+    })
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     return committedFallback(options, now, totalStart, `browser KZG commit failed validation; used committed WASM fallback: ${message}`)
-  }
-
-  const diagnostics = kzgCommitDiagnosticsForBackend(kzgCommitBackend)
-  const totalMs = now() - totalStart
-  return {
-    witness_flat: witnessFlat,
-    mdu_root: rootBytes,
-    shards_flat: expanded.shardsFlat,
-    shard_len: expanded.shardLen,
-    perf: perfFromSplitAndCommit(
-      expanded.perf,
-      committedRaw.perf,
-      commitMs,
-      rootMs,
-      totalMs,
-      expanded.shardsFlat,
-      expanded.shardLen,
-      diagnostics,
-    ),
   }
 }

--- a/polystore-website/src/lib/upload/userMduKzgScheduler.test.ts
+++ b/polystore-website/src/lib/upload/userMduKzgScheduler.test.ts
@@ -1,0 +1,191 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { KZG_BLOB_SIZE } from '../kzgCommitBackend'
+import { UserMduKzgScheduler } from './userMduKzgScheduler'
+import type { UserMduBrowserKzgResult, UserMduUncommittedExpansion } from './userMduBrowserKzg'
+
+function expansion(sequence: number): UserMduUncommittedExpansion {
+  return {
+    contract: 'mode2-user-mdu-uncommitted-v1',
+    kind: 'payload',
+    k: 2,
+    m: 1,
+    payloadId: `payload:${sequence}`,
+    profile: true,
+    sequence,
+    shardsFlat: new Uint8Array(KZG_BLOB_SIZE * 3),
+    shardLen: KZG_BLOB_SIZE,
+    perf: { encode_ms: 1, rs_ms: 2, total_ms: 3, rows: 1, shards_total: 3, shard_len: KZG_BLOB_SIZE },
+  }
+}
+
+function resultFor(sequence: number): UserMduBrowserKzgResult {
+  return {
+    witness_flat: new Uint8Array(3 * 48).fill(sequence),
+    mdu_root: new Uint8Array(32).fill(sequence),
+    shards_flat: new Uint8Array(KZG_BLOB_SIZE * 3).fill(sequence),
+    shard_len: KZG_BLOB_SIZE,
+    perf: {
+      expandMs: 3,
+      commitMs: 4,
+      rootMs: 5,
+      totalMs: 12,
+      shardCount: 3,
+      shardLen: KZG_BLOB_SIZE,
+      rustEncodeMs: 1,
+      rustRsMs: 2,
+      rustCommitDecodeMs: 0,
+      rustCommitTransformMs: 0,
+      rustCommitMsmScalarPrepMs: 0,
+      rustCommitMsmBucketFillMs: 0,
+      rustCommitMsmReduceMs: 0,
+      rustCommitMsmDoubleMs: 0,
+      rustCommitMsmMs: 0,
+      rustCommitCompressMs: 0,
+      rustCommitMs: 4,
+      rustTotalMs: 12,
+      rustCommitBackend: 'webgpu-msm',
+      rustCommitMsmSubphasesAvailable: false,
+      rows: 1,
+      shardsTotal: 3,
+      kzgCommitBackend: 'webgpu',
+      kzgWebGpuAvailable: true,
+      kzgWebGpuFallbackReason: '',
+      kzgWebGpuProbeStatus: 'passed',
+      kzgWebGpuCircuitOpen: false,
+      kzgWebGpuProbeTimeoutMs: 0,
+      kzgWebGpuCommitTimeoutMs: 0,
+      kzgWebGpuMinBlobs: 0,
+      kzgWebGpuBucketWidth: 12,
+      kzgWebGpuReductionMode: 'parallel16',
+      kzgWebGpuCalibrationStatus: 'cached',
+      kzgWebGpuCalibrationSource: 'cache',
+      kzgWebGpuCalibrationCacheKey: 'test',
+    },
+  }
+}
+
+test('KZG scheduler preserves enqueue order even when later RS expansion finishes first', async () => {
+  let now = 0
+  let resolveFirst!: (value: UserMduUncommittedExpansion) => void
+  const first = new Promise<UserMduUncommittedExpansion>((resolve) => {
+    resolveFirst = resolve
+  })
+  const calls: number[] = []
+  const scheduler = new UserMduKzgScheduler({ now: () => now, maxQueueDepth: 4 })
+
+  const p0 = scheduler.enqueue({
+    sequence: 0,
+    expansion: first,
+    commit: async (expanded) => {
+      calls.push(expanded.sequence ?? -1)
+      return resultFor(expanded.sequence ?? 0)
+    },
+  })
+  const p1 = scheduler.enqueue({
+    sequence: 1,
+    expansion: Promise.resolve(expansion(1)),
+    commit: async (expanded) => {
+      calls.push(expanded.sequence ?? -1)
+      return resultFor(expanded.sequence ?? 0)
+    },
+  })
+
+  await Promise.resolve()
+  assert.deepEqual(calls, [])
+  now = 10
+  resolveFirst(expansion(0))
+  const [r0, r1] = await Promise.all([p0, p1])
+
+  assert.deepEqual(calls, [0, 1])
+  assert.equal(r0.perf.kzgSchedulerSequence, 0)
+  assert.equal(r1.perf.kzgSchedulerSequence, 1)
+  assert.equal(r1.perf.kzgSchedulerOwner, 'browser-user-mdu-kzg-scheduler-v1')
+})
+
+test('KZG scheduler rejects commit errors when no fallback is provided', async () => {
+  const scheduler = new UserMduKzgScheduler({ maxQueueDepth: 4 })
+  await assert.rejects(
+    scheduler.enqueue({
+      sequence: 0,
+      expansion: Promise.resolve(expansion(0)),
+      commit: async () => {
+        throw new Error('synthetic commit failure')
+      },
+    }),
+    /synthetic commit failure/,
+  )
+  assert.equal(scheduler.getStatus().failed, 1)
+})
+
+test('KZG scheduler uses fallback and records queue diagnostics', async () => {
+  let now = 100
+  const scheduler = new UserMduKzgScheduler({ now: () => now, maxQueueDepth: 4 })
+  const promise = scheduler.enqueue({
+    sequence: 7,
+    expansion: Promise.resolve(expansion(7)),
+    commit: async () => {
+      now += 5
+      throw new Error('backend validation failed')
+    },
+    fallback: async (reason) => {
+      now += 9
+      const fallback = resultFor(7)
+      fallback.perf.browserKzgCommitFallbackReason = reason
+      fallback.perf.rustCommitBackend = 'blst'
+      return fallback
+    },
+  })
+  now += 3
+  const result = await promise
+  assert.equal(result.perf.rustCommitBackend, 'blst')
+  assert.match(result.perf.browserKzgCommitFallbackReason ?? '', /backend validation failed/)
+  assert.equal(result.perf.kzgSchedulerSequence, 7)
+  assert.equal(result.perf.kzgSchedulerFallbackCount, 1)
+  assert.equal(result.perf.kzgSchedulerMaxQueueDepth, 4)
+  assert.ok((result.perf.kzgSchedulerTotalMs ?? 0) >= (result.perf.kzgSchedulerQueueWaitMs ?? 0))
+})
+
+test('KZG scheduler honors abort before a queued task starts', async () => {
+  let release!: (value: UserMduUncommittedExpansion) => void
+  const scheduler = new UserMduKzgScheduler({ maxQueueDepth: 4 })
+  const controller = new AbortController()
+  const first = scheduler.enqueue({
+    sequence: 0,
+    expansion: new Promise<UserMduUncommittedExpansion>((resolve) => {
+      release = resolve
+    }),
+    commit: async (expanded) => resultFor(expanded.sequence ?? 0),
+  })
+  const second = scheduler.enqueue({
+    sequence: 1,
+    expansion: Promise.resolve(expansion(1)),
+    signal: controller.signal,
+    commit: async (expanded) => resultFor(expanded.sequence ?? 0),
+  })
+
+  controller.abort()
+  release(expansion(0))
+  await first
+  await assert.rejects(second, (error) => error instanceof Error && error.name === 'AbortError')
+})
+
+test('KZG scheduler bounds queue depth', async () => {
+  const scheduler = new UserMduKzgScheduler({ maxQueueDepth: 1 })
+  await assert.rejects(
+    Promise.all([
+      scheduler.enqueue({
+        sequence: 0,
+        expansion: new Promise<UserMduUncommittedExpansion>(() => undefined),
+        commit: async (expanded) => resultFor(expanded.sequence ?? 0),
+      }),
+      scheduler.enqueue({
+        sequence: 1,
+        expansion: Promise.resolve(expansion(1)),
+        commit: async (expanded) => resultFor(expanded.sequence ?? 0),
+      }),
+    ]),
+    /queue is full/,
+  )
+})

--- a/polystore-website/src/lib/upload/userMduKzgScheduler.ts
+++ b/polystore-website/src/lib/upload/userMduKzgScheduler.ts
@@ -1,0 +1,234 @@
+import type { UserMduBrowserKzgResult, UserMduUncommittedExpansion } from './userMduBrowserKzg'
+
+// Issue #194 seam inventory:
+// - Before this scheduler, each browser expansion worker ran RS expansion and
+//   initialized/used its own browser KZG backend for the resulting shard blobs.
+// - Expansion workers now return the deterministic uncommitted contract from
+//   userMduBrowserKzg.ts; this queue is the single browser-side owner that
+//   orders those uncommitted batches and forwards them to the KZG worker owner.
+// - The queue is intentionally MDU-scoped. Cross-MDU batching is only exposed by
+//   the stable enqueue/commit seam and remains the follow-up #195 work.
+
+export type UserMduKzgSchedulerDiagnostics = {
+  sequence: number
+  queueWaitMs: number
+  totalMs: number
+  depthAtEnqueue: number
+  activeAtEnqueue: number
+  queueDepthAtStart: number
+  maxQueueDepth: number
+  fallbackCount: number
+  owner: 'browser-user-mdu-kzg-scheduler-v1'
+}
+
+export type UserMduKzgSchedulerCommitContext = UserMduKzgSchedulerDiagnostics & {
+  signal?: AbortSignal
+}
+
+export type UserMduKzgSchedulerTask = {
+  sequence: number
+  expansion: Promise<UserMduUncommittedExpansion>
+  commit: (
+    expansion: UserMduUncommittedExpansion,
+    context: UserMduKzgSchedulerCommitContext,
+  ) => Promise<UserMduBrowserKzgResult>
+  fallback?: (reason: string, context: UserMduKzgSchedulerCommitContext) => Promise<UserMduBrowserKzgResult>
+  signal?: AbortSignal
+}
+
+export type UserMduKzgSchedulerOptions = {
+  maxQueueDepth?: number
+  concurrency?: number
+  now?: () => number
+}
+
+export type UserMduKzgSchedulerStatus = {
+  active: number
+  queued: number
+  maxQueueDepth: number
+  concurrency: number
+  nextSequence: number
+  completed: number
+  failed: number
+  fallbackCount: number
+  lastError: string | null
+  lastQueueWaitMs: number | null
+  lastTotalMs: number | null
+}
+
+type QueuedTask = {
+  task: UserMduKzgSchedulerTask
+  resolve: (value: UserMduBrowserKzgResult) => void
+  reject: (reason?: unknown) => void
+  enqueuedAtMs: number
+  depthAtEnqueue: number
+  activeAtEnqueue: number
+}
+
+const OWNER = 'browser-user-mdu-kzg-scheduler-v1' as const
+
+function defaultNow(): number {
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') return performance.now()
+  return Date.now()
+}
+
+function abortError(): Error {
+  const error = new Error('user MDU KZG scheduler task aborted')
+  error.name = 'AbortError'
+  return error
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export function attachUserMduKzgSchedulerDiagnostics(
+  result: UserMduBrowserKzgResult,
+  diagnostics: UserMduKzgSchedulerDiagnostics,
+): UserMduBrowserKzgResult {
+  return {
+    ...result,
+    perf: {
+      ...result.perf,
+      kzgSchedulerSequence: diagnostics.sequence,
+      kzgSchedulerQueueWaitMs: diagnostics.queueWaitMs,
+      kzgSchedulerCommitMs: result.perf.commitMs,
+      kzgSchedulerTotalMs: diagnostics.totalMs,
+      kzgSchedulerDepthAtEnqueue: diagnostics.depthAtEnqueue,
+      kzgSchedulerActiveAtEnqueue: diagnostics.activeAtEnqueue,
+      kzgSchedulerQueueDepthAtStart: diagnostics.queueDepthAtStart,
+      kzgSchedulerMaxQueueDepth: diagnostics.maxQueueDepth,
+      kzgSchedulerFallbackCount: diagnostics.fallbackCount,
+      kzgSchedulerOwner: diagnostics.owner,
+    },
+  }
+}
+
+export class UserMduKzgScheduler {
+  private readonly maxQueueDepth: number
+  private readonly concurrency: number
+  private readonly now: () => number
+  private queue: QueuedTask[] = []
+  private active = 0
+  private completed = 0
+  private failed = 0
+  private fallbackCount = 0
+  private lastError: string | null = null
+  private lastQueueWaitMs: number | null = null
+  private lastTotalMs: number | null = null
+
+  constructor(options: UserMduKzgSchedulerOptions = {}) {
+    const maxQueueDepth = Math.floor(Number(options.maxQueueDepth ?? 32))
+    const concurrency = Math.floor(Number(options.concurrency ?? 1))
+    this.maxQueueDepth = Number.isFinite(maxQueueDepth) && maxQueueDepth > 0 ? maxQueueDepth : 32
+    this.concurrency = Number.isFinite(concurrency) && concurrency > 0 ? concurrency : 1
+    this.now = options.now ?? defaultNow
+  }
+
+  getStatus(): UserMduKzgSchedulerStatus {
+    return {
+      active: this.active,
+      queued: this.queue.length,
+      maxQueueDepth: this.maxQueueDepth,
+      concurrency: this.concurrency,
+      nextSequence: this.queue[0]?.task.sequence ?? -1,
+      completed: this.completed,
+      failed: this.failed,
+      fallbackCount: this.fallbackCount,
+      lastError: this.lastError,
+      lastQueueWaitMs: this.lastQueueWaitMs,
+      lastTotalMs: this.lastTotalMs,
+    }
+  }
+
+  enqueue(task: UserMduKzgSchedulerTask): Promise<UserMduBrowserKzgResult> {
+    if (!Number.isInteger(task.sequence) || task.sequence < 0) {
+      return Promise.reject(new Error('scheduler task sequence must be a non-negative integer'))
+    }
+    if (this.active + this.queue.length >= this.maxQueueDepth) {
+      return Promise.reject(new Error(`user MDU KZG scheduler queue is full (${this.maxQueueDepth})`))
+    }
+    if (task.signal?.aborted) {
+      return Promise.reject(abortError())
+    }
+
+    return new Promise<UserMduBrowserKzgResult>((resolve, reject) => {
+      this.queue.push({
+        task,
+        resolve,
+        reject,
+        enqueuedAtMs: this.now(),
+        depthAtEnqueue: this.queue.length,
+        activeAtEnqueue: this.active,
+      })
+      this.pump()
+    })
+  }
+
+  private pump(): void {
+    while (this.active < this.concurrency && this.queue.length > 0) {
+      const item = this.queue.shift()
+      if (!item) return
+      this.active += 1
+      void this.run(item)
+    }
+  }
+
+  private async run(item: QueuedTask): Promise<void> {
+    const startedAtMs = this.now()
+    const baseDiagnostics: UserMduKzgSchedulerDiagnostics = {
+      sequence: item.task.sequence,
+      queueWaitMs: Math.max(0, startedAtMs - item.enqueuedAtMs),
+      totalMs: 0,
+      depthAtEnqueue: item.depthAtEnqueue,
+      activeAtEnqueue: item.activeAtEnqueue,
+      queueDepthAtStart: this.queue.length,
+      maxQueueDepth: this.maxQueueDepth,
+      fallbackCount: this.fallbackCount,
+      owner: OWNER,
+    }
+    this.lastQueueWaitMs = baseDiagnostics.queueWaitMs
+
+    try {
+      if (item.task.signal?.aborted) throw abortError()
+      const expansion = await item.task.expansion
+      if (item.task.signal?.aborted) throw abortError()
+      let result: UserMduBrowserKzgResult
+      let usedFallback = false
+      try {
+        result = await item.task.commit(expansion, { ...baseDiagnostics, signal: item.task.signal })
+      } catch (error) {
+        if (!item.task.fallback) throw error
+        usedFallback = true
+        this.fallbackCount += 1
+        const reason = errorMessage(error)
+        result = await item.task.fallback(reason, {
+          ...baseDiagnostics,
+          fallbackCount: this.fallbackCount,
+          signal: item.task.signal,
+        })
+      }
+      const diagnostics: UserMduKzgSchedulerDiagnostics = {
+        ...baseDiagnostics,
+        totalMs: Math.max(0, this.now() - item.enqueuedAtMs),
+        fallbackCount: this.fallbackCount,
+      }
+      this.completed += 1
+      this.lastTotalMs = diagnostics.totalMs
+      this.lastError = null
+      const decorated = attachUserMduKzgSchedulerDiagnostics(result, diagnostics)
+      if (usedFallback) {
+        decorated.perf.browserKzgCommitFallbackReason = decorated.perf.browserKzgCommitFallbackReason || 'scheduler fallback used'
+      }
+      item.resolve(decorated)
+    } catch (error) {
+      const message = errorMessage(error)
+      this.failed += 1
+      this.lastError = message
+      item.reject(error)
+    } finally {
+      this.active -= 1
+      this.pump()
+    }
+  }
+}

--- a/polystore-website/src/lib/uploadStatus.test.ts
+++ b/polystore-website/src/lib/uploadStatus.test.ts
@@ -58,6 +58,26 @@ test('normalizeKzgBackendStatus ignores zero-valued scheduler defaults', () => {
   assert.equal(status.commitWorkerCount, null)
 })
 
+test('normalizeKzgBackendStatus surfaces browser KZG scheduler diagnostics', () => {
+  const status = normalizeKzgBackendStatus({
+    rustCommitBackend: 'webgpu-msm',
+    kzgCommitBackend: 'webgpu',
+    kzgSchedulerQueueWaitMs: 12,
+    kzgSchedulerTotalMs: 34,
+    kzgSchedulerDepthAtEnqueue: 3,
+    kzgSchedulerActiveAtEnqueue: 1,
+    kzgSchedulerMaxQueueDepth: 32,
+    kzgSchedulerFallbackCount: 2,
+  })
+
+  assert.equal(status.schedulerQueueWaitMs, 12)
+  assert.equal(status.schedulerTotalMs, 34)
+  assert.equal(status.schedulerQueueDepth, 3)
+  assert.equal(status.schedulerActive, 1)
+  assert.equal(status.schedulerMaxQueueDepth, 32)
+  assert.equal(status.schedulerFallbackCount, 2)
+})
+
 test('patchUploadPipelineStatus preserves nested state and records elapsed time', () => {
   const initial = createUploadPipelineStatus({
     dealId: '42',

--- a/polystore-website/src/lib/uploadStatus.ts
+++ b/polystore-website/src/lib/uploadStatus.ts
@@ -42,6 +42,12 @@ export type KzgBackendStatus = {
   calibrationStatus: string | null
   calibrationSource: string | null
   calibrationCacheKey: string | null
+  schedulerQueueWaitMs: number | null
+  schedulerTotalMs: number | null
+  schedulerQueueDepth: number | null
+  schedulerActive: number | null
+  schedulerMaxQueueDepth: number | null
+  schedulerFallbackCount: number | null
   probeTimeoutMs: number | null
   commitTimeoutMs: number | null
   minBlobs: number | null
@@ -118,6 +124,18 @@ export type KzgDiagnosticsInput = {
   workerKzgWebGpuCalibrationSource?: string
   kzgWebGpuCalibrationCacheKey?: string
   workerKzgWebGpuCalibrationCacheKey?: string
+  kzgSchedulerQueueWaitMs?: number
+  workerKzgSchedulerQueueWaitMs?: number
+  kzgSchedulerTotalMs?: number
+  workerKzgSchedulerTotalMs?: number
+  kzgSchedulerDepthAtEnqueue?: number
+  workerKzgSchedulerDepthAtEnqueue?: number
+  kzgSchedulerActiveAtEnqueue?: number
+  workerKzgSchedulerActiveAtEnqueue?: number
+  kzgSchedulerMaxQueueDepth?: number
+  workerKzgSchedulerMaxQueueDepth?: number
+  kzgSchedulerFallbackCount?: number
+  workerKzgSchedulerFallbackCount?: number
   kzgWebGpuProbeTimeoutMs?: number
   workerKzgWebGpuProbeTimeoutMs?: number
   kzgWebGpuCommitTimeoutMs?: number
@@ -156,6 +174,12 @@ export const PENDING_KZG_BACKEND_STATUS: KzgBackendStatus = {
   calibrationStatus: null,
   calibrationSource: null,
   calibrationCacheKey: null,
+  schedulerQueueWaitMs: null,
+  schedulerTotalMs: null,
+  schedulerQueueDepth: null,
+  schedulerActive: null,
+  schedulerMaxQueueDepth: null,
+  schedulerFallbackCount: null,
   probeTimeoutMs: null,
   commitTimeoutMs: null,
   minBlobs: null,
@@ -229,6 +253,12 @@ export function normalizeKzgBackendStatus(input?: KzgDiagnosticsInput | null): K
     calibrationStatus,
     calibrationSource,
     calibrationCacheKey,
+    schedulerQueueWaitMs: firstNumber(input.kzgSchedulerQueueWaitMs, input.workerKzgSchedulerQueueWaitMs),
+    schedulerTotalMs: firstNumber(input.kzgSchedulerTotalMs, input.workerKzgSchedulerTotalMs),
+    schedulerQueueDepth: firstNumber(input.kzgSchedulerDepthAtEnqueue, input.workerKzgSchedulerDepthAtEnqueue),
+    schedulerActive: firstNumber(input.kzgSchedulerActiveAtEnqueue, input.workerKzgSchedulerActiveAtEnqueue),
+    schedulerMaxQueueDepth: firstNumber(input.kzgSchedulerMaxQueueDepth, input.workerKzgSchedulerMaxQueueDepth),
+    schedulerFallbackCount: firstNumber(input.kzgSchedulerFallbackCount, input.workerKzgSchedulerFallbackCount),
     probeTimeoutMs: firstNumber(input.kzgWebGpuProbeTimeoutMs, input.workerKzgWebGpuProbeTimeoutMs),
     commitTimeoutMs: firstNumber(input.kzgWebGpuCommitTimeoutMs, input.workerKzgWebGpuCommitTimeoutMs),
     minBlobs: firstNumber(input.kzgWebGpuMinBlobs, input.workerKzgWebGpuMinBlobs),

--- a/polystore-website/src/lib/worker-client.ts
+++ b/polystore-website/src/lib/worker-client.ts
@@ -3,6 +3,8 @@
 // This file provides a simple client API to interact with the gateway.worker.ts
 // It abstracts the message passing and Promise-based communication.
 import { DEFAULT_EXPANSION_HARDWARE_CONCURRENCY, pickExpansionWorkerCount } from './expansionWorkers'
+import { UserMduKzgScheduler } from './upload/userMduKzgScheduler'
+import type { UserMduBrowserKzgResult, UserMduUncommittedExpansion } from './upload/userMduBrowserKzg'
 
 // Instantiate the worker
 const worker = new Worker(new URL('../workers/gateway.worker.ts', import.meta.url), {
@@ -27,6 +29,8 @@ const expansionPending = new Map<number, ExpansionWorkerPending>()
 const expansionPendingByWorker = new Map<Worker, Set<number>>()
 let expansionNextMessageId = 1
 let expansionRoundRobin = 0
+let nextUserMduKzgSequence = 0
+const userMduKzgScheduler = new UserMduKzgScheduler({ concurrency: 1, maxQueueDepth: 32 })
 
 // Handle messages coming back from the worker
 worker.onmessage = (event) => {
@@ -137,7 +141,12 @@ function sendMessageToWorker(
 }
 
 function sendExpansionMessageToWorker(
-  type: 'expandMduRs' | 'expandPayloadRs' | 'commitMduProfiled' | 'computeManifest',
+  type:
+    | 'expandMduRsUncommitted'
+    | 'expandPayloadRsUncommitted'
+    | 'expandMduRsCommitted'
+    | 'expandPayloadRsCommitted'
+    | 'computeManifest',
   payload: unknown,
   transferables?: Transferable[],
 ): Promise<unknown> {
@@ -274,11 +283,68 @@ export type KzgCommitDiagnostics = {
   kzgWebGpuCalibrationStatus?: string
   kzgWebGpuCalibrationSource?: string
   kzgWebGpuCalibrationCacheKey?: string
+  kzgSchedulerSequence?: number
+  kzgSchedulerQueueWaitMs?: number
+  kzgSchedulerCommitMs?: number
+  kzgSchedulerTotalMs?: number
+  kzgSchedulerDepthAtEnqueue?: number
+  kzgSchedulerActiveAtEnqueue?: number
+  kzgSchedulerQueueDepthAtStart?: number
+  kzgSchedulerMaxQueueDepth?: number
+  kzgSchedulerFallbackCount?: number
+  kzgSchedulerOwner?: string
   commitWorkerCount?: number
 }
 
 type ExpandStripeOptions = {
   profile?: boolean
+}
+
+async function expandStripeWithScheduledKzg(
+  kind: 'mdu' | 'payload',
+  data: Uint8Array,
+  k: number,
+  m: number,
+  opts?: ExpandStripeOptions,
+): Promise<ExpandedStripe> {
+  if (!(data instanceof Uint8Array)) throw new Error('data must be Uint8Array')
+  const sequence = nextUserMduKzgSequence++
+  const profile = opts?.profile !== false
+  const payloadId = `user-mdu:${kind}:${sequence}`
+  // Keep one copy only for the rare scheduler/owner failure path. Normal
+  // WebGPU/validation fallbacks happen inside the single KZG owner and return
+  // the original shard bytes, but a worker crash can detach transferred shards.
+  const fallbackData = data.slice()
+  const expansionType = kind === 'mdu' ? 'expandMduRsUncommitted' : 'expandPayloadRsUncommitted'
+  const committedType = kind === 'mdu' ? 'expandMduRsCommitted' : 'expandPayloadRsCommitted'
+  const expansion = sendExpansionMessageToWorker(
+    expansionType,
+    { data, k, m, profile, payloadId, sequence },
+    [data.buffer],
+  ) as Promise<UserMduUncommittedExpansion>
+
+  return userMduKzgScheduler.enqueue({
+    sequence,
+    expansion,
+    commit: async (expanded) => sendMessageToWorker(
+      'commitExpandedUserMdu',
+      { expansion: expanded },
+      [expanded.shardsFlat.buffer],
+    ) as Promise<UserMduBrowserKzgResult>,
+    fallback: async (reason) => {
+      const result = await sendExpansionMessageToWorker(
+        committedType,
+        { data: fallbackData, k, m, profile, fallbackReason: reason, payloadId, sequence },
+        [fallbackData.buffer],
+      ) as UserMduBrowserKzgResult
+      result.perf = {
+        ...(result.perf ?? {}),
+        browserKzgCommitFallbackReason:
+          result.perf?.browserKzgCommitFallbackReason ?? `scheduler owner failed; used committed WASM fallback: ${reason}`,
+      }
+      return result
+    },
+  }) as Promise<ExpandedStripe>
 }
 
 // --- Public API for interacting with the Worker ---
@@ -381,13 +447,11 @@ export const workerClient = {
   },
 
   async commitMduProfiled(data: Uint8Array): Promise<ExpandedMdu> {
-    return sendExpansionMessageToWorker('commitMduProfiled', { data }, [data.buffer]) as Promise<ExpandedMdu>;
+    return sendMessageToWorker('commitMduProfiled', { data }, [data.buffer]) as Promise<ExpandedMdu>;
   },
 
   async expandMduRs(data: Uint8Array, k: number, m: number, opts?: ExpandStripeOptions): Promise<ExpandedStripe> {
-    return sendExpansionMessageToWorker('expandMduRs', { data, k, m, profile: opts?.profile !== false }, [
-      data.buffer,
-    ]) as Promise<ExpandedStripe>;
+    return expandStripeWithScheduledKzg('mdu', data, k, m, opts);
   },
 
   async expandPayloadRs(
@@ -396,9 +460,7 @@ export const workerClient = {
     m: number,
     opts?: ExpandStripeOptions,
   ): Promise<ExpandedStripe> {
-    return sendExpansionMessageToWorker('expandPayloadRs', { data, k, m, profile: opts?.profile !== false }, [
-      data.buffer,
-    ]) as Promise<ExpandedStripe>;
+    return expandStripeWithScheduledKzg('payload', data, k, m, opts);
   },
 
   // Compute Manifest Root from a list of MDU roots (concatenated 32-byte roots)
@@ -407,6 +469,10 @@ export const workerClient = {
       root: Uint8Array;
       blob: Uint8Array;
     }>;
+  },
+
+  getUserMduKzgSchedulerStatus() {
+    return userMduKzgScheduler.getStatus();
   },
 
   async computeMduRoot(witness: Uint8Array): Promise<Uint8Array> {

--- a/polystore-website/src/workers/expand.worker.ts
+++ b/polystore-website/src/workers/expand.worker.ts
@@ -1,25 +1,14 @@
 import init, { PolyStoreWasm } from '../lib/polystoreCoreRuntime.js'
-import { createBrowserKzgCommitBackend, type KzgCommitBackend } from '../lib/kzgCommitBackend'
 import {
-  expandUserMduRsWithBrowserKzg,
-  kzgCommitDiagnosticsForBackend,
+  committedExpansionToUserMduBrowserKzgResult,
+  parseCommittedExpansion,
+  parseUserMduUncommittedExpansion,
 } from '../lib/upload/userMduBrowserKzg'
 
 let wasmInitialized = false
 let wasmInitPromise: Promise<void> | null = null
 let wasmInitError: unknown = null
 let polyStoreWasmInstance: PolyStoreWasm | null = null
-let kzgCommitBackend: KzgCommitBackend | null = null
-
-// User MDU batches are large (default Mode 2 RS 8+4 commits 96 blobs), so
-// do not let a one-blob probe reject WebGPU for the dominant upload stage.
-// Validation failures still fall back through expandUserMduRsWithBrowserKzg.
-const USER_UPLOAD_KZG_OPTIONS = {
-  preferWebGpu: true,
-  webGpuMode: 'force' as const,
-  webGpuProbeTimeoutMs: 15_000,
-  webGpuCommitTimeoutMs: 60_000,
-}
 
 function initializeWasm(): Promise<void> {
   if (wasmInitialized) return Promise.resolve()
@@ -40,8 +29,10 @@ function initializeWasm(): Promise<void> {
 
 void initializeWasm()
 
-function kzgCommitDiagnostics() {
-  return kzgCommitDiagnosticsForBackend(kzgCommitBackend)
+function committedFallbackReason(fallbackReason: unknown): string | undefined {
+  return typeof fallbackReason === 'string' && fallbackReason.trim()
+    ? `scheduler owner failed; used committed WASM fallback: ${fallbackReason}`
+    : undefined
 }
 
 self.onmessage = async (event) => {
@@ -59,110 +50,63 @@ self.onmessage = async (event) => {
         const { trustedSetupBytes } = payload as { trustedSetupBytes: Uint8Array }
         if (!trustedSetupBytes) throw new Error('Trusted setup bytes required')
         polyStoreWasmInstance = new PolyStoreWasm(trustedSetupBytes)
-        kzgCommitBackend = await createBrowserKzgCommitBackend(polyStoreWasmInstance, trustedSetupBytes, USER_UPLOAD_KZG_OPTIONS)
         ;(self as unknown as Worker).postMessage({ id, type: 'result', payload: 'ok' })
         return
       }
-      case 'expandMduRs': {
-        if (!polyStoreWasmInstance || !kzgCommitBackend) throw new Error('PolyStoreWasm not initialized')
-        const { data, k, m, profile = true } = payload as { data: Uint8Array; k: number; m: number; profile?: boolean }
-        if (!(data instanceof Uint8Array)) throw new Error('data must be Uint8Array')
-        const result = await expandUserMduRsWithBrowserKzg({
-          kind: 'mdu',
-          data,
-          k: Number(k),
-          m: Number(m),
-          profile,
-          wasm: polyStoreWasmInstance,
-          kzgCommitBackend,
-        })
-        const transferables: Transferable[] = [result.witness_flat.buffer, result.mdu_root.buffer, result.shards_flat.buffer]
-        ;(self as unknown as Worker).postMessage(
-          {
-            id,
-            type: 'result',
-            payload: result,
-          },
-          transferables,
-        )
-        return
-      }
-      case 'expandPayloadRs': {
-        if (!polyStoreWasmInstance || !kzgCommitBackend) throw new Error('PolyStoreWasm not initialized')
-        const { data, k, m, profile = true } = payload as {
+      case 'expandMduRsUncommitted':
+      case 'expandPayloadRsUncommitted': {
+        if (!polyStoreWasmInstance) throw new Error('PolyStoreWasm not initialized')
+        const { data, k, m, profile = true, payloadId, sequence, mduIndex } = payload as {
           data: Uint8Array
           k: number
           m: number
           profile?: boolean
+          payloadId?: string
+          sequence?: number
+          mduIndex?: number
         }
         if (!(data instanceof Uint8Array)) throw new Error('data must be Uint8Array')
-
-        const result = await expandUserMduRsWithBrowserKzg({
-          kind: 'payload',
-          data,
+        const kind = type === 'expandMduRsUncommitted' ? 'mdu' : 'payload'
+        const raw = kind === 'mdu'
+          ? polyStoreWasmInstance.expand_mdu_rs_flat_uncommitted(data, Number(k), Number(m))
+          : polyStoreWasmInstance.expand_payload_rs_flat_uncommitted(data, Number(k), Number(m))
+        const result = parseUserMduUncommittedExpansion(raw, {
+          kind,
           k: Number(k),
           m: Number(m),
           profile,
-          wasm: polyStoreWasmInstance,
-          kzgCommitBackend,
+          payloadId,
+          sequence,
+          mduIndex,
+          label: kind === 'mdu' ? 'expandMduRsUncommitted' : 'expandPayloadRsUncommitted',
         })
-        ;(self as unknown as Worker).postMessage(
-          {
-            id,
-            type: 'result',
-            payload: result,
-          },
-          [result.witness_flat.buffer, result.mdu_root.buffer, result.shards_flat.buffer],
-        )
+        ;(self as unknown as Worker).postMessage({ id, type: 'result', payload: result }, [result.shardsFlat.buffer])
         return
       }
-      case 'commitMduProfiled': {
-        if (!polyStoreWasmInstance || !kzgCommitBackend) throw new Error('PolyStoreWasm not initialized')
-        const { data } = payload as { data: Uint8Array }
-        const BLOBS_PER_MDU = 64
+      case 'expandMduRsCommitted':
+      case 'expandPayloadRsCommitted': {
+        if (!polyStoreWasmInstance) throw new Error('PolyStoreWasm not initialized')
+        const { data, k, m, profile = true, fallbackReason } = payload as {
+          data: Uint8Array
+          k: number
+          m: number
+          profile?: boolean
+          fallbackReason?: string
+        }
         if (!(data instanceof Uint8Array)) throw new Error('data must be Uint8Array')
-        if (data.byteLength !== 8 * 1024 * 1024) throw new Error('MDU bytes must be exactly 8 MiB')
-
-        const opStart = performance.now()
-        const commitStart = performance.now()
-        const committedRaw = await kzgCommitBackend.commitBlobsProfiled(data)
-        const commitMs = performance.now() - commitStart
-        const witnessFlat = committedRaw.witnessFlat
-        const commitPerf = committedRaw.perf
-
-        const rootStart = performance.now()
-        const root = polyStoreWasmInstance.compute_mdu_root(witnessFlat) as unknown
-        const rootMs = performance.now() - rootStart
-        const rootBytes = root instanceof Uint8Array ? root : new Uint8Array(root as ArrayBufferLike)
+        const isMdu = type === 'expandMduRsCommitted'
+        const raw = isMdu
+          ? profile
+            ? polyStoreWasmInstance.expand_mdu_rs_flat_committed_profiled(data, Number(k), Number(m))
+            : polyStoreWasmInstance.expand_mdu_rs_flat_committed(data, Number(k), Number(m))
+          : profile
+            ? polyStoreWasmInstance.expand_payload_rs_flat_committed_profiled(data, Number(k), Number(m))
+            : polyStoreWasmInstance.expand_payload_rs_flat_committed(data, Number(k), Number(m))
+        const parsed = parseCommittedExpansion(raw, isMdu ? 'expandMduRsCommitted' : 'expandPayloadRsCommitted')
+        const result = committedExpansionToUserMduBrowserKzgResult(parsed, committedFallbackReason(fallbackReason))
         ;(self as unknown as Worker).postMessage(
-          {
-            id,
-            type: 'result',
-            payload: {
-              witness_flat: witnessFlat,
-              mdu_root: rootBytes,
-              perf: {
-                commitMs,
-                rootMs,
-                totalMs: performance.now() - opStart,
-                blobCount: BLOBS_PER_MDU,
-                batchCount: 1,
-                batchSize: BLOBS_PER_MDU,
-                rustCommitDecodeMs: commitPerf.decodeMs,
-                rustCommitTransformMs: commitPerf.transformMs,
-                rustCommitMsmScalarPrepMs: commitPerf.msmScalarPrepMs,
-                rustCommitMsmBucketFillMs: commitPerf.msmBucketFillMs,
-                rustCommitMsmReduceMs: commitPerf.msmReduceMs,
-                rustCommitMsmDoubleMs: commitPerf.msmDoubleMs,
-                rustCommitMsmMs: commitPerf.msmMs,
-                rustCommitCompressMs: commitPerf.compressMs,
-                rustCommitMs: commitPerf.totalMs || commitMs,
-                rustCommitMsmSubphasesAvailable: false,
-                ...kzgCommitDiagnostics(),
-              },
-            },
-          },
-          [witnessFlat.buffer, rootBytes.buffer],
+          { id, type: 'result', payload: result },
+          [parsed.witnessFlat.buffer, parsed.mduRoot.buffer, parsed.shardsFlat.buffer],
         )
         return
       }

--- a/polystore-website/src/workers/gateway.worker.ts
+++ b/polystore-website/src/workers/gateway.worker.ts
@@ -8,8 +8,12 @@
 import init, { WasmMdu0Builder, PolyStoreWasm } from '../lib/polystoreCoreRuntime.js';
 import { createBrowserKzgCommitBackend, type KzgCommitBackend } from '../lib/kzgCommitBackend';
 import {
+    committedExpansionToUserMduBrowserKzgResult,
+    commitUserMduUncommittedWithBrowserKzg,
     expandUserMduRsWithBrowserKzg,
     kzgCommitDiagnosticsForBackend,
+    parseCommittedExpansion,
+    parseUserMduUncommittedExpansion,
 } from '../lib/upload/userMduBrowserKzg';
 
 let wasmInitialized = false;
@@ -165,6 +169,12 @@ function commitBlobsWithPool(data: Uint8Array): Promise<Uint8Array> {
 
 function kzgCommitDiagnostics() {
     return kzgCommitDiagnosticsForBackend(kzgCommitBackend);
+}
+
+function committedFallbackReason(fallbackReason: unknown): string | undefined {
+    return typeof fallbackReason === 'string' && fallbackReason.trim()
+        ? `scheduler owner failed; used committed WASM fallback: ${fallbackReason}`
+        : undefined;
 }
 
 // Start fetching + compiling the WASM as soon as the worker loads so the first
@@ -601,6 +611,84 @@ self.onmessage = async (event) => {
                         ...kzgCommitDiagnostics(),
                     },
                 };
+                break;
+            }
+            case 'expandMduRsUncommitted':
+            case 'expandPayloadRsUncommitted': {
+                if (!polyStoreWasmInstance) throw new Error('PolyStoreWasm not initialized. Call initPolyStoreWasm first.');
+                const { data, k, m, profile = true, payloadId, sequence, mduIndex } = payload as {
+                    data: Uint8Array;
+                    k: number;
+                    m: number;
+                    profile?: boolean;
+                    payloadId?: string;
+                    sequence?: number;
+                    mduIndex?: number;
+                };
+                if (!(data instanceof Uint8Array)) throw new Error('data must be Uint8Array');
+                const kind = type === 'expandMduRsUncommitted' ? 'mdu' : 'payload';
+                const raw = kind === 'mdu'
+                    ? polyStoreWasmInstance.expand_mdu_rs_flat_uncommitted(data, Number(k), Number(m))
+                    : polyStoreWasmInstance.expand_payload_rs_flat_uncommitted(data, Number(k), Number(m));
+                result = parseUserMduUncommittedExpansion(raw, {
+                    kind,
+                    k: Number(k),
+                    m: Number(m),
+                    profile,
+                    payloadId,
+                    sequence,
+                    mduIndex,
+                    label: kind === 'mdu' ? 'expandMduRsUncommitted' : 'expandPayloadRsUncommitted',
+                });
+                break;
+            }
+            case 'expandMduRsCommitted':
+            case 'expandPayloadRsCommitted': {
+                if (!polyStoreWasmInstance) throw new Error('PolyStoreWasm not initialized. Call initPolyStoreWasm first.');
+                const { data, k, m, profile = true, fallbackReason } = payload as {
+                    data: Uint8Array;
+                    k: number;
+                    m: number;
+                    profile?: boolean;
+                    fallbackReason?: string;
+                };
+                if (!(data instanceof Uint8Array)) throw new Error('data must be Uint8Array');
+                const isMdu = type === 'expandMduRsCommitted';
+                const raw = isMdu
+                    ? profile
+                        ? polyStoreWasmInstance.expand_mdu_rs_flat_committed_profiled(data, Number(k), Number(m))
+                        : polyStoreWasmInstance.expand_mdu_rs_flat_committed(data, Number(k), Number(m))
+                    : profile
+                        ? polyStoreWasmInstance.expand_payload_rs_flat_committed_profiled(data, Number(k), Number(m))
+                        : polyStoreWasmInstance.expand_payload_rs_flat_committed(data, Number(k), Number(m));
+                result = committedExpansionToUserMduBrowserKzgResult(
+                    parseCommittedExpansion(raw, isMdu ? 'expandMduRsCommitted' : 'expandPayloadRsCommitted'),
+                    committedFallbackReason(fallbackReason),
+                );
+                break;
+            }
+            case 'commitExpandedUserMdu': {
+                if (!polyStoreWasmInstance) throw new Error('PolyStoreWasm not initialized. Call initPolyStoreWasm first.');
+                if (!kzgCommitBackend) throw new Error('PolyStoreWasm not initialized. Call initPolyStoreWasm first.');
+                const { expansion } = payload as {
+                    expansion: {
+                        shardsFlat: Uint8Array;
+                        shardLen: number;
+                        perf?: Record<string, unknown>;
+                    };
+                };
+                if (!expansion || !(expansion.shardsFlat instanceof Uint8Array)) {
+                    throw new Error('commitExpandedUserMdu requires uncommitted shards');
+                }
+                result = await commitUserMduUncommittedWithBrowserKzg({
+                    expansion: {
+                        shardsFlat: expansion.shardsFlat,
+                        shardLen: Number(expansion.shardLen),
+                        perf: expansion.perf ?? {},
+                    },
+                    wasm: polyStoreWasmInstance,
+                    kzgCommitBackend,
+                });
                 break;
             }
             case 'expandMduRs': {


### PR DESCRIPTION
**Latest validation update (2026-05-30):** Native Apple M3 and NVIDIA/Ampere no-gateway sparse upload-prep smokes passed with `kzgCommitBackend=webgpu`, `rustCommitBackend=webgpu-msm`, and WebGPU probe `passed`. Evidence supports this scheduler-seam PR, conditional on #201 landing first.

---

## Summary

Refs #194 and parent tracker #192. Stacked on #193 / PR #201 (`website/webgpu-msm-autotune-193`, head `15db9074`).

This PR splits browser Mode 2 RS expansion from browser KZG scheduling:

- Adds `mode2-user-mdu-uncommitted-v1`, a deterministic internal contract for uncommitted user-MDU expansion results (`kind`, `k/m`, `payloadId`, `sequence`, shard bytes/length, RS perf).
- Removes WebGPU KZG backend ownership from `expand.worker.ts`; expansion workers now do CPU/WASM RS expansion only.
- Adds `UserMduKzgScheduler`, a bounded deterministic queue that owns user-MDU KZG scheduling on the client side and forwards commits to the single `gateway.worker.ts` KZG owner.
- Adds `commitExpandedUserMdu` in `gateway.worker.ts` to consume uncommitted shard batches and return witness bytes + MDU root.
- Preserves safe fallback to the committed WASM path if the scheduler/owner fails.
- Extends upload profiling/status with KZG scheduler queue wait/depth/fallback diagnostics.

## Current-flow inventory

Before this PR, `workerClient.expandMduRs` / `expandPayloadRs` dispatched directly into the expansion pool. Each `expand.worker.ts` initialized `createBrowserKzgCommitBackend(...)`, then `expandUserMduRsWithBrowserKzg(...)` performed RS expansion and immediately committed the resulting shard blobs inside that same expansion worker. With multiple expansion workers, each worker independently owned/contended on WebGPU KZG.

After this PR, expansion workers only return validated uncommitted RS artifacts. `worker-client.ts` assigns deterministic sequence IDs, enqueues them in `UserMduKzgScheduler`, and commits through `gateway.worker.ts` (`commitExpandedUserMdu`). The queue seam is intentionally MDU-scoped; cross-MDU batching is deferred to #195.

## Tests

Local:

- `cd polystore-website && npm run test:unit` ✅ (275 tests; known OPFS cleanup warning is exercised by an existing resilience test and the suite exits 0)
- `cd polystore-website && npm run lint` ✅
- `cd polystore-website && npm run build:app` ✅ (existing Vite/chunk-size/browser-mapping warnings only)

CI:

- GitHub checks on `8a50e0bf` ✅ all required/triggered checks completed successfully, including Website Build & Lint, Playwright E2E, Native/WASM Parity, Browser Sparse Upload Proof, Mode2 Stripe, gateway/no-gateway lifecycle e2e, gateway retrieval, Rust/Go suites, policy simulator, and Cloudflare Workers preview.

## Benchmark / evidence

Environment: Linux `6.8.0-111-generic`, x64, 12 CPUs, ~31 GiB RAM, HeadlessChrome `143.0.7499.4`.

Native WebGPU limitation: `navigator.gpu` is present in headless Chrome, but `requestAdapter()` returns `null`, so this environment uses WASM/blst fallback. PR is draft until native WebGPU contention evidence is available.

### WebGPU lifecycle smoke (baseline vs candidate)

Command: `cd polystore-website && npm run perf:kzg-webgpu-lifecycle`

| Branch/SHA | Backend | Fallback reason | 1-blob wall | Rust total |
| --- | --- | --- | ---: | ---: |
| baseline `15db9074` | `webgpu-wasm-fallback` | `WebGPU adapter request returned null` | 285.50 ms | 285 ms |
| candidate `8a50e0bf` | `webgpu-wasm-fallback` | `WebGPU adapter request returned null` | 287.56 ms | 287 ms |

### WASM prepare-stage boundary smoke (baseline vs candidate)

Command: `FILE_BYTES=16777216 RS_K=8 RS_M=4 WARMUP_RUNS=0 MEASURE_RUNS=1 npm run perf:prepare-stages`

| Branch/SHA | File | User MDUs | Total prepare | User stage | RS expand sum | KZG commit sum | Root sum |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| baseline `15db9074` | 16 MiB | 3 | 56,739.10 ms | 56,592.44 ms | 52 ms | 54,744 ms | 1.86 ms |
| candidate `8a50e0bf` | 16 MiB | 3 | 56,392.46 ms | 56,244.33 ms | 53 ms | 54,330 ms | 1.32 ms |

Attempted 100 MiB `perf:prepare-stages` with RS 8+4 under WASM fallback; it exceeded a 300s local timeout, so no valid 100 MiB local measurement is available from this environment.

## Risk / limitations

- Native WebGPU contention improvement is not proven in this headless environment; this PR should stay draft until native GPU evidence is collected.
- The new queue is MDU-scoped (`concurrency=1`, bounded depth 32). It intentionally does not batch across MDUs; #195 should consume this seam for batching.
- A rare scheduler-owner crash keeps one fallback copy of each input chunk so the committed WASM path can still reconstruct outputs.

## AI review status

- Copilot: requested in PR comment; no formal review yet.
- CodeRabbit: requested in PR comment; no formal review yet.
- Codex: requested; unavailable here (`chatgpt-codex-connector` replied that Codex account/GitHub connector setup is required).

