### PR TITLE
feat(website): batch browser KZG commitments across user MDUs

### DIFF
--- a/polystore-website/src/components/FileSharder.tsx
+++ b/polystore-website/src/components/FileSharder.tsx
@@ -185,6 +185,11 @@ type PreparePerfSample = {
   workerKzgSchedulerActiveAtEnqueue?: number
   workerKzgSchedulerMaxQueueDepth?: number
   workerKzgSchedulerFallbackCount?: number
+  workerKzgSchedulerBatchSize?: number
+  workerKzgSchedulerBatchBlobs?: number
+  workerKzgSchedulerBatchBytes?: number
+  workerKzgSchedulerBatchSplitCount?: number
+  workerKzgSchedulerBatchFallbackCount?: number
   workerRustEncodeMs: number
   workerRustRsMs: number
   workerRustCommitDecodeMs: number
@@ -311,6 +316,11 @@ type PreparePerfProfile = {
     kzgWebGpuMinBlobs?: number
     kzgSchedulerMaxQueueDepth?: number
     kzgSchedulerFallbackCount?: number
+    kzgSchedulerBatchSize?: number
+    kzgSchedulerBatchBlobs?: number
+    kzgSchedulerBatchBytes?: number
+    kzgSchedulerBatchSplitCount?: number
+    kzgSchedulerBatchFallbackCount?: number
     commitWorkerCount?: number
   }
   samples: {
@@ -3615,6 +3625,11 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
             const workerKzgSchedulerActiveAtEnqueue = Number(result.perf?.kzgSchedulerActiveAtEnqueue ?? 0) || undefined
             const workerKzgSchedulerMaxQueueDepth = Number(result.perf?.kzgSchedulerMaxQueueDepth ?? 0) || undefined
             const workerKzgSchedulerFallbackCount = Number(result.perf?.kzgSchedulerFallbackCount ?? 0) || undefined
+            const workerKzgSchedulerBatchSize = Number(result.perf?.kzgSchedulerBatchSize ?? 0) || undefined
+            const workerKzgSchedulerBatchBlobs = Number(result.perf?.kzgSchedulerBatchBlobs ?? 0) || undefined
+            const workerKzgSchedulerBatchBytes = Number(result.perf?.kzgSchedulerBatchBytes ?? 0) || undefined
+            const workerKzgSchedulerBatchSplitCount = Number(result.perf?.kzgSchedulerBatchSplitCount ?? 0) || undefined
+            const workerKzgSchedulerBatchFallbackCount = Number(result.perf?.kzgSchedulerBatchFallbackCount ?? 0) || undefined
             const workerRustEncodeMs = Number(result.perf?.rustEncodeMs ?? 0)
             const workerRustRsMs = Number(result.perf?.rustRsMs ?? 0)
             const workerRustCommitDecodeMs = Number(result.perf?.rustCommitDecodeMs ?? 0)
@@ -3706,6 +3721,11 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
               workerKzgSchedulerActiveAtEnqueue,
               workerKzgSchedulerMaxQueueDepth,
               workerKzgSchedulerFallbackCount,
+              workerKzgSchedulerBatchSize,
+              workerKzgSchedulerBatchBlobs,
+              workerKzgSchedulerBatchBytes,
+              workerKzgSchedulerBatchSplitCount,
+              workerKzgSchedulerBatchFallbackCount,
               workerRustEncodeMs,
               workerRustRsMs,
               workerRustCommitDecodeMs,
@@ -4450,6 +4470,11 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
             kzgWebGpuMinBlobs: kzgDiagnosticSample?.workerKzgWebGpuMinBlobs,
             kzgSchedulerMaxQueueDepth: kzgDiagnosticSample?.workerKzgSchedulerMaxQueueDepth,
             kzgSchedulerFallbackCount: kzgDiagnosticSample?.workerKzgSchedulerFallbackCount,
+            kzgSchedulerBatchSize: kzgDiagnosticSample?.workerKzgSchedulerBatchSize,
+            kzgSchedulerBatchBlobs: kzgDiagnosticSample?.workerKzgSchedulerBatchBlobs,
+            kzgSchedulerBatchBytes: kzgDiagnosticSample?.workerKzgSchedulerBatchBytes,
+            kzgSchedulerBatchSplitCount: kzgDiagnosticSample?.workerKzgSchedulerBatchSplitCount,
+            kzgSchedulerBatchFallbackCount: kzgDiagnosticSample?.workerKzgSchedulerBatchFallbackCount,
             commitWorkerCount: kzgDiagnosticSample?.workerCommitWorkerCount,
           },
           samples: perfSamples,

--- a/polystore-website/src/lib/upload/userMduBrowserKzg.test.ts
+++ b/polystore-website/src/lib/upload/userMduBrowserKzg.test.ts
@@ -5,6 +5,7 @@ import test from 'node:test'
 import init, { PolyStoreWasm } from '../../../public/wasm/polystore_core.js'
 import { createWasmBlstKzgCommitBackend, KZG_BLOB_SIZE, type KzgCommitBackend, type KzgCommitBackendStatus } from '../kzgCommitBackend'
 import {
+  commitUserMduBatchUncommittedWithBrowserKzg,
   expandUserMduRsWithBrowserKzg,
   parseUserMduUncommittedExpansion,
   toUserMduUint8Array,
@@ -242,6 +243,39 @@ test('partial payload expansion uses the same browser KZG route and preserves sh
   assert.equal(result.perf.shardCount, 3)
   assert.equal(result.perf.rows, 1)
   assert.equal(result.perf.shardsTotal, 3)
+})
+
+test('batch browser KZG commits multiple uncommitted user MDUs in one backend call and demuxes roots', async () => {
+  const { wasm, calls, payloadShards, shardLen } = makeWasm()
+  const { backend, calls: backendCalls } = makeBackend({ selectedBackend: 'webgpu', witnessSeed: 31 })
+  const first = parseUserMduUncommittedExpansion(
+    { shards_flat: payloadShards.slice(), shard_len: shardLen, perf: { encode_ms: 1, rs_ms: 2, total_ms: 3, rows: 1, shards_total: 3, shard_len: shardLen } },
+    { kind: 'payload', k: 2, m: 1, payloadId: 'a', sequence: 0 },
+  )
+  const second = parseUserMduUncommittedExpansion(
+    { shards_flat: payloadShards.slice(), shard_len: shardLen, perf: { encode_ms: 4, rs_ms: 5, total_ms: 9, rows: 1, shards_total: 3, shard_len: shardLen } },
+    { kind: 'payload', k: 2, m: 1, payloadId: 'b', sequence: 1 },
+  )
+
+  const results = await commitUserMduBatchUncommittedWithBrowserKzg({
+    expansions: [first, second],
+    wasm,
+    kzgCommitBackend: backend,
+  })
+
+  assert.equal(backendCalls.commitProfiled, 1)
+  assert.equal(calls.computeRoot, 2)
+  assert.equal(results.length, 2)
+  assert.equal(results[0].witness_flat.byteLength, 3 * 48)
+  assert.equal(results[1].witness_flat.byteLength, 3 * 48)
+  assert.deepEqual(results[0].mdu_root, rootFromWitness(results[0].witness_flat))
+  assert.deepEqual(results[1].mdu_root, rootFromWitness(results[1].witness_flat))
+  assert.deepEqual(results[0].shards_flat, first.shardsFlat)
+  assert.deepEqual(results[1].shards_flat, second.shardsFlat)
+  assert.equal(results[0].perf.browserKzgBatchSize, 2)
+  assert.equal(results[1].perf.browserKzgBatchPosition, 1)
+  assert.equal(results[1].perf.browserKzgBatchBlobs, 6)
+  assert.equal(results[0].perf.rustCommitBackend, 'webgpu-msm')
 })
 
 test('browser KZG failure falls back to the existing committed WASM path', async () => {

--- a/polystore-website/src/lib/upload/userMduBrowserKzg.ts
+++ b/polystore-website/src/lib/upload/userMduBrowserKzg.ts
@@ -4,6 +4,11 @@ import {
   type KzgCommitBackend,
   type KzgCommitPerf,
 } from '../kzgCommitBackend'
+import {
+  concatenateUserMduKzgBatch,
+  demuxUserMduKzgCommitments,
+  estimateUserMduKzgBatchMemoryBytes,
+} from './userMduKzgBatch'
 
 export type UserMduExpansionKind = 'mdu' | 'payload'
 
@@ -41,6 +46,14 @@ export type UserMduBrowserKzgPerf = ReturnType<typeof kzgCommitDiagnosticsForBac
   rows: number
   shardsTotal: number
   browserKzgCommitFallbackReason?: string
+  browserKzgBatchSize?: number
+  browserKzgBatchPosition?: number
+  browserKzgBatchBlobs?: number
+  browserKzgBatchBytes?: number
+  browserKzgBatchEstimatedMemoryBytes?: number
+  browserKzgBatchCommitMs?: number
+  browserKzgBatchRootMs?: number
+  browserKzgBatchSplitCount?: number
   kzgSchedulerSequence?: number
   kzgSchedulerQueueWaitMs?: number
   kzgSchedulerCommitMs?: number
@@ -50,6 +63,17 @@ export type UserMduBrowserKzgPerf = ReturnType<typeof kzgCommitDiagnosticsForBac
   kzgSchedulerQueueDepthAtStart?: number
   kzgSchedulerMaxQueueDepth?: number
   kzgSchedulerFallbackCount?: number
+  kzgSchedulerBatchSize?: number
+  kzgSchedulerBatchPosition?: number
+  kzgSchedulerBatchBlobs?: number
+  kzgSchedulerBatchBytes?: number
+  kzgSchedulerBatchEstimatedMemoryBytes?: number
+  kzgSchedulerBatchMaxMdus?: number
+  kzgSchedulerBatchMaxBlobs?: number
+  kzgSchedulerBatchMaxBytes?: number
+  kzgSchedulerBatchPlanReason?: string
+  kzgSchedulerBatchSplitCount?: number
+  kzgSchedulerBatchFallbackCount?: number
   kzgSchedulerOwner?: string
 }
 
@@ -308,6 +332,22 @@ function committedPerfToKzgCommitPerf(perf: CommittedExpansionPerf): KzgCommitPe
   }
 }
 
