### PR TITLE
feat(website): autotune upload prep worker concurrency

### DIFF
--- a/polystore-website/package.json
+++ b/polystore-website/package.json
@@ -25,6 +25,7 @@
     "perf:prepare-stages": "tsx scripts/benchmark_prepare_stages.ts",
     "perf:prepare-compare": "tsx scripts/benchmark_prepare_compare.ts",
     "perf:user-stage-concurrency": "tsx scripts/benchmark_user_stage_concurrency.ts",
+    "perf:worker-autotune-sim": "tsx scripts/benchmark_worker_autotune_sim.ts",
     "perf:browser-kzg-baseline": "tsx scripts/benchmark_browser_kzg_baseline.ts",
     "perf:upload-pipeline": "tsx scripts/benchmark_upload_pipelining.ts",
     "perf:msm-windows": "tsx scripts/benchmark_pippenger_windows.ts",

--- a/polystore-website/scripts/benchmark_user_stage_concurrency.ts
+++ b/polystore-website/scripts/benchmark_user_stage_concurrency.ts
@@ -6,6 +6,8 @@ import { performance } from 'node:perf_hooks'
 
 import {
   buildExpansionWorkerAutotuneCandidates,
+  buildExpansionWorkerCalibrationPlan,
+  finalizeExpansionWorkerAutotuneSelection,
   pickExpansionWorkerCount,
   selectExpansionWorkerCountFromSamples,
 } from '../src/lib/expansionWorkers'
@@ -253,6 +255,50 @@ for (let cycle = 0; cycle < cycles; cycle += 1) {
   }
 }
 
+const autotuneShape = {
+  hardwareConcurrency,
+  totalJobs: chunks.length,
+  rsK,
+  rsM,
+  kzgCommitBackend: `node-${basisMode}`,
+  rustCommitBackend: basisMode,
+  schedulerOwner: `benchmark-user-stage-${pipelineModes.join('+')}`,
+  schedulerConcurrency: 1,
+  schedulerMaxQueueDepth: 32,
+}
+const autotunePlan = buildExpansionWorkerCalibrationPlan(autotuneShape)
+const selectedByPipelineMode = Object.fromEntries(
+  pipelineModes.map((pipelineMode) => {
+    const samples = concurrencies.map((concurrency) => {
+      const result = results.get(`${pipelineMode}:${concurrency}`)
+      const stats = result ? readStats(result.runs) : null
+      return {
+        workerCount: concurrency,
+        wallMs: stats ? stats.median : Number.NaN,
+        sampleJobs: chunks.length,
+        scoreMs: stats ? stats.median / Math.max(1, chunks.length) : Number.NaN,
+      }
+    })
+    const selection = finalizeExpansionWorkerAutotuneSelection(autotuneShape, samples, {
+      calibrationComplete: true,
+      nowMs: Date.now(),
+    })
+    return [
+      pipelineMode,
+      {
+        selected_worker_count: selection.workerCount,
+        static_worker_count: selection.staticWorkerCount,
+        source: selection.source,
+        cache_hit: selection.cacheHit,
+        reason: selection.reason,
+        score_ms_per_user_mdu: selection.scoreMs,
+        sampled_candidates: selection.sampledCandidates,
+        legacy_selected_worker_count: selectExpansionWorkerCountFromSamples(samples, hardwareConcurrency, chunks.length),
+      },
+    ]
+  }),
+)
+
 const output = {
   file_bytes: fileBytes,
   total_user_mdus: chunks.length,
@@ -264,18 +310,9 @@ const output = {
         hardware_concurrency: hardwareConcurrency,
         static_worker_count: pickExpansionWorkerCount(hardwareConcurrency, chunks.length),
         candidates: concurrencies,
-        selected_by_pipeline_mode: Object.fromEntries(
-          pipelineModes.map((pipelineMode) => {
-            const samples = concurrencies.map((concurrency) => {
-              const result = results.get(`${pipelineMode}:${concurrency}`)
-              return {
-                workerCount: concurrency,
-                wallMs: result ? readStats(result.runs).median : Number.NaN,
-              }
-            })
-            return [pipelineMode, selectExpansionWorkerCountFromSamples(samples, hardwareConcurrency, chunks.length)]
-          }),
-        ),
+        cache_key: autotunePlan.cacheKey,
+        plan: autotunePlan,
+        selected_by_pipeline_mode: selectedByPipelineMode,
       }
     : null,
   concurrencies,

--- a/polystore-website/scripts/benchmark_worker_autotune_sim.ts
+++ b/polystore-website/scripts/benchmark_worker_autotune_sim.ts
@@ -1,0 +1,115 @@
+import {
+  ExpansionWorkerAutotuneCacheStore,
+  buildExpansionWorkerAutotuneCandidates,
+  buildExpansionWorkerCalibrationPlan,
+  finalizeExpansionWorkerAutotuneSelection,
+  getCachedExpansionWorkerAutotuneSelection,
+  pickExpansionWorkerCount,
+} from '../src/lib/expansionWorkers'
+
+function parseNumberEnv(name: string, fallback: number): number {
+  const value = Number(process.env[name])
+  return Number.isFinite(value) && value > 0 ? value : fallback
+}
+
+function memoryStorage() {
+  const values = new Map<string, string>()
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      values.set(key, value)
+    },
+    removeItem: (key: string) => {
+      values.delete(key)
+    },
+  }
+}
+
+const hardwareConcurrency = parseNumberEnv('HARDWARE_CONCURRENCY', 12)
+const totalUserMdus = parseNumberEnv('TOTAL_USER_MDUS', 13)
+const rsK = parseNumberEnv('RS_K', 8)
+const rsM = parseNumberEnv('RS_M', 4)
+
+// Default fixture mirrors issue #196's documented 100 MiB / RS 8+4 / 12 logical CPU browser profile.
+// Values are total prepare wall-clock milliseconds by user-MDU worker concurrency.
+const defaultWallMsByWorker: Record<number, number> = {
+  1: 179_300,
+  3: 115_200,
+  5: 100_900,
+  6: 109_700,
+}
+const wallMsByWorker = process.env.WALL_MS_BY_WORKER
+  ? (JSON.parse(process.env.WALL_MS_BY_WORKER) as Record<string, number>)
+  : defaultWallMsByWorker
+
+const shape = {
+  hardwareConcurrency,
+  totalJobs: totalUserMdus,
+  rsK,
+  rsM,
+  kzgCommitBackend: 'webgpu-scheduler',
+  rustCommitBackend: 'webgpu-msm',
+  kzgWebGpuAvailable: true,
+  kzgWebGpuProbeStatus: 'passed',
+  kzgWebGpuBucketWidth: 12,
+  kzgWebGpuReductionMode: 'parallel16',
+  kzgWebGpuCalibrationStatus: 'benchmark-matrix',
+  kzgWebGpuCalibrationSource: 'benchmark-matrix',
+  kzgWebGpuCalibrationCacheKey: 'simulated-webgpu-msm-fixture',
+  schedulerOwner: 'browser-user-mdu-kzg-scheduler-v1',
+  schedulerConcurrency: 1,
+  schedulerMaxQueueDepth: 32,
+}
+
+const candidates = buildExpansionWorkerAutotuneCandidates(hardwareConcurrency, totalUserMdus)
+const staticWorkerCount = pickExpansionWorkerCount(hardwareConcurrency, totalUserMdus)
+const plan = buildExpansionWorkerCalibrationPlan(shape)
+const samples = candidates.map((workerCount) => {
+  const wallMs = Number(wallMsByWorker[workerCount] ?? wallMsByWorker[String(workerCount)])
+  return {
+    workerCount,
+    wallMs,
+    sampleJobs: totalUserMdus,
+    scoreMs: wallMs / totalUserMdus,
+  }
+})
+const store = new ExpansionWorkerAutotuneCacheStore({ storage: memoryStorage() })
+const selection = finalizeExpansionWorkerAutotuneSelection(shape, samples, {
+  cacheStore: store,
+  calibrationComplete: true,
+  nowMs: Date.now(),
+})
+const cached = getCachedExpansionWorkerAutotuneSelection(shape, store)
+const staticWallMs = Number(wallMsByWorker[staticWorkerCount] ?? wallMsByWorker[String(staticWorkerCount)] ?? Number.NaN)
+const selectedWallMs = Number(wallMsByWorker[selection.workerCount] ?? wallMsByWorker[String(selection.workerCount)] ?? Number.NaN)
+
+console.log(
+  JSON.stringify(
+    {
+      fixture: 'issue-196-deterministic-worker-autotune-sim',
+      note:
+        'Deterministic selector simulation; use browser prepare profiles for native WebGPU wall-clock evidence when available.',
+      hardware_concurrency: hardwareConcurrency,
+      total_user_mdus: totalUserMdus,
+      rs_profile: `${rsK}+${rsM}`,
+      static_worker_count: staticWorkerCount,
+      candidates,
+      plan,
+      samples,
+      selected_worker_count: selection.workerCount,
+      selected_source: selection.source,
+      selected_reason: selection.reason,
+      cache_hit_after_store: cached?.cacheHit ?? false,
+      cache_key: selection.cacheKey,
+      static_wall_ms: staticWallMs,
+      selected_wall_ms: selectedWallMs,
+      improvement_vs_static_ms: Number.isFinite(staticWallMs) && Number.isFinite(selectedWallMs) ? staticWallMs - selectedWallMs : null,
+      improvement_vs_static_pct:
+        Number.isFinite(staticWallMs) && Number.isFinite(selectedWallMs) && staticWallMs > 0
+          ? ((staticWallMs - selectedWallMs) / staticWallMs) * 100
+          : null,
+    },
+    null,
+    2,
+  ),
+)

--- a/polystore-website/src/components/FileSharder.tsx
+++ b/polystore-website/src/components/FileSharder.tsx
@@ -2,7 +2,17 @@ import { useMemo, useState, useCallback, useEffect, useRef } from 'react';
 import { useAccount, usePublicClient, useWalletClient } from 'wagmi';
 import { CheckCircle2, ClipboardCopy, Cpu, Database, FileJson, LoaderCircle, Network, UploadCloud, Wallet } from 'lucide-react';
 import { useConnectModal } from '@rainbow-me/rainbowkit';
-import { pickExpansionWorkerCount } from '../lib/expansionWorkers';
+import {
+  buildExpansionWorkerCalibrationPlan,
+  defaultExpansionWorkerAutotuneCacheStore,
+  finalizeExpansionWorkerAutotuneSelection,
+  getCachedExpansionWorkerAutotuneSelection,
+  pickExpansionWorkerCount,
+  staticExpansionWorkerAutotuneSelection,
+  type ExpansionWorkerAutotuneSample,
+  type ExpansionWorkerAutotuneSelection,
+  type ExpansionWorkerAutotuneShape,
+} from '../lib/expansionWorkers';
 import { workerClient } from '../lib/worker-client';
 import { useDirectUpload } from '../hooks/useDirectUpload'; // New import
 import { useDirectCommit } from '../hooks/useDirectCommit'; // New import
