### PR TITLE
feat(website): pipeline browser upload artifacts

### DIFF
--- a/polystore-website/scripts/benchmark_upload_pipelining.ts
+++ b/polystore-website/scripts/benchmark_upload_pipelining.ts
@@ -1,41 +1,76 @@
-import { createUploadEngine, type PipelinedUploadArtifact, type UploadTarget, type UploadTransportRequest } from '../src/lib/upload/engine'
+import { performance } from 'node:perf_hooks'
 
-const artifactCount = Math.max(1, Number(process.env.ARTIFACTS || 8))
-const computeMs = Math.max(0, Number(process.env.COMPUTE_MS || 40))
-const uploadMs = Math.max(0, Number(process.env.UPLOAD_MS || 30))
-const concurrency = Math.max(1, Number(process.env.CONCURRENCY || 3))
+import {
+  createUploadEngine,
+  type PipelinedUploadArtifact,
+  type UploadTarget,
+  type UploadTaskEvent,
+  type UploadTransportRequest,
+} from '../src/lib/upload/engine'
+
+const artifactCount = Math.max(1, Number(process.env.ARTIFACTS || 24))
+const computeMs = Math.max(0, Number(process.env.COMPUTE_MS || 35))
+const uploadMs = Math.max(0, Number(process.env.UPLOAD_MS || 45))
+const concurrency = Math.max(1, Number(process.env.CONCURRENCY || 4))
+const providers = Math.max(1, Number(process.env.PROVIDERS || 1))
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
 function nowMs(): number {
-  return typeof performance !== 'undefined' ? performance.now() : Date.now()
+  return performance.now()
 }
 