+function scaleKzgCommitPerf(perf: KzgCommitPerf, ratio: number, blobs: number): KzgCommitPerf {
+  const scale = (value: number) => (Number.isFinite(value) ? value * ratio : 0)
+  return {
+    decodeMs: scale(perf.decodeMs),
+    transformMs: scale(perf.transformMs),
+    msmScalarPrepMs: scale(perf.msmScalarPrepMs),
+    msmBucketFillMs: scale(perf.msmBucketFillMs),
+    msmReduceMs: scale(perf.msmReduceMs),
+    msmDoubleMs: scale(perf.msmDoubleMs),
+    msmMs: scale(perf.msmMs),
+    compressMs: scale(perf.compressMs),
+    totalMs: scale(perf.totalMs),
+    blobs,
+  }
+}
+
 function committedFallback(
   options: ExpandWithBrowserKzgOptions,
   now: () => number,
@@ -423,6 +463,82 @@ export async function commitUserMduUncommittedWithBrowserKzg(options: {
       diagnostics,
     ),
   }
+}
+
+export async function commitUserMduBatchUncommittedWithBrowserKzg(options: {
+  expansions: UserMduUncommittedExpansion[]
+  wasm: Pick<UserMduBrowserKzgWasm, 'compute_mdu_root'>
+  kzgCommitBackend: KzgCommitBackend
+  now?: () => number
+  totalStartMs?: number
+}): Promise<UserMduBrowserKzgResult[]> {
+  const { expansions, wasm, kzgCommitBackend } = options
+  if (!Array.isArray(expansions) || expansions.length === 0) {
+    throw new Error('browser KZG batch requires at least one uncommitted user MDU')
+  }
+  const now = options.now ?? defaultNow
+  const totalStart = options.totalStartMs
+  const batchBlobs = expansions.reduce((sum, expansion) => sum + expansion.shardsFlat.byteLength / KZG_BLOB_SIZE, 0)
+  const batchBytes = expansions.reduce((sum, expansion) => sum + expansion.shardsFlat.byteLength, 0)
+  const batchEstimatedMemoryBytes = estimateUserMduKzgBatchMemoryBytes(batchBytes, batchBlobs)
+  const batchBlobsFlat = concatenateUserMduKzgBatch(expansions)
+
+  const commitStart = now()
+  const committedRaw = await kzgCommitBackend.commitBlobsProfiled(batchBlobsFlat)
+  const commitMs = now() - commitStart
+  const witnessFlat = committedRaw.witnessFlat
+  const expectedWitnessBytes = batchBlobs * KZG_COMMITMENT_SIZE
+  if (witnessFlat.byteLength !== expectedWitnessBytes) {
+    throw new Error(`browser KZG batch returned ${witnessFlat.byteLength} witness bytes, expected ${expectedWitnessBytes}`)
+  }
+
+  const witnessGroups = demuxUserMduKzgCommitments(witnessFlat, expansions)
+  const rootStart = now()
+  const roots = witnessGroups.map((group, index) => {
+    const root = wasm.compute_mdu_root(group) as unknown
+    const rootBytes = toUserMduUint8Array(root)
+    if (rootBytes.byteLength !== 32) {
+      throw new Error(`compute_mdu_root for batch item ${index} returned ${rootBytes.byteLength} bytes, expected 32`)
+    }
+    return rootBytes
+  })
+  const rootMs = now() - rootStart
+  const diagnostics = kzgCommitDiagnosticsForBackend(kzgCommitBackend)
+
+  return expansions.map((expansion, index) => {
+    const itemBlobs = expansion.shardsFlat.byteLength / KZG_BLOB_SIZE
+    const ratio = batchBlobs > 0 ? itemBlobs / batchBlobs : 0
+    const itemCommitPerf = scaleKzgCommitPerf(committedRaw.perf, ratio, itemBlobs)
+    const itemCommitMs = commitMs * ratio
+    const itemRootMs = rootMs / expansions.length
+    return {
+      witness_flat: witnessGroups[index],
+      mdu_root: roots[index],
+      shards_flat: expansion.shardsFlat,
+      shard_len: expansion.shardLen,
+      perf: {
+        ...perfFromSplitAndCommit(
+          expansion.perf,
+          itemCommitPerf,
+          itemCommitMs,
+          itemRootMs,
+          totalStart === undefined
+            ? numberField(expansion.perf.total_ms) + itemCommitMs + itemRootMs
+            : now() - totalStart,
+          expansion.shardsFlat,
+          expansion.shardLen,
+          diagnostics,
+        ),
+        browserKzgBatchSize: expansions.length,
+        browserKzgBatchPosition: index,
+        browserKzgBatchBlobs: batchBlobs,
+        browserKzgBatchBytes: batchBytes,
+        browserKzgBatchEstimatedMemoryBytes: batchEstimatedMemoryBytes,
+        browserKzgBatchCommitMs: commitMs,
+        browserKzgBatchRootMs: rootMs,
+      },
+    }
+  })
 }
 
 export async function expandUserMduRsWithBrowserKzg(

--- a/polystore-website/src/lib/upload/userMduKzgBatch.test.ts
+++ b/polystore-website/src/lib/upload/userMduKzgBatch.test.ts
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { KZG_BLOB_SIZE, KZG_COMMITMENT_SIZE } from '../kzgCommitBackend'
+import {
+  concatenateUserMduKzgBatch,
+  demuxUserMduKzgCommitments,
+  describeUserMduKzgExpansionShape,
+  estimateUserMduKzgBatchMemoryBytes,
+  planUserMduKzgBatch,
+  splitUserMduKzgBatch,
+  validateHomogeneousUserMduKzgBatch,
+} from './userMduKzgBatch'
+import type { UserMduUncommittedExpansion } from './userMduBrowserKzg'
+
+function expansion(sequence: number, blobs = 3, options: Partial<UserMduUncommittedExpansion> = {}): UserMduUncommittedExpansion {
+  return {
+    contract: 'mode2-user-mdu-uncommitted-v1',
+    kind: 'payload',
+    k: 2,
+    m: 1,
+    payloadId: `payload:${sequence}`,
+    profile: true,
+    sequence,
+    shardsFlat: new Uint8Array(KZG_BLOB_SIZE * blobs).fill(sequence),
+    shardLen: KZG_BLOB_SIZE,
+    perf: { rows: blobs / 3, shards_total: 3, shard_len: KZG_BLOB_SIZE },
+    ...options,
+  }
+}
+
+function commitments(blobs: number): Uint8Array {
+  const out = new Uint8Array(blobs * KZG_COMMITMENT_SIZE)
+  for (let i = 0; i < out.length; i += 1) out[i] = (17 + i * 11) & 0xff
+  return out
+}
+
+test('batch planner honors max MDU, blob, byte, and memory budgets', () => {
+  const candidates = [expansion(0, 3), expansion(1, 3), expansion(2, 3), expansion(3, 3)]
+
+  assert.deepEqual(
+    planUserMduKzgBatch(candidates, { maxBatchMdus: 2, maxBatchBlobs: 99, maxBatchBytes: 99 * KZG_BLOB_SIZE }).count,
+    2,
+  )
+  assert.equal(planUserMduKzgBatch(candidates, { maxBatchBlobs: 6 }).reason, 'max_blobs')
+  assert.equal(planUserMduKzgBatch(candidates, { maxBatchBytes: 6 * KZG_BLOB_SIZE }).count, 2)
+  assert.equal(
+    planUserMduKzgBatch(candidates, { maxEstimatedMemoryBytes: estimateUserMduKzgBatchMemoryBytes(6 * KZG_BLOB_SIZE, 6) }).count,
+    2,
+  )
+})
+
+test('batch shape validation rejects incompatible RS shard layouts', () => {
+  const a = expansion(0, 3)
+  const b = expansion(1, 3)
+  const incompatible = expansion(2, 4, { shardLen: KZG_BLOB_SIZE * 2, k: 1, m: 1 })
+
+  assert.equal(describeUserMduKzgExpansionShape(a).blobCount, 3)
+  assert.equal(validateHomogeneousUserMduKzgBatch([a, b]).shardCount, 3)
+  assert.throws(() => validateHomogeneousUserMduKzgBatch([a, incompatible]), /incompatible user MDU shard shape/)
+  assert.equal(planUserMduKzgBatch([a, incompatible]).reason, 'incompatible_shape')
+})
+
+test('batch concatenation and commitment demux preserve exact MDU ordering', () => {
+  const a = expansion(0, 3)
+  const b = expansion(1, 3)
+  const flat = concatenateUserMduKzgBatch([a, b])
+  assert.equal(flat.byteLength, a.shardsFlat.byteLength + b.shardsFlat.byteLength)
+  assert.deepEqual(flat.subarray(0, a.shardsFlat.byteLength), a.shardsFlat)
+  assert.deepEqual(flat.subarray(a.shardsFlat.byteLength), b.shardsFlat)
+
+  const witnessFlat = commitments(6)
+  const groups = demuxUserMduKzgCommitments(witnessFlat, [a, b])
+  assert.equal(groups.length, 2)
+  assert.deepEqual(groups[0], witnessFlat.slice(0, 3 * KZG_COMMITMENT_SIZE))
+  assert.deepEqual(groups[1], witnessFlat.slice(3 * KZG_COMMITMENT_SIZE))
+})
+
+test('commitment demux rejects malformed witness lengths', () => {
+  assert.throws(
+    () => demuxUserMduKzgCommitments(new Uint8Array(1), [expansion(0, 3)]),
+    /returned 1 witness bytes, expected 144/,
+  )
+})
+
+test('fallback splitter halves oversized batches deterministically', () => {
+  assert.deepEqual(splitUserMduKzgBatch(1), [1, 0])
+  assert.deepEqual(splitUserMduKzgBatch(2), [1, 1])
+  assert.deepEqual(splitUserMduKzgBatch(5), [3, 2])
+})

--- a/polystore-website/src/lib/upload/userMduKzgBatch.ts
+++ b/polystore-website/src/lib/upload/userMduKzgBatch.ts
@@ -1,0 +1,227 @@
+import { KZG_BLOB_SIZE, KZG_COMMITMENT_SIZE } from '../kzgCommitBackend'
+import type { UserMduUncommittedExpansion } from './userMduBrowserKzg'
+
+export type UserMduKzgBatchConstraints = {
+  maxBatchMdus?: number
+  maxBatchBlobs?: number
+  maxBatchBytes?: number
+  maxEstimatedMemoryBytes?: number
+}
+
+export type NormalizedUserMduKzgBatchConstraints = Required<UserMduKzgBatchConstraints>
+
+export type UserMduKzgExpansionShape = {
+  k: number
+  m: number
+  shardLen: number
+  shardCount: number
+  blobCount: number
+  byteLength: number
+}
+
+export type UserMduKzgBatchPlan = {
+  count: number
+  blobs: number
+  bytes: number
+  estimatedMemoryBytes: number
+  reason: 'empty' | 'planned' | 'max_batch_mdus' | 'max_blobs' | 'max_bytes' | 'max_estimated_memory' | 'incompatible_shape'
+  shape: UserMduKzgExpansionShape | null
+}
+
+export type UserMduKzgDemuxInput = Pick<UserMduUncommittedExpansion, 'shardsFlat' | 'shardLen'>
+
+const DEFAULT_MAX_BATCH_MDUS = 4
+const DEFAULT_MAX_BATCH_BLOBS = 384
+const DEFAULT_MAX_BATCH_BYTES = 64 * 1024 * 1024
+const DEFAULT_MAX_ESTIMATED_MEMORY_BYTES = 128 * 1024 * 1024
+
+export const DEFAULT_USER_MDU_KZG_BATCH_CONSTRAINTS: NormalizedUserMduKzgBatchConstraints = {
+  maxBatchMdus: DEFAULT_MAX_BATCH_MDUS,
+  maxBatchBlobs: DEFAULT_MAX_BATCH_BLOBS,
+  maxBatchBytes: DEFAULT_MAX_BATCH_BYTES,
+  maxEstimatedMemoryBytes: DEFAULT_MAX_ESTIMATED_MEMORY_BYTES,
+}
+
+function positiveInteger(value: number | undefined, fallback: number): number {
+  const parsed = Math.floor(Number(value ?? fallback))
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+export function normalizeUserMduKzgBatchConstraints(
+  constraints: UserMduKzgBatchConstraints = {},
+): NormalizedUserMduKzgBatchConstraints {
+  return {
+    maxBatchMdus: positiveInteger(constraints.maxBatchMdus, DEFAULT_MAX_BATCH_MDUS),
+    maxBatchBlobs: positiveInteger(constraints.maxBatchBlobs, DEFAULT_MAX_BATCH_BLOBS),
+    maxBatchBytes: positiveInteger(constraints.maxBatchBytes, DEFAULT_MAX_BATCH_BYTES),
+    maxEstimatedMemoryBytes: positiveInteger(
+      constraints.maxEstimatedMemoryBytes,
+      DEFAULT_MAX_ESTIMATED_MEMORY_BYTES,
+    ),
+  }
+}
+
+function assertUint8Array(value: unknown, label: string): asserts value is Uint8Array {
+  if (!(value instanceof Uint8Array)) throw new Error(`${label} must be a Uint8Array`)
+}
+
+export function describeUserMduKzgExpansionShape(expansion: UserMduKzgDemuxInput & Partial<UserMduUncommittedExpansion>): UserMduKzgExpansionShape {
+  assertUint8Array(expansion.shardsFlat, 'shardsFlat')
+  const shardLen = Math.floor(Number(expansion.shardLen))
+  if (!Number.isFinite(shardLen) || shardLen <= 0) throw new Error('shardLen must be a positive integer')
+  if (expansion.shardsFlat.byteLength === 0) throw new Error('shardsFlat must not be empty')
+  if (expansion.shardsFlat.byteLength % shardLen !== 0) {
+    throw new Error('shardsFlat length must be a multiple of shardLen')
+  }
+  if (expansion.shardsFlat.byteLength % KZG_BLOB_SIZE !== 0) {
+    throw new Error('shardsFlat length must be a multiple of the KZG blob size')
+  }
+  const shardCount = expansion.shardsFlat.byteLength / shardLen
+  const blobCount = expansion.shardsFlat.byteLength / KZG_BLOB_SIZE
+  const k = Number(expansion.k ?? 0)
+  const m = Number(expansion.m ?? 0)
+  if ((k || m) && shardCount !== k + m) {
+    throw new Error(`shard count ${shardCount} does not match RS profile ${k}+${m}`)
+  }
+  return {
+    k,
+    m,
+    shardLen,
+    shardCount,
+    blobCount,
+    byteLength: expansion.shardsFlat.byteLength,
+  }
+}
+
+export function areUserMduKzgShapesCompatible(
+  left: UserMduKzgExpansionShape,
+  right: UserMduKzgExpansionShape,
+): boolean {
+  return left.k === right.k && left.m === right.m && left.shardLen === right.shardLen && left.shardCount === right.shardCount
+}
+
+export function validateHomogeneousUserMduKzgBatch(
+  expansions: Array<UserMduKzgDemuxInput & Partial<UserMduUncommittedExpansion>>,
+): UserMduKzgExpansionShape {
+  if (expansions.length === 0) throw new Error('KZG batch must contain at least one user MDU')
+  const first = describeUserMduKzgExpansionShape(expansions[0])
+  for (let i = 1; i < expansions.length; i += 1) {
+    const current = describeUserMduKzgExpansionShape(expansions[i])
+    if (!areUserMduKzgShapesCompatible(first, current)) {
+      throw new Error(
+        `incompatible user MDU shard shape at index ${i}: expected k=${first.k}, m=${first.m}, shardLen=${first.shardLen}, shardCount=${first.shardCount}; got k=${current.k}, m=${current.m}, shardLen=${current.shardLen}, shardCount=${current.shardCount}`,
+      )
+    }
+  }
+  return first
+}
+
+export function estimateUserMduKzgBatchMemoryBytes(bytes: number, blobs: number): number {
+  // During a browser-owner KZG call the worker keeps the per-MDU shard views,
+  // builds one concatenated blob buffer, and receives one 48-byte commitment per
+  // blob. This estimate intentionally excludes backend/GPU private memory and is
+  // used only as a deterministic guardrail before attempting a batch.
+  return bytes * 2 + blobs * KZG_COMMITMENT_SIZE
+}
+
+export function planUserMduKzgBatch(
+  candidates: Array<UserMduKzgDemuxInput & Partial<UserMduUncommittedExpansion>>,
+  constraints: UserMduKzgBatchConstraints = {},
+): UserMduKzgBatchPlan {
+  const normalized = normalizeUserMduKzgBatchConstraints(constraints)
+  if (candidates.length === 0) {
+    return { count: 0, blobs: 0, bytes: 0, estimatedMemoryBytes: 0, reason: 'empty', shape: null }
+  }
+
+  let count = 0
+  let blobs = 0
+  let bytes = 0
+  let shape: UserMduKzgExpansionShape | null = null
+  let reason: UserMduKzgBatchPlan['reason'] = 'planned'
+
+  for (const candidate of candidates) {
+    const current = describeUserMduKzgExpansionShape(candidate)
+    if (shape && !areUserMduKzgShapesCompatible(shape, current)) {
+      reason = 'incompatible_shape'
+      break
+    }
+    const nextCount = count + 1
+    const nextBlobs = blobs + current.blobCount
+    const nextBytes = bytes + current.byteLength
+    const nextEstimated = estimateUserMduKzgBatchMemoryBytes(nextBytes, nextBlobs)
+    if (nextCount > normalized.maxBatchMdus) {
+      reason = 'max_batch_mdus'
+      break
+    }
+    if (nextBlobs > normalized.maxBatchBlobs) {
+      reason = 'max_blobs'
+      break
+    }
+    if (nextBytes > normalized.maxBatchBytes) {
+      reason = 'max_bytes'
+      break
+    }
+    if (nextEstimated > normalized.maxEstimatedMemoryBytes) {
+      reason = 'max_estimated_memory'
+      break
+    }
+    shape = shape ?? current
+    count = nextCount
+    blobs = nextBlobs
+    bytes = nextBytes
+  }
+
+  return {
+    count,
+    blobs,
+    bytes,
+    estimatedMemoryBytes: estimateUserMduKzgBatchMemoryBytes(bytes, blobs),
+    reason,
+    shape,
+  }
+}
+
+export function concatenateUserMduKzgBatch(
+  expansions: Array<UserMduKzgDemuxInput & Partial<UserMduUncommittedExpansion>>,
+): Uint8Array {
+  validateHomogeneousUserMduKzgBatch(expansions)
+  const totalBytes = expansions.reduce((sum, expansion) => sum + expansion.shardsFlat.byteLength, 0)
+  const out = new Uint8Array(totalBytes)
+  let offset = 0
+  for (const expansion of expansions) {
+    out.set(expansion.shardsFlat, offset)
+    offset += expansion.shardsFlat.byteLength
+  }
+  return out
+}
+
+export function demuxUserMduKzgCommitments(
+  witnessFlat: Uint8Array,
+  expansions: Array<UserMduKzgDemuxInput & Partial<UserMduUncommittedExpansion>>,
+): Uint8Array[] {
+  assertUint8Array(witnessFlat, 'witnessFlat')
+  validateHomogeneousUserMduKzgBatch(expansions)
+  const expectedBytes = expansions.reduce(
+    (sum, expansion) => sum + (expansion.shardsFlat.byteLength / KZG_BLOB_SIZE) * KZG_COMMITMENT_SIZE,
+    0,
+  )
+  if (witnessFlat.byteLength !== expectedBytes) {
+    throw new Error(`KZG batch returned ${witnessFlat.byteLength} witness bytes, expected ${expectedBytes}`)
+  }
+
+  const groups: Uint8Array[] = []
+  let offset = 0
+  for (const expansion of expansions) {
+    const bytes = (expansion.shardsFlat.byteLength / KZG_BLOB_SIZE) * KZG_COMMITMENT_SIZE
+    groups.push(witnessFlat.slice(offset, offset + bytes))
+    offset += bytes
+  }
+  return groups
+}
+
+export function splitUserMduKzgBatch(count: number): [number, number] {
+  const normalized = Math.floor(Number(count))
+  if (!Number.isFinite(normalized) || normalized <= 1) return [normalized, 0]
+  const left = Math.ceil(normalized / 2)
+  return [left, normalized - left]
+}

--- a/polystore-website/src/lib/upload/userMduKzgScheduler.test.ts
+++ b/polystore-website/src/lib/upload/userMduKzgScheduler.test.ts
@@ -189,3 +189,78 @@ test('KZG scheduler bounds queue depth', async () => {
     /queue is full/,
   )
 })
+
+test('KZG scheduler batches ready sequence-adjacent user MDUs and resolves each promise deterministically', async () => {
+  let releaseFirst!: (value: UserMduUncommittedExpansion) => void
+  const first = new Promise<UserMduUncommittedExpansion>((resolve) => {
+    releaseFirst = resolve
+  })
+  const batchCalls: number[][] = []
+  const singleCalls: number[] = []
+  const scheduler = new UserMduKzgScheduler({ maxQueueDepth: 8, batch: { maxBatchMdus: 4, maxBatchBlobs: 12 } })
+
+  const makeTask = (sequence: number, expansionPromise: Promise<UserMduUncommittedExpansion>) => ({
+    sequence,
+    expansion: expansionPromise,
+    commit: async (expanded: UserMduUncommittedExpansion) => {
+      singleCalls.push(expanded.sequence ?? -1)
+      return resultFor(expanded.sequence ?? 0)
+    },
+    commitBatch: async (expandedBatch: UserMduUncommittedExpansion[]) => {
+      batchCalls.push(expandedBatch.map((expanded) => expanded.sequence ?? -1))
+      return expandedBatch.map((expanded) => resultFor(expanded.sequence ?? 0))
+    },
+  })
+
+  const p0 = scheduler.enqueue(makeTask(0, first))
+  const p1 = scheduler.enqueue(makeTask(1, Promise.resolve(expansion(1))))
+  const p2 = scheduler.enqueue(makeTask(2, Promise.resolve(expansion(2))))
+
+  await Promise.resolve()
+  releaseFirst(expansion(0))
+  const [r0, r1, r2] = await Promise.all([p0, p1, p2])
+
+  assert.deepEqual(batchCalls, [[0, 1, 2]])
+  assert.deepEqual(singleCalls, [])
+  assert.equal(r0.perf.kzgSchedulerSequence, 0)
+  assert.equal(r1.perf.kzgSchedulerSequence, 1)
+  assert.equal(r2.perf.kzgSchedulerSequence, 2)
+  assert.equal(r0.perf.kzgSchedulerBatchSize, 3)
+  assert.equal(r1.perf.kzgSchedulerBatchPosition, 1)
+  assert.equal(r2.perf.kzgSchedulerBatchBlobs, 9)
+})
+
+test('KZG scheduler splits failed batches down to per-MDU commits before using fallback', async () => {
+  let releaseFirst!: (value: UserMduUncommittedExpansion) => void
+  const first = new Promise<UserMduUncommittedExpansion>((resolve) => {
+    releaseFirst = resolve
+  })
+  const batchCalls: number[][] = []
+  const singleCalls: number[] = []
+  const scheduler = new UserMduKzgScheduler({ maxQueueDepth: 8, batch: { maxBatchMdus: 4, maxBatchBlobs: 12 } })
+
+  const tasks = Array.from({ length: 4 }, (_, sequence) =>
+    scheduler.enqueue({
+      sequence,
+      expansion: sequence === 0 ? first : Promise.resolve(expansion(sequence)),
+      commit: async (expanded) => {
+        singleCalls.push(expanded.sequence ?? -1)
+        return resultFor(expanded.sequence ?? 0)
+      },
+      commitBatch: async (expandedBatch) => {
+        batchCalls.push(expandedBatch.map((expanded) => expanded.sequence ?? -1))
+        throw new Error('synthetic batch timeout')
+      },
+    }),
+  )
+
+  await Promise.resolve()
+  releaseFirst(expansion(0))
+  const results = await Promise.all(tasks)
+
+  assert.deepEqual(batchCalls, [[0, 1, 2, 3], [0, 1], [2, 3]])
+  assert.deepEqual(singleCalls, [0, 1, 2, 3])
+  assert.equal(results[0].perf.kzgSchedulerBatchSize, 4)
+  assert.ok((results[0].perf.kzgSchedulerBatchSplitCount ?? 0) >= 3)
+  assert.equal(scheduler.getStatus().batchSplitCount, 3)
+})

--- a/polystore-website/src/lib/upload/userMduKzgScheduler.ts
+++ b/polystore-website/src/lib/upload/userMduKzgScheduler.ts
@@ -1,4 +1,12 @@
 import type { UserMduBrowserKzgResult, UserMduUncommittedExpansion } from './userMduBrowserKzg'
+import {
+  normalizeUserMduKzgBatchConstraints,
+  planUserMduKzgBatch,
+  splitUserMduKzgBatch,
+  type NormalizedUserMduKzgBatchConstraints,
+  type UserMduKzgBatchConstraints,
+  type UserMduKzgBatchPlan,
+} from './userMduKzgBatch'
 
 // Issue #194 seam inventory:
 // - Before this scheduler, each browser expansion worker ran RS expansion and
@@ -6,8 +14,9 @@ import type { UserMduBrowserKzgResult, UserMduUncommittedExpansion } from './use
 // - Expansion workers now return the deterministic uncommitted contract from
 //   userMduBrowserKzg.ts; this queue is the single browser-side owner that
 //   orders those uncommitted batches and forwards them to the KZG worker owner.
-// - The queue is intentionally MDU-scoped. Cross-MDU batching is only exposed by
-//   the stable enqueue/commit seam and remains the follow-up #195 work.
+// - Issue #195 extends the same enqueue seam with bounded sequence-ordered
+//   batching. Public callers still enqueue one user MDU and receive one promise;
+//   the scheduler may commit several ready consecutive MDUs in one owner call.
 
 export type UserMduKzgSchedulerDiagnostics = {
   sequence: number
@@ -18,11 +27,26 @@ export type UserMduKzgSchedulerDiagnostics = {
   queueDepthAtStart: number
   maxQueueDepth: number
   fallbackCount: number
+  batchSize: number
+  batchPosition: number
+  batchBlobs: number
+  batchBytes: number
+  batchEstimatedMemoryBytes: number
+  batchMaxMdus: number
+  batchMaxBlobs: number
+  batchMaxBytes: number
+  batchPlanReason: UserMduKzgBatchPlan['reason']
+  batchSplitCount: number
+  batchFallbackCount: number
   owner: 'browser-user-mdu-kzg-scheduler-v1'
 }
 
 export type UserMduKzgSchedulerCommitContext = UserMduKzgSchedulerDiagnostics & {
   signal?: AbortSignal
+}
+
+export type UserMduKzgSchedulerBatchCommitContext = UserMduKzgSchedulerCommitContext & {
+  sequences: number[]
 }
 
 export type UserMduKzgSchedulerTask = {
@@ -32,6 +56,10 @@ export type UserMduKzgSchedulerTask = {
     expansion: UserMduUncommittedExpansion,
     context: UserMduKzgSchedulerCommitContext,
   ) => Promise<UserMduBrowserKzgResult>
+  commitBatch?: (
+    expansions: UserMduUncommittedExpansion[],
+    context: UserMduKzgSchedulerBatchCommitContext,
+  ) => Promise<UserMduBrowserKzgResult[]>
   fallback?: (reason: string, context: UserMduKzgSchedulerCommitContext) => Promise<UserMduBrowserKzgResult>
   signal?: AbortSignal
 }
@@ -40,6 +68,9 @@ export type UserMduKzgSchedulerOptions = {
   maxQueueDepth?: number
   concurrency?: number
   now?: () => number
+  batch?: UserMduKzgBatchConstraints & {
+    enabled?: boolean
+  }
 }
 
 export type UserMduKzgSchedulerStatus = {
@@ -51,10 +82,21 @@ export type UserMduKzgSchedulerStatus = {
   completed: number
   failed: number
   fallbackCount: number
+  batchSplitCount: number
+  batchFallbackCount: number
+  lastBatchSize: number | null
+  lastBatchBlobs: number | null
+  lastBatchBytes: number | null
+  lastBatchPlanReason: UserMduKzgBatchPlan['reason'] | null
   lastError: string | null
   lastQueueWaitMs: number | null
   lastTotalMs: number | null
 }
+
+type ExpansionState =
+  | { status: 'pending' }
+  | { status: 'fulfilled'; value: UserMduUncommittedExpansion }
+  | { status: 'rejected'; reason: unknown }
 
 type QueuedTask = {
   task: UserMduKzgSchedulerTask
@@ -63,6 +105,18 @@ type QueuedTask = {
   enqueuedAtMs: number
   depthAtEnqueue: number
   activeAtEnqueue: number
+  expansionState: ExpansionState
+}
+
+type BatchItem = {
+  queued: QueuedTask
+  expansion: UserMduUncommittedExpansion
+}
+
+type BatchMeta = {
+  plan: UserMduKzgBatchPlan
+  splitCountAtStart: number
+  fallbackCountAtStart: number
 }
 
 const OWNER = 'browser-user-mdu-kzg-scheduler-v1' as const
@@ -99,6 +153,17 @@ export function attachUserMduKzgSchedulerDiagnostics(
       kzgSchedulerQueueDepthAtStart: diagnostics.queueDepthAtStart,
       kzgSchedulerMaxQueueDepth: diagnostics.maxQueueDepth,
       kzgSchedulerFallbackCount: diagnostics.fallbackCount,
+      kzgSchedulerBatchSize: diagnostics.batchSize,
+      kzgSchedulerBatchPosition: diagnostics.batchPosition,
+      kzgSchedulerBatchBlobs: diagnostics.batchBlobs,
+      kzgSchedulerBatchBytes: diagnostics.batchBytes,
+      kzgSchedulerBatchEstimatedMemoryBytes: diagnostics.batchEstimatedMemoryBytes,
+      kzgSchedulerBatchMaxMdus: diagnostics.batchMaxMdus,
+      kzgSchedulerBatchMaxBlobs: diagnostics.batchMaxBlobs,
+      kzgSchedulerBatchMaxBytes: diagnostics.batchMaxBytes,
+      kzgSchedulerBatchPlanReason: diagnostics.batchPlanReason,
+      kzgSchedulerBatchSplitCount: diagnostics.batchSplitCount,
+      kzgSchedulerBatchFallbackCount: diagnostics.batchFallbackCount,
       kzgSchedulerOwner: diagnostics.owner,
     },
   }
@@ -108,11 +173,19 @@ export class UserMduKzgScheduler {
   private readonly maxQueueDepth: number
   private readonly concurrency: number
   private readonly now: () => number
+  private readonly batchEnabled: boolean
+  private readonly batchConstraints: NormalizedUserMduKzgBatchConstraints
   private queue: QueuedTask[] = []
   private active = 0
   private completed = 0
   private failed = 0
   private fallbackCount = 0
+  private batchSplitCount = 0
+  private batchFallbackCount = 0
+  private lastBatchSize: number | null = null
+  private lastBatchBlobs: number | null = null
+  private lastBatchBytes: number | null = null
+  private lastBatchPlanReason: UserMduKzgBatchPlan['reason'] | null = null
   private lastError: string | null = null
   private lastQueueWaitMs: number | null = null
   private lastTotalMs: number | null = null
@@ -123,6 +196,8 @@ export class UserMduKzgScheduler {
     this.maxQueueDepth = Number.isFinite(maxQueueDepth) && maxQueueDepth > 0 ? maxQueueDepth : 32
     this.concurrency = Number.isFinite(concurrency) && concurrency > 0 ? concurrency : 1
     this.now = options.now ?? defaultNow
+    this.batchEnabled = options.batch?.enabled !== false
+    this.batchConstraints = normalizeUserMduKzgBatchConstraints(options.batch)
   }
 
   getStatus(): UserMduKzgSchedulerStatus {
@@ -135,6 +210,12 @@ export class UserMduKzgScheduler {
       completed: this.completed,
       failed: this.failed,
       fallbackCount: this.fallbackCount,
+      batchSplitCount: this.batchSplitCount,
+      batchFallbackCount: this.batchFallbackCount,
+      lastBatchSize: this.lastBatchSize,
+      lastBatchBlobs: this.lastBatchBlobs,
+      lastBatchBytes: this.lastBatchBytes,
+      lastBatchPlanReason: this.lastBatchPlanReason,
       lastError: this.lastError,
       lastQueueWaitMs: this.lastQueueWaitMs,
       lastTotalMs: this.lastTotalMs,
@@ -153,14 +234,24 @@ export class UserMduKzgScheduler {
     }
 
     return new Promise<UserMduBrowserKzgResult>((resolve, reject) => {
-      this.queue.push({
+      const item: QueuedTask = {
         task,
         resolve,
         reject,
         enqueuedAtMs: this.now(),
         depthAtEnqueue: this.queue.length,
         activeAtEnqueue: this.active,
-      })
+        expansionState: { status: 'pending' },
+      }
+      task.expansion.then(
+        (value) => {
+          item.expansionState = { status: 'fulfilled', value }
+        },
+        (reason) => {
+          item.expansionState = { status: 'rejected', reason }
+        },
+      )
+      this.queue.push(item)
       this.pump()
     })
   }
@@ -174,58 +265,177 @@ export class UserMduKzgScheduler {
     }
   }
 
-  private async run(item: QueuedTask): Promise<void> {
-    const startedAtMs = this.now()
-    const baseDiagnostics: UserMduKzgSchedulerDiagnostics = {
+  private makeDiagnostics(
+    item: QueuedTask,
+    startedAtMs: number,
+    finishedAtMs: number,
+    batch: BatchItem[],
+    meta: BatchMeta,
+    position: number,
+  ): UserMduKzgSchedulerDiagnostics {
+    return {
       sequence: item.task.sequence,
       queueWaitMs: Math.max(0, startedAtMs - item.enqueuedAtMs),
-      totalMs: 0,
+      totalMs: Math.max(0, finishedAtMs - item.enqueuedAtMs),
       depthAtEnqueue: item.depthAtEnqueue,
       activeAtEnqueue: item.activeAtEnqueue,
       queueDepthAtStart: this.queue.length,
       maxQueueDepth: this.maxQueueDepth,
       fallbackCount: this.fallbackCount,
+      batchSize: batch.length,
+      batchPosition: position,
+      batchBlobs: meta.plan.blobs,
+      batchBytes: meta.plan.bytes,
+      batchEstimatedMemoryBytes: meta.plan.estimatedMemoryBytes,
+      batchMaxMdus: this.batchConstraints.maxBatchMdus,
+      batchMaxBlobs: this.batchConstraints.maxBatchBlobs,
+      batchMaxBytes: this.batchConstraints.maxBatchBytes,
+      batchPlanReason: meta.plan.reason,
+      batchSplitCount: this.batchSplitCount - meta.splitCountAtStart,
+      batchFallbackCount: this.batchFallbackCount - meta.fallbackCountAtStart,
       owner: OWNER,
     }
-    this.lastQueueWaitMs = baseDiagnostics.queueWaitMs
+  }
+
+  private async awaitExpansion(item: QueuedTask): Promise<UserMduUncommittedExpansion> {
+    if (item.expansionState.status === 'fulfilled') return item.expansionState.value
+    if (item.expansionState.status === 'rejected') throw item.expansionState.reason
+    return item.task.expansion
+  }
+
+  private collectReadyBatch(first: QueuedTask, firstExpansion: UserMduUncommittedExpansion): { batch: BatchItem[]; plan: UserMduKzgBatchPlan } {
+    const batch: BatchItem[] = [{ queued: first, expansion: firstExpansion }]
+    let acceptedFromQueue = 0
+    let plan = planUserMduKzgBatch([firstExpansion], this.batchConstraints)
+
+    if (!this.batchEnabled || !first.task.commitBatch) {
+      return { batch, plan }
+    }
+
+    for (const queued of this.queue) {
+      if (!queued.task.commitBatch || queued.task.signal?.aborted) break
+      if (queued.expansionState.status !== 'fulfilled') break
+      const candidateExpansions = [...batch.map((item) => item.expansion), queued.expansionState.value]
+      const candidatePlan = planUserMduKzgBatch(candidateExpansions, this.batchConstraints)
+      if (candidatePlan.count !== candidateExpansions.length) {
+        plan = candidatePlan.count === batch.length ? candidatePlan : plan
+        break
+      }
+      batch.push({ queued, expansion: queued.expansionState.value })
+      plan = candidatePlan
+      acceptedFromQueue += 1
+    }
+
+    if (acceptedFromQueue > 0) this.queue.splice(0, acceptedFromQueue)
+    return { batch, plan }
+  }
+
+  private async commitSingle(
+    item: BatchItem,
+    startedAtMs: number,
+    meta: BatchMeta,
+    reason?: string,
+  ): Promise<{ result: UserMduBrowserKzgResult; usedFallback: boolean }> {
+    const baseContext = this.makeDiagnostics(item.queued, startedAtMs, this.now(), [item], meta, 0)
+    try {
+      if (item.queued.task.signal?.aborted) throw abortError()
+      const result = await item.queued.task.commit(item.expansion, { ...baseContext, signal: item.queued.task.signal })
+      return { result, usedFallback: false }
+    } catch (error) {
+      if (!item.queued.task.fallback) throw error
+      this.fallbackCount += 1
+      this.batchFallbackCount += 1
+      const message = reason ? `${reason}; ${errorMessage(error)}` : errorMessage(error)
+      const result = await item.queued.task.fallback(message, {
+        ...baseContext,
+        fallbackCount: this.fallbackCount,
+        batchFallbackCount: this.batchFallbackCount - meta.fallbackCountAtStart,
+        signal: item.queued.task.signal,
+      })
+      return { result, usedFallback: true }
+    }
+  }
+
+  private async commitBatchItems(
+    batch: BatchItem[],
+    startedAtMs: number,
+    meta: BatchMeta,
+  ): Promise<Array<{ result: UserMduBrowserKzgResult; usedFallback: boolean }>> {
+    if (batch.length === 1 || !batch[0].queued.task.commitBatch) {
+      return [await this.commitSingle(batch[0], startedAtMs, meta)]
+    }
+
+    const context = this.makeDiagnostics(batch[0].queued, startedAtMs, this.now(), batch, meta, 0)
+    try {
+      const results = await batch[0].queued.task.commitBatch(
+        batch.map((item) => item.expansion),
+        {
+          ...context,
+          sequences: batch.map((item) => item.queued.task.sequence),
+          signal: batch[0].queued.task.signal,
+        },
+      )
+      if (!Array.isArray(results) || results.length !== batch.length) {
+        throw new Error(`batch KZG owner returned ${results?.length ?? 0} results for ${batch.length} user MDUs`)
+      }
+      return results.map((result) => ({ result, usedFallback: false }))
+    } catch (error) {
+      if (batch.length <= 1) throw error
+      this.batchSplitCount += 1
+      const [leftCount, rightCount] = splitUserMduKzgBatch(batch.length)
+      if (leftCount <= 0 || rightCount <= 0) {
+        return Promise.all(batch.map((item) => this.commitSingle(item, startedAtMs, meta, errorMessage(error))))
+      }
+      const left = batch.slice(0, leftCount)
+      const right = batch.slice(leftCount)
+      const leftResults = await this.commitBatchItems(left, startedAtMs, meta)
+      const rightResults = await this.commitBatchItems(right, startedAtMs, meta)
+      return [...leftResults, ...rightResults]
+    }
+  }
+
+  private async run(first: QueuedTask): Promise<void> {
+    const startedAtMs = this.now()
+    this.lastQueueWaitMs = Math.max(0, startedAtMs - first.enqueuedAtMs)
+    let activeBatch: BatchItem[] | null = null
 
     try {
-      if (item.task.signal?.aborted) throw abortError()
-      const expansion = await item.task.expansion
-      if (item.task.signal?.aborted) throw abortError()
-      let result: UserMduBrowserKzgResult
-      let usedFallback = false
-      try {
-        result = await item.task.commit(expansion, { ...baseDiagnostics, signal: item.task.signal })
-      } catch (error) {
-        if (!item.task.fallback) throw error
-        usedFallback = true
-        this.fallbackCount += 1
-        const reason = errorMessage(error)
-        result = await item.task.fallback(reason, {
-          ...baseDiagnostics,
-          fallbackCount: this.fallbackCount,
-          signal: item.task.signal,
-        })
+      if (first.task.signal?.aborted) throw abortError()
+      const firstExpansion = await this.awaitExpansion(first)
+      if (first.task.signal?.aborted) throw abortError()
+      const { batch, plan } = this.collectReadyBatch(first, firstExpansion)
+      activeBatch = batch
+      const meta: BatchMeta = {
+        plan,
+        splitCountAtStart: this.batchSplitCount,
+        fallbackCountAtStart: this.batchFallbackCount,
       }
-      const diagnostics: UserMduKzgSchedulerDiagnostics = {
-        ...baseDiagnostics,
-        totalMs: Math.max(0, this.now() - item.enqueuedAtMs),
-        fallbackCount: this.fallbackCount,
-      }
-      this.completed += 1
-      this.lastTotalMs = diagnostics.totalMs
-      this.lastError = null
-      const decorated = attachUserMduKzgSchedulerDiagnostics(result, diagnostics)
-      if (usedFallback) {
-        decorated.perf.browserKzgCommitFallbackReason = decorated.perf.browserKzgCommitFallbackReason || 'scheduler fallback used'
-      }
-      item.resolve(decorated)
+      this.lastBatchSize = batch.length
+      this.lastBatchBlobs = plan.blobs
+      this.lastBatchBytes = plan.bytes
+      this.lastBatchPlanReason = plan.reason
+
+      const outcomes = await this.commitBatchItems(batch, startedAtMs, meta)
+      const finishedAtMs = this.now()
+      outcomes.forEach((outcome, index) => {
+        const item = batch[index]
+        const diagnostics = this.makeDiagnostics(item.queued, startedAtMs, finishedAtMs, batch, meta, index)
+        this.completed += 1
+        this.lastTotalMs = diagnostics.totalMs
+        this.lastError = null
+        const decorated = attachUserMduKzgSchedulerDiagnostics(outcome.result, diagnostics)
+        if (outcome.usedFallback) {
+          decorated.perf.browserKzgCommitFallbackReason =
+            decorated.perf.browserKzgCommitFallbackReason || 'scheduler fallback used'
+        }
+        item.queued.resolve(decorated)
+      })
     } catch (error) {
       const message = errorMessage(error)
-      this.failed += 1
+      const failedItems = activeBatch?.length ? activeBatch : [{ queued: first, expansion: first.expansionState.status === 'fulfilled' ? first.expansionState.value : ({} as UserMduUncommittedExpansion) }]
+      this.failed += failedItems.length
       this.lastError = message
-      item.reject(error)
+      for (const item of failedItems) item.queued.reject(error)
     } finally {
       this.active -= 1
       this.pump()

--- a/polystore-website/src/lib/uploadStatus.test.ts
+++ b/polystore-website/src/lib/uploadStatus.test.ts
@@ -68,6 +68,11 @@ test('normalizeKzgBackendStatus surfaces browser KZG scheduler diagnostics', () 
     kzgSchedulerActiveAtEnqueue: 1,
     kzgSchedulerMaxQueueDepth: 32,
     kzgSchedulerFallbackCount: 2,
+    kzgSchedulerBatchSize: 4,
+    kzgSchedulerBatchBlobs: 384,
+    kzgSchedulerBatchBytes: 50_331_648,
+    kzgSchedulerBatchSplitCount: 1,
+    kzgSchedulerBatchFallbackCount: 0,
   })
 
   assert.equal(status.schedulerQueueWaitMs, 12)
@@ -76,6 +81,11 @@ test('normalizeKzgBackendStatus surfaces browser KZG scheduler diagnostics', () 
   assert.equal(status.schedulerActive, 1)
   assert.equal(status.schedulerMaxQueueDepth, 32)
   assert.equal(status.schedulerFallbackCount, 2)
+  assert.equal(status.schedulerBatchSize, 4)
+  assert.equal(status.schedulerBatchBlobs, 384)
+  assert.equal(status.schedulerBatchBytes, 50_331_648)
+  assert.equal(status.schedulerBatchSplitCount, 1)
+  assert.equal(status.schedulerBatchFallbackCount, null)
 })
 
 test('patchUploadPipelineStatus preserves nested state and records elapsed time', () => {

--- a/polystore-website/src/lib/uploadStatus.ts
+++ b/polystore-website/src/lib/uploadStatus.ts
@@ -48,6 +48,11 @@ export type KzgBackendStatus = {
   schedulerActive: number | null
   schedulerMaxQueueDepth: number | null
   schedulerFallbackCount: number | null
+  schedulerBatchSize: number | null
+  schedulerBatchBlobs: number | null
+  schedulerBatchBytes: number | null
+  schedulerBatchSplitCount: number | null
+  schedulerBatchFallbackCount: number | null
   probeTimeoutMs: number | null
   commitTimeoutMs: number | null
   minBlobs: number | null
@@ -136,6 +141,16 @@ export type KzgDiagnosticsInput = {
   workerKzgSchedulerMaxQueueDepth?: number
   kzgSchedulerFallbackCount?: number
   workerKzgSchedulerFallbackCount?: number
+  kzgSchedulerBatchSize?: number
+  workerKzgSchedulerBatchSize?: number
+  kzgSchedulerBatchBlobs?: number
+  workerKzgSchedulerBatchBlobs?: number
+  kzgSchedulerBatchBytes?: number
+  workerKzgSchedulerBatchBytes?: number
+  kzgSchedulerBatchSplitCount?: number
+  workerKzgSchedulerBatchSplitCount?: number
+  kzgSchedulerBatchFallbackCount?: number
+  workerKzgSchedulerBatchFallbackCount?: number
   kzgWebGpuProbeTimeoutMs?: number
   workerKzgWebGpuProbeTimeoutMs?: number
   kzgWebGpuCommitTimeoutMs?: number
@@ -180,6 +195,11 @@ export const PENDING_KZG_BACKEND_STATUS: KzgBackendStatus = {
   schedulerActive: null,
   schedulerMaxQueueDepth: null,
   schedulerFallbackCount: null,
+  schedulerBatchSize: null,
+  schedulerBatchBlobs: null,
+  schedulerBatchBytes: null,
+  schedulerBatchSplitCount: null,
+  schedulerBatchFallbackCount: null,
   probeTimeoutMs: null,
   commitTimeoutMs: null,
   minBlobs: null,
@@ -259,6 +279,11 @@ export function normalizeKzgBackendStatus(input?: KzgDiagnosticsInput | null): K
     schedulerActive: firstNumber(input.kzgSchedulerActiveAtEnqueue, input.workerKzgSchedulerActiveAtEnqueue),
     schedulerMaxQueueDepth: firstNumber(input.kzgSchedulerMaxQueueDepth, input.workerKzgSchedulerMaxQueueDepth),
     schedulerFallbackCount: firstNumber(input.kzgSchedulerFallbackCount, input.workerKzgSchedulerFallbackCount),
+    schedulerBatchSize: firstNumber(input.kzgSchedulerBatchSize, input.workerKzgSchedulerBatchSize),
+    schedulerBatchBlobs: firstNumber(input.kzgSchedulerBatchBlobs, input.workerKzgSchedulerBatchBlobs),
+    schedulerBatchBytes: firstNumber(input.kzgSchedulerBatchBytes, input.workerKzgSchedulerBatchBytes),
+    schedulerBatchSplitCount: firstNumber(input.kzgSchedulerBatchSplitCount, input.workerKzgSchedulerBatchSplitCount),
+    schedulerBatchFallbackCount: firstNumber(input.kzgSchedulerBatchFallbackCount, input.workerKzgSchedulerBatchFallbackCount),
     probeTimeoutMs: firstNumber(input.kzgWebGpuProbeTimeoutMs, input.workerKzgWebGpuProbeTimeoutMs),
     commitTimeoutMs: firstNumber(input.kzgWebGpuCommitTimeoutMs, input.workerKzgWebGpuCommitTimeoutMs),
     minBlobs: firstNumber(input.kzgWebGpuMinBlobs, input.workerKzgWebGpuMinBlobs),

--- a/polystore-website/src/lib/worker-client.ts
+++ b/polystore-website/src/lib/worker-client.ts
@@ -265,6 +265,14 @@ export interface ExpandedStripe {
       rows?: number;
       shardsTotal?: number;
       browserKzgCommitFallbackReason?: string;
+      browserKzgBatchSize?: number;
+      browserKzgBatchPosition?: number;
+      browserKzgBatchBlobs?: number;
+      browserKzgBatchBytes?: number;
+      browserKzgBatchEstimatedMemoryBytes?: number;
+      browserKzgBatchCommitMs?: number;
+      browserKzgBatchRootMs?: number;
+      browserKzgBatchSplitCount?: number;
     };
 }
 
@@ -292,6 +300,17 @@ export type KzgCommitDiagnostics = {
   kzgSchedulerQueueDepthAtStart?: number
   kzgSchedulerMaxQueueDepth?: number
   kzgSchedulerFallbackCount?: number
+  kzgSchedulerBatchSize?: number
+  kzgSchedulerBatchPosition?: number
+  kzgSchedulerBatchBlobs?: number
+  kzgSchedulerBatchBytes?: number
+  kzgSchedulerBatchEstimatedMemoryBytes?: number
+  kzgSchedulerBatchMaxMdus?: number
+  kzgSchedulerBatchMaxBlobs?: number
+  kzgSchedulerBatchMaxBytes?: number
+  kzgSchedulerBatchPlanReason?: string
+  kzgSchedulerBatchSplitCount?: number
+  kzgSchedulerBatchFallbackCount?: number
   kzgSchedulerOwner?: string
   commitWorkerCount?: number
 }
@@ -331,6 +350,22 @@ async function expandStripeWithScheduledKzg(
       { expansion: expanded },
       [expanded.shardsFlat.buffer],
     ) as Promise<UserMduBrowserKzgResult>,
+    commitBatch: async (expandedBatch) => {
+      const transferables: Transferable[] = []
+      const seen = new Set<ArrayBuffer>()
+      for (const expanded of expandedBatch) {
+        const buffer = expanded.shardsFlat.buffer as ArrayBuffer
+        if (!seen.has(buffer)) {
+          seen.add(buffer)
+          transferables.push(buffer)
+        }
+      }
+      return sendMessageToWorker(
+        'commitExpandedUserMduBatch',
+        { expansions: expandedBatch },
+        transferables,
+      ) as Promise<UserMduBrowserKzgResult[]>
+    },
     fallback: async (reason) => {
       const result = await sendExpansionMessageToWorker(
         committedType,

--- a/polystore-website/src/workers/gateway.worker.ts
+++ b/polystore-website/src/workers/gateway.worker.ts
@@ -9,11 +9,14 @@ import init, { WasmMdu0Builder, PolyStoreWasm } from '../lib/polystoreCoreRuntim
 import { createBrowserKzgCommitBackend, type KzgCommitBackend } from '../lib/kzgCommitBackend';
 import {
     committedExpansionToUserMduBrowserKzgResult,
+    commitUserMduBatchUncommittedWithBrowserKzg,
     commitUserMduUncommittedWithBrowserKzg,
     expandUserMduRsWithBrowserKzg,
     kzgCommitDiagnosticsForBackend,
     parseCommittedExpansion,
     parseUserMduUncommittedExpansion,
+    type UserMduBrowserKzgResult,
+    type UserMduUncommittedExpansion,
 } from '../lib/upload/userMduBrowserKzg';
 
 let wasmInitialized = false;
@@ -175,6 +178,35 @@ function committedFallbackReason(fallbackReason: unknown): string | undefined {
     return typeof fallbackReason === 'string' && fallbackReason.trim()
         ? `scheduler owner failed; used committed WASM fallback: ${fallbackReason}`
         : undefined;
+}
+
+async function commitUserMduBatchWithSplitting(
+    expansions: UserMduUncommittedExpansion[],
+    splitCount = { value: 0 },
+): Promise<UserMduBrowserKzgResult[]> {
+    if (!polyStoreWasmInstance) throw new Error('PolyStoreWasm not initialized. Call initPolyStoreWasm first.');
+    if (!kzgCommitBackend) throw new Error('PolyStoreWasm not initialized. Call initPolyStoreWasm first.');
+    try {
+        const results = await commitUserMduBatchUncommittedWithBrowserKzg({
+            expansions,
+            wasm: polyStoreWasmInstance,
+            kzgCommitBackend,
+        });
+        return results.map((result) => ({
+            ...result,
+            perf: {
+                ...result.perf,
+                browserKzgBatchSplitCount: splitCount.value,
+            },
+        }));
+    } catch (error) {
+        if (expansions.length <= 1) throw error;
+        splitCount.value += 1;
+        const mid = Math.ceil(expansions.length / 2);
+        const left = await commitUserMduBatchWithSplitting(expansions.slice(0, mid), splitCount);
+        const right = await commitUserMduBatchWithSplitting(expansions.slice(mid), splitCount);
+        return [...left, ...right];
+    }
 }
 
 // Start fetching + compiling the WASM as soon as the worker loads so the first
@@ -689,6 +721,19 @@ self.onmessage = async (event) => {
                     wasm: polyStoreWasmInstance,
                     kzgCommitBackend,
                 });
+                break;
+            }
+            case 'commitExpandedUserMduBatch': {
+                const { expansions } = payload as { expansions: UserMduUncommittedExpansion[] };
+                if (!Array.isArray(expansions) || expansions.length === 0) {
+                    throw new Error('commitExpandedUserMduBatch requires at least one uncommitted user MDU');
+                }
+                for (const [index, expansion] of expansions.entries()) {
+                    if (!expansion || !(expansion.shardsFlat instanceof Uint8Array)) {
+                        throw new Error(`commitExpandedUserMduBatch item ${index} requires uncommitted shards`);
+                    }
+                }
+                result = await commitUserMduBatchWithSplitting(expansions);
                 break;
             }
             case 'expandMduRs': {


### PR DESCRIPTION
**Latest validation update (2026-05-30):** Native Apple M3 and NVIDIA/Ampere sparse upload-prep smokes passed with batching observed (`sampled/batched user MDUs`, WebGPU backend/probe passed). Evidence supports the batched browser KZG PR, conditional on #202 landing first.

---

## Summary

Draft stacked PR for #195 (parent tracker #192), based on #194 / PR #202 (`website/split-rs-kzg-scheduler-194`, which is stacked on #193 / PR #201).

- Adds a deterministic `mode2-user-mdu-uncommitted-v1` KZG batch planner/contract for user-MDU groups:
  - sequence-ordered concatenation,
  - homogeneous RS/shard-shape validation,
  - max MDU / blob / byte / estimated-memory guardrails,
  - exact 48-byte commitment demux back into per-MDU witness slices.
- Extends `UserMduKzgScheduler` without breaking the per-MDU enqueue API:
  - ready, sequence-adjacent user MDUs are batched into one KZG owner call where possible,
  - promises still resolve one result per request in deterministic order,
  - batch failures split down to smaller batches/per-MDU, then existing committed-WASM fallback remains intact.
- Extends `gateway.worker.ts` with `commitExpandedUserMduBatch` and worker-side split retry, preserving single-MDU fallback.
- Surfaces batch diagnostics in upload status/perf samples: batch size/blobs/bytes/split/fallback counts.

## Scope boundaries

Non-goals intentionally unchanged: RS algorithms, provider transports, chain/protocol, upload worker-count tuning (#196), upload pipelining (#197), transport bundling (#198), runtime prewarm (#199).

## Tests

Latest local head: `a51a53fbf70561235430f1e3d11f7bf6348e2e2b`.

- `cd polystore-website && npm run test:unit` ✅
  - 283 passed
- `cd polystore-website && npm run lint` ✅
- `cd polystore-website && npm run build:app` ✅

Latest GitHub CI at head `a51a53fb`: all checks passing ✅ (including Website Build & Lint, Playwright, gateway-absent Playwright, Mode2 Stripe, Gateway Retrieval, Native/WASM Parity, Go/Rust suites).

## Benchmark / evidence

Native WebGPU evidence is limited in this environment: the WebGPU MSM benchmark fails closed because Chromium only exposes a fallback/software adapter.

- Command attempted: `POLYSTORE_WEBGPU_MSM_BLOBS_LIST=96 POLYSTORE_WEBGPU_MSM_BUCKET_WIDTHS=10 POLYSTORE_WEBGPU_MSM_REDUCTIONS=serial POLYSTORE_WEBGPU_MSM_RUNS=1 npm run perf:kzg-webgpu-msm --silent`
- Result: `Error: WebGPU adapter is a fallback/software adapter`
- PR remains **draft** until native WebGPU can be measured.

WASM/headless smoke measurements (HeadlessChrome 143, 12 logical CPUs, 31.2 GiB host RAM):

| Shape | Command | Median wall | Per blob | Notes |
| --- | --- | ---: | ---: | --- |
| 96 blobs | `KZG_BENCH_BLOBS=96 KZG_BENCH_WARMUP_RUNS=1 KZG_BENCH_MEASURE_RUNS=1 npm run perf:kzg-browser` | 27,517.4 ms | 286.64 ms | one full Mode 2 8+4 user MDU shape |
| 192 blobs | `KZG_BENCH_BLOBS=192 KZG_BENCH_WARMUP_RUNS=1 KZG_BENCH_MEASURE_RUNS=1 npm run perf:kzg-browser` | 55,067.2 ms | 286.81 ms | equivalent to batching 2 full user MDUs |
| 384 blobs | `KZG_BENCH_BLOBS=384 KZG_BENCH_WARMUP_RUNS=1 KZG_BENCH_MEASURE_RUNS=1 npm run perf:kzg-browser` | 110,701.5 ms | 288.29 ms | default max 4 full user MDUs |

WASM fallback before/after interpretation against #194 per-MDU shape:

| Comparison | #194-style per-MDU estimate | #195 batch measurement | Delta |
| --- | ---: | ---: | ---: |
| 2 MDUs (2 × 96 vs 192) | 55,034.8 ms | 55,067.2 ms | +0.06% |
| 4 MDUs (4 × 96 vs 384) | 110,069.6 ms | 110,701.5 ms | +0.57% |

Prepare-stage smoke:

- `FILE_BYTES=8126464 WARMUP_RUNS=0 MEASURE_RUNS=1 BASIS_MODE=blst npm run perf:prepare-stages --silent` ✅
- Result: total prepare median 26,900.16 ms; user stage 26,763.17 ms; manifest 35.18 ms.

1248-blob native measurement was not run because native WebGPU is unavailable here; the WASM fallback extrapolates to a multi-minute run plus mandatory warmup and would not exercise the intended WebGPU backend.

## Risk / review notes

- The hot path now concatenates ready user-MDU shard batches inside the KZG owner before one backend call. Guardrails cap defaults at 4 MDUs / 384 blobs / 64 MiB input / 128 MiB estimated JS memory.
- If a batch is oversized, times out, or device loss trips the owner, worker/scheduler splitting and existing committed-WASM fallback preserve correctness at the cost of speed.
- Artifact ordering remains sequence-based; witness slices and MDU roots are demuxed per original request before manifest construction.

## AI review status

- `@copilot review` requested; bot reacted with 👀, no findings posted yet.
- `@coderabbitai review` requested; no findings posted yet.
- `@codex review` requested; Codex connector replied that a Codex account/GitHub connector is not configured, so Codex review is unavailable here.