@@ -231,6 +241,7 @@ type PreparePerfProfile = {
   totalUserMdus: number
   totalWitnessMdus: number
   userConcurrency: number
+  workerAutotune: ExpansionWorkerAutotuneSelection | null
   manifestMs: number
   wallClock: {
     prepareMs: number
@@ -322,6 +333,12 @@ type PreparePerfProfile = {
     kzgSchedulerBatchSplitCount?: number
     kzgSchedulerBatchFallbackCount?: number
     commitWorkerCount?: number
+    workerAutotuneSource?: string
+    workerAutotuneReason?: string
+    workerAutotuneCacheHit?: boolean
+    workerAutotuneCandidates?: number[]
+    workerAutotuneSampledCandidates?: number[]
+    workerAutotuneScoreMs?: number | null
   }
   samples: {
     user: PreparePerfSample[]
@@ -343,6 +360,52 @@ function roundPerfMs(value: number | null | undefined): number | null {
   return Math.round(Number(value) * 100) / 100
 }
 
+function numberOrNull(value: number | null | undefined): number | null {
+  return Number.isFinite(value ?? NaN) ? Number(value) : null
+}
+
+function uploadWorkerAutotuneStatus(selection: ExpansionWorkerAutotuneSelection): UploadPipelineStatus['workerAutotune'] {
+  return {
+    selectedWorkerCount: selection.workerCount,
+    staticWorkerCount: selection.staticWorkerCount,
+    candidates: selection.candidates,
+    sampledCandidates: selection.sampledCandidates,
+    source: selection.source,
+    cacheHit: selection.cacheHit,
+    cacheKey: selection.cacheKey,
+    reason: selection.reason,
+    scoreMs: selection.scoreMs,
+    sampleCount: selection.sampleCount,
+    hardwareConcurrency: selection.hardwareConcurrency,
+    totalJobs: selection.totalJobs,
+    rsK: selection.rsK,
+    rsM: selection.rsM,
+    timedOut: selection.timedOut,
+  }
+}
+
+function shapeBackendFromDiagnostics(diagnostics: KzgDiagnosticsInput | null | undefined): Partial<ExpansionWorkerAutotuneShape> {
+  if (!diagnostics) return {}
+  const hasWebGpuSchedulerShape =
+    typeof diagnostics.kzgWebGpuCalibrationCacheKey === 'string' && diagnostics.kzgWebGpuCalibrationCacheKey.trim().length > 0
+  return {
+    kzgCommitBackend: hasWebGpuSchedulerShape
+      ? 'webgpu-scheduler'
+      : diagnostics.kzgCommitBackend ?? diagnostics.workerKzgCommitBackend,
+    rustCommitBackend: diagnostics.rustCommitBackend ?? diagnostics.workerRustCommitBackend,
+    kzgWebGpuAvailable: diagnostics.kzgWebGpuAvailable ?? diagnostics.workerKzgWebGpuAvailable,
+    kzgWebGpuProbeStatus: diagnostics.kzgWebGpuProbeStatus ?? diagnostics.workerKzgWebGpuProbeStatus,
+    kzgWebGpuCircuitOpen: diagnostics.kzgWebGpuCircuitOpen ?? diagnostics.workerKzgWebGpuCircuitOpen,
+    kzgWebGpuBucketWidth: numberOrNull(diagnostics.kzgWebGpuBucketWidth ?? diagnostics.workerKzgWebGpuBucketWidth),
+    kzgWebGpuReductionMode: diagnostics.kzgWebGpuReductionMode ?? diagnostics.workerKzgWebGpuReductionMode,
+    kzgWebGpuCalibrationStatus:
+      diagnostics.kzgWebGpuCalibrationStatus ?? diagnostics.workerKzgWebGpuCalibrationStatus,
+    kzgWebGpuCalibrationSource: diagnostics.kzgWebGpuCalibrationSource ?? diagnostics.workerKzgWebGpuCalibrationSource,
+    kzgWebGpuCalibrationCacheKey:
+      diagnostics.kzgWebGpuCalibrationCacheKey ?? diagnostics.workerKzgWebGpuCalibrationCacheKey,
+  }
+}
+
 type PolyStoreBrowserPerfBundle = {
   browserPerfLog: Array<Record<string, unknown>>
   browserPerfLast: Record<string, unknown> | null
@@ -353,6 +416,9 @@ type PolyStoreBrowserPerfBundle = {
 
 type PolyStorePrepareSummary = PreparePerfProfile['summary'] & {
   prepareWallMs: number
+  workerAutotuneSelectedWorkerCount?: number | null
+  workerAutotuneSource?: string | null
+  workerAutotuneCacheHit?: boolean | null
   manifestMs: number
   userStageWallMs: number
   witnessConcatWallMs: number
@@ -3560,12 +3626,61 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
           typeof navigator !== 'undefined' && Number.isFinite(navigator.hardwareConcurrency)
             ? Math.max(1, Number(navigator.hardwareConcurrency))
             : 4
+        let workerAutotuneSelection: ExpansionWorkerAutotuneSelection | null = null
 
         if (useMode2) {
-          const userConcurrency = pickExpansionWorkerCount(prepareHardwareConcurrency, totalUserChunks)
+          const schedulerStatus = workerClient.getUserMduKzgSchedulerStatus()
+          let preflightKzgDiagnostics: KzgDiagnosticsInput | null = null
+          try {
+            preflightKzgDiagnostics = await workerClient.getKzgCommitDiagnostics()
+            updateUploadKzgStatus(preflightKzgDiagnostics, 'kzg:preflight')
+          } catch (error) {
+            console.warn('Worker KZG diagnostics unavailable before upload-prep autotune.', error)
+          }
+          const workerAutotuneShape: ExpansionWorkerAutotuneShape = {
+            hardwareConcurrency: prepareHardwareConcurrency,
+            totalJobs: totalUserChunks,
+            rsK,
+            rsM,
+            ...shapeBackendFromDiagnostics(preflightKzgDiagnostics),
+            schedulerOwner: 'browser-user-mdu-kzg-scheduler-v1',
+            schedulerConcurrency: schedulerStatus.concurrency,
+            schedulerMaxQueueDepth: schedulerStatus.maxQueueDepth,
+          }
+          const workerAutotuneEnabled = import.meta.env.VITE_POLYSTORE_EXPANSION_WORKER_AUTOTUNE !== '0'
+          const workerCalibrationPlan = buildExpansionWorkerCalibrationPlan(workerAutotuneShape, {
+            enabled: workerAutotuneEnabled,
+          })
+          const cachedWorkerAutotune = workerAutotuneEnabled
+            ? getCachedExpansionWorkerAutotuneSelection(workerAutotuneShape, defaultExpansionWorkerAutotuneCacheStore)
+            : null
+          workerAutotuneSelection =
+            cachedWorkerAutotune ??
+            staticExpansionWorkerAutotuneSelection(
+              workerAutotuneShape,
+              workerCalibrationPlan.source,
+              cachedWorkerAutotune ? 'cached worker autotune result' : workerCalibrationPlan.reason,
+            )
+          let userConcurrency = workerAutotuneSelection.workerCount
+          updateUploadStatus(
+            { workerAutotune: uploadWorkerAutotuneStatus(workerAutotuneSelection) },
+            cachedWorkerAutotune ? 'worker_autotune:cache_hit' : 'worker_autotune:cache_miss',
+          )
+          browserPerfLog('worker_autotune:initial', {
+            selectedWorkerCount: workerAutotuneSelection.workerCount,
+            staticWorkerCount: workerAutotuneSelection.staticWorkerCount,
+            source: workerAutotuneSelection.source,
+            cacheHit: workerAutotuneSelection.cacheHit,
+            candidates: workerAutotuneSelection.candidates,
+            cacheKey: workerAutotuneSelection.cacheKey,
+            reason: workerAutotuneSelection.reason,
+            totalUserMdus: totalUserChunks,
+            rsK,
+            rsM,
+          })
           let nextUserIndex = 0
 
-          const processMode2UserMdu = async (i: number): Promise<void> => {
+          const processMode2UserMdu = async (i: number, activeUserConcurrency = userConcurrency): Promise<void> => {
             const opStart = performance.now()
             const isExisting = appendMode2 && i < existingUserCount
             const nonTrivialBlobs = nonTrivialBlobsForPayload(userPayloads[i] ?? 0)
@@ -3573,7 +3688,7 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
             setShardProgress((p) => ({
               ...p,
               phase: 'shard_user',
-              label: userConcurrency > 1 ? `Sharding user MDUs in parallel (${userConcurrency} workers)...` : `Sharding user MDU #${i}...`,
+              label: activeUserConcurrency > 1 ? `Sharding user MDUs in parallel (${activeUserConcurrency} workers)...` : `Sharding user MDU #${i}...`,
               currentOpStartedAtMs: opStart,
               currentMduKind: 'user',
               currentMduIndex: i,
@@ -3706,7 +3821,7 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
               kind: 'user',
               rawBytes: isExisting ? userPayloads[i] ?? 0 : rawChunk.byteLength,
               expansionPath: isExisting ? 'encoded_mdu' : 'payload',
-              concurrency: userConcurrency,
+              concurrency: activeUserConcurrency,
               encodeMs,
               copyMs,
               wasmMs,
@@ -3788,19 +3903,85 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
             )
           }
 
-          const workers = Array.from({ length: userConcurrency }, async () => {
-            let hasMore = true
-            while (hasMore) {
-              const i = nextUserIndex
-              nextUserIndex += 1
-              if (i >= totalUserChunks) {
-                hasMore = false
-                continue
+          const runMode2UserPool = async (workerCount: number, stopIndexExclusive = totalUserChunks): Promise<void> => {
+            const boundedWorkerCount = Math.max(1, Math.min(Math.floor(workerCount), Math.max(1, stopIndexExclusive - nextUserIndex)))
+            const workers = Array.from({ length: boundedWorkerCount }, async () => {
+              while (nextUserIndex < stopIndexExclusive && nextUserIndex < totalUserChunks) {
+                const i = nextUserIndex
+                nextUserIndex += 1
+                await processMode2UserMdu(i, boundedWorkerCount)
               }
-              await processMode2UserMdu(i)
+            })
+            await Promise.all(workers)
+          }
+
+          if (!cachedWorkerAutotune && workerCalibrationPlan.shouldCalibrate) {
+            const calibrationSamples: ExpansionWorkerAutotuneSample[] = []
+            const calibrationStart = performance.now()
+            let calibrationTimedOut = false
+            addLog(
+              `> Autotuning upload-prep workers across candidates ${workerCalibrationPlan.candidates.join(', ')} (bounded sample)...`,
+            )
+            for (const batch of workerCalibrationPlan.sampleBatches) {
+              if (performance.now() - calibrationStart >= workerCalibrationPlan.timeoutMs) {
+                calibrationTimedOut = true
+                break
+              }
+              const batchStartIndex = nextUserIndex
+              const batchStop = Math.min(totalUserChunks, batchStartIndex + batch.sampleJobs)
+              const actualSampleJobs = batchStop - batchStartIndex
+              if (actualSampleJobs <= 0) break
+              const sampleStart = performance.now()
+              addLog(`> Worker autotune sample: ${batch.workerCount} workers over ${actualSampleJobs} user MDU(s)...`)
+              await runMode2UserPool(batch.workerCount, batchStop)
+              const wallMs = performance.now() - sampleStart
+              calibrationSamples.push({
+                workerCount: batch.workerCount,
+                wallMs,
+                sampleJobs: actualSampleJobs,
+                scoreMs: wallMs / Math.max(1, actualSampleJobs),
+              })
             }
-          })
-          await Promise.all(workers)
+            if (calibrationSamples.length < workerCalibrationPlan.sampleBatches.length) {
+              calibrationTimedOut = true
+            }
+            workerAutotuneSelection = finalizeExpansionWorkerAutotuneSelection(
+              workerAutotuneShape,
+              calibrationSamples,
+              {
+                timedOut: calibrationTimedOut,
+                calibrationComplete: !calibrationTimedOut,
+                cacheStore: defaultExpansionWorkerAutotuneCacheStore,
+              },
+            )
+            userConcurrency = workerAutotuneSelection.workerCount
+            updateUploadStatus(
+              { workerAutotune: uploadWorkerAutotuneStatus(workerAutotuneSelection) },
+              workerAutotuneSelection.source === 'calibrated'
+                ? 'worker_autotune:calibrated'
+                : 'worker_autotune:fallback',
+            )
+            browserPerfLog('worker_autotune:complete', {
+              selectedWorkerCount: workerAutotuneSelection.workerCount,
+              staticWorkerCount: workerAutotuneSelection.staticWorkerCount,
+              source: workerAutotuneSelection.source,
+              cacheHit: workerAutotuneSelection.cacheHit,
+              candidates: workerAutotuneSelection.candidates,
+              sampledCandidates: workerAutotuneSelection.sampledCandidates,
+              samples: calibrationSamples,
+              scoreMs: roundPerfMs(workerAutotuneSelection.scoreMs),
+              cacheKey: workerAutotuneSelection.cacheKey,
+              reason: workerAutotuneSelection.reason,
+              totalUserMdus: totalUserChunks,
+              rsK,
+              rsM,
+            })
+            addLog(`> Upload-prep worker selection: ${userConcurrency} workers (${workerAutotuneSelection.reason}).`)
+          }
+
+          if (nextUserIndex < totalUserChunks) {
+            await runMode2UserPool(userConcurrency, totalUserChunks)
+          }
         } else {
           for (let i = 0; i < totalUserChunks; i++) {
               const opStart = performance.now();
@@ -4380,7 +4561,8 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
           totalMdus: finalMdus.length,
           totalUserMdus: totalUserChunks,
           totalWitnessMdus: witnessMduCount,
-          userConcurrency: useMode2 ? pickExpansionWorkerCount(prepareHardwareConcurrency, totalUserChunks) : 1,
+          userConcurrency: useMode2 ? workerAutotuneSelection?.workerCount ?? pickExpansionWorkerCount(prepareHardwareConcurrency, totalUserChunks) : 1,
+          workerAutotune: workerAutotuneSelection,
           manifestMs,
           wallClock: {
             prepareMs: elapsedMs,
@@ -4476,6 +4658,12 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
             kzgSchedulerBatchSplitCount: kzgDiagnosticSample?.workerKzgSchedulerBatchSplitCount,
             kzgSchedulerBatchFallbackCount: kzgDiagnosticSample?.workerKzgSchedulerBatchFallbackCount,
             commitWorkerCount: kzgDiagnosticSample?.workerCommitWorkerCount,
+            workerAutotuneSource: workerAutotuneSelection?.source,
+            workerAutotuneReason: workerAutotuneSelection?.reason,
+            workerAutotuneCacheHit: workerAutotuneSelection?.cacheHit,
+            workerAutotuneCandidates: workerAutotuneSelection?.candidates,
+            workerAutotuneSampledCandidates: workerAutotuneSelection?.sampledCandidates,
+            workerAutotuneScoreMs: workerAutotuneSelection?.scoreMs,
           },
           samples: perfSamples,
         }
@@ -4509,6 +4697,9 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
             mdu0AppendWallMs: roundPerfMs(mdu0AppendMs) ?? 0,
             mdu0StageWallMs: roundPerfMs(mdu0StageMs) ?? 0,
             rootsAssembleWallMs: roundPerfMs(rootsAssembleMs) ?? 0,
+            workerAutotuneSelectedWorkerCount: workerAutotuneSelection?.workerCount ?? null,
+            workerAutotuneSource: workerAutotuneSelection?.source ?? null,
+            workerAutotuneCacheHit: workerAutotuneSelection?.cacheHit ?? null,
             ...prepareProfile.summary,
           }
           ;(
@@ -4554,6 +4745,11 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
         console.log('[perf] prepare summary', {
           prepareWallMs: roundPerfMs(elapsedMs),
           userConcurrency: prepareProfile.userConcurrency,
+          workerAutotuneSource: workerAutotuneSelection?.source,
+          workerAutotuneCacheHit: workerAutotuneSelection?.cacheHit,
+          workerAutotuneCandidates: workerAutotuneSelection?.candidates,
+          workerAutotuneSampledCandidates: workerAutotuneSelection?.sampledCandidates,
+          workerAutotuneReason: workerAutotuneSelection?.reason,
           totalUserMdus: totalUserChunks,
           totalWitnessMdus: witnessMduCount,
           userStageWallMs: roundPerfMs(userStageMs),
@@ -4602,6 +4798,10 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
           totalUserMdus: totalUserChunks,
           totalWitnessMdus: witnessMduCount,
           userConcurrency: prepareProfile.userConcurrency,
+          workerAutotuneSource: workerAutotuneSelection?.source,
+          workerAutotuneCacheHit: workerAutotuneSelection?.cacheHit,
+          workerAutotuneCandidates: workerAutotuneSelection?.candidates,
+          workerAutotuneSampledCandidates: workerAutotuneSelection?.sampledCandidates,
           userStageWallMs: roundPerfMs(userStageMs),
           witnessConcatWallMs: roundPerfMs(witnessConcatMs),
           witnessStageWallMs: roundPerfMs(witnessStageMs),
@@ -4820,6 +5020,13 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
         value: [uploadStatus.kzg.calibrationStatus, uploadStatus.kzg.calibrationSource]
           .filter(Boolean)
           .join(' / ') || 'default',
+      },
+      {
+        label: 'prep workers',
+        value:
+          uploadStatus.workerAutotune.selectedWorkerCount === null
+            ? 'pending'
+            : `${uploadStatus.workerAutotune.selectedWorkerCount} (${uploadStatus.workerAutotune.source ?? 'static'})`,
       },
       { label: 'storage', value: uploadStatus.storage.stage.replace(/_/g, ' ') },
       { label: 'transport', value: uploadStatus.transport.mode.replace(/-/g, ' ') },

--- a/polystore-website/src/lib/expansionWorkers.test.ts
+++ b/polystore-website/src/lib/expansionWorkers.test.ts
@@ -3,11 +3,48 @@ import assert from 'node:assert/strict'
 
 import {
   EXPANSION_WORKER_AUTOTUNE_VERSION,
+  ExpansionWorkerAutotuneCacheStore,
   buildExpansionWorkerAutotuneCandidates,
+  buildExpansionWorkerCalibrationPlan,
+  createExpansionWorkerAutotuneCacheKey,
+  finalizeExpansionWorkerAutotuneSelection,
+  getCachedExpansionWorkerAutotuneSelection,
   isUsableExpansionWorkerAutotuneCache,
   pickExpansionWorkerCount,
   selectExpansionWorkerCountFromSamples,
 } from './expansionWorkers'
+
+function memoryStorage() {
+  const values = new Map<string, string>()
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      values.set(key, value)
+    },
+    removeItem: (key: string) => {
+      values.delete(key)
+    },
+  }
+}
+
+const defaultShape = {
+  hardwareConcurrency: 12,
+  totalJobs: 13,
+  rsK: 8,
+  rsM: 4,
+  kzgCommitBackend: 'webgpu-scheduler',
+  rustCommitBackend: 'webgpu-msm',
+  kzgWebGpuAvailable: true,
+  kzgWebGpuProbeStatus: 'passed',
+  kzgWebGpuBucketWidth: 12,
+  kzgWebGpuReductionMode: 'parallel16',
+  kzgWebGpuCalibrationStatus: 'cached',
+  kzgWebGpuCalibrationSource: 'benchmark-matrix',
+  kzgWebGpuCalibrationCacheKey: 'adapter-cache-key',
+  schedulerOwner: 'browser-user-mdu-kzg-scheduler-v1',
+  schedulerConcurrency: 1,
+  schedulerMaxQueueDepth: 32,
+}
 
 test('pickExpansionWorkerCount falls back safely for undefined and NaN hardware concurrency', () => {
   assert.equal(pickExpansionWorkerCount(undefined), 3)
@@ -42,10 +79,11 @@ test('pickExpansionWorkerCount floors fractional inputs and clamps invalid job c
   assert.equal(pickExpansionWorkerCount(12, Number.NaN), 6)
 })
 
-test('buildExpansionWorkerAutotuneCandidates probes near the static worker count', () => {
-  assert.deepEqual(buildExpansionWorkerAutotuneCandidates(12, 32), [5, 6, 7, 8])
-  assert.deepEqual(buildExpansionWorkerAutotuneCandidates(8, 12), [4, 5, 6, 7])
-  assert.deepEqual(buildExpansionWorkerAutotuneCandidates(4, 16), [2, 3, 4])
+test('buildExpansionWorkerAutotuneCandidates includes low-risk sweep points and static default', () => {
+  assert.deepEqual(buildExpansionWorkerAutotuneCandidates(12, 32), [1, 3, 5, 6])
+  assert.deepEqual(buildExpansionWorkerAutotuneCandidates(8, 12), [1, 3, 5])
+  assert.deepEqual(buildExpansionWorkerAutotuneCandidates(6, 16), [1, 3, 4])
+  assert.deepEqual(buildExpansionWorkerAutotuneCandidates(4, 16), [1, 2, 3])
 })
 
 test('buildExpansionWorkerAutotuneCandidates skips tiny jobs and single-worker machines', () => {
@@ -54,19 +92,35 @@ test('buildExpansionWorkerAutotuneCandidates skips tiny jobs and single-worker m
   assert.deepEqual(buildExpansionWorkerAutotuneCandidates(2, 16), [1])
 })
 
-test('selectExpansionWorkerCountFromSamples picks the fastest allowed sample', () => {
+test('buildExpansionWorkerCalibrationPlan bounds large-upload sampling', () => {
+  const plan = buildExpansionWorkerCalibrationPlan(defaultShape)
+  assert.equal(plan.shouldCalibrate, true)
+  assert.deepEqual(plan.candidates, [1, 3, 5, 6])
+  assert.deepEqual(plan.sampleBatches, [
+    { workerCount: 5, sampleJobs: 5 },
+    { workerCount: 6, sampleJobs: 6 },
+  ])
+  assert.equal(plan.staticWorkerCount, 6)
+})
+
+test('buildExpansionWorkerCalibrationPlan disables calibration for small uploads or explicit opt-out', () => {
+  assert.equal(buildExpansionWorkerCalibrationPlan({ ...defaultShape, totalJobs: 3 }).shouldCalibrate, false)
+  assert.equal(buildExpansionWorkerCalibrationPlan(defaultShape, { enabled: false }).source, 'static-disabled')
+})
+
+test('selectExpansionWorkerCountFromSamples picks the fastest allowed normalized sample', () => {
   assert.equal(
     selectExpansionWorkerCountFromSamples(
       [
-        { workerCount: 5, wallMs: 1200 },
-        { workerCount: 6, wallMs: 980 },
-        { workerCount: 7, wallMs: 760 },
-        { workerCount: 9, wallMs: 100 },
+        { workerCount: 1, wallMs: 1100, sampleJobs: 1 },
+        { workerCount: 3, wallMs: 2400, sampleJobs: 3 },
+        { workerCount: 5, wallMs: 3000, sampleJobs: 5 },
+        { workerCount: 9, wallMs: 100, sampleJobs: 1 },
       ],
       12,
       32,
     ),
-    7,
+    5,
   )
 })
 
@@ -84,20 +138,93 @@ test('selectExpansionWorkerCountFromSamples falls back to static count when samp
   )
 })
 
-test('isUsableExpansionWorkerAutotuneCache validates version, hardware, and candidate bounds', () => {
+test('cache key changes for hardware, backend, scheduler, profile, and version contract shape', () => {
+  const baseline = createExpansionWorkerAutotuneCacheKey(defaultShape)
+  assert.notEqual(createExpansionWorkerAutotuneCacheKey({ ...defaultShape, hardwareConcurrency: 8 }), baseline)
+  assert.notEqual(createExpansionWorkerAutotuneCacheKey({ ...defaultShape, rsK: 4, rsM: 2 }), baseline)
+  assert.notEqual(createExpansionWorkerAutotuneCacheKey({ ...defaultShape, kzgWebGpuCalibrationCacheKey: 'other' }), baseline)
+  assert.notEqual(createExpansionWorkerAutotuneCacheKey({ ...defaultShape, schedulerMaxQueueDepth: 64 }), baseline)
+  assert.match(baseline, new RegExp(`v${EXPANSION_WORKER_AUTOTUNE_VERSION}`))
+})
+
+test('cache store validates and invalidates selected worker count by shape', () => {
+  const store = new ExpansionWorkerAutotuneCacheStore({ storage: memoryStorage() })
+  const selection = finalizeExpansionWorkerAutotuneSelection(
+    defaultShape,
+    [
+      { workerCount: 1, wallMs: 1000, sampleJobs: 1 },
+      { workerCount: 3, wallMs: 2100, sampleJobs: 3 },
+      { workerCount: 5, wallMs: 2500, sampleJobs: 5 },
+    ],
+    { cacheStore: store, nowMs: 1234 },
+  )
+
+  assert.equal(selection.workerCount, 5)
+  assert.equal(selection.cacheWritable, true)
+  const cached = getCachedExpansionWorkerAutotuneSelection(defaultShape, store)
+  assert.equal(cached?.workerCount, 5)
+  assert.equal(cached?.source, 'cache-hit')
+  assert.equal(getCachedExpansionWorkerAutotuneSelection({ ...defaultShape, hardwareConcurrency: 8 }, store), null)
+  assert.equal(getCachedExpansionWorkerAutotuneSelection({ ...defaultShape, rsM: 5 }, store), null)
+  assert.equal(getCachedExpansionWorkerAutotuneSelection({ ...defaultShape, kzgCommitBackend: 'wasm-blst' }, store), null)
+})
+
+test('isUsableExpansionWorkerAutotuneCache rejects malformed and out-of-candidate entries', () => {
   const cache = {
     version: EXPANSION_WORKER_AUTOTUNE_VERSION,
+    contract: 'mode2-user-mdu-rs-kzg-v2',
+    cacheKey: createExpansionWorkerAutotuneCacheKey(defaultShape),
     hardwareConcurrency: 12,
-    selectedWorkerCount: 7,
+    totalJobs: 13,
+    jobBucket: '8-15',
+    rsK: 8,
+    rsM: 4,
+    backendKey: 'kzg:webgpu-scheduler:webgpu-msm:true:passed:unknown:12:parallel16:cached:benchmark-matrix:adapter-cache-key',
+    schedulerKey: 'scheduler:browser-user-mdu-kzg-scheduler-v1:1:32:unknown:unknown:unknown',
+    selectedWorkerCount: 5,
+    staticWorkerCount: 6,
+    candidates: [1, 3, 5, 6],
+    sampledCandidates: [1, 3, 5],
     measuredAtMs: 1000,
-    scoreMs: 760,
+    scoreMs: 500,
+    sampleCount: 3,
+    reason: 'selected 5 workers',
   }
 
-  assert.equal(isUsableExpansionWorkerAutotuneCache(cache, 12, 32), true)
-  assert.equal(isUsableExpansionWorkerAutotuneCache({ ...cache, version: 0 }, 12, 32), false)
-  assert.equal(isUsableExpansionWorkerAutotuneCache({ ...cache, hardwareConcurrency: 8 }, 12, 32), false)
-  assert.equal(isUsableExpansionWorkerAutotuneCache({ ...cache, selectedWorkerCount: 9 }, 12, 32), false)
-  assert.equal(isUsableExpansionWorkerAutotuneCache({ ...cache, selectedWorkerCount: 7.5 }, 12, 32), false)
-  assert.equal(isUsableExpansionWorkerAutotuneCache({ ...cache, measuredAtMs: 0 }, 12, 32), false)
-  assert.equal(isUsableExpansionWorkerAutotuneCache({ ...cache, scoreMs: Number.NaN }, 12, 32), false)
+  assert.equal(isUsableExpansionWorkerAutotuneCache(cache, defaultShape), true)
+  assert.equal(isUsableExpansionWorkerAutotuneCache({ ...cache, version: 0 }, defaultShape), false)
+  assert.equal(isUsableExpansionWorkerAutotuneCache({ ...cache, selectedWorkerCount: 9 }, defaultShape), false)
+  assert.equal(isUsableExpansionWorkerAutotuneCache({ ...cache, measuredAtMs: 0 }, defaultShape), false)
+  assert.equal(isUsableExpansionWorkerAutotuneCache({ ...cache, scoreMs: Number.NaN }, defaultShape), false)
+})
+
+test('finalizeExpansionWorkerAutotuneSelection fails closed on timeout, error, and invalid samples', () => {
+  const timedOut = finalizeExpansionWorkerAutotuneSelection(
+    defaultShape,
+    [{ workerCount: 5, wallMs: 2500, sampleJobs: 5 }],
+    { timedOut: true },
+  )
+  assert.equal(timedOut.workerCount, 6)
+  assert.equal(timedOut.source, 'fallback-timeout')
+  assert.equal(timedOut.cacheWritable, false)
+
+  const failed = finalizeExpansionWorkerAutotuneSelection(defaultShape, [], { error: new Error('boom') })
+  assert.equal(failed.workerCount, 6)
+  assert.equal(failed.source, 'fallback-error')
+
+  const noSamples = finalizeExpansionWorkerAutotuneSelection(defaultShape, [{ workerCount: 9, wallMs: 1 }])
+  assert.equal(noSamples.workerCount, 6)
+  assert.equal(noSamples.source, 'fallback-no-samples')
+})
+
+test('finalizeExpansionWorkerAutotuneSelection does not cache incomplete calibration', () => {
+  const store = new ExpansionWorkerAutotuneCacheStore({ storage: memoryStorage() })
+  const selection = finalizeExpansionWorkerAutotuneSelection(
+    defaultShape,
+    [{ workerCount: 5, wallMs: 2500, sampleJobs: 5 }],
+    { calibrationComplete: false, cacheStore: store },
+  )
+  assert.equal(selection.workerCount, 5)
+  assert.equal(selection.cacheWritable, false)
+  assert.equal(getCachedExpansionWorkerAutotuneSelection(defaultShape, store), null)
 })

--- a/polystore-website/src/lib/expansionWorkers.test.ts
+++ b/polystore-website/src/lib/expansionWorkers.test.ts
@@ -198,14 +198,11 @@ test('isUsableExpansionWorkerAutotuneCache rejects malformed and out-of-candidat
   assert.equal(isUsableExpansionWorkerAutotuneCache({ ...cache, scoreMs: Number.NaN }, defaultShape), false)
 })
 
-test('finalizeExpansionWorkerAutotuneSelection fails closed on timeout, error, and invalid samples', () => {
-  const timedOut = finalizeExpansionWorkerAutotuneSelection(
-    defaultShape,
-    [{ workerCount: 5, wallMs: 2500, sampleJobs: 5 }],
-    { timedOut: true },
-  )
+test('finalizeExpansionWorkerAutotuneSelection fails closed on timeout without samples, error, and invalid samples', () => {
+  const timedOut = finalizeExpansionWorkerAutotuneSelection(defaultShape, [], { timedOut: true })
   assert.equal(timedOut.workerCount, 6)
   assert.equal(timedOut.source, 'fallback-timeout')
+  assert.equal(timedOut.sampleCount, 0)
   assert.equal(timedOut.cacheWritable, false)
 
   const failed = finalizeExpansionWorkerAutotuneSelection(defaultShape, [], { error: new Error('boom') })
@@ -215,6 +212,27 @@ test('finalizeExpansionWorkerAutotuneSelection fails closed on timeout, error, a
   const noSamples = finalizeExpansionWorkerAutotuneSelection(defaultShape, [{ workerCount: 9, wallMs: 1 }])
   assert.equal(noSamples.workerCount, 6)
   assert.equal(noSamples.source, 'fallback-no-samples')
+})
+
+test('finalizeExpansionWorkerAutotuneSelection uses valid timed-out samples without caching partial results', () => {
+  const store = new ExpansionWorkerAutotuneCacheStore({ storage: memoryStorage() })
+  const timedOut = finalizeExpansionWorkerAutotuneSelection(
+    { ...defaultShape, totalJobs: 9 },
+    [
+      { workerCount: 3, wallMs: 29_004, sampleJobs: 3 },
+      { workerCount: 5, wallMs: 54_080, sampleJobs: 5 },
+    ],
+    { timedOut: true, cacheStore: store },
+  )
+
+  assert.equal(timedOut.workerCount, 3)
+  assert.equal(timedOut.source, 'calibrated')
+  assert.equal(timedOut.timedOut, true)
+  assert.deepEqual(timedOut.sampledCandidates, [3, 5])
+  assert.equal(timedOut.sampleCount, 2)
+  assert.equal(timedOut.cacheWritable, false)
+  assert.match(timedOut.reason, /partial timed-out runtime calibration/)
+  assert.equal(getCachedExpansionWorkerAutotuneSelection({ ...defaultShape, totalJobs: 9 }, store), null)
 })
 
 test('finalizeExpansionWorkerAutotuneSelection does not cache incomplete calibration', () => {

--- a/polystore-website/src/lib/expansionWorkers.ts
+++ b/polystore-website/src/lib/expansionWorkers.ts
@@ -1,26 +1,190 @@
 export const DEFAULT_EXPANSION_HARDWARE_CONCURRENCY = 4
 const MAX_EXPANSION_WORKERS = 6
-export const EXPANSION_WORKER_AUTOTUNE_VERSION = 1
+export const EXPANSION_WORKER_AUTOTUNE_VERSION = 2
+export const EXPANSION_WORKER_AUTOTUNE_CONTRACT = 'mode2-user-mdu-rs-kzg-v2'
+export const EXPANSION_WORKER_AUTOTUNE_STORAGE_PREFIX = 'polystore:upload-prep-worker-autotune:'
+export const MIN_AUTOTUNE_USER_MDUS = 8
+export const MAX_AUTOTUNE_SAMPLE_USER_MDUS = 11
+export const DEFAULT_EXPANSION_WORKER_AUTOTUNE_TIMEOUT_MS = 30_000
 export const MAX_AUTOTUNE_EXPANSION_WORKERS = 8
+
+export type ExpansionWorkerAutotuneSource =
+  | 'static-disabled'
+  | 'static-small-upload'
+  | 'static-single-candidate'
+  | 'static-unavailable'
+  | 'cache-hit'
+  | 'cache-miss'
+  | 'calibrated'
+  | 'fallback-timeout'
+  | 'fallback-error'
+  | 'fallback-no-samples'
+
+export type ExpansionWorkerAutotuneShape = {
+  hardwareConcurrency?: number
+  totalJobs?: number
+  rsK?: number
+  rsM?: number
+  contract?: string
+  kzgCommitBackend?: string | null
+  rustCommitBackend?: string | null
+  kzgWebGpuAvailable?: boolean | null
+  kzgWebGpuProbeStatus?: string | null
+  kzgWebGpuCircuitOpen?: boolean | null
+  kzgWebGpuBucketWidth?: number | null
+  kzgWebGpuReductionMode?: string | null
+  kzgWebGpuCalibrationStatus?: string | null
+  kzgWebGpuCalibrationSource?: string | null
+  kzgWebGpuCalibrationCacheKey?: string | null
+  schedulerOwner?: string | null
+  schedulerConcurrency?: number | null
+  schedulerMaxQueueDepth?: number | null
+  schedulerBatchMaxMdus?: number | null
+  schedulerBatchMaxBlobs?: number | null
+  schedulerBatchMaxBytes?: number | null
+}
+
+export type NormalizedExpansionWorkerAutotuneShape = Required<
+  Pick<ExpansionWorkerAutotuneShape, 'contract'>
+> & {
+  hardwareConcurrency: number
+  totalJobs: number
+  rsK: number
+  rsM: number
+  jobBucket: string
+  backendKey: string
+  schedulerKey: string
+  cacheKey: string
+}
 
 export type ExpansionWorkerAutotuneCache = {
   version: number
+  contract: string
+  cacheKey: string
   hardwareConcurrency: number
+  totalJobs: number
+  jobBucket: string
+  rsK: number
+  rsM: number
+  backendKey: string
+  schedulerKey: string
   selectedWorkerCount: number
+  staticWorkerCount: number
+  candidates: number[]
+  sampledCandidates: number[]
   measuredAtMs: number
   scoreMs: number
+  sampleCount: number
+  reason: string
 }
 
 export type ExpansionWorkerAutotuneSample = {
   workerCount: number
   wallMs: number
+  sampleJobs?: number
+  scoreMs?: number
+}
+
+export type ExpansionWorkerCalibrationPlan = {
+  enabled: boolean
+  shouldCalibrate: boolean
+  source: ExpansionWorkerAutotuneSource
+  reason: string
+  staticWorkerCount: number
+  candidates: number[]
+  sampleBatches: Array<{ workerCount: number; sampleJobs: number }>
+  maxSampleJobs: number
+  minJobs: number
+  timeoutMs: number
+  cacheKey: string
+  hardwareConcurrency: number
+  totalJobs: number
+  rsK: number
+  rsM: number
+}
+
+export type ExpansionWorkerAutotuneSelection = {
+  version: number
+  contract: string
+  workerCount: number
+  selectedWorkerCount: number
+  staticWorkerCount: number
+  candidates: number[]
+  sampledCandidates: number[]
+  source: ExpansionWorkerAutotuneSource
+  cacheHit: boolean
+  cacheKey: string
+  reason: string
+  scoreMs: number | null
+  measuredAtMs: number | null
+  sampleCount: number
+  hardwareConcurrency: number
+  totalJobs: number
+  rsK: number
+  rsM: number
+  jobBucket: string
+  backendKey: string
+  schedulerKey: string
+  timedOut: boolean
+  cacheWritable: boolean
+  samples: ExpansionWorkerAutotuneSample[]
+}
+
+export type ExpansionWorkerAutotuneStorage = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>
+
+function normalizePositiveInteger(value: unknown, fallback: number): number {
+  const numeric = Math.floor(Number(value))
+  if (Number.isFinite(numeric) && numeric > 0) return numeric
+  return fallback
+}
+
+function normalizeOptionalPositiveInteger(value: unknown): number | null {
+  const numeric = Math.floor(Number(value))
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : null
+}
+
+function normalizePart(value: unknown): string {
+  const normalized = String(value ?? 'unknown').trim().toLowerCase()
+  return normalized || 'unknown'
+}
+
+function normalizeBoolPart(value: unknown): string {
+  return typeof value === 'boolean' ? String(value) : 'unknown'
+}
+
+function normalizeNumberPart(value: unknown): string {
+  const numeric = normalizeOptionalPositiveInteger(value)
+  return numeric === null ? 'unknown' : String(numeric)
+}
+
+function uniqueSorted(values: number[]): number[] {
+  return [...new Set(values.map((value) => Math.floor(value)).filter((value) => Number.isFinite(value) && value > 0))].sort(
+    (a, b) => a - b,
+  )
+}
+
+export function normalizeExpansionHardwareConcurrency(hardwareConcurrency?: number): number {
+  return Number.isFinite(hardwareConcurrency)
+    ? Math.max(1, Math.floor(Number(hardwareConcurrency)))
+    : DEFAULT_EXPANSION_HARDWARE_CONCURRENCY
+}
+
+export function normalizeExpansionTotalJobs(totalJobs?: number): number {
+  return Number.isFinite(totalJobs) ? Math.max(1, Math.floor(Number(totalJobs))) : 1
+}
+
+export function expansionWorkerJobBucket(totalJobs?: number): string {
+  const jobs = normalizeExpansionTotalJobs(totalJobs)
+  if (jobs < MIN_AUTOTUNE_USER_MDUS) return `lt${MIN_AUTOTUNE_USER_MDUS}`
+  if (jobs < 16) return '8-15'
+  if (jobs < 32) return '16-31'
+  if (jobs < 64) return '32-63'
+  return '64+'
 }
 
 export function pickExpansionWorkerCount(hardwareConcurrency?: number, totalJobs?: number): number {
-  const hc = Number.isFinite(hardwareConcurrency)
-    ? Math.max(1, Math.floor(Number(hardwareConcurrency)))
-    : DEFAULT_EXPANSION_HARDWARE_CONCURRENCY
-  const jobCap = Number.isFinite(totalJobs) ? Math.max(1, Math.floor(Number(totalJobs))) : Number.POSITIVE_INFINITY
+  const hc = normalizeExpansionHardwareConcurrency(hardwareConcurrency)
+  const jobCap = Number.isFinite(totalJobs) ? normalizeExpansionTotalJobs(totalJobs) : Number.POSITIVE_INFINITY
 
   let desired = 1
   if (hc >= 10) desired = MAX_EXPANSION_WORKERS
@@ -34,41 +198,377 @@ export function pickExpansionWorkerCount(hardwareConcurrency?: number, totalJobs
 
 export function buildExpansionWorkerAutotuneCandidates(hardwareConcurrency?: number, totalJobs?: number): number[] {
   const staticCount = pickExpansionWorkerCount(hardwareConcurrency, totalJobs)
-  const jobCap = Number.isFinite(totalJobs) ? Math.max(1, Math.floor(Number(totalJobs))) : Number.POSITIVE_INFINITY
-  if (jobCap < 4 || staticCount <= 1) return [staticCount]
+  const jobCap = Number.isFinite(totalJobs) ? normalizeExpansionTotalJobs(totalJobs) : Number.POSITIVE_INFINITY
+  if (jobCap < MIN_AUTOTUNE_USER_MDUS || staticCount <= 1) return [staticCount]
 
-  const hc = Number.isFinite(hardwareConcurrency)
-    ? Math.max(1, Math.floor(Number(hardwareConcurrency)))
-    : DEFAULT_EXPANSION_HARDWARE_CONCURRENCY
-  const upper = Math.max(staticCount, Math.min(MAX_AUTOTUNE_EXPANSION_WORKERS, jobCap, hc))
-  const lower = Math.max(1, staticCount - 2)
-  const preferred = [staticCount - 1, staticCount, staticCount + 1, staticCount + 2]
+  const hc = normalizeExpansionHardwareConcurrency(hardwareConcurrency)
+  const upper = Math.max(1, Math.min(MAX_AUTOTUNE_EXPANSION_WORKERS, jobCap, hc, Math.max(staticCount, 1)))
+  const preferred = staticCount <= 3 ? [1, 2, staticCount] : [1, 3, 5, staticCount]
+  return uniqueSorted(preferred.filter((candidate) => candidate <= upper))
+}
 
-  const candidates = new Set<number>()
-  for (const candidate of preferred) {
-    const normalized = Math.floor(candidate)
-    if (normalized >= lower && normalized <= upper) candidates.add(normalized)
+export function createExpansionWorkerAutotuneBackendKey(shape: ExpansionWorkerAutotuneShape = {}): string {
+  return [
+    'kzg',
+    normalizePart(shape.kzgCommitBackend),
+    normalizePart(shape.rustCommitBackend),
+    normalizeBoolPart(shape.kzgWebGpuAvailable),
+    normalizePart(shape.kzgWebGpuProbeStatus),
+    normalizeBoolPart(shape.kzgWebGpuCircuitOpen),
+    normalizeNumberPart(shape.kzgWebGpuBucketWidth),
+    normalizePart(shape.kzgWebGpuReductionMode),
+    normalizePart(shape.kzgWebGpuCalibrationStatus),
+    normalizePart(shape.kzgWebGpuCalibrationSource),
+    normalizePart(shape.kzgWebGpuCalibrationCacheKey),
+  ].join(':')
+}
+
+export function createExpansionWorkerAutotuneSchedulerKey(shape: ExpansionWorkerAutotuneShape = {}): string {
+  return [
+    'scheduler',
+    normalizePart(shape.schedulerOwner),
+    normalizeNumberPart(shape.schedulerConcurrency),
+    normalizeNumberPart(shape.schedulerMaxQueueDepth),
+    normalizeNumberPart(shape.schedulerBatchMaxMdus),
+    normalizeNumberPart(shape.schedulerBatchMaxBlobs),
+    normalizeNumberPart(shape.schedulerBatchMaxBytes),
+  ].join(':')
+}
+
+export function normalizeExpansionWorkerAutotuneShape(
+  shape: ExpansionWorkerAutotuneShape = {},
+): NormalizedExpansionWorkerAutotuneShape {
+  const hardwareConcurrency = normalizeExpansionHardwareConcurrency(shape.hardwareConcurrency)
+  const totalJobs = normalizeExpansionTotalJobs(shape.totalJobs)
+  const rsK = normalizePositiveInteger(shape.rsK, 8)
+  const rsM = normalizePositiveInteger(shape.rsM, 4)
+  const contract = normalizePart(shape.contract ?? EXPANSION_WORKER_AUTOTUNE_CONTRACT)
+  const jobBucket = expansionWorkerJobBucket(totalJobs)
+  const backendKey = createExpansionWorkerAutotuneBackendKey(shape)
+  const schedulerKey = createExpansionWorkerAutotuneSchedulerKey(shape)
+  const cacheKey = [
+    `v${EXPANSION_WORKER_AUTOTUNE_VERSION}`,
+    contract,
+    `hc=${hardwareConcurrency}`,
+    `rs=${rsK}+${rsM}`,
+    `jobs=${jobBucket}`,
+    backendKey,
+    schedulerKey,
+  ].join('|')
+
+  return {
+    contract,
+    hardwareConcurrency,
+    totalJobs,
+    rsK,
+    rsM,
+    jobBucket,
+    backendKey,
+    schedulerKey,
+    cacheKey,
   }
-  candidates.add(staticCount)
+}
 
-  return [...candidates].sort((a, b) => a - b)
+export function createExpansionWorkerAutotuneCacheKey(shape: ExpansionWorkerAutotuneShape = {}): string {
+  return normalizeExpansionWorkerAutotuneShape(shape).cacheKey
+}
+
+function resolveDefaultAutotuneStorage(): ExpansionWorkerAutotuneStorage | null {
+  try {
+    return (globalThis as unknown as { localStorage?: ExpansionWorkerAutotuneStorage }).localStorage ?? null
+  } catch {
+    return null
+  }
+}
+
+function normalizeExpansionWorkerAutotuneCache(
+  raw: unknown,
+  shape: ExpansionWorkerAutotuneShape = {},
+): ExpansionWorkerAutotuneCache | null {
+  const normalized = normalizeExpansionWorkerAutotuneShape(shape)
+  const obj = raw as Partial<ExpansionWorkerAutotuneCache> | null | undefined
+  if (!obj || obj.version !== EXPANSION_WORKER_AUTOTUNE_VERSION) return null
+  if (obj.contract !== normalized.contract || obj.cacheKey !== normalized.cacheKey) return null
+  if (obj.hardwareConcurrency !== normalized.hardwareConcurrency) return null
+  if (obj.rsK !== normalized.rsK || obj.rsM !== normalized.rsM) return null
+  if (obj.jobBucket !== normalized.jobBucket) return null
+  if (obj.backendKey !== normalized.backendKey || obj.schedulerKey !== normalized.schedulerKey) return null
+
+  const candidates = buildExpansionWorkerAutotuneCandidates(normalized.hardwareConcurrency, normalized.totalJobs)
+  const candidateSet = new Set(candidates)
+  const selectedWorkerCount = Math.floor(Number(obj.selectedWorkerCount))
+  if (!candidateSet.has(selectedWorkerCount)) return null
+  const staticWorkerCount = pickExpansionWorkerCount(normalized.hardwareConcurrency, normalized.totalJobs)
+  const measuredAtMs = Number(obj.measuredAtMs)
+  const scoreMs = Number(obj.scoreMs)
+  const sampleCount = Math.floor(Number(obj.sampleCount))
+  if (!Number.isFinite(measuredAtMs) || measuredAtMs <= 0) return null
+  if (!Number.isFinite(scoreMs) || scoreMs <= 0) return null
+  if (!Number.isInteger(sampleCount) || sampleCount <= 0) return null
+
+  return {
+    version: EXPANSION_WORKER_AUTOTUNE_VERSION,
+    contract: normalized.contract,
+    cacheKey: normalized.cacheKey,
+    hardwareConcurrency: normalized.hardwareConcurrency,
+    totalJobs: normalized.totalJobs,
+    jobBucket: normalized.jobBucket,
+    rsK: normalized.rsK,
+    rsM: normalized.rsM,
+    backendKey: normalized.backendKey,
+    schedulerKey: normalized.schedulerKey,
+    selectedWorkerCount,
+    staticWorkerCount,
+    candidates,
+    sampledCandidates: uniqueSorted(Array.isArray(obj.sampledCandidates) ? obj.sampledCandidates : []),
+    measuredAtMs,
+    scoreMs,
+    sampleCount,
+    reason: typeof obj.reason === 'string' && obj.reason.trim() ? obj.reason : 'cached worker autotune result',
+  }
 }
 
 export function isUsableExpansionWorkerAutotuneCache(
   cache: ExpansionWorkerAutotuneCache | null | undefined,
-  hardwareConcurrency?: number,
+  shapeOrHardwareConcurrency?: ExpansionWorkerAutotuneShape | number,
   totalJobs?: number,
 ): cache is ExpansionWorkerAutotuneCache {
-  if (!cache || cache.version !== EXPANSION_WORKER_AUTOTUNE_VERSION) return false
-  const hc = Number.isFinite(hardwareConcurrency)
-    ? Math.max(1, Math.floor(Number(hardwareConcurrency)))
-    : DEFAULT_EXPANSION_HARDWARE_CONCURRENCY
-  if (cache.hardwareConcurrency !== hc) return false
-  if (!Number.isInteger(cache.selectedWorkerCount) || cache.selectedWorkerCount < 1) return false
-  if (!Number.isFinite(cache.measuredAtMs) || cache.measuredAtMs <= 0) return false
-  if (!Number.isFinite(cache.scoreMs) || cache.scoreMs <= 0) return false
-  const candidates = buildExpansionWorkerAutotuneCandidates(hardwareConcurrency, totalJobs)
-  return candidates.includes(cache.selectedWorkerCount)
+  if (!cache) return false
+  const shape =
+    typeof shapeOrHardwareConcurrency === 'object'
+      ? shapeOrHardwareConcurrency
+      : { hardwareConcurrency: shapeOrHardwareConcurrency, totalJobs }
+  return normalizeExpansionWorkerAutotuneCache(cache, shape) !== null
+}
+
+export class ExpansionWorkerAutotuneCacheStore {
+  private readonly entries = new Map<string, ExpansionWorkerAutotuneCache>()
+  private readonly storage: ExpansionWorkerAutotuneStorage | null
+  private readonly storagePrefix: string
+
+  constructor(options: { storage?: ExpansionWorkerAutotuneStorage | null; storagePrefix?: string } = {}) {
+    this.storage = options.storage === undefined ? resolveDefaultAutotuneStorage() : options.storage
+    this.storagePrefix = options.storagePrefix ?? EXPANSION_WORKER_AUTOTUNE_STORAGE_PREFIX
+  }
+
+  get(shape: ExpansionWorkerAutotuneShape): ExpansionWorkerAutotuneCache | null {
+    const normalized = normalizeExpansionWorkerAutotuneShape(shape)
+    const memoryEntry = normalizeExpansionWorkerAutotuneCache(this.entries.get(normalized.cacheKey), shape)
+    if (memoryEntry) return memoryEntry
+    this.entries.delete(normalized.cacheKey)
+
+    if (!this.storage) return null
+    try {
+      const raw = this.storage.getItem(`${this.storagePrefix}${normalized.cacheKey}`)
+      if (!raw) return null
+      const parsed = normalizeExpansionWorkerAutotuneCache(JSON.parse(raw), shape)
+      if (!parsed) {
+        this.storage.removeItem(`${this.storagePrefix}${normalized.cacheKey}`)
+        return null
+      }
+      this.entries.set(normalized.cacheKey, parsed)
+      return parsed
+    } catch {
+      return null
+    }
+  }
+
+  set(shape: ExpansionWorkerAutotuneShape, cache: ExpansionWorkerAutotuneCache): void {
+    const normalized = normalizeExpansionWorkerAutotuneCache(cache, shape)
+    if (!normalized) throw new Error('invalid expansion worker autotune cache entry')
+    this.entries.set(normalized.cacheKey, normalized)
+    try {
+      this.storage?.setItem(`${this.storagePrefix}${normalized.cacheKey}`, JSON.stringify(normalized))
+    } catch {
+      // Persistent storage is best-effort. The in-memory cache remains valid for this page session.
+    }
+  }
+
+  invalidate(shape?: ExpansionWorkerAutotuneShape): void {
+    if (shape) {
+      const key = normalizeExpansionWorkerAutotuneShape(shape).cacheKey
+      this.entries.delete(key)
+      try {
+        this.storage?.removeItem(`${this.storagePrefix}${key}`)
+      } catch {
+        // best effort
+      }
+      return
+    }
+
+    for (const key of this.entries.keys()) {
+      try {
+        this.storage?.removeItem(`${this.storagePrefix}${key}`)
+      } catch {
+        // best effort
+      }
+    }
+    this.entries.clear()
+  }
+}
+
+export const defaultExpansionWorkerAutotuneCacheStore = new ExpansionWorkerAutotuneCacheStore()
+
+export function selectionFromExpansionWorkerAutotuneCache(
+  cache: ExpansionWorkerAutotuneCache,
+  shape: ExpansionWorkerAutotuneShape = {},
+): ExpansionWorkerAutotuneSelection {
+  const normalized = normalizeExpansionWorkerAutotuneShape(shape)
+  return {
+    version: EXPANSION_WORKER_AUTOTUNE_VERSION,
+    contract: normalized.contract,
+    workerCount: cache.selectedWorkerCount,
+    selectedWorkerCount: cache.selectedWorkerCount,
+    staticWorkerCount: cache.staticWorkerCount,
+    candidates: cache.candidates,
+    sampledCandidates: cache.sampledCandidates,
+    source: 'cache-hit',
+    cacheHit: true,
+    cacheKey: cache.cacheKey,
+    reason: cache.reason || 'cached worker autotune result',
+    scoreMs: cache.scoreMs,
+    measuredAtMs: cache.measuredAtMs,
+    sampleCount: cache.sampleCount,
+    hardwareConcurrency: normalized.hardwareConcurrency,
+    totalJobs: normalized.totalJobs,
+    rsK: normalized.rsK,
+    rsM: normalized.rsM,
+    jobBucket: normalized.jobBucket,
+    backendKey: normalized.backendKey,
+    schedulerKey: normalized.schedulerKey,
+    timedOut: false,
+    cacheWritable: false,
+    samples: [],
+  }
+}
+
+export function getCachedExpansionWorkerAutotuneSelection(
+  shape: ExpansionWorkerAutotuneShape,
+  cacheStore: ExpansionWorkerAutotuneCacheStore | null | undefined = defaultExpansionWorkerAutotuneCacheStore,
+): ExpansionWorkerAutotuneSelection | null {
+  const cache = cacheStore?.get(shape) ?? null
+  return cache ? selectionFromExpansionWorkerAutotuneCache(cache, shape) : null
+}
+
+export function staticExpansionWorkerAutotuneSelection(
+  shape: ExpansionWorkerAutotuneShape = {},
+  source: ExpansionWorkerAutotuneSource = 'static-unavailable',
+  reason = 'using static hardware-concurrency worker count',
+): ExpansionWorkerAutotuneSelection {
+  const normalized = normalizeExpansionWorkerAutotuneShape(shape)
+  const staticWorkerCount = pickExpansionWorkerCount(normalized.hardwareConcurrency, normalized.totalJobs)
+  return {
+    version: EXPANSION_WORKER_AUTOTUNE_VERSION,
+    contract: normalized.contract,
+    workerCount: staticWorkerCount,
+    selectedWorkerCount: staticWorkerCount,
+    staticWorkerCount,
+    candidates: buildExpansionWorkerAutotuneCandidates(normalized.hardwareConcurrency, normalized.totalJobs),
+    sampledCandidates: [],
+    source,
+    cacheHit: false,
+    cacheKey: normalized.cacheKey,
+    reason,
+    scoreMs: null,
+    measuredAtMs: null,
+    sampleCount: 0,
+    hardwareConcurrency: normalized.hardwareConcurrency,
+    totalJobs: normalized.totalJobs,
+    rsK: normalized.rsK,
+    rsM: normalized.rsM,
+    jobBucket: normalized.jobBucket,
+    backendKey: normalized.backendKey,
+    schedulerKey: normalized.schedulerKey,
+    timedOut: false,
+    cacheWritable: false,
+    samples: [],
+  }
+}
+
+export function buildExpansionWorkerCalibrationPlan(
+  shape: ExpansionWorkerAutotuneShape = {},
+  options: {
+    enabled?: boolean
+    minJobs?: number
+    maxSampleJobs?: number
+    timeoutMs?: number
+  } = {},
+): ExpansionWorkerCalibrationPlan {
+  const normalized = normalizeExpansionWorkerAutotuneShape(shape)
+  const enabled = options.enabled !== false
+  const minJobs = normalizePositiveInteger(options.minJobs, MIN_AUTOTUNE_USER_MDUS)
+  const maxSampleJobs = normalizePositiveInteger(options.maxSampleJobs, MAX_AUTOTUNE_SAMPLE_USER_MDUS)
+  const timeoutMs = normalizePositiveInteger(options.timeoutMs, DEFAULT_EXPANSION_WORKER_AUTOTUNE_TIMEOUT_MS)
+  const staticWorkerCount = pickExpansionWorkerCount(normalized.hardwareConcurrency, normalized.totalJobs)
+  const candidates = buildExpansionWorkerAutotuneCandidates(normalized.hardwareConcurrency, normalized.totalJobs)
+
+  let source: ExpansionWorkerAutotuneSource = 'cache-miss'
+  let reason = 'runtime calibration required: no valid cached worker count for this shape'
+  let shouldCalibrate = true
+
+  if (!enabled) {
+    source = 'static-disabled'
+    reason = 'worker autotune disabled; using static hardware-concurrency worker count'
+    shouldCalibrate = false
+  } else if (normalized.totalJobs < minJobs) {
+    source = 'static-small-upload'
+    reason = `small upload (${normalized.totalJobs} user MDUs < ${minJobs}); skipping worker calibration`
+    shouldCalibrate = false
+  } else if (candidates.length <= 1) {
+    source = 'static-single-candidate'
+    reason = 'only one safe worker-count candidate; using static hardware-concurrency worker count'
+    shouldCalibrate = false
+  }
+
+  const sampleBatches: Array<{ workerCount: number; sampleJobs: number }> = []
+  if (shouldCalibrate) {
+    const lowerCandidates = candidates.filter((candidate) => candidate < staticWorkerCount).sort((a, b) => b - a)
+    const higherCandidates = candidates.filter((candidate) => candidate > staticWorkerCount).sort((a, b) => a - b)
+    const orderedCandidates = [
+      ...lowerCandidates.slice(0, 1),
+      staticWorkerCount,
+      ...lowerCandidates.slice(1),
+      ...higherCandidates,
+    ].filter((candidate, index, values) => candidates.includes(candidate) && values.indexOf(candidate) === index)
+    let remaining = Math.min(maxSampleJobs, normalized.totalJobs)
+    for (const workerCount of orderedCandidates) {
+      if (remaining <= 0) break
+      const sampleJobs = Math.min(workerCount, remaining, normalized.totalJobs)
+      if (workerCount > 1 && sampleJobs < workerCount) continue
+      sampleBatches.push({ workerCount, sampleJobs })
+      remaining -= sampleJobs
+    }
+    if (sampleBatches.length === 0) {
+      source = 'static-unavailable'
+      reason = 'calibration budget could not fit a valid worker-count sample; using static worker count'
+      shouldCalibrate = false
+    }
+  }
+
+  return {
+    enabled,
+    shouldCalibrate,
+    source,
+    reason,
+    staticWorkerCount,
+    candidates,
+    sampleBatches,
+    maxSampleJobs,
+    minJobs,
+    timeoutMs,
+    cacheKey: normalized.cacheKey,
+    hardwareConcurrency: normalized.hardwareConcurrency,
+    totalJobs: normalized.totalJobs,
+    rsK: normalized.rsK,
+    rsM: normalized.rsM,
+  }
+}
+
+function sampleScore(sample: ExpansionWorkerAutotuneSample): number {
+  if (Number.isFinite(sample.scoreMs) && Number(sample.scoreMs) > 0) return Number(sample.scoreMs)
+  const wallMs = Number(sample.wallMs)
+  const sampleJobs = Number.isFinite(sample.sampleJobs) ? Math.max(1, Math.floor(Number(sample.sampleJobs))) : 1
+  return wallMs / sampleJobs
 }
 
 export function selectExpansionWorkerCountFromSamples(
@@ -83,13 +583,143 @@ export function selectExpansionWorkerCountFromSamples(
 
   for (const sample of samples) {
     const workerCount = Math.floor(Number(sample.workerCount))
-    const wallMs = Number(sample.wallMs)
-    if (!allowed.has(workerCount) || !Number.isFinite(wallMs) || wallMs <= 0) continue
-    if (wallMs < bestScore || (wallMs === bestScore && workerCount < bestWorkerCount)) {
-      bestScore = wallMs
+    const score = sampleScore(sample)
+    if (!allowed.has(workerCount) || !Number.isFinite(score) || score <= 0) continue
+    if (score < bestScore || (score === bestScore && workerCount < bestWorkerCount)) {
+      bestScore = score
       bestWorkerCount = workerCount
     }
   }
 
   return bestWorkerCount
+}
+
+function cacheFromSelection(selection: ExpansionWorkerAutotuneSelection): ExpansionWorkerAutotuneCache {
+  return {
+    version: EXPANSION_WORKER_AUTOTUNE_VERSION,
+    contract: selection.contract,
+    cacheKey: selection.cacheKey,
+    hardwareConcurrency: selection.hardwareConcurrency,
+    totalJobs: selection.totalJobs,
+    jobBucket: selection.jobBucket,
+    rsK: selection.rsK,
+    rsM: selection.rsM,
+    backendKey: selection.backendKey,
+    schedulerKey: selection.schedulerKey,
+    selectedWorkerCount: selection.workerCount,
+    staticWorkerCount: selection.staticWorkerCount,
+    candidates: selection.candidates,
+    sampledCandidates: selection.sampledCandidates,
+    measuredAtMs: selection.measuredAtMs ?? Date.now(),
+    scoreMs: selection.scoreMs ?? 1,
+    sampleCount: selection.sampleCount,
+    reason: selection.reason,
+  }
+}
+
+export function finalizeExpansionWorkerAutotuneSelection(
+  shape: ExpansionWorkerAutotuneShape,
+  samples: ExpansionWorkerAutotuneSample[],
+  options: {
+    timedOut?: boolean
+    error?: unknown
+    calibrationComplete?: boolean
+    nowMs?: number
+    cacheStore?: ExpansionWorkerAutotuneCacheStore | null
+  } = {},
+): ExpansionWorkerAutotuneSelection {
+  const normalized = normalizeExpansionWorkerAutotuneShape(shape)
+  const staticWorkerCount = pickExpansionWorkerCount(normalized.hardwareConcurrency, normalized.totalJobs)
+  const candidates = buildExpansionWorkerAutotuneCandidates(normalized.hardwareConcurrency, normalized.totalJobs)
+  const allowed = new Set(candidates)
+  const validSamples = samples.filter((sample) => {
+    const workerCount = Math.floor(Number(sample.workerCount))
+    const score = sampleScore(sample)
+    return allowed.has(workerCount) && Number.isFinite(score) && score > 0
+  })
+
+  const base = staticExpansionWorkerAutotuneSelection(shape)
+  const measuredAtMs = Number.isFinite(options.nowMs) ? Number(options.nowMs) : Date.now()
+
+  if (options.timedOut) {
+    return {
+      ...base,
+      source: 'fallback-timeout',
+      reason: 'worker calibration timed out; using static hardware-concurrency worker count and not caching partial samples',
+      timedOut: true,
+      samples,
+      sampledCandidates: uniqueSorted(validSamples.map((sample) => sample.workerCount)),
+      sampleCount: validSamples.length,
+    }
+  }
+
+  if (options.error) {
+    const message = options.error instanceof Error ? options.error.message : String(options.error)
+    return {
+      ...base,
+      source: 'fallback-error',
+      reason: `worker calibration failed (${message}); using static hardware-concurrency worker count`,
+      samples,
+      sampledCandidates: uniqueSorted(validSamples.map((sample) => sample.workerCount)),
+      sampleCount: validSamples.length,
+    }
+  }
+
+  if (validSamples.length === 0) {
+    return {
+      ...base,
+      source: 'fallback-no-samples',
+      reason: 'worker calibration produced no valid samples; using static hardware-concurrency worker count',
+      samples,
+    }
+  }
+
+  let bestSample = validSamples[0]
+  let bestScore = sampleScore(bestSample)
+  for (const sample of validSamples.slice(1)) {
+    const score = sampleScore(sample)
+    const workerCount = Math.floor(Number(sample.workerCount))
+    const bestWorkerCount = Math.floor(Number(bestSample.workerCount))
+    if (score < bestScore || (score === bestScore && workerCount < bestWorkerCount)) {
+      bestSample = sample
+      bestScore = score
+    }
+  }
+
+  const workerCount = Math.floor(Number(bestSample.workerCount))
+  const calibrationComplete = options.calibrationComplete !== false
+  const selection: ExpansionWorkerAutotuneSelection = {
+    version: EXPANSION_WORKER_AUTOTUNE_VERSION,
+    contract: normalized.contract,
+    workerCount,
+    selectedWorkerCount: workerCount,
+    staticWorkerCount,
+    candidates,
+    sampledCandidates: uniqueSorted(validSamples.map((sample) => sample.workerCount)),
+    source: 'calibrated',
+    cacheHit: false,
+    cacheKey: normalized.cacheKey,
+    reason: calibrationComplete
+      ? `selected ${workerCount} upload-prep workers from runtime calibration (${bestScore.toFixed(2)} ms/user MDU)`
+      : `selected ${workerCount} upload-prep workers from incomplete runtime calibration (${bestScore.toFixed(2)} ms/user MDU); result not cached`,
+    scoreMs: bestScore,
+    measuredAtMs,
+    sampleCount: validSamples.length,
+    hardwareConcurrency: normalized.hardwareConcurrency,
+    totalJobs: normalized.totalJobs,
+    rsK: normalized.rsK,
+    rsM: normalized.rsM,
+    jobBucket: normalized.jobBucket,
+    backendKey: normalized.backendKey,
+    schedulerKey: normalized.schedulerKey,
+    timedOut: false,
+    cacheWritable: calibrationComplete,
+    samples,
+  }
+
+  if (selection.cacheWritable) {
+    options.cacheStore?.set(shape, cacheFromSelection(selection))
+  }
+
+  return selection
 }

--- a/polystore-website/src/lib/expansionWorkers.ts
+++ b/polystore-website/src/lib/expansionWorkers.ts
@@ -641,15 +641,15 @@ export function finalizeExpansionWorkerAutotuneSelection(
   const base = staticExpansionWorkerAutotuneSelection(shape)
   const measuredAtMs = Number.isFinite(options.nowMs) ? Number(options.nowMs) : Date.now()
 
-  if (options.timedOut) {
+  if (options.timedOut && validSamples.length === 0) {
     return {
       ...base,
       source: 'fallback-timeout',
-      reason: 'worker calibration timed out; using static hardware-concurrency worker count and not caching partial samples',
+      reason: 'worker calibration timed out before producing valid samples; using static hardware-concurrency worker count',
       timedOut: true,
       samples,
-      sampledCandidates: uniqueSorted(validSamples.map((sample) => sample.workerCount)),
-      sampleCount: validSamples.length,
+      sampledCandidates: [],
+      sampleCount: 0,
     }
   }
 
@@ -687,7 +687,7 @@ export function finalizeExpansionWorkerAutotuneSelection(
   }
 
   const workerCount = Math.floor(Number(bestSample.workerCount))
-  const calibrationComplete = options.calibrationComplete !== false
+  const calibrationComplete = options.calibrationComplete !== false && !options.timedOut
   const selection: ExpansionWorkerAutotuneSelection = {
     version: EXPANSION_WORKER_AUTOTUNE_VERSION,
     contract: normalized.contract,
@@ -701,7 +701,9 @@ export function finalizeExpansionWorkerAutotuneSelection(
     cacheKey: normalized.cacheKey,
     reason: calibrationComplete
       ? `selected ${workerCount} upload-prep workers from runtime calibration (${bestScore.toFixed(2)} ms/user MDU)`
-      : `selected ${workerCount} upload-prep workers from incomplete runtime calibration (${bestScore.toFixed(2)} ms/user MDU); result not cached`,
+      : options.timedOut
+        ? `selected ${workerCount} upload-prep workers from partial timed-out runtime calibration (${bestScore.toFixed(2)} ms/user MDU); result not cached`
+        : `selected ${workerCount} upload-prep workers from incomplete runtime calibration (${bestScore.toFixed(2)} ms/user MDU); result not cached`,
     scoreMs: bestScore,
     measuredAtMs,
     sampleCount: validSamples.length,
@@ -712,7 +714,7 @@ export function finalizeExpansionWorkerAutotuneSelection(
     jobBucket: normalized.jobBucket,
     backendKey: normalized.backendKey,
     schedulerKey: normalized.schedulerKey,
-    timedOut: false,
+    timedOut: Boolean(options.timedOut),
     cacheWritable: calibrationComplete,
     samples,
   }

--- a/polystore-website/src/lib/uploadStatus.test.ts
+++ b/polystore-website/src/lib/uploadStatus.test.ts
@@ -58,6 +58,14 @@ test('normalizeKzgBackendStatus ignores zero-valued scheduler defaults', () => {
   assert.equal(status.commitWorkerCount, null)
 })
 
+test('createUploadPipelineStatus initializes worker autotune as pending', () => {
+  const status = createUploadPipelineStatus({ dealId: '42', nowMs: 10 })
+
+  assert.equal(status.workerAutotune.selectedWorkerCount, null)
+  assert.deepEqual(status.workerAutotune.candidates, [])
+  assert.equal(status.workerAutotune.cacheHit, null)
+})
+
 test('normalizeKzgBackendStatus surfaces browser KZG scheduler diagnostics', () => {
   const status = normalizeKzgBackendStatus({
     rustCommitBackend: 'webgpu-msm',
@@ -103,6 +111,12 @@ test('patchUploadPipelineStatus preserves nested state and records elapsed time'
       phaseLabel: 'Planning slab layout',
       totals: { totalMdus: 3, workDone: 1 },
       storage: { stage: 'browser_memory', browserMemoryBytes: 1024 },
+      workerAutotune: {
+        selectedWorkerCount: 5,
+        staticWorkerCount: 6,
+        candidates: [1, 3, 5, 6],
+        source: 'calibrated',
+      },
     },
     250,
   )
@@ -112,6 +126,8 @@ test('patchUploadPipelineStatus preserves nested state and records elapsed time'
   assert.equal(next.totals.totalMdus, 3)
   assert.equal(next.totals.workDone, 1)
   assert.equal(next.storage.stage, 'browser_memory')
+  assert.equal(next.workerAutotune.selectedWorkerCount, 5)
+  assert.deepEqual(next.workerAutotune.candidates, [1, 3, 5, 6])
   assert.equal(next.timing.elapsedMs, 150)
 })
 
@@ -130,6 +146,13 @@ test('sanitizeUploadPipelineStatus truncates user-controlled text', () => {
       ...status.kzg,
       fallbackReason: 'f'.repeat(800),
     },
+    workerAutotune: {
+      ...status.workerAutotune,
+      cacheKey: 'k'.repeat(800),
+      reason: 'r'.repeat(800),
+      candidates: Array.from({ length: 32 }, (_, i) => i + 1),
+      sampledCandidates: Array.from({ length: 32 }, (_, i) => i + 1),
+    },
   })
 
   assert.equal(sanitized.dealId.length, 160)
@@ -138,4 +161,8 @@ test('sanitizeUploadPipelineStatus truncates user-controlled text', () => {
   assert.equal(sanitized.file.name?.length, 160)
   assert.equal(sanitized.error?.length, 500)
   assert.equal(sanitized.kzg.fallbackReason?.length, 500)
+  assert.equal(sanitized.workerAutotune.cacheKey?.length, 240)
+  assert.equal(sanitized.workerAutotune.reason?.length, 500)
+  assert.equal(sanitized.workerAutotune.candidates.length, 16)
+  assert.equal(sanitized.workerAutotune.sampledCandidates.length, 16)
 })

--- a/polystore-website/src/lib/uploadStatus.ts
+++ b/polystore-website/src/lib/uploadStatus.ts
@@ -1,3 +1,21 @@
+export type UploadWorkerAutotuneStatus = {
+  selectedWorkerCount: number | null
+  staticWorkerCount: number | null
+  candidates: number[]
+  sampledCandidates: number[]
+  source: string | null
+  cacheHit: boolean | null
+  cacheKey: string | null
+  reason: string | null
+  scoreMs: number | null
+  sampleCount: number | null
+  hardwareConcurrency: number | null
+  totalJobs: number | null
+  rsK: number | null
+  rsM: number | null
+  timedOut: boolean | null
+}
+
 export type UploadPipelinePhase =
   | 'idle'
   | 'read_file'
@@ -101,6 +119,7 @@ export type UploadPipelineStatus = {
     lastError: string | null
   }
   kzg: KzgBackendStatus
+  workerAutotune: UploadWorkerAutotuneStatus
   timing: UploadPipelineTiming
   latestEvent: string | null
   error: string | null
@@ -163,16 +182,35 @@ export type KzgDiagnosticsInput = {
 
 export type DeepPartialUploadPipelineStatus = Omit<
   Partial<UploadPipelineStatus>,
-  'file' | 'totals' | 'storage' | 'transport' | 'kzg' | 'timing'
+  'file' | 'totals' | 'storage' | 'transport' | 'kzg' | 'workerAutotune' | 'timing'
 > & {
   file?: Partial<UploadPipelineStatus['file']>
   totals?: Partial<UploadPipelineStatus['totals']>
   storage?: Partial<UploadPipelineStatus['storage']>
   transport?: Partial<UploadPipelineStatus['transport']>
   kzg?: Partial<UploadPipelineStatus['kzg']>
+  workerAutotune?: Partial<UploadPipelineStatus['workerAutotune']>
   timing?: Partial<UploadPipelineStatus['timing']> & {
     phases?: Record<string, number>
   }
+}
+
+export const PENDING_WORKER_AUTOTUNE_STATUS: UploadWorkerAutotuneStatus = {
+  selectedWorkerCount: null,
+  staticWorkerCount: null,
+  candidates: [],
+  sampledCandidates: [],
+  source: null,
+  cacheHit: null,
+  cacheKey: null,
+  reason: null,
+  scoreMs: null,
+  sampleCount: null,
+  hardwareConcurrency: null,
+  totalJobs: null,
+  rsK: null,
+  rsM: null,
+  timedOut: null,
 }
 
 export const PENDING_KZG_BACKEND_STATUS: KzgBackendStatus = {
@@ -334,6 +372,7 @@ export function createUploadPipelineStatus(input: {
       lastError: null,
     },
     kzg: { ...PENDING_KZG_BACKEND_STATUS },
+    workerAutotune: { ...PENDING_WORKER_AUTOTUNE_STATUS },
     timing: {
       startedAtMs: now,
       updatedAtMs: now,
@@ -365,6 +404,7 @@ export function patchUploadPipelineStatus(
     storage: { ...base.storage, ...(patch.storage ?? {}) },
     transport: { ...base.transport, ...(patch.transport ?? {}) },
     kzg: { ...base.kzg, ...(patch.kzg ?? {}) },
+    workerAutotune: { ...base.workerAutotune, ...(patch.workerAutotune ?? {}) },
     timing: {
       ...base.timing,
       ...(patch.timing ?? {}),
@@ -400,6 +440,13 @@ export function sanitizeUploadPipelineStatus(status: UploadPipelineStatus): Uplo
       ...status.kzg,
       fallbackReason: truncate(status.kzg.fallbackReason, 500),
       calibrationCacheKey: truncate(status.kzg.calibrationCacheKey, 240),
+    },
+    workerAutotune: {
+      ...status.workerAutotune,
+      cacheKey: truncate(status.workerAutotune.cacheKey, 240),
+      reason: truncate(status.workerAutotune.reason, 500),
+      candidates: status.workerAutotune.candidates.slice(0, 16),
+      sampledCandidates: status.workerAutotune.sampledCandidates.slice(0, 16),
     },
   }
 }

--- a/polystore-website/src/lib/worker-client.ts
+++ b/polystore-website/src/lib/worker-client.ts
@@ -510,6 +510,18 @@ export const workerClient = {
     return userMduKzgScheduler.getStatus();
   },
 
+  getExpansionWorkerPoolStatus() {
+    return {
+      ready: expansionWorkersReady !== null,
+      workerCount: expansionWorkers.length,
+      pendingMessages: expansionPending.size,
+    };
+  },
+
+  async getKzgCommitDiagnostics(): Promise<KzgCommitDiagnostics> {
+    return sendMessageToWorker('getKzgCommitDiagnostics', {}) as Promise<KzgCommitDiagnostics>;
+  },
+
   async computeMduRoot(witness: Uint8Array): Promise<Uint8Array> {
     return sendMessageToWorker('computeMduRoot', { witness }) as Promise<Uint8Array>;
   },

--- a/polystore-website/src/workers/gateway.worker.ts
+++ b/polystore-website/src/workers/gateway.worker.ts
@@ -267,6 +267,10 @@ self.onmessage = async (event) => {
                 result = 'PolyStoreWasm initialized';
                 break;
             }
+            case 'getKzgCommitDiagnostics': {
+                result = kzgCommitDiagnostics();
+                break;
+            }
             case 'initMdu0Builder': {
                 if (!polyStoreWasmInstance) throw new Error('PolyStoreWasm not initialized. Call initPolyStoreWasm first.');
                 const { maxUserMdus, commitmentsPerMdu } = payload as { maxUserMdus: number; commitmentsPerMdu?: number };


### PR DESCRIPTION
**Latest validation update (2026-05-30):** Latest head `3edf49b3` was rerun on Apple M3. The 64 MiB threshold case passed and selected 3 workers from valid partial runtime calibration samples (`3` beat static `5` by measured score). Partial timed-out results are used only for the current run and are not cached. Evidence now supports the worker-autotune claim, conditional on #203 landing first.

---

## Summary

Implements issue #196 for the #192 browser upload-prep performance stack.

- Adds a versioned Mode 2 upload-prep worker autotune contract in `expansionWorkers.ts`.
- Keys cached selections by hardware concurrency, RS profile, KZG/backend shape, scheduler shape, job-count bucket, and contract/version.
- Adds bounded runtime calibration for large Mode 2 browser uploads, preferring safe cache hits and failing closed to the static `navigator.hardwareConcurrency` policy on timeout/error/disabled/small uploads.
- Surfaces selected worker count, candidates, sampled candidates, source/cache hit/reason, cache key, and score in upload status, `__nilPreparePerf`, and `__polyStorePerfBundle`.
- Adds benchmark helpers for deterministic selector simulation and richer user-stage concurrency sweep output.

Links: closes #196; parent tracker #192. Stacked on #195/#203, which is stacked on #194/#202 and #193/#201.

## Stack / Draft Status

Draft because parent PRs are still draft/unmerged:

- #193 / PR #201: WebGPU MSM calibration
- #194 / PR #202: RS/KZG scheduler seam
- #195 / PR #203: KZG batching seam

Base branch: `website/batch-browser-kzg-195`.

## Tests

- `cd polystore-website && npm run test:unit`
  - 290 passed
  - Note: existing OPFS cleanup-failure test logs an expected `NoModificationAllowedError` during a passing test.
- `cd polystore-website && npm run lint`
  - passed
- `cd polystore-website && npm run build:app`
  - passed
  - Vite emitted existing dependency/chunk-size warnings.
- `git diff --check`
  - passed

## Benchmark / Evidence

Native browser WebGPU hardware was not available in this headless agent environment, so this PR remains draft for native 100 MiB WebGPU revalidation. Fresh local evidence collected:

### Deterministic selector simulation using issue #196 profile table

Command:

```sh
cd polystore-website && npm run perf:worker-autotune-sim
```

Fixture: issue #196 100 MiB Mode 2 RS 8+4, 13 user MDUs, 12 logical CPUs, WebGPU MSM fixture values from the tracker.

| worker count | wall ms |
| ---: | ---: |
| 1 | 179300 |
| 3 | 115200 |
| 5 | 100900 |
| static 6 | 109700 |

Result:

- candidates: `[1, 3, 5, 6]`
- runtime sample plan for first uncached upload: `5 x 5 MDUs`, then `6 x 6 MDUs` (bounded, no duplicate work)
- selected worker count: `5`
- cache hit after store: `true`
- improvement vs static fixture: `8800ms` / `8.02%`
- cache key includes `v2|mode2-user-mdu-rs-kzg-v2|hc=12|rs=8+4|jobs=8-15|...webgpu...|scheduler...`

### Bounded headless WASM smoke

Command:

```sh
cd polystore-website && FILE_BYTES=1048576 CYCLES=1 CONCURRENCIES=1,3,5,6 PIPELINE_MODES=fused_batch_unprofiled npm run perf:user-stage-concurrency
```

Environment: Node/headless WASM (`basis_mode=blst`), 1 user MDU, no native WebGPU. This validates the benchmark harness and reports requested concurrency rows, but effective worker count clamps to 1 for a one-MDU file.

Observed runs:

- 1 requested / 1 effective: ~6756ms
- 3 requested / 1 effective: ~6750ms
- 5 requested / 1 effective: ~6879ms
- 6 requested / 1 effective: ~6691ms

## Risk Assessment

- First uncached large upload spends up to 11 real user MDUs in a bounded calibration schedule before applying the selected count to the remainder. Results are cached by backend/profile/scheduler shape.
- Failed, timed-out, disabled, unavailable, or small-upload paths use the pre-existing static worker policy and do not write partial cache entries.
- No protocol/correctness format changes; provider upload concurrency is untouched.
- Native WebGPU 100 MiB evidence is still required before marking ready for merge.

## AI Review Status

Requested reviews from Copilot, CodeRabbit, and Codex in PR comments. Codex connector replied that a Codex account/GitHub connector is not configured, so Codex review is unavailable for this PR at the moment. Copilot/CodeRabbit are pending.