-const target: UploadTarget = {
-  baseUrl: 'http://provider.test',
-  mduPath: '/sp/upload_mdu',
-  manifestPath: '/sp/upload_manifest',
-  label: 'provider.test',
+function target(index: number): UploadTarget {
+  return {
+    baseUrl: `http://provider-${index}.test`,
+    mduPath: '/sp/upload_mdu',
+    manifestPath: '/sp/upload_manifest',
+    shardPath: '/sp/upload_shard',
+    label: `provider-${index}`,
+  }
 }
+
+const targets = Array.from({ length: providers }, (_, index) => target(index))
 
 function makeArtifact(index: number): PipelinedUploadArtifact {
+  const slot = index % providers
   return {
-    target,
+    target: targets[slot],
     artifact: {
-      kind: 'mdu',
-      index,
+      kind: 'shard',
+      index: 1 + index,
+      slot,
       bytes: new Uint8Array([index & 0xff]),
-      fullSize: 8,
+      fullSize: 1024 * 1024,
     },
   }
 }
 
+function requestBytes(request: UploadTransportRequest): number {
+  return Math.max(0, request.artifact.bytes.byteLength)
+}
+
 function makeTransport() {
   const starts: Array<{ kind: string; tMs: number; manifestRoot: string; generation: string }> = []
+  let active = 0
+  let peakActiveUploads = 0
+  let requestCount = 0
+  let bytesSent = 0
   return {
-    starts,
+    metrics: {
+      starts,
+      get peakActiveUploads() {
+        return peakActiveUploads
+      },
+      get requestCount() {
+        return requestCount
+      },
+      get bytesSent() {
+        return bytesSent
+      },
+    },
     transport: {
       async sendArtifact(request: UploadTransportRequest) {
         starts.push({
@@ -44,38 +79,77 @@ function makeTransport() {
           manifestRoot: request.manifestRoot,
           generation: request.uploadGeneration || '',
         })
+        requestCount += 1
+        bytesSent += requestBytes(request)
+        active += 1
+        peakActiveUploads = Math.max(peakActiveUploads, active)
         await sleep(uploadMs)
+        active -= 1
       },
     },
   }
 }
 
-async function runSequential(): Promise<number> {
+async function prepareArtifacts(): Promise<{ artifacts: PipelinedUploadArtifact[]; prepareWallMs: number }> {
   const prepared: PipelinedUploadArtifact[] = []
   const startedAt = nowMs()
   for (let i = 0; i < artifactCount; i += 1) {
     await sleep(computeMs)
     prepared.push(makeArtifact(i))
   }
-  const transport = makeTransport()
-  const engine = createUploadEngine({ transport: transport.transport, parallelism: { direct: concurrency } })
-  await engine.uploadDirect({
-    dealId: '1',
-    manifestRoot: '0xnext',
-    manifestBlob: new Uint8Array([0xff]),
-    mdus: prepared.map((item) => {
-      if (item.artifact.kind !== 'mdu') throw new Error('expected mdu artifact')
-      return { index: item.artifact.index, data: item.artifact.bytes, fullSize: item.artifact.fullSize }
-    }),
-    target,
-  })
-  return nowMs() - startedAt
+  return { artifacts: prepared, prepareWallMs: nowMs() - startedAt }
 }
 
-async function runPipelined(): Promise<{ elapsedMs: number; starts: ReturnType<typeof makeTransport>['starts'] }> {
+async function runSequential() {
+  const startedAt = nowMs()
+  const prepared = await prepareArtifacts()
   const transport = makeTransport()
   const engine = createUploadEngine({ transport: transport.transport, parallelism: { direct: concurrency } })
+  const uploadStartedAt = nowMs()
+  async function* artifacts() {
+    for (const artifact of prepared.artifacts) {
+      yield artifact
+    }
+  }
+  const result = await engine.uploadPipelinedGeneration({
+    dealId: '197',
+    previousManifestRoot: '0xprev',
+    uploadGeneration: 'benchmark-sequential',
+    artifacts: artifacts(),
+    manifest: Promise.resolve({
+      manifestRoot: '0xnext',
+      manifestBlob: new Uint8Array([0xff]),
+      manifestTargets: targets,
+    }),
+  })
+  if (!result.ok) throw new Error(result.error || 'sequential upload failed')
+  const finishedAt = nowMs()
+  const stats = result.transportStats
+  return {
+    scenario: 'sequential_prepare_then_upload',
+    prepareWallMs: prepared.prepareWallMs,
+    uploadWallMs: finishedAt - uploadStartedAt,
+    overlapWallMs: 0,
+    endToEndWallMs: finishedAt - startedAt,
+    artifactCount: stats?.artifactCount ?? artifactCount + 1,
+    peakActiveUploads: Math.max(transport.metrics.peakActiveUploads, stats?.peakActiveUploads ?? 0),
+    requestCount: stats?.requestCount ?? transport.metrics.requestCount,
+    bundleCount: stats?.bundleCount ?? 0,
+    fallbackCount: stats?.fallbackCount ?? 0,
+    bytesSent: stats?.bytesSent ?? transport.metrics.bytesSent,
+  }
+}
+
+async function runPipelined() {
+  const transport = makeTransport()
+  const engine = createUploadEngine({ transport: transport.transport, parallelism: { direct: concurrency } })
+  const taskEvents: UploadTaskEvent[] = []
   let computed = 0
+  let prepareDoneAt = 0
+  let resolveManifest!: (value: { manifestRoot: string; manifestBlob: Uint8Array; manifestTargets: UploadTarget[] }) => void
+  const manifest = new Promise<{ manifestRoot: string; manifestBlob: Uint8Array; manifestTargets: UploadTarget[] }>((resolve) => {
+    resolveManifest = resolve
+  })
 
   async function* artifacts() {
     for (let i = 0; i < artifactCount; i += 1) {
@@ -83,42 +157,85 @@ async function runPipelined(): Promise<{ elapsedMs: number; starts: ReturnType<t
       computed += 1
       yield makeArtifact(i)
     }
+    prepareDoneAt = nowMs()
+    resolveManifest({
+      manifestRoot: '0xnext',
+      manifestBlob: new Uint8Array([0xff]),
+      manifestTargets: targets,
+    })
   }
 
   const startedAt = nowMs()
   const result = await engine.uploadPipelinedGeneration({
-    dealId: '1',
-    uploadGeneration: 'pipelined',
+    dealId: '197',
+    previousManifestRoot: '0xprev',
+    uploadGeneration: 'benchmark-pipelined',
     artifacts: artifacts(),
-    manifest: (async () => {
-      while (computed < artifactCount) {
-        await sleep(1)
-      }
-      return {
-        manifestRoot: '0xnext',
-        manifestBlob: new Uint8Array([0xff]),
-        manifestTargets: [target],
-      }
-    })(),
+    manifest,
+    onTaskEvent(event) {
+      taskEvents.push(event)
+    },
   })
   if (!result.ok) throw new Error(result.error || 'pipelined upload failed')
-  return { elapsedMs: nowMs() - startedAt, starts: transport.starts }
+  const finishedAt = nowMs()
+  const stats = result.transportStats
+  const prepareWallMs = prepareDoneAt - startedAt
+  const firstTransportStart = transport.metrics.starts[0]?.tMs ?? startedAt
+  const uploadWallMs = finishedAt - firstTransportStart
+  const overlapWallMs = Math.max(0, Math.min(prepareDoneAt, finishedAt) - firstTransportStart)
+  return {
+    scenario: 'pipelined_prepare_and_upload',
+    prepareWallMs,
+    uploadWallMs,
+    overlapWallMs,
+    endToEndWallMs: finishedAt - startedAt,
+    artifactCount: stats?.artifactCount ?? artifactCount + providers,
+    queuedArtifactCount: stats?.queuedArtifactCount ?? artifactCount,
+    stagedArtifactCount: stats?.stagedArtifactCount ?? artifactCount,
+    activatedArtifactCount: stats?.activatedArtifactCount ?? providers,
+    peakActiveUploads: Math.max(transport.metrics.peakActiveUploads, stats?.peakActiveUploads ?? 0),
+    requestCount: stats?.requestCount ?? transport.metrics.requestCount,
+    bundleCount: stats?.bundleCount ?? 0,
+    fallbackCount: stats?.fallbackCount ?? 0,
+    bytesSent: stats?.bytesSent ?? transport.metrics.bytesSent,
+    preparedArtifacts: computed,
+    stagedBeforeManifest: transport.metrics.starts.filter((start) => start.kind !== 'manifest' && start.manifestRoot === '').length,
+  }
 }
 
-const sequentialMs = await runSequential()
+const sequential = await runSequential()
 const pipelined = await runPipelined()
-const speedup = sequentialMs / pipelined.elapsedMs
+const speedup = sequential.endToEndWallMs / pipelined.endToEndWallMs
 
+const rows = [sequential, pipelined].map((row) => ({
+  ...row,
+  prepareWallMs: Math.round(row.prepareWallMs * 10) / 10,
+  uploadWallMs: Math.round(row.uploadWallMs * 10) / 10,
+  overlapWallMs: Math.round(row.overlapWallMs * 10) / 10,
+  endToEndWallMs: Math.round(row.endToEndWallMs * 10) / 10,
+}))
+
+console.table(rows.map((row) => ({
+  scenario: row.scenario,
+  prepareMs: row.prepareWallMs,
+  uploadMs: row.uploadWallMs,
+  overlapMs: row.overlapWallMs,
+  e2eMs: row.endToEndWallMs,
+  artifacts: row.artifactCount,
+  requests: row.requestCount,
+  bundles: row.bundleCount,
+  fallbacks: row.fallbackCount,
+  peakActive: row.peakActiveUploads,
+})))
 console.log(JSON.stringify({
   scenario: {
     artifact_count: artifactCount,
+    provider_count: providers,
     compute_ms_per_artifact: computeMs,
-    upload_ms_per_artifact: uploadMs,
+    upload_ms_per_request: uploadMs,
     upload_concurrency: concurrency,
+    note: 'Mocked latency benchmark; measures end-to-end overlap, not KZG speedup.',
   },
-  sequential_ms: sequentialMs,
-  pipelined_ms: pipelined.elapsedMs,
   speedup,
-  decision: speedup > 1.05 ? 'improvement' : speedup < 0.95 ? 'regression' : 'same',
-  pipelined_started_before_manifest_count: pipelined.starts.filter((start) => start.kind !== 'manifest' && start.manifestRoot === '').length,
+  rows,
 }, null, 2))

--- a/polystore-website/src/components/FileSharder.tsx
+++ b/polystore-website/src/components/FileSharder.tsx
@@ -45,7 +45,14 @@ import {
   PLANNER_TRIVIAL_BLOB_WEIGHT,
   weightedWorkForMdu,
 } from '../lib/upload/planner';
-import { createUploadEngine, type UploadTaskEvent, type UploadTarget } from '../lib/upload/engine';
+import {
+  createUploadEngine,
+  type PipelinedManifestBinding,
+  type PipelinedUploadArtifact,
+  type UploadEngineResult,
+  type UploadTaskEvent,
+  type UploadTarget,
+} from '../lib/upload/engine';
 import { createSparseHttpTransportPort } from '../lib/upload/httpTransport';
 import { pickUploadParallelism } from '../lib/upload/uploadParallelism';
 import { bootstrapAppendBaseFromMdus as buildBootstrappedAppendBase } from '../lib/upload/bootstrapAppendBase';
@@ -618,6 +625,8 @@ const MANIFEST_BLOB_SIZE_BYTES = 128 * 1024
 interface UploadTransportCounters {
   queued: number
   uploaded: number
+  staged: number
+  activated: number
   artifactCount: number
   perArtifactCount: number
   bundledArtifactCount: number
@@ -628,6 +637,7 @@ interface UploadTransportCounters {
   fallbackReason: string | null
   activeUploads: number
   peakActiveUploads: number
+  queuedArtifacts: Set<string>
   startedBundles: Set<string>
   finishedBundles: Set<string>
 }
@@ -636,6 +646,8 @@ function createUploadTransportCounters(): UploadTransportCounters {
   return {
     queued: 0,
     uploaded: 0,
+    staged: 0,
+    activated: 0,
     artifactCount: 0,
     perArtifactCount: 0,
     bundledArtifactCount: 0,
@@ -646,6 +658,7 @@ function createUploadTransportCounters(): UploadTransportCounters {
     fallbackReason: null,
     activeUploads: 0,
     peakActiveUploads: 0,
+    queuedArtifacts: new Set<string>(),
     startedBundles: new Set<string>(),
     finishedBundles: new Set<string>(),
   }
@@ -674,6 +687,81 @@ function buildMode2UploadTarget(baseUrl: string): UploadTarget {
     bundlePath: '/sp/upload_bundle',
     label: baseUrl,
   }
+}
+
+type AsyncUploadArtifactQueue<T> = AsyncIterable<T> & {
+  push(item: T): void
+  close(): void
+  fail(error: unknown): void
+  readonly size: number
+}
+
+function createAsyncUploadArtifactQueue<T>(): AsyncUploadArtifactQueue<T> {
+  const values: T[] = []
+  const waiters: Array<{
+    resolve: (result: IteratorResult<T>) => void
+    reject: (error: unknown) => void
+  }> = []
+  let closed = false
+  let failure: unknown = null
+
+  const flush = () => {
+    while (waiters.length > 0) {
+      const waiter = waiters.shift()
+      if (!waiter) continue
+      if (failure) {
+        waiter.reject(failure)
+      } else if (values.length > 0) {
+        waiter.resolve({ value: values.shift() as T, done: false })
+      } else if (closed) {
+        waiter.resolve({ value: undefined as T, done: true })
+      } else {
+        waiters.unshift(waiter)
+        return
+      }
+    }
+  }
+
+  return {
+    get size() {
+      return values.length
+    },
+    push(item: T) {
+      if (failure || closed) return
+      values.push(item)
+      flush()
+    },
+    close() {
+      if (failure || closed) return
+      closed = true
+      flush()
+    },
+    fail(error: unknown) {
+      if (failure || closed) return
+      failure = error instanceof Error ? error : new Error(String(error))
+      flush()
+    },
+    [Symbol.asyncIterator]() {
+      return {
+        next(): Promise<IteratorResult<T>> {
+          if (failure) return Promise.reject(failure)
+          if (values.length > 0) return Promise.resolve({ value: values.shift() as T, done: false })
+          if (closed) return Promise.resolve({ value: undefined as T, done: true })
+          return new Promise<IteratorResult<T>>((resolve, reject) => {
+            waiters.push({ resolve, reject })
+          })
+        },
+      }
+    },
+  }
+}
+
+function createBrowserUploadGenerationId(dealId: string): string {
+  const randomPart =
+    globalThis.crypto && 'randomUUID' in globalThis.crypto && typeof globalThis.crypto.randomUUID === 'function'
+      ? globalThis.crypto.randomUUID()
+      : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+  return `browser-${String(dealId || 'deal').replace(/[^a-zA-Z0-9_.-]/g, '-')}-${randomPart}`.slice(0, 96)
 }
 
 export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }: FileSharderProps) {
@@ -978,10 +1066,18 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
       const bundleId = event.bundleId || ''
       const bundleArtifactCount = Math.max(0, Number(event.bundleArtifactCount) || 0)
       const bundleBytes = Math.max(0, Number(event.bundleBytes) || 0)
-
-      if (event.phase === 'start') {
+      const artifactKey = `${event.target}|${event.kind}|${event.index ?? 'manifest'}|${event.slot ?? '-'}`
+      const markQueued = () => {
+        if (counters.queuedArtifacts.has(artifactKey)) return
+        counters.queuedArtifacts.add(artifactKey)
         counters.queued += 1
         counters.artifactCount += 1
+      }
+
+      if (event.phase === 'queued') {
+        markQueued()
+      } else if (event.phase === 'start') {
+        markQueued()
         if (event.transportKind === 'bundle' && bundleId) {
           if (!counters.startedBundles.has(bundleId)) {
             counters.startedBundles.add(bundleId)
@@ -1011,7 +1107,11 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
           counters.activeUploads = Math.max(0, counters.activeUploads - 1)
         }
       } else if (event.phase === 'end') {
-        if (event.ok !== false) counters.uploaded += 1
+        if (event.ok !== false) {
+          counters.uploaded += 1
+          if (event.staged) counters.staged += 1
+          if (event.activating) counters.activated += 1
+        }
         if (event.transportKind === 'bundle' && bundleId) {
           if (!counters.finishedBundles.has(bundleId)) {
             counters.finishedBundles.add(bundleId)
@@ -1020,6 +1120,8 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
         } else if (!event.fallbackReason) {
           counters.activeUploads = Math.max(0, counters.activeUploads - 1)
         }
+      } else if (event.phase === 'activate') {
+        counters.activated += 1
       }
 
       browserPerfLog(`upload_task:${event.phase}`, {
@@ -1038,27 +1140,57 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
         bundleBytes: event.bundleBytes ?? null,
         fallbackArtifactCount: event.fallbackArtifactCount ?? null,
         fallbackReason: event.fallbackReason ?? null,
+        queuedDepth: event.queuedDepth ?? null,
+        staged: event.staged ?? null,
+        activating: event.activating ?? null,
         requestCount: counters.requestCount,
         bytesSent: counters.bytesSent,
+        activeUploads: counters.activeUploads,
         peakActiveUploads: counters.peakActiveUploads,
       })
       const isFallback = event.phase === 'fallback'
+      const isQueued = event.phase === 'queued'
+      const isActivating = Boolean(event.activating)
+      const nextStage =
+        event.ok === false
+          ? 'upload_queue'
+          : isActivating
+            ? event.phase === 'end'
+              ? 'provider'
+              : 'manifest_activation'
+            : event.phase === 'end' && event.staged
+              ? 'provider_staged'
+              : event.phase === 'end'
+                ? 'provider'
+                : 'upload_queue'
       updateUploadStatus(
         {
           phase: 'upload_transport',
           phaseLabel: isFallback
             ? 'Bundle unsupported; using per-artifact fallback'
-            : event.phase === 'start'
-              ? event.transportKind === 'bundle'
-                ? 'Uploading provider bundle'
-                : 'Uploading artifact'
-              : event.ok === false
-                ? 'Artifact upload failed'
-                : 'Uploaded artifact',
+            : isQueued
+              ? 'Queued artifact for provider staging'
+              : event.phase === 'start'
+                ? isActivating
+                  ? 'Activating final manifest'
+                  : event.transportKind === 'bundle'
+                    ? 'Uploading provider bundle'
+                    : event.staged
+                      ? 'Uploading staged artifact'
+                      : 'Uploading artifact'
+                : event.ok === false
+                  ? 'Artifact upload failed'
+                  : isActivating
+                    ? 'Final manifest activated staged artifacts'
+                    : event.staged
+                      ? 'Staged artifact at provider'
+                      : 'Uploaded artifact',
           tone: event.ok === false ? 'error' : isFallback ? 'warning' : 'active',
           storage: {
-            stage: event.phase === 'end' && event.ok !== false ? 'provider' : 'upload_queue',
+            stage: nextStage,
             queuedArtifacts: counters.queued,
+            activeArtifacts: counters.activeUploads,
+            stagedArtifacts: counters.staged,
             uploadedArtifacts: counters.uploaded,
           },
           transport: {
@@ -3610,6 +3742,113 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
 
     setShards(() => uploadPlan.shardItems.map((item) => ({ ...item })));
 
+    type BrowserPipelineController = {
+      uploadGeneration: string
+      targets: UploadTarget[]
+      queue: AsyncUploadArtifactQueue<PipelinedUploadArtifact>
+      result: Promise<UploadEngineResult>
+      resolveManifest: (binding: PipelinedManifestBinding) => void
+      failed: boolean
+      failureMessage: string | null
+      startedAtMs: number
+    }
+
+    let browserPipeline: BrowserPipelineController | null = null
+    const enqueuePipelinedArtifact = (artifact: PipelinedUploadArtifact) => {
+      if (!browserPipeline || browserPipeline.failed) return
+      browserPipeline.queue.push(artifact)
+    }
+
+    if (useMode2) {
+      const slotCount = rsK + rsM
+      const bases = slotBases.slice(0, slotCount)
+      const providers = slotProviders.slice(0, slotCount)
+      if (bases.length < slotCount || providers.length < slotCount || bases.some((base) => !base) || providers.some((provider) => !provider)) {
+        const message = 'Missing provider endpoints for all Mode 2 slots.'
+        setMode2UploadError(message)
+        setShardProgress((p) => ({
+          ...p,
+          phase: 'error',
+          label: message,
+          currentOpStartedAtMs: null,
+          lastOpMs: performance.now() - startTs,
+        }))
+        browserPerfEndPhase('prepare', {
+          ok: false,
+          error: message,
+        })
+        setProcessing(false)
+        return
+      }
+
+      const uploadGeneration = createBrowserUploadGenerationId(dealId)
+      const queue = createAsyncUploadArtifactQueue<PipelinedUploadArtifact>()
+      let resolveManifest!: (binding: PipelinedManifestBinding) => void
+      const manifestPromise = new Promise<PipelinedManifestBinding>((resolve) => {
+        resolveManifest = resolve
+      })
+      const targets = bases.map((base) => buildMode2UploadTarget(base))
+      browserPerfStartPhase('upload', {
+        trigger: 'pipeline',
+        mode: 'mode2',
+        uploadGeneration,
+        providerCount: slotCount,
+        expectedUserShardArtifacts: totalUserChunks * slotCount,
+        expectedMetadataArtifacts: (1 + witnessMduCount) * slotCount,
+        expectedManifestArtifacts: slotCount,
+      })
+      setMode2Uploading(true)
+      setMode2UploadError(null)
+      setMode2UploadComplete(false)
+      updateUploadStatus(
+        {
+          phase: 'upload_transport',
+          phaseLabel: 'Provider staging pipeline active',
+          tone: 'active',
+          storage: {
+            stage: 'upload_queue',
+            queuedArtifacts: 0,
+            activeArtifacts: 0,
+            stagedArtifacts: 0,
+            uploadedArtifacts: 0,
+          },
+          transport: {
+            mode: 'striped-provider',
+            artifactCount: 0,
+            requestCount: 0,
+            bytesSent: 0,
+            peakActiveUploads: 0,
+          },
+        },
+        'upload_pipeline:start',
+      )
+      const controller: BrowserPipelineController = {
+        uploadGeneration,
+        targets,
+        queue,
+        result: Promise.resolve({ ok: false, steps: [], error: 'pipeline not started' }),
+        resolveManifest,
+        failed: false,
+        failureMessage: null,
+        startedAtMs: performance.now(),
+      }
+      controller.result = uploadEngine.uploadPipelinedGeneration({
+        dealId,
+        previousManifestRoot: baseManifestRoot || '',
+        uploadGeneration,
+        artifacts: queue,
+        manifest: manifestPromise,
+        onTaskEvent: browserPerfUploadTaskEvent,
+        onPipelineError: (error) => {
+          controller.failed = true
+          controller.failureMessage = error.message
+          queue.fail(error)
+        },
+      })
+      browserPipeline = controller
+      addLog(`> Provider staging pipeline started (generation ${uploadGeneration}).`)
+    }
+
     const toU8 = (v: Uint8Array | number[]): Uint8Array => (v instanceof Uint8Array ? v : new Uint8Array(v));
 
     try {
@@ -3804,6 +4043,19 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
               }
             }
             mode2UserShards[i] = { index: i, shards: shardsList }
+            if (browserPipeline) {
+              const slabIndex = 1 + witnessMduCount + i
+              for (let slot = 0; slot < shardsList.length; slot += 1) {
+                const shard = shardsList[slot]
+                const target = browserPipeline.targets[slot]
+                if (shard && target) {
+                  enqueuePipelinedArtifact({
+                    target,
+                    artifact: { kind: 'shard', index: slabIndex, slot, bytes: shard.data, fullSize: shard.fullSize },
+                  })
+                }
+              }
+            }
 
             const opMs = performance.now() - opStart
             const perfSample: PreparePerfSample = {
@@ -4187,7 +4439,21 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
 
             const rootBytes = toU8(result.mdu_root);
             witnessRoots.push(rootBytes);
-            witnessMdus.push(makePreparedMdu(1 + i, witnessMduBytes)); 
+            const preparedWitnessMdu = makePreparedMdu(1 + i, witnessMduBytes)
+            witnessMdus.push(preparedWitnessMdu);
+            if (browserPipeline) {
+              for (const target of browserPipeline.targets) {
+                enqueuePipelinedArtifact({
+                  target,
+                  artifact: {
+                    kind: 'mdu',
+                    index: preparedWitnessMdu.index,
+                    bytes: preparedWitnessMdu.data,
+                    fullSize: preparedWitnessMdu.fullSize,
+                  },
+                })
+              }
+            }
 
             const opMs = performance.now() - opStart;
             const perfSample: PreparePerfSample = {
@@ -4333,6 +4599,20 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
             ? mdu0PrepareResult.perf.rustCommitMsmSubphasesAvailable
             : undefined
         const mdu0Root = toU8(mdu0PrepareResult.mdu_root);
+        const preparedMdu0 = makePreparedMdu(0, mdu0Bytes)
+        if (browserPipeline) {
+          for (const target of browserPipeline.targets) {
+            enqueuePipelinedArtifact({
+              target,
+              artifact: {
+                kind: 'mdu',
+                index: preparedMdu0.index,
+                bytes: preparedMdu0.data,
+                fullSize: preparedMdu0.fullSize,
+              },
+            })
+          }
+        }
         setShards((prev) => prev.map((s) => (s.id === 0 ? { ...s, status: 'expanded' } : s)));
         const opMs = performance.now() - opStartMdu0;
         const mdu0StageMs = opMs
@@ -4430,7 +4710,7 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
         console.log('[perf] manifest aggregation', { ms: manifestMs, roots: allRoots.length / 32 });
         
         const finalMdus = [
-          makePreparedMdu(0, mdu0Bytes),
+          preparedMdu0,
           ...witnessMdus,
           ...userMdus.map((m) => ({ ...m, index: 1 + witnessMduCount + m.index })),
         ];
@@ -4463,7 +4743,8 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
             ? `> Total MDUs: ${finalMdus.length} (1 Meta + ${witnessMduCount} Witness + ${userMdus.length} User); ${mode2UserShards.length} striped user MDUs uploaded for this generation`
             : `> Total MDUs: ${finalMdus.length} (1 Meta + ${witnessMduCount} Witness + ${userMdus.length} User)`,
         );
-        const elapsedMs = performance.now() - startTs;
+        const prepareCompletedAtMs = performance.now();
+        const elapsedMs = prepareCompletedAtMs - startTs;
         const sumBy = (samples: PreparePerfSample[], pick: (sample: PreparePerfSample) => number) =>
           samples.reduce((total, sample) => total + pick(sample), 0)
         const allSamples = [...perfSamples.user, ...perfSamples.witness, ...perfSamples.meta]
@@ -4764,9 +5045,132 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
           `Done. Client-side expansion complete. Time: ${formatDuration(elapsedMs)}. Data: ${sizeLabel}. Speed: ${speedStr}.`,
         );
 
+        if (browserPipeline) {
+          autoUploadManifestRef.current = finalRootHex
+          browserPipeline.queue.close()
+          if (!browserPipeline.failed) {
+            browserPipeline.resolveManifest({
+              manifestRoot: finalRootHex,
+              manifestBlob: finalManifest.bytes,
+              manifestBlobFullSize: finalManifest.fullSize,
+              manifestTargets: browserPipeline.targets,
+            })
+          }
+
+          const pipelineResult = await browserPipeline.result
+          const uploadFinishedAtMs = performance.now()
+          const uploadWallMs = uploadFinishedAtMs - browserPipeline.startedAtMs
+          const prepareUploadOverlapMs = Math.max(
+            0,
+            Math.min(prepareCompletedAtMs, uploadFinishedAtMs) - browserPipeline.startedAtMs,
+          )
+          const transportSummary = pipelineResult.transportStats
+          browserPerfEndPhase('upload', {
+            ok: pipelineResult.ok,
+            mode: 'mode2',
+            uploadGeneration: browserPipeline.uploadGeneration,
+            prepareUploadOverlapMs: roundPerfMs(prepareUploadOverlapMs),
+            uploadWallMs: roundPerfMs(uploadWallMs),
+            requestCount: transportSummary?.requestCount ?? null,
+            bundleCount: transportSummary?.bundleCount ?? null,
+            artifactCount: transportSummary?.artifactCount ?? null,
+            queuedArtifactCount: transportSummary?.queuedArtifactCount ?? null,
+            stagedArtifactCount: transportSummary?.stagedArtifactCount ?? null,
+            activatedArtifactCount: transportSummary?.activatedArtifactCount ?? null,
+            perArtifactCount: transportSummary?.perArtifactCount ?? null,
+            bundledArtifactCount: transportSummary?.bundledArtifactCount ?? null,
+            bytesSent: transportSummary?.bytesSent ?? null,
+            fallbackCount: transportSummary?.fallbackCount ?? null,
+            fallbackReason: transportSummary?.fallbackReason ?? null,
+            peakActiveUploads: transportSummary?.peakActiveUploads ?? null,
+            error: pipelineResult.error ?? browserPipeline.failureMessage ?? null,
+          })
+
+          if (pipelineResult.ok) {
+            setMode2UploadComplete(true)
+            setMode2UploadError(null)
+            updateUploadStatus(
+              {
+                phase: 'chain_handoff',
+                phaseLabel: 'Provider staging activated; chain commit pending',
+                tone: 'active',
+                storage: {
+                  stage: 'provider',
+                  stagedArtifacts: transportSummary?.stagedArtifactCount ?? null,
+                  uploadedArtifacts: transportSummary?.artifactCount ?? null,
+                },
+                transport: {
+                  mode: 'striped-provider',
+                  artifactCount: transportSummary?.artifactCount ?? null,
+                  perArtifactCount: transportSummary?.perArtifactCount ?? null,
+                  bundledArtifactCount: transportSummary?.bundledArtifactCount ?? null,
+                  bundleCount: transportSummary?.bundleCount ?? null,
+                  requestCount: transportSummary?.requestCount ?? null,
+                  bytesSent: transportSummary?.bytesSent ?? null,
+                  fallbackCount: transportSummary?.fallbackCount ?? null,
+                  fallbackReason: transportSummary?.fallbackReason ?? null,
+                  peakActiveUploads: transportSummary?.peakActiveUploads ?? null,
+                },
+                timing: {
+                  phases: {
+                    upload_wall: roundPerfMs(uploadWallMs) ?? uploadWallMs,
+                    prepare_upload_overlap: roundPerfMs(prepareUploadOverlapMs) ?? prepareUploadOverlapMs,
+                  },
+                },
+              },
+              'upload_pipeline:activated',
+            )
+            addLog(
+              `> Provider staging activated for ${String(transportSummary?.artifactCount ?? 0)} artifacts ` +
+                `(overlap ${formatDuration(prepareUploadOverlapMs)}, upload wall ${formatDuration(uploadWallMs)}).`,
+            )
+          } else {
+            const message = pipelineResult.error || browserPipeline.failureMessage || 'Provider staging pipeline failed'
+            setMode2UploadComplete(false)
+            setMode2UploadError(message)
+            updateUploadStatus(
+              {
+                phase: 'error',
+                phaseLabel: `Provider staging failed: ${message}`,
+                tone: 'error',
+                error: message,
+                storage: {
+                  stage: 'upload_queue',
+                  stagedArtifacts: transportSummary?.stagedArtifactCount ?? null,
+                  uploadedArtifacts: transportSummary?.artifactCount ?? null,
+                },
+                transport: {
+                  mode: 'striped-provider',
+                  lastError: message,
+                  artifactCount: transportSummary?.artifactCount ?? null,
+                  perArtifactCount: transportSummary?.perArtifactCount ?? null,
+                  requestCount: transportSummary?.requestCount ?? null,
+                  bytesSent: transportSummary?.bytesSent ?? null,
+                  peakActiveUploads: transportSummary?.peakActiveUploads ?? null,
+                },
+              },
+              'upload_pipeline:error',
+            )
+            addLog(`> Provider staging failed after partial upload. Final manifest was not activated: ${message}`)
+          }
+          setMode2Uploading(false)
+        }
+
     } catch (e: unknown) {
         console.error(e);
         const msg = e instanceof Error ? e.message : String(e);
+        if (browserPipeline) {
+          browserPipeline.failed = true
+          browserPipeline.failureMessage = msg
+          browserPipeline.queue.fail(e)
+          setMode2Uploading(false)
+          browserPerfEndPhase('upload', {
+            ok: false,
+            mode: 'mode2',
+            uploadGeneration: browserPipeline.uploadGeneration,
+            error: msg,
+          })
+        }
         browserPerfLog('run:error', {
           error: msg,
         })
@@ -4793,7 +5197,7 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
     } finally {
         setProcessing(false);
     }
-  }, [addLog, baseManifestRoot, bootstrapMode2AppendBaseFromNetwork, browserPerfEndPhase, browserPerfLog, browserPerfStartPhase, browserPerfStartRun, compressUploads, dealId, dealSetupStatus, ensureWasmReady, gatewayMode2Enabled, isConnected, localGateway.status, localGateway.url, rehydrateGatewayFromOpfs, resetUpload, stripeParams, stripeParamsLoaded, updateUploadKzgStatus, updateUploadStatus]);
+  }, [addLog, baseManifestRoot, bootstrapMode2AppendBaseFromNetwork, browserPerfEndPhase, browserPerfLog, browserPerfStartPhase, browserPerfStartRun, browserPerfUploadTaskEvent, compressUploads, dealId, dealSetupStatus, ensureWasmReady, gatewayMode2Enabled, isConnected, localGateway.status, localGateway.url, rehydrateGatewayFromOpfs, resetUpload, slotBases, slotProviders, stripeParams, stripeParamsLoaded, updateUploadKzgStatus, updateUploadStatus, uploadEngine]);
 
   // Helper for encoding (matches polystore_core/coding.rs encode_to_mdu)
   function encodeToMdu(rawData: Uint8Array): Uint8Array {
@@ -4907,6 +5311,8 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
     const timingPhases = uploadStatus.timing.phases
     const uploaded = uploadStatus.storage.uploadedArtifacts
     const queued = uploadStatus.storage.queuedArtifacts
+    const staged = uploadStatus.storage.stagedArtifacts
+    const activeArtifacts = uploadStatus.storage.activeArtifacts
     const requestCount = uploadStatus.transport.requestCount
     const bundleCount = uploadStatus.transport.bundleCount
     const bytesSent = uploadStatus.transport.bytesSent
@@ -4950,6 +5356,13 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
           queued === null && uploaded === null
             ? '—'
             : `${String(uploaded ?? 0)} uploaded / ${String(queued ?? 0)} queued`,
+      },
+      {
+        label: 'pipeline',
+        value:
+          staged === null && activeArtifacts === null
+            ? '—'
+            : `${String(staged ?? 0)} staged • ${String(activeArtifacts ?? 0)} active`,
       },
       {
         label: 'requests',

--- a/polystore-website/src/lib/upload/engine.test.ts
+++ b/polystore-website/src/lib/upload/engine.test.ts
@@ -328,6 +328,102 @@ test('upload engine: pipelined generation does not finalize manifest after artif
   assert.deepEqual(starts, ['mdu'])
 })
 
+test('upload engine: pipelined generation emits queued/staged/activation progress', async () => {
+  const target = {
+    baseUrl: 'http://provider-a',
+    mduPath: '/sp/upload_mdu',
+    manifestPath: '/sp/upload_manifest',
+    label: 'provider-a',
+  }
+  const events: UploadTaskEvent[] = []
+  const engine = createUploadEngine({
+    transport: {
+      async sendArtifact() {
+        await new Promise((resolve) => setTimeout(resolve, 1))
+      },
+    },
+    parallelism: { direct: 1 },
+  })
+
+  async function* artifacts() {
+    yield {
+      target,
+      artifact: { kind: 'shard' as const, index: 7, slot: 2, bytes: new Uint8Array([1]), fullSize: 8 },
+    }
+  }
+
+  const result = await engine.uploadPipelinedGeneration({
+    dealId: '26',
+    previousManifestRoot: '0xprev',
+    uploadGeneration: 'browser-run-3',
+    artifacts: artifacts(),
+    manifest: Promise.resolve({
+      manifestRoot: '0xnext',
+      manifestBlob: new Uint8Array([9]),
+      manifestTargets: [target],
+    }),
+    onTaskEvent(event) {
+      events.push(event)
+    },
+  })
+
+  assert.equal(result.ok, true)
+  assert.deepEqual(
+    events.map((event) => `${event.phase}:${event.kind}:${event.staged ? 'staged' : event.activating ? 'activating' : 'bound'}`),
+    [
+      'queued:shard:staged',
+      'start:shard:staged',
+      'end:shard:staged',
+      'start:manifest:activating',
+      'end:manifest:activating',
+    ],
+  )
+  assert.equal(result.transportStats?.queuedArtifactCount, 1)
+  assert.equal(result.transportStats?.stagedArtifactCount, 1)
+  assert.equal(result.transportStats?.activatedArtifactCount, 1)
+})
+
+test('upload engine: pipelined generation reports manifest computation failure without activation', async () => {
+  const target = {
+    baseUrl: 'http://provider-a',
+    mduPath: '/sp/upload_mdu',
+    manifestPath: '/sp/upload_manifest',
+    label: 'provider-a',
+  }
+  const starts: string[] = []
+  const engine = createUploadEngine({
+    transport: {
+      async sendArtifact(request: UploadTransportRequest) {
+        starts.push(`${request.artifact.kind}:${request.manifestRoot || 'staged'}`)
+      },
+    },
+  })
+
+  async function* artifacts() {
+    yield {
+      target,
+      artifact: { kind: 'mdu' as const, index: 0, bytes: new Uint8Array([1]), fullSize: 8 },
+    }
+  }
+
+  let rejectManifest!: (error: Error) => void
+  const manifest = new Promise<never>((_, reject) => {
+    rejectManifest = reject
+  })
+  setTimeout(() => rejectManifest(new Error('manifest kzg failed')), 0)
+
+  const result = await engine.uploadPipelinedGeneration({
+    dealId: '27',
+    uploadGeneration: 'browser-run-4',
+    artifacts: artifacts(),
+    manifest,
+  })
+
+  assert.equal(result.ok, false)
+  assert.equal(result.error, 'manifest kzg failed')
+  assert.deepEqual(starts, ['mdu:staged'])
+})
+
 test('upload engine: striped upload overlaps metadata and shard requests with combined bounded concurrency', async () => {
   let activeTotal = 0
   let peakTotal = 0

--- a/polystore-website/src/lib/upload/engine.ts
+++ b/polystore-website/src/lib/upload/engine.ts
@@ -37,7 +37,7 @@ export interface UploadProgressStep {
 }
 
 export interface UploadTaskEvent {
-  phase: 'start' | 'end' | 'fallback'
+  phase: 'queued' | 'start' | 'end' | 'fallback' | 'activate'
   kind: SparseArtifactKind
   target: string
   index?: number
@@ -53,10 +53,17 @@ export interface UploadTaskEvent {
   bundleBytes?: number
   fallbackArtifactCount?: number
   fallbackReason?: string
+  queuedDepth?: number
+  activeUploads?: number
+  staged?: boolean
+  activating?: boolean
 }
 
 export interface UploadTransportStats {
   artifactCount: number
+  queuedArtifactCount: number
+  stagedArtifactCount: number
+  activatedArtifactCount: number
   perArtifactCount: number
   bundledArtifactCount: number
   bundleCount: number
@@ -175,6 +182,7 @@ export interface PipelinedGenerationUploadInput {
   artifacts: AsyncIterable<PipelinedUploadArtifact>
   manifest: Promise<PipelinedManifestBinding>
   onTaskEvent?: (event: UploadTaskEvent) => void
+  onPipelineError?: (error: Error) => void
 }
 
 export interface PreparedCommitInput {
@@ -346,6 +354,9 @@ const DEFAULT_STRIPED_SHARD_UPLOAD_CONCURRENCY = 6
 function createUploadTransportStats(): UploadTransportStats {
   return {
     artifactCount: 0,
+    queuedArtifactCount: 0,
+    stagedArtifactCount: 0,
+    activatedArtifactCount: 0,
     perArtifactCount: 0,
     bundledArtifactCount: 0,
     bundleCount: 0,
@@ -371,6 +382,9 @@ function mergeUploadTransportStats(...statsList: Array<UploadTransportStats | un
   const merged = createUploadTransportStats()
   for (const stats of filtered) {
     merged.artifactCount += stats.artifactCount
+    merged.queuedArtifactCount += stats.queuedArtifactCount
+    merged.stagedArtifactCount += stats.stagedArtifactCount
+    merged.activatedArtifactCount += stats.activatedArtifactCount
     merged.perArtifactCount += stats.perArtifactCount
     merged.bundledArtifactCount += stats.bundledArtifactCount
     merged.bundleCount += stats.bundleCount
@@ -434,6 +448,11 @@ async function runUploadTasks(
         const slot = trackTaskEvents && 'slot' in task.request.artifact ? task.request.artifact.slot : undefined
         const bytes = trackTaskEvents ? task.request.artifact.bytes.byteLength : 0
         const fullSize = trackTaskEvents ? task.request.artifact.fullSize : undefined
+        const staged = String(task.request.manifestRoot || '').trim() === '' && String(task.request.uploadGeneration || '').trim() !== ''
+        const activating =
+          task.request.artifact.kind === 'manifest' &&
+          String(task.request.manifestRoot || '').trim() !== '' &&
+          String(task.request.uploadGeneration || '').trim() !== ''
         if (trackTaskEvents) {
           onTaskEvent?.({
             phase: 'start',
@@ -444,6 +463,9 @@ async function runUploadTasks(
             bytes,
             fullSize,
             transportKind: 'artifact',
+            activeUploads: active,
+            staged,
+            activating,
           })
         }
 
@@ -454,6 +476,8 @@ async function runUploadTasks(
         void transport
           .sendArtifact(task.request)
           .then(() => {
+            if (staged) stats.stagedArtifactCount += 1
+            if (activating) stats.activatedArtifactCount += 1
             if (trackTaskEvents) {
               const finishedAt = typeof performance !== 'undefined' ? performance.now() : Date.now()
               onTaskEvent?.({
@@ -467,6 +491,9 @@ async function runUploadTasks(
                 durationMs: finishedAt - startedAt,
                 ok: true,
                 transportKind: 'artifact',
+                activeUploads: active,
+                staged,
+                activating,
               })
             }
             if (trackProgress) {
@@ -490,6 +517,9 @@ async function runUploadTasks(
                 ok: false,
                 error: message,
                 transportKind: 'artifact',
+                activeUploads: active,
+                staged,
+                activating,
               })
             }
             if (trackProgress) {
@@ -518,6 +548,7 @@ async function runPipelinedUploadTaskProducer(
   const trackTaskEvents = Boolean(input.onTaskEvent)
   let producerDone = false
   let firstError: string | null = null
+  let active = 0
   const stats = createUploadTransportStats()
   const queue: PipelinedUploadArtifact[] = []
   const waiters: Array<() => void> = []
@@ -535,52 +566,66 @@ async function runPipelinedUploadTaskProducer(
     })
   }
 
+  const requestForItem = (item: PipelinedUploadArtifact): UploadTransportRequest => ({
+    dealId: input.dealId,
+    manifestRoot: '',
+    previousManifestRoot: input.previousManifestRoot,
+    uploadGeneration: input.uploadGeneration,
+    target: item.target,
+    artifact: item.artifact,
+  })
+
+  const eventFieldsForRequest = (request: UploadTransportRequest) => {
+    const target = request.target.label || request.target.baseUrl
+    const index = 'index' in request.artifact ? request.artifact.index : undefined
+    const slot = 'slot' in request.artifact ? request.artifact.slot : undefined
+    const bytes = request.artifact.bytes.byteLength
+    const fullSize = request.artifact.fullSize
+    const staged = String(request.manifestRoot || '').trim() === '' && String(request.uploadGeneration || '').trim() !== ''
+    return { target, index, slot, bytes, fullSize, staged }
+  }
+
   const uploadOne = async (item: PipelinedUploadArtifact): Promise<void> => {
-    const request: UploadTransportRequest = {
-      dealId: input.dealId,
-      manifestRoot: '',
-      previousManifestRoot: input.previousManifestRoot,
-      uploadGeneration: input.uploadGeneration,
-      target: item.target,
-      artifact: item.artifact,
-    }
-    stats.artifactCount += 1
+    const request = requestForItem(item)
+    active += 1
     stats.perArtifactCount += 1
     stats.requestCount += 1
     stats.bytesSent += Math.max(0, request.artifact.bytes.byteLength)
+    stats.peakActiveUploads = Math.max(stats.peakActiveUploads, active)
     const startedAt = trackTaskEvents ? (typeof performance !== 'undefined' ? performance.now() : Date.now()) : 0
-    const target = trackTaskEvents ? request.target.label || request.target.baseUrl : ''
-    const index = trackTaskEvents && 'index' in request.artifact ? request.artifact.index : undefined
-    const slot = trackTaskEvents && 'slot' in request.artifact ? request.artifact.slot : undefined
-    const bytes = trackTaskEvents ? request.artifact.bytes.byteLength : 0
-    const fullSize = trackTaskEvents ? request.artifact.fullSize : undefined
+    const fields = eventFieldsForRequest(request)
     if (trackTaskEvents) {
       input.onTaskEvent?.({
         phase: 'start',
         kind: request.artifact.kind,
-        target,
-        index,
-        slot,
-        bytes,
-        fullSize,
+        target: fields.target,
+        index: fields.index,
+        slot: fields.slot,
+        bytes: fields.bytes,
+        fullSize: fields.fullSize,
         transportKind: 'artifact',
+        activeUploads: active,
+        staged: fields.staged,
       })
     }
     try {
       await transport.sendArtifact(request)
+      if (fields.staged) stats.stagedArtifactCount += 1
       if (trackTaskEvents) {
         const finishedAt = typeof performance !== 'undefined' ? performance.now() : Date.now()
         input.onTaskEvent?.({
           phase: 'end',
           kind: request.artifact.kind,
-          target,
-          index,
-          slot,
-          bytes,
-          fullSize,
+          target: fields.target,
+          index: fields.index,
+          slot: fields.slot,
+          bytes: fields.bytes,
+          fullSize: fields.fullSize,
           durationMs: finishedAt - startedAt,
           ok: true,
           transportKind: 'artifact',
+          activeUploads: active,
+          staged: fields.staged,
         })
       }
     } catch (error: unknown) {
@@ -590,18 +635,22 @@ async function runPipelinedUploadTaskProducer(
         input.onTaskEvent?.({
           phase: 'end',
           kind: request.artifact.kind,
-          target,
-          index,
-          slot,
-          bytes,
-          fullSize,
+          target: fields.target,
+          index: fields.index,
+          slot: fields.slot,
+          bytes: fields.bytes,
+          fullSize: fields.fullSize,
           durationMs: finishedAt - startedAt,
           ok: false,
           error: message,
           transportKind: 'artifact',
+          activeUploads: active,
+          staged: fields.staged,
         })
       }
       throw new Error(message)
+    } finally {
+      active = Math.max(0, active - 1)
     }
   }
 
@@ -609,6 +658,24 @@ async function runPipelinedUploadTaskProducer(
     try {
       for await (const item of input.artifacts) {
         if (firstError) break
+        const request = requestForItem(item)
+        stats.artifactCount += 1
+        stats.queuedArtifactCount += 1
+        if (trackTaskEvents) {
+          const fields = eventFieldsForRequest(request)
+          input.onTaskEvent?.({
+            phase: 'queued',
+            kind: request.artifact.kind,
+            target: fields.target,
+            index: fields.index,
+            slot: fields.slot,
+            bytes: fields.bytes,
+            fullSize: fields.fullSize,
+            transportKind: 'artifact',
+            queuedDepth: queue.length + 1,
+            staged: fields.staged,
+          })
+        }
         queue.push(item)
         wakeWorkers()
       }
@@ -629,7 +696,9 @@ async function runPipelinedUploadTaskProducer(
       try {
         await uploadOne(item)
       } catch (error: unknown) {
-        if (!firstError) firstError = error instanceof Error ? error.message : String(error)
+        const pipelineError = error instanceof Error ? error : new Error(String(error))
+        if (!firstError) firstError = pipelineError.message
+        input.onPipelineError?.(pipelineError)
         wakeWorkers()
         return
       }
@@ -1183,7 +1252,18 @@ export function createUploadEngine(options: UploadEngineOptions) {
       if (!artifactResult.ok) {
         return artifactResult
       }
-      const manifest = await input.manifest
+      let manifest: PipelinedManifestBinding
+      try {
+        manifest = await input.manifest
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error)
+        return {
+          ok: false,
+          steps: [],
+          error: message,
+          transportStats: artifactResult.transportStats,
+        }
+      }
       const manifestTasks: UploadTask[] = manifest.manifestTargets.map((target) => ({
         stepIndex: -1,
         request: {

--- a/polystore-website/src/lib/uploadStatus.test.ts
+++ b/polystore-website/src/lib/uploadStatus.test.ts
@@ -112,7 +112,34 @@ test('patchUploadPipelineStatus preserves nested state and records elapsed time'
   assert.equal(next.totals.totalMdus, 3)
   assert.equal(next.totals.workDone, 1)
   assert.equal(next.storage.stage, 'browser_memory')
+  assert.equal(next.storage.activeArtifacts, null)
+  assert.equal(next.storage.stagedArtifacts, null)
   assert.equal(next.timing.elapsedMs, 150)
+})
+
+test('patchUploadPipelineStatus tracks staged provider artifacts', () => {
+  const initial = createUploadPipelineStatus({ dealId: '42', nowMs: 0 })
+  const next = patchUploadPipelineStatus(
+    initial,
+    {
+      phase: 'upload_transport',
+      phaseLabel: 'Staging artifacts',
+      storage: {
+        stage: 'provider_staged',
+        queuedArtifacts: 4,
+        activeArtifacts: 1,
+        stagedArtifacts: 3,
+        uploadedArtifacts: 3,
+      },
+    },
+    50,
+  )
+
+  assert.equal(next.storage.stage, 'provider_staged')
+  assert.equal(next.storage.queuedArtifacts, 4)
+  assert.equal(next.storage.activeArtifacts, 1)
+  assert.equal(next.storage.stagedArtifacts, 3)
+  assert.equal(next.storage.uploadedArtifacts, 3)
 })
 
 test('sanitizeUploadPipelineStatus truncates user-controlled text', () => {

--- a/polystore-website/src/lib/uploadStatus.ts
+++ b/polystore-website/src/lib/uploadStatus.ts
@@ -21,6 +21,8 @@ export type UploadPipelineStorageStage =
   | 'browser_memory'
   | 'opfs'
   | 'upload_queue'
+  | 'provider_staged'
+  | 'manifest_activation'
   | 'provider'
   | 'chain'
 
@@ -92,6 +94,8 @@ export type UploadPipelineStatus = {
     browserMemoryBytes: number | null
     opfsBytes: number | null
     queuedArtifacts: number | null
+    activeArtifacts: number | null
+    stagedArtifacts: number | null
     uploadedArtifacts: number | null
   }
   transport: {
@@ -334,6 +338,8 @@ export function createUploadPipelineStatus(input: {
       browserMemoryBytes: null,
       opfsBytes: null,
       queuedArtifacts: null,
+      activeArtifacts: null,
+      stagedArtifacts: null,
       uploadedArtifacts: null,
     },
     transport: {

--- a/polystore-website/tests/direct-upload-sparse.spec.ts
+++ b/polystore-website/tests/direct-upload-sparse.spec.ts
@@ -394,6 +394,10 @@ test('Thick Client: no-gateway Mode 2 browser upload sends sparse MDU, manifest,
   const uploadStatus = await page.evaluate(() => {
     return (window as Window & { __polyStoreUploadStatus?: unknown }).__polyStoreUploadStatus ?? null
   }) as {
+    storage?: {
+      stagedArtifacts?: number | null
+      uploadedArtifacts?: number | null
+    }
     transport?: {
       requestCount?: number | null
       bundleCount?: number | null
@@ -432,8 +436,14 @@ test('Thick Client: no-gateway Mode 2 browser upload sends sparse MDU, manifest,
   } else {
     expect(bundleUploads.length).toBe(0)
     expect(perArtifactPostRequests).toBe(logicalArtifactCount)
-    expect(uploadStatus?.transport?.fallbackCount ?? 0).toBeGreaterThanOrEqual(1)
-    expect(uploadStatus?.transport?.fallbackReason || '').toMatch(/bundle/i)
+    const fallbackCount = uploadStatus?.transport?.fallbackCount ?? 0
+    if (fallbackCount > 0) {
+      expect(uploadStatus?.transport?.fallbackReason || '').toMatch(/bundle/i)
+    } else {
+      // Pipelined browser staging intentionally uses per-artifact generation uploads
+      // until the final manifest root is known, so no bundle fallback is required.
+      expect(uploadStatus?.storage?.stagedArtifacts ?? 0).toBeGreaterThan(0)
+    }
   }
 
   expect(sparseMduUploads.length).toBeGreaterThan(0)

--- a/polystore_gateway/polystore-gateway-spec.md
+++ b/polystore_gateway/polystore-gateway-spec.md
@@ -78,8 +78,8 @@ These endpoints support the `polystore-website` "Thin Client" flow.
 
 *   **`POST /sp/upload_shard`** *(Striped Provider API)*
     *   **Input:** Raw shard bytes (body) with headers:
-        * `X-PolyStore-Deal-ID` (uint64), `X-PolyStore-Mdu-Index` (uint64), `X-PolyStore-Slot` (uint64), `X-PolyStore-Manifest-Root` (`0x` + 96 hex).
-    *   **Logic:** Stores the shard as `mdu_<index>_slot_<slot>.bin` under `uploads/<manifest_root_key>/`.
+        * `X-PolyStore-Deal-ID` (uint64), `X-PolyStore-Mdu-Index` (uint64), `X-PolyStore-Slot` (uint64), and either `X-PolyStore-Manifest-Root` (`0x` + 96 hex) **or** `X-PolyStore-Upload-Generation` (browser-run staging id).
+    *   **Logic:** With a manifest root, stores the shard as `mdu_<index>_slot_<slot>.bin` under `uploads/<manifest_root_key>/`. With only `upload_generation`, stores it under `uploads/deals/<deal_id>/staging/<generation>/` until `/sp/upload_manifest` supplies the final root and promotes the generation.
     *   **Role:** Slot-specific shard ingestion for the striped StripeReplica layout.
         *   **Provider is a dumb pipe:** the server does not need to understand layout variants beyond writing/serving bytes addressed by the headers.
         *   Metadata MDUs (MDU #0 + Witness) remain replicated to all slots via `/sp/upload_mdu`.
@@ -91,6 +91,7 @@ These endpoints support the `polystore-website` "Thin Client" flow.
     *   **Metadata JSON:** `{ "deal_id": uint64, "manifest_root": "0x...", "previous_manifest_root": "0x...", "upload_generation": "optional-devnet-id", "artifacts": [{ "part": "artifact_00", "kind": "mdu|shard|manifest", "mdu_index": uint64?, "slot": uint64?, "full_size": int64, "send_size": int64 }] }`.
     *   **Sparse artifacts:** `send_size` MAY be smaller than `full_size`; providers write the prefix bytes and zero-extend/truncate the stored file to `full_size`, matching per-artifact `X-PolyStore-Full-Size` semantics.
     *   **Validation:** All artifacts in a bundle share the same deal/root/generation scope. Providers reject missing/invalid roots, too many artifacts, duplicate target filenames, malformed generation IDs, body length mismatches, and unexpected trailing bytes without committing partial files.
+    *   **Staging note:** bundle uploads are root-bound for #198 compatibility. Browser pipelining stages early shards/metadata with per-artifact `/sp/upload_*` requests carrying `X-PolyStore-Upload-Generation`; the final `/sp/upload_manifest` request carries both `X-PolyStore-Manifest-Root` and the generation id to promote the staged artifacts.
     *   **CORS:** Providers answer `OPTIONS /sp/upload_bundle` and allow `Content-Type` plus `X-PolyStore-*` headers so browser-only uploads remain gateway-optional.
 
 *   **`POST /gateway/mirror_mdu` / `/gateway/mirror_manifest` / `/gateway/mirror_shard`** *(Gateway mirror helpers)*


### PR DESCRIPTION
**Latest validation update (2026-05-30):** Pipeline benchmark and small browser sparse-upload smoke were rerun. Evidence supports this PR's overlap/pipelining claim: mocked latency benchmark shows ~1.24x end-to-end speedup and browser smoke passes with WebGPU status healthy. This is an overlap benchmark, not a KZG speedup claim.

---

## Summary
- Closes #197; parent tracker #192.
- Builds on stack dependencies #193/#201, #194/#202, #195/#203.
- This draft branch also includes sibling dependency #198/#200 (`website/bundle-mode2-upload-198`) via merge commit `88a8a913`; keep draft until #198 lands and this branch is rebased/trimmed as needed.
- Pipelines browser Mode 2 provider upload while later MDU/KZG work continues: user shards and metadata MDUs are staged with `X-PolyStore-Upload-Generation`, and final manifest upload/activation waits for the final manifest root.
- Extends upload status/perf counters for queued, active, staged, uploaded, and manifest activation states.
- Adds controlled mocked-latency benchmark for sequential prepare-then-upload vs pipelined prepare/upload.

## Staging / safety contract
- Early provider writes are generation-scoped (`browser-...`) and intentionally omit `X-PolyStore-Manifest-Root`, so providers write to staging instead of a live root directory.
- Final manifest upload carries both final `manifest_root` and the upload generation, causing provider promotion only after manifest KZG/root computation completes.
- Deal commit remains gated on successful provider activation and the final manifest/root/witness state.
- On partial staging failure, the final manifest is not resolved/uploaded; UI surfaces the failure and keeps prepared artifacts available for manual retry through the existing upload path.

## Tests
- `cd polystore-website && npm run test:unit` — 288 pass (OPFS cleanup warning is from an existing test exercising cleanup failure handling).
- `cd polystore-website && npm run lint` — pass.
- `cd polystore-website && npm run build:app` — pass (Vite/browserlist/chunk warnings only).

## Benchmark evidence
Command:
```bash
cd polystore-website && PROVIDERS=4 ARTIFACTS=24 COMPUTE_MS=35 UPLOAD_MS=45 CONCURRENCY=4 npm run perf:upload-pipeline
```
Result summary:
- Sequential prepare-then-upload: prepare 843.9ms, upload 317.4ms, overlap 0ms, e2e 1161.6ms, 28 artifacts/requests, peak active 4.
- Pipelined prepare/upload: prepare 841.5ms, upload wall 896.8ms, overlap 806.1ms, e2e 932.1ms, 28 artifacts/requests, 24 staged before manifest, 4 activated manifest uploads, peak active 4.
- Speedup: ~1.246x end-to-end under mocked latency. This is an overlap benchmark, not a KZG speedup claim.

## Risks / limitations
- Draft until #198/#200 and the ancestor stack merge; this PR currently includes #198 commits.
- Browser pipeline uses per-artifact staging for provisional uploads; bundle uploads remain root-bound per #198 and are consumed by retry/non-pipelined paths.
- Full browser smoke was not rerun here; validation is targeted unit/build plus mocked-latency benchmark.

## AI review status
- Pending: @copilot review
- Pending: @coderabbitai review
- Pending: @codex review

