### PR TITLE
feat(website): adaptive WebGPU KZG batching

### DIFF
--- a/polystore-website/src/components/FileSharder.tsx
+++ b/polystore-website/src/components/FileSharder.tsx
@@ -190,6 +190,13 @@ type PreparePerfSample = {
   workerKzgSchedulerBatchBytes?: number
   workerKzgSchedulerBatchSplitCount?: number
   workerKzgSchedulerBatchFallbackCount?: number
+  workerKzgSchedulerBatchTimeoutCount?: number
+  workerKzgSchedulerSafeMaxBatchMdus?: number
+  workerKzgWebGpuCommitTimeoutCount?: number
+  workerKzgWebGpuBatchTooLargeCount?: number
+  workerKzgWebGpuLastTimeoutBlobs?: number
+  workerKzgWebGpuLastTimeoutBytes?: number
+  workerKzgWebGpuLastTimeoutBatchMdus?: number
   workerRustEncodeMs: number
   workerRustRsMs: number
   workerRustCommitDecodeMs: number
@@ -321,6 +328,13 @@ type PreparePerfProfile = {
     kzgSchedulerBatchBytes?: number
     kzgSchedulerBatchSplitCount?: number
     kzgSchedulerBatchFallbackCount?: number
+    kzgSchedulerBatchTimeoutCount?: number
+    kzgSchedulerSafeMaxBatchMdus?: number
+    kzgWebGpuCommitTimeoutCount?: number
+    kzgWebGpuBatchTooLargeCount?: number
+    kzgWebGpuLastTimeoutBlobs?: number
+    kzgWebGpuLastTimeoutBytes?: number
+    kzgWebGpuLastTimeoutBatchMdus?: number
     commitWorkerCount?: number
   }
   samples: {
@@ -3727,11 +3741,23 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
             const workerKzgSchedulerActiveAtEnqueue = Number(result.perf?.kzgSchedulerActiveAtEnqueue ?? 0) || undefined
             const workerKzgSchedulerMaxQueueDepth = Number(result.perf?.kzgSchedulerMaxQueueDepth ?? 0) || undefined
             const workerKzgSchedulerFallbackCount = Number(result.perf?.kzgSchedulerFallbackCount ?? 0) || undefined
-            const workerKzgSchedulerBatchSize = Number(result.perf?.kzgSchedulerBatchSize ?? 0) || undefined
-            const workerKzgSchedulerBatchBlobs = Number(result.perf?.kzgSchedulerBatchBlobs ?? 0) || undefined
-            const workerKzgSchedulerBatchBytes = Number(result.perf?.kzgSchedulerBatchBytes ?? 0) || undefined
-            const workerKzgSchedulerBatchSplitCount = Number(result.perf?.kzgSchedulerBatchSplitCount ?? 0) || undefined
+            const workerKzgSchedulerBatchSize =
+              Number(result.perf?.kzgSchedulerBatchSize ?? 0) || Number(result.perf?.browserKzgBatchSize ?? 0) || undefined
+            const workerKzgSchedulerBatchBlobs =
+              Number(result.perf?.kzgSchedulerBatchBlobs ?? 0) || Number(result.perf?.browserKzgBatchBlobs ?? 0) || undefined
+            const workerKzgSchedulerBatchBytes =
+              Number(result.perf?.kzgSchedulerBatchBytes ?? 0) || Number(result.perf?.browserKzgBatchBytes ?? 0) || undefined
+            const workerKzgSchedulerBatchSplitCount =
+              Number(result.perf?.kzgSchedulerBatchSplitCount ?? 0) || Number(result.perf?.browserKzgBatchSplitCount ?? 0) || undefined
             const workerKzgSchedulerBatchFallbackCount = Number(result.perf?.kzgSchedulerBatchFallbackCount ?? 0) || undefined
+            const workerKzgSchedulerBatchTimeoutCount =
+              Number(result.perf?.kzgSchedulerBatchTimeoutCount ?? 0) || Number(result.perf?.browserKzgBatchTimeoutCount ?? 0) || undefined
+            const workerKzgSchedulerSafeMaxBatchMdus = Number(result.perf?.kzgSchedulerSafeMaxBatchMdus ?? 0) || undefined
+            const workerKzgWebGpuCommitTimeoutCount = Number(result.perf?.kzgWebGpuCommitTimeoutCount ?? 0) || undefined
+            const workerKzgWebGpuBatchTooLargeCount = Number(result.perf?.kzgWebGpuBatchTooLargeCount ?? 0) || undefined
+            const workerKzgWebGpuLastTimeoutBlobs = Number(result.perf?.kzgWebGpuLastTimeoutBlobs ?? 0) || undefined
+            const workerKzgWebGpuLastTimeoutBytes = Number(result.perf?.kzgWebGpuLastTimeoutBytes ?? 0) || undefined
+            const workerKzgWebGpuLastTimeoutBatchMdus = Number(result.perf?.kzgWebGpuLastTimeoutBatchMdus ?? 0) || undefined
             const workerRustEncodeMs = Number(result.perf?.rustEncodeMs ?? 0)
             const workerRustRsMs = Number(result.perf?.rustRsMs ?? 0)
             const workerRustCommitDecodeMs = Number(result.perf?.rustCommitDecodeMs ?? 0)
@@ -3828,6 +3854,13 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
               workerKzgSchedulerBatchBytes,
               workerKzgSchedulerBatchSplitCount,
               workerKzgSchedulerBatchFallbackCount,
+              workerKzgSchedulerBatchTimeoutCount,
+              workerKzgSchedulerSafeMaxBatchMdus,
+              workerKzgWebGpuCommitTimeoutCount,
+              workerKzgWebGpuBatchTooLargeCount,
+              workerKzgWebGpuLastTimeoutBlobs,
+              workerKzgWebGpuLastTimeoutBytes,
+              workerKzgWebGpuLastTimeoutBatchMdus,
               workerRustEncodeMs,
               workerRustRsMs,
               workerRustCommitDecodeMs,
@@ -4577,6 +4610,13 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
             kzgSchedulerBatchBytes: kzgDiagnosticSample?.workerKzgSchedulerBatchBytes,
             kzgSchedulerBatchSplitCount: kzgDiagnosticSample?.workerKzgSchedulerBatchSplitCount,
             kzgSchedulerBatchFallbackCount: kzgDiagnosticSample?.workerKzgSchedulerBatchFallbackCount,
+            kzgSchedulerBatchTimeoutCount: kzgDiagnosticSample?.workerKzgSchedulerBatchTimeoutCount,
+            kzgSchedulerSafeMaxBatchMdus: kzgDiagnosticSample?.workerKzgSchedulerSafeMaxBatchMdus,
+            kzgWebGpuCommitTimeoutCount: kzgDiagnosticSample?.workerKzgWebGpuCommitTimeoutCount,
+            kzgWebGpuBatchTooLargeCount: kzgDiagnosticSample?.workerKzgWebGpuBatchTooLargeCount,
+            kzgWebGpuLastTimeoutBlobs: kzgDiagnosticSample?.workerKzgWebGpuLastTimeoutBlobs,
+            kzgWebGpuLastTimeoutBytes: kzgDiagnosticSample?.workerKzgWebGpuLastTimeoutBytes,
+            kzgWebGpuLastTimeoutBatchMdus: kzgDiagnosticSample?.workerKzgWebGpuLastTimeoutBatchMdus,
             commitWorkerCount: kzgDiagnosticSample?.workerCommitWorkerCount,
           },
           samples: perfSamples,

--- a/polystore-website/src/lib/kzgCommitBackend.test.ts
+++ b/polystore-website/src/lib/kzgCommitBackend.test.ts
@@ -13,6 +13,8 @@ import {
   createWasmBlstKzgCommitBackend,
   parseTrustedSetupG1Srs,
   parseKzgCommitProfiledResult,
+  WebGpuKzgCommitTimeoutError,
+  isWebGpuKzgCommitTimeoutError,
 } from './kzgCommitBackend'
 import {
   WebGpuKzgMsmCalibrationCache,
@@ -138,6 +140,56 @@ function fakeCommitter(options: {
           debug: {
             bucketWidth: options.bucketWidth ?? 10,
             reductionMode: options.reductionMode ?? 'serial',
+            bucketCount: 1,
+            baseIndexCount: 1,
+            numWindows: 1,
+            maxBucketSize: 1,
+            meanBucketSize: 1,
+            uploadBytes: 4,
+            readbackBytes: 384,
+            windowSumNonZeroBytes: 1,
+            processedBlobs: blobs,
+            commandSubmissions: blobs,
+            readbackCount: blobs,
+            scratchCapacityBytes: 4096,
+            scratchResizeCount: 1,
+          },
+        }
+      },
+    },
+  }
+}
+
+function fakeCommitterSequence(delaysMs: number[], commitmentsSeed = 1) {
+  const destroyed = { value: false }
+  let calls = 0
+  return {
+    destroyed,
+    committer: {
+      destroy: () => {
+        destroyed.value = true
+      },
+      getDeviceLostInfo: async () => null,
+      commitBlobs: async (input: Uint8Array) => {
+        const delayMs = delaysMs[Math.min(calls, delaysMs.length - 1)] ?? 0
+        calls += 1
+        if (delayMs) await new Promise((resolve) => setTimeout(resolve, delayMs))
+        const blobs = input.byteLength / KZG_BLOB_SIZE
+        const totalMs = Math.max(1, delayMs || 1)
+        return {
+          commitments: commitments(blobs, commitmentsSeed),
+          timings: {
+            scalarPrepMs: 0,
+            bucketBuildMs: 0,
+            uploadMs: 0,
+            dispatchReadbackMs: totalMs,
+            foldMs: 0,
+            totalMs,
+          },
+          blobs,
+          debug: {
+            bucketWidth: 10,
+            reductionMode: 'parallel16' as const,
             bucketCount: 1,
             baseIndexCount: 1,
             numWindows: 1,
@@ -485,6 +537,85 @@ test('browser backend opens session circuit breaker on WebGPU timeout', async ()
   assert.equal(status.webgpu?.scheduler?.circuitOpen, true)
   assert.equal(status.webgpu?.scheduler?.probeStatus, 'timeout')
   assert.match(status.fallbackReason || '', /probe exceeded/)
+})
+
+test('browser backend surfaces multi-MDU WebGPU commit timeout without opening the circuit', async () => {
+  const fake = fakeCommitterSequence([0, 25])
+  const backend = await createBrowserKzgCommitBackend(dynamicMockWasm(), await loadTrustedSetupBytes(), {
+    preferWebGpu: true,
+    webGpuMode: 'force',
+    webGpuCommitTimeoutMs: 5,
+    navigatorLike: fakeNavigator({ vendor: 'apple', architecture: 'metal', isFallbackAdapter: false }),
+    webGpuCommitterFactory: async () => fake.committer as never,
+  })
+
+  await assert.rejects(
+    Promise.resolve(backend.commitBlobsProfiled(blobBatch(6), { batchMduCount: 2, batchLabel: 'test-batch' })),
+    (error: unknown) => {
+      assert.equal(isWebGpuKzgCommitTimeoutError(error), true)
+      assert.equal((error as WebGpuKzgCommitTimeoutError).details.batchMduCount, 2)
+      assert.equal((error as WebGpuKzgCommitTimeoutError).details.blobs, 6)
+      assert.equal((error as WebGpuKzgCommitTimeoutError).details.bytes, 6 * KZG_BLOB_SIZE)
+      assert.equal((error as WebGpuKzgCommitTimeoutError).details.timeoutMs, 5)
+      assert.equal((error as WebGpuKzgCommitTimeoutError).details.retryableAsSmallerBatch, true)
+      assert.equal((error as WebGpuKzgCommitTimeoutError).details.reductionMode, 'parallel16')
+      return true
+    },
+  )
+
+  const status = backend.getStatus()
+  assert.equal(status.webgpu?.scheduler?.circuitOpen, false)
+  assert.equal(status.webgpu?.scheduler?.commitTimeoutCount, 1)
+  assert.equal(status.webgpu?.scheduler?.batchTooLargeCount, 1)
+  assert.equal(status.webgpu?.scheduler?.lastTimeoutBatchMdus, 2)
+  assert.equal(status.webgpu?.scheduler?.lastTimeoutRetryable, true)
+  assert.equal(status.selectedBackend, 'webgpu')
+})
+
+test('browser backend opens circuit and falls back on single-MDU WebGPU commit timeout', async () => {
+  const fake = fakeCommitterSequence([0, 25])
+  const backend = await createBrowserKzgCommitBackend(dynamicMockWasm(), await loadTrustedSetupBytes(), {
+    preferWebGpu: true,
+    webGpuMode: 'force',
+    webGpuCommitTimeoutMs: 5,
+    navigatorLike: fakeNavigator({ vendor: 'nvidia', architecture: 'ampere', isFallbackAdapter: false }),
+    webGpuCommitterFactory: async () => fake.committer as never,
+  })
+
+  const result = await backend.commitBlobsProfiled(blobBatch(3), { batchMduCount: 1 })
+  assert.deepEqual(result.witnessFlat, commitments(3))
+  const status = backend.getStatus()
+  assert.equal(status.selectedBackend, 'wasm-blst')
+  assert.equal(status.webgpu?.scheduler?.circuitOpen, true)
+  assert.equal(status.webgpu?.scheduler?.commitTimeoutCount, 1)
+  assert.equal(status.webgpu?.scheduler?.batchTooLargeCount, 0)
+  assert.match(status.fallbackReason || '', /commit exceeded 5ms/)
+})
+
+test('browser backend stale timeout cleanup does not destroy replacement committer', async () => {
+  const first = fakeCommitterSequence([0, 25])
+  const second = fakeCommitterSequence([0], 17)
+  const committers = [first, second]
+  const backend = await createBrowserKzgCommitBackend(dynamicMockWasm(), await loadTrustedSetupBytes(), {
+    preferWebGpu: true,
+    webGpuMode: 'force',
+    webGpuCommitTimeoutMs: 5,
+    navigatorLike: fakeNavigator({ vendor: 'apple', architecture: 'metal', isFallbackAdapter: false }),
+    webGpuCommitterFactory: async () => committers.shift()?.committer as never,
+  })
+
+  await assert.rejects(
+    Promise.resolve(backend.commitBlobsProfiled(blobBatch(6), { batchMduCount: 2 })),
+    (error: unknown) => isWebGpuKzgCommitTimeoutError(error),
+  )
+  assert.equal(first.destroyed.value, false)
+
+  const result = await backend.commitBlobsProfiled(blobBatch(3), { batchMduCount: 1 })
+  assert.deepEqual(result.witnessFlat, commitments(3, 17))
+  await new Promise((resolve) => setTimeout(resolve, 35))
+  assert.equal(first.destroyed.value, true)
+  assert.equal(second.destroyed.value, false)
+  assert.equal(backend.getStatus().webgpu?.scheduler?.circuitOpen, false)
 })
 
 test('browser backend fails closed on incompatible trusted setup bytes before GPU upload', async () => {

--- a/polystore-website/src/lib/kzgCommitBackend.ts
+++ b/polystore-website/src/lib/kzgCommitBackend.ts
@@ -1,5 +1,6 @@
 import {
   calibrateWebGpuKzgMsmAdapter,
+  createWebGpuKzgMsmAdapterCacheKey,
   createWebGpuKzgMsmCommitter,
   defaultWebGpuKzgMsmAdapterCalibration,
   defaultWebGpuKzgMsmCalibrationCache,
@@ -63,11 +64,55 @@ export type KzgCommitBackendStatus = {
   webgpu?: WebGpuKzgStatus
 }
 
+export type KzgCommitBatchContext = {
+  /** Number of logical user MDUs represented by this commitment batch. */
+  batchMduCount?: number
+  /** Human-readable source for diagnostics (for example, `user-mdu-batch`). */
+  batchLabel?: string
+  /** Set false for callers that cannot safely retry smaller WebGPU batches. */
+  allowWebGpuBatchTimeoutRetry?: boolean
+}
+
+export type WebGpuKzgCommitTimeoutDetails = {
+  kind: 'webgpu-commit-timeout'
+  blobs: number
+  bytes: number
+  timeoutMs: number
+  batchMduCount: number
+  batchLabel?: string
+  retryableAsSmallerBatch: boolean
+  bucketWidth?: number
+  reductionMode?: WebGpuKzgMsmReductionMode
+  adapter?: WebGpuKzgAdapterInfo | null
+  adapterCacheKey?: string
+}
+
+export class WebGpuKzgCommitTimeoutError extends Error {
+  readonly details: WebGpuKzgCommitTimeoutDetails
+
+  constructor(details: WebGpuKzgCommitTimeoutDetails) {
+    super(
+      `WebGPU commit exceeded ${details.timeoutMs}ms for ${details.batchMduCount} user MDU(s), ${details.blobs} blob(s), ${details.bytes} byte(s)`,
+    )
+    this.name = 'WebGpuKzgCommitTimeoutError'
+    this.details = details
+  }
+}
+
+export function isWebGpuKzgCommitTimeoutError(error: unknown): error is WebGpuKzgCommitTimeoutError {
+  return error instanceof WebGpuKzgCommitTimeoutError ||
+    ((error as { name?: unknown; details?: { kind?: unknown } } | null)?.name === 'WebGpuKzgCommitTimeoutError' &&
+      (error as { details?: { kind?: unknown } }).details?.kind === 'webgpu-commit-timeout')
+}
+
 export type KzgCommitBackend = {
   readonly kind: KzgCommitBackendKind
   getStatus(): KzgCommitBackendStatus
-  commitBlobs(blobsFlat: Uint8Array): Uint8Array | Promise<Uint8Array>
-  commitBlobsProfiled(blobsFlat: Uint8Array): KzgCommitProfiledResult | Promise<KzgCommitProfiledResult>
+  commitBlobs(blobsFlat: Uint8Array, context?: KzgCommitBatchContext): Uint8Array | Promise<Uint8Array>
+  commitBlobsProfiled(
+    blobsFlat: Uint8Array,
+    context?: KzgCommitBatchContext,
+  ): KzgCommitProfiledResult | Promise<KzgCommitProfiledResult>
 }
 
 type GpuBufferLike = {
@@ -181,6 +226,15 @@ export type WebGpuKzgSchedulerStatus = {
   lastWebGpuMs?: number
   lastWasmMs?: number
   lastFallbackReason?: string
+  commitTimeoutCount?: number
+  batchTooLargeCount?: number
+  lastTimeoutBlobs?: number
+  lastTimeoutBytes?: number
+  lastTimeoutBatchMdus?: number
+  lastTimeoutRetryable?: boolean
+  lastTimeoutBucketWidth?: number
+  lastTimeoutReductionMode?: WebGpuKzgMsmReductionMode
+  lastTimeoutAdapterCacheKey?: string
 }
 
 export type CreateKzgCommitBackendOptions = {
@@ -282,6 +336,15 @@ async function withTimeout<T>(
     promise.then((value) => ({ timedOut: false as const, value })),
     delay(timeoutMs, { timedOut: true as const }),
   ])
+}
+
+function normalizeBatchMduCount(context?: KzgCommitBatchContext): number {
+  const value = Math.floor(Number(context?.batchMduCount ?? 1))
+  return Number.isFinite(value) && value > 0 ? value : 1
+}
+
+function canRetryWebGpuTimeoutAsSmallerBatch(context: KzgCommitBatchContext | undefined): boolean {
+  return context?.allowWebGpuBatchTimeoutRetry !== false && normalizeBatchMduCount(context) > 1
 }
 
 async function readAdapterInfo(adapter: GpuAdapterLike): Promise<WebGpuKzgAdapterInfo | null> {
@@ -468,12 +531,12 @@ export class WebGpuKzgLifecycleBackend implements KzgCommitBackend {
     }
   }
 
-  commitBlobs(blobsFlat: Uint8Array): Uint8Array | Promise<Uint8Array> {
-    return this.wasmFallback.commitBlobs(blobsFlat)
+  commitBlobs(blobsFlat: Uint8Array, context?: KzgCommitBatchContext): Uint8Array | Promise<Uint8Array> {
+    return this.wasmFallback.commitBlobs(blobsFlat, context)
   }
 
-  commitBlobsProfiled(blobsFlat: Uint8Array): KzgCommitProfiledResult | Promise<KzgCommitProfiledResult> {
-    return this.wasmFallback.commitBlobsProfiled(blobsFlat)
+  commitBlobsProfiled(blobsFlat: Uint8Array, context?: KzgCommitBatchContext): KzgCommitProfiledResult | Promise<KzgCommitProfiledResult> {
+    return this.wasmFallback.commitBlobsProfiled(blobsFlat, context)
   }
 }
 
@@ -644,6 +707,56 @@ export class ScheduledWebGpuKzgCommitBackend implements KzgCommitBackend {
     })
   }
 
+  private retireTimedOutCommitter(
+    committer: WebGpuKzgMsmCommitter | null,
+    promise: Promise<WebGpuKzgMsmResult>,
+  ): void {
+    if (!committer) return
+    if (this.committer === committer) {
+      this.committer = null
+      this.status = {
+        ...this.status,
+        available: false,
+      }
+    }
+    promise.catch(() => undefined).finally(() => committer.destroy())
+  }
+
+  private makeCommitTimeoutError(
+    blobs: number,
+    context: KzgCommitBatchContext | undefined,
+  ): WebGpuKzgCommitTimeoutError {
+    const batchMduCount = normalizeBatchMduCount(context)
+    return new WebGpuKzgCommitTimeoutError({
+      kind: 'webgpu-commit-timeout',
+      blobs,
+      bytes: blobs * KZG_BLOB_SIZE,
+      timeoutMs: this.commitTimeoutMs,
+      batchMduCount,
+      batchLabel: context?.batchLabel,
+      retryableAsSmallerBatch: canRetryWebGpuTimeoutAsSmallerBatch(context),
+      bucketWidth: this.status.bucketWidth,
+      reductionMode: this.status.reductionMode,
+      adapter: this.status.adapter ?? null,
+      adapterCacheKey: createWebGpuKzgMsmAdapterCacheKey(this.status.adapter ?? null),
+    })
+  }
+
+  private recordCommitTimeout(error: WebGpuKzgCommitTimeoutError): void {
+    const scheduler = this.status.scheduler
+    this.updateScheduler({
+      commitTimeoutCount: (scheduler?.commitTimeoutCount ?? 0) + 1,
+      batchTooLargeCount: (scheduler?.batchTooLargeCount ?? 0) + (error.details.retryableAsSmallerBatch ? 1 : 0),
+      lastTimeoutBlobs: error.details.blobs,
+      lastTimeoutBytes: error.details.bytes,
+      lastTimeoutBatchMdus: error.details.batchMduCount,
+      lastTimeoutRetryable: error.details.retryableAsSmallerBatch,
+      lastTimeoutBucketWidth: error.details.bucketWidth,
+      lastTimeoutReductionMode: error.details.reductionMode,
+      lastTimeoutAdapterCacheKey: error.details.adapterCacheKey,
+    })
+  }
+
   private async initCommitter(): Promise<WebGpuKzgMsmCommitter> {
     if (this.committer) return this.committer
     const committerOptions: WebGpuKzgMsmOptions = {
@@ -750,7 +863,18 @@ export class ScheduledWebGpuKzgCommitBackend implements KzgCommitBackend {
     }
     if (this.status.scheduler?.circuitOpen) return false
     if (!(await this.ensureCalibration(realBatchBlobs))) return false
-    if (this.status.scheduler?.probeStatus === 'passed') return true
+    if (this.status.scheduler?.probeStatus === 'passed') {
+      if (this.committer) return true
+      try {
+        await this.initCommitter()
+        return true
+      } catch (error) {
+        const reason = `WebGPU committer reinitialization failed: ${error instanceof Error ? error.message : String(error)}`
+        this.openCircuit(reason)
+        this.updateScheduler({ probeStatus: 'failed' })
+        return false
+      }
+    }
     if (this.probePromise) return this.probePromise
 
     this.updateScheduler({ probeStatus: 'running' })
@@ -771,7 +895,7 @@ export class ScheduledWebGpuKzgCommitBackend implements KzgCommitBackend {
       const gpuPromise = committer.commitBlobs(probeBlob)
       const timed = await withTimeout(gpuPromise, this.probeTimeoutMs)
       if (timed.timedOut) {
-        gpuPromise.catch(() => undefined).finally(() => this.committer?.destroy())
+        gpuPromise.catch(() => undefined).finally(() => committer.destroy())
         this.openCircuit(`WebGPU probe exceeded ${this.probeTimeoutMs}ms`)
         this.updateScheduler({ probeStatus: 'timeout', lastProbeMs: nowMs(this.options.now) - probeStarted, lastWasmMs: wasmMs })
         return false
@@ -819,30 +943,45 @@ export class ScheduledWebGpuKzgCommitBackend implements KzgCommitBackend {
     }
   }
 
-  async commitBlobs(blobsFlat: Uint8Array): Promise<Uint8Array> {
+  async commitBlobs(blobsFlat: Uint8Array, context?: KzgCommitBatchContext): Promise<Uint8Array> {
     const blobs = assertBlobBatch(blobsFlat)
     if (blobs < this.minBlobs) {
       this.fallBack(`batch below WebGPU threshold: ${blobs} < ${this.minBlobs}`)
-      return this.wasmFallback.commitBlobs(blobsFlat)
+      return this.wasmFallback.commitBlobs(blobsFlat, context)
     }
     if (!(await this.probe(blobs)) || !this.committer) {
-      return this.wasmFallback.commitBlobs(blobsFlat)
+      return this.wasmFallback.commitBlobs(blobsFlat, context)
     }
 
-    const gpuPromise = this.committer.commitBlobs(blobsFlat)
-    const timed = await withTimeout(gpuPromise, this.commitTimeoutMs)
+    const committer = this.committer
+    const gpuPromise = committer.commitBlobs(blobsFlat)
+    let timed: { timedOut: false; value: WebGpuKzgMsmResult } | { timedOut: true }
+    try {
+      timed = await withTimeout(gpuPromise, this.commitTimeoutMs)
+    } catch (error) {
+      const reason = `WebGPU commit failed: ${error instanceof Error ? error.message : String(error)}`
+      this.openCircuit(reason)
+      return this.wasmFallback.commitBlobs(blobsFlat, context)
+    }
     if (timed.timedOut) {
-      gpuPromise.catch(() => undefined).finally(() => this.committer?.destroy())
+      this.retireTimedOutCommitter(committer, gpuPromise)
+      const timeoutError = this.makeCommitTimeoutError(blobs, context)
+      this.recordCommitTimeout(timeoutError)
+      if (timeoutError.details.retryableAsSmallerBatch) {
+        throw timeoutError
+      }
       this.openCircuit(`WebGPU commit exceeded ${this.commitTimeoutMs}ms`)
-      return this.wasmFallback.commitBlobs(blobsFlat)
+      return this.wasmFallback.commitBlobs(blobsFlat, context)
     }
 
     this.status = {
       ...this.status,
+      available: true,
       fallbackActive: false,
       selectedBackend: 'webgpu',
       bucketWidth: timed.value.debug?.bucketWidth ?? this.status.bucketWidth,
       reductionMode: timed.value.debug?.reductionMode ?? this.status.reductionMode,
+      reason: undefined,
     }
     this.updateScheduler({
       bucketWidth: timed.value.debug?.bucketWidth ?? this.status.bucketWidth,
@@ -853,30 +992,45 @@ export class ScheduledWebGpuKzgCommitBackend implements KzgCommitBackend {
     return timed.value.commitments
   }
 
-  async commitBlobsProfiled(blobsFlat: Uint8Array): Promise<KzgCommitProfiledResult> {
+  async commitBlobsProfiled(blobsFlat: Uint8Array, context?: KzgCommitBatchContext): Promise<KzgCommitProfiledResult> {
     const blobs = assertBlobBatch(blobsFlat)
     if (blobs < this.minBlobs) {
       this.fallBack(`batch below WebGPU threshold: ${blobs} < ${this.minBlobs}`)
-      return this.wasmFallback.commitBlobsProfiled(blobsFlat)
+      return this.wasmFallback.commitBlobsProfiled(blobsFlat, context)
     }
     if (!(await this.probe(blobs)) || !this.committer) {
-      return this.wasmFallback.commitBlobsProfiled(blobsFlat)
+      return this.wasmFallback.commitBlobsProfiled(blobsFlat, context)
     }
 
-    const gpuPromise = this.committer.commitBlobs(blobsFlat)
-    const timed = await withTimeout(gpuPromise, this.commitTimeoutMs)
+    const committer = this.committer
+    const gpuPromise = committer.commitBlobs(blobsFlat)
+    let timed: { timedOut: false; value: WebGpuKzgMsmResult } | { timedOut: true }
+    try {
+      timed = await withTimeout(gpuPromise, this.commitTimeoutMs)
+    } catch (error) {
+      const reason = `WebGPU commit failed: ${error instanceof Error ? error.message : String(error)}`
+      this.openCircuit(reason)
+      return this.wasmFallback.commitBlobsProfiled(blobsFlat, context)
+    }
     if (timed.timedOut) {
-      gpuPromise.catch(() => undefined).finally(() => this.committer?.destroy())
+      this.retireTimedOutCommitter(committer, gpuPromise)
+      const timeoutError = this.makeCommitTimeoutError(blobs, context)
+      this.recordCommitTimeout(timeoutError)
+      if (timeoutError.details.retryableAsSmallerBatch) {
+        throw timeoutError
+      }
       this.openCircuit(`WebGPU commit exceeded ${this.commitTimeoutMs}ms`)
-      return this.wasmFallback.commitBlobsProfiled(blobsFlat)
+      return this.wasmFallback.commitBlobsProfiled(blobsFlat, context)
     }
 
     this.status = {
       ...this.status,
+      available: true,
       fallbackActive: false,
       selectedBackend: 'webgpu',
       bucketWidth: timed.value.debug?.bucketWidth ?? this.status.bucketWidth,
       reductionMode: timed.value.debug?.reductionMode ?? this.status.reductionMode,
+      reason: undefined,
     }
     this.updateScheduler({
       bucketWidth: timed.value.debug?.bucketWidth ?? this.status.bucketWidth,

--- a/polystore-website/src/lib/upload/userMduBrowserKzg.ts
+++ b/polystore-website/src/lib/upload/userMduBrowserKzg.ts
@@ -54,6 +54,14 @@ export type UserMduBrowserKzgPerf = ReturnType<typeof kzgCommitDiagnosticsForBac
   browserKzgBatchCommitMs?: number
   browserKzgBatchRootMs?: number
   browserKzgBatchSplitCount?: number
+  browserKzgBatchTimeoutCount?: number
+  kzgWebGpuCommitTimeoutCount?: number
+  kzgWebGpuBatchTooLargeCount?: number
+  kzgWebGpuLastTimeoutBlobs?: number
+  kzgWebGpuLastTimeoutBytes?: number
+  kzgWebGpuLastTimeoutBatchMdus?: number
+  kzgWebGpuLastTimeoutRetryable?: boolean
+  kzgWebGpuLastTimeoutAdapterCacheKey?: string
   kzgSchedulerSequence?: number
   kzgSchedulerQueueWaitMs?: number
   kzgSchedulerCommitMs?: number
@@ -74,6 +82,9 @@ export type UserMduBrowserKzgPerf = ReturnType<typeof kzgCommitDiagnosticsForBac
   kzgSchedulerBatchPlanReason?: string
   kzgSchedulerBatchSplitCount?: number
   kzgSchedulerBatchFallbackCount?: number
+  kzgSchedulerBatchTimeoutCount?: number
+  kzgSchedulerSafeMaxBatchMdus?: number
+  kzgSchedulerRetriedBatchSizes?: string
   kzgSchedulerOwner?: string
 }
 
@@ -268,6 +279,13 @@ export function kzgCommitDiagnosticsForBackend(kzgCommitBackend: KzgCommitBacken
     kzgWebGpuCalibrationStatus: status?.webgpu?.calibration?.status ?? scheduler?.calibrationStatus ?? '',
     kzgWebGpuCalibrationSource: status?.webgpu?.calibration?.source ?? scheduler?.calibrationSource ?? '',
     kzgWebGpuCalibrationCacheKey: status?.webgpu?.calibration?.cacheKey ?? '',
+    kzgWebGpuCommitTimeoutCount: scheduler?.commitTimeoutCount ?? 0,
+    kzgWebGpuBatchTooLargeCount: scheduler?.batchTooLargeCount ?? 0,
+    kzgWebGpuLastTimeoutBlobs: scheduler?.lastTimeoutBlobs ?? 0,
+    kzgWebGpuLastTimeoutBytes: scheduler?.lastTimeoutBytes ?? 0,
+    kzgWebGpuLastTimeoutBatchMdus: scheduler?.lastTimeoutBatchMdus ?? 0,
+    kzgWebGpuLastTimeoutRetryable: Boolean(scheduler?.lastTimeoutRetryable),
+    kzgWebGpuLastTimeoutAdapterCacheKey: scheduler?.lastTimeoutAdapterCacheKey ?? '',
   }
 }
 
@@ -430,7 +448,11 @@ export async function commitUserMduUncommittedWithBrowserKzg(options: {
   const totalStart = options.totalStartMs
 
   const commitStart = now()
-  const committedRaw = await kzgCommitBackend.commitBlobsProfiled(expansion.shardsFlat)
+  const committedRaw = await kzgCommitBackend.commitBlobsProfiled(expansion.shardsFlat, {
+    batchMduCount: 1,
+    batchLabel: 'user-mdu-single',
+    allowWebGpuBatchTimeoutRetry: false,
+  })
   const commitMs = now() - commitStart
   const witnessFlat = committedRaw.witnessFlat
   const expectedWitnessBytes = (expansion.shardsFlat.byteLength / KZG_BLOB_SIZE) * KZG_COMMITMENT_SIZE
@@ -484,7 +506,11 @@ export async function commitUserMduBatchUncommittedWithBrowserKzg(options: {
   const batchBlobsFlat = concatenateUserMduKzgBatch(expansions)
 
   const commitStart = now()
-  const committedRaw = await kzgCommitBackend.commitBlobsProfiled(batchBlobsFlat)
+  const committedRaw = await kzgCommitBackend.commitBlobsProfiled(batchBlobsFlat, {
+    batchMduCount: expansions.length,
+    batchLabel: 'user-mdu-batch',
+    allowWebGpuBatchTimeoutRetry: expansions.length > 1,
+  })
   const commitMs = now() - commitStart
   const witnessFlat = committedRaw.witnessFlat
   const expectedWitnessBytes = batchBlobs * KZG_COMMITMENT_SIZE

--- a/polystore-website/src/lib/upload/userMduKzgBatch.test.ts
+++ b/polystore-website/src/lib/upload/userMduKzgBatch.test.ts
@@ -8,6 +8,7 @@ import {
   describeUserMduKzgExpansionShape,
   estimateUserMduKzgBatchMemoryBytes,
   planUserMduKzgBatch,
+  recommendedUserMduKzgBatchCapForWebGpuAdapter,
   splitUserMduKzgBatch,
   validateHomogeneousUserMduKzgBatch,
 } from './userMduKzgBatch'
@@ -87,4 +88,19 @@ test('fallback splitter halves oversized batches deterministically', () => {
   assert.deepEqual(splitUserMduKzgBatch(1), [1, 0])
   assert.deepEqual(splitUserMduKzgBatch(2), [1, 1])
   assert.deepEqual(splitUserMduKzgBatch(5), [3, 2])
+})
+
+test('adapter batch cap keeps Apple Metal below the measured timeout cliff', () => {
+  assert.equal(
+    recommendedUserMduKzgBatchCapForWebGpuAdapter({ vendor: 'Apple', architecture: 'Metal', isFallbackAdapter: false }, 4),
+    3,
+  )
+  assert.equal(
+    recommendedUserMduKzgBatchCapForWebGpuAdapter(null, 4, 'MacIntel'),
+    3,
+  )
+  assert.equal(
+    recommendedUserMduKzgBatchCapForWebGpuAdapter({ vendor: 'NVIDIA', architecture: 'Ampere', isFallbackAdapter: false }, 4, 'Linux x86_64'),
+    4,
+  )
 })

--- a/polystore-website/src/lib/upload/userMduKzgBatch.ts
+++ b/polystore-website/src/lib/upload/userMduKzgBatch.ts
@@ -42,6 +42,34 @@ export const DEFAULT_USER_MDU_KZG_BATCH_CONSTRAINTS: NormalizedUserMduKzgBatchCo
   maxEstimatedMemoryBytes: DEFAULT_MAX_ESTIMATED_MEMORY_BYTES,
 }
 
+export type UserMduKzgAdapterInfoLike = {
+  vendor?: string
+  architecture?: string
+  device?: string
+  description?: string
+  isFallbackAdapter?: boolean
+} | null | undefined
+
+export function recommendedUserMduKzgBatchCapForWebGpuAdapter(
+  adapter: UserMduKzgAdapterInfoLike,
+  fallback = DEFAULT_MAX_BATCH_MDUS,
+  platformHint = '',
+): number {
+  const normalizedFallback = positiveInteger(fallback, DEFAULT_MAX_BATCH_MDUS)
+  const vendor = String(adapter?.vendor ?? '').toLowerCase()
+  const architecture = String(adapter?.architecture ?? '').toLowerCase()
+  const device = String(adapter?.device ?? '').toLowerCase()
+  const description = String(adapter?.description ?? '').toLowerCase()
+  const platform = String(platformHint).toLowerCase()
+  const isAppleMetal =
+    vendor.includes('apple') ||
+    architecture.includes('metal') ||
+    device.includes('apple') ||
+    description.includes('metal') ||
+    platform.includes('mac')
+  return isAppleMetal ? Math.min(normalizedFallback, 3) : normalizedFallback
+}
+
 function positiveInteger(value: number | undefined, fallback: number): number {
   const parsed = Math.floor(Number(value ?? fallback))
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback

--- a/polystore-website/src/lib/upload/userMduKzgScheduler.test.ts
+++ b/polystore-website/src/lib/upload/userMduKzgScheduler.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { KZG_BLOB_SIZE } from '../kzgCommitBackend'
+import { KZG_BLOB_SIZE, WebGpuKzgCommitTimeoutError } from '../kzgCommitBackend'
 import { UserMduKzgScheduler } from './userMduKzgScheduler'
 import type { UserMduBrowserKzgResult, UserMduUncommittedExpansion } from './userMduBrowserKzg'
 
@@ -62,8 +62,29 @@ function resultFor(sequence: number): UserMduBrowserKzgResult {
       kzgWebGpuCalibrationStatus: 'cached',
       kzgWebGpuCalibrationSource: 'cache',
       kzgWebGpuCalibrationCacheKey: 'test',
+      kzgWebGpuCommitTimeoutCount: 0,
+      kzgWebGpuBatchTooLargeCount: 0,
+      kzgWebGpuLastTimeoutBlobs: 0,
+      kzgWebGpuLastTimeoutBytes: 0,
+      kzgWebGpuLastTimeoutBatchMdus: 0,
+      kzgWebGpuLastTimeoutRetryable: false,
+      kzgWebGpuLastTimeoutAdapterCacheKey: '',
     },
   }
+}
+
+function webGpuTimeout(batchMduCount: number, blobs = batchMduCount * 3): WebGpuKzgCommitTimeoutError {
+  return new WebGpuKzgCommitTimeoutError({
+    kind: 'webgpu-commit-timeout',
+    blobs,
+    bytes: blobs * KZG_BLOB_SIZE,
+    timeoutMs: 60_000,
+    batchMduCount,
+    retryableAsSmallerBatch: batchMduCount > 1,
+    bucketWidth: 10,
+    reductionMode: 'parallel16',
+    adapterCacheKey: 'test-adapter',
+  })
 }
 
 test('KZG scheduler preserves enqueue order even when later RS expansion finishes first', async () => {
@@ -263,4 +284,89 @@ test('KZG scheduler splits failed batches down to per-MDU commits before using f
   assert.equal(results[0].perf.kzgSchedulerBatchSize, 4)
   assert.ok((results[0].perf.kzgSchedulerBatchSplitCount ?? 0) >= 3)
   assert.equal(scheduler.getStatus().batchSplitCount, 3)
+})
+
+test('KZG scheduler treats typed multi-MDU WebGPU timeout as batch-too-large and retries smaller batches', async () => {
+  let releaseFirst!: (value: UserMduUncommittedExpansion) => void
+  const first = new Promise<UserMduUncommittedExpansion>((resolve) => {
+    releaseFirst = resolve
+  })
+  const batchCalls: number[][] = []
+  const singleCalls: number[] = []
+  const scheduler = new UserMduKzgScheduler({ maxQueueDepth: 8, batch: { maxBatchMdus: 4, maxBatchBlobs: 12 } })
+
+  const tasks = Array.from({ length: 4 }, (_, sequence) =>
+    scheduler.enqueue({
+      sequence,
+      expansion: sequence === 0 ? first : Promise.resolve(expansion(sequence)),
+      commit: async (expanded) => {
+        singleCalls.push(expanded.sequence ?? -1)
+        return resultFor(expanded.sequence ?? 0)
+      },
+      commitBatch: async (expandedBatch) => {
+        const sequences = expandedBatch.map((expanded) => expanded.sequence ?? -1)
+        batchCalls.push(sequences)
+        if (expandedBatch.length === 4) throw webGpuTimeout(4, 12)
+        return expandedBatch.map((expanded) => resultFor(expanded.sequence ?? 0))
+      },
+      fallback: async (reason) => {
+        const fallback = resultFor(sequence)
+        fallback.perf.rustCommitBackend = 'blst'
+        fallback.perf.browserKzgCommitFallbackReason = reason
+        return fallback
+      },
+    }),
+  )
+
+  await Promise.resolve()
+  releaseFirst(expansion(0))
+  const results = await Promise.all(tasks)
+
+  assert.deepEqual(batchCalls, [[0, 1, 2, 3], [0, 1], [2, 3]])
+  assert.deepEqual(singleCalls, [])
+  assert.equal(results[0].perf.rustCommitBackend, 'webgpu-msm')
+  assert.equal(results[0].perf.browserKzgCommitFallbackReason, undefined)
+  assert.equal(results[0].perf.kzgSchedulerBatchTimeoutCount, 1)
+  assert.equal(results[0].perf.kzgSchedulerSafeMaxBatchMdus, 2)
+  assert.equal(results[0].perf.kzgSchedulerRetriedBatchSizes, '2,2')
+  assert.equal(scheduler.getStatus().batchTimeoutCount, 1)
+  assert.equal(scheduler.getStatus().safeMaxBatchMdus, 2)
+  assert.deepEqual(scheduler.getStatus().lastRetriedBatchSizes, [2, 2])
+})
+
+test('KZG scheduler uses fallback when a single-MDU retry still times out', async () => {
+  const batchCalls: number[][] = []
+  const fallbackReasons: string[] = []
+  const scheduler = new UserMduKzgScheduler({ maxQueueDepth: 4, batch: { maxBatchMdus: 2, maxBatchBlobs: 6 } })
+
+  const tasks = Array.from({ length: 2 }, (_, sequence) =>
+    scheduler.enqueue({
+      sequence,
+      expansion: Promise.resolve(expansion(sequence)),
+      commit: async () => {
+        throw webGpuTimeout(1, 3)
+      },
+      commitBatch: async (expandedBatch) => {
+        batchCalls.push(expandedBatch.map((expanded) => expanded.sequence ?? -1))
+        throw webGpuTimeout(expandedBatch.length, expandedBatch.length * 3)
+      },
+      fallback: async (reason) => {
+        fallbackReasons.push(reason)
+        const fallback = resultFor(sequence)
+        fallback.perf.rustCommitBackend = 'blst'
+        fallback.perf.browserKzgCommitFallbackReason = reason
+        return fallback
+      },
+    }),
+  )
+
+  const results = await Promise.all(tasks)
+
+  assert.deepEqual(batchCalls, [[0, 1]])
+  assert.equal(results[0].perf.rustCommitBackend, 'blst')
+  assert.equal(results[1].perf.rustCommitBackend, 'blst')
+  assert.match(fallbackReasons[0], /WebGPU commit exceeded 60000ms/)
+  assert.equal(results[0].perf.kzgSchedulerBatchTimeoutCount, 1)
+  assert.equal(results[0].perf.kzgSchedulerBatchFallbackCount, 2)
+  assert.equal(scheduler.getStatus().batchFallbackCount, 2)
 })

--- a/polystore-website/src/lib/upload/userMduKzgScheduler.ts
+++ b/polystore-website/src/lib/upload/userMduKzgScheduler.ts
@@ -1,3 +1,4 @@
+import { isWebGpuKzgCommitTimeoutError } from '../kzgCommitBackend'
 import type { UserMduBrowserKzgResult, UserMduUncommittedExpansion } from './userMduBrowserKzg'
 import {
   normalizeUserMduKzgBatchConstraints,
@@ -38,6 +39,9 @@ export type UserMduKzgSchedulerDiagnostics = {
   batchPlanReason: UserMduKzgBatchPlan['reason']
   batchSplitCount: number
   batchFallbackCount: number
+  batchTimeoutCount: number
+  safeMaxBatchMdus: number
+  retriedBatchSizes: string
   owner: 'browser-user-mdu-kzg-scheduler-v1'
 }
 
@@ -84,6 +88,10 @@ export type UserMduKzgSchedulerStatus = {
   fallbackCount: number
   batchSplitCount: number
   batchFallbackCount: number
+  batchTimeoutCount: number
+  safeMaxBatchMdus: number
+  adaptiveBatchCapReason: string | null
+  lastRetriedBatchSizes: number[]
   lastBatchSize: number | null
   lastBatchBlobs: number | null
   lastBatchBytes: number | null
@@ -164,6 +172,9 @@ export function attachUserMduKzgSchedulerDiagnostics(
       kzgSchedulerBatchPlanReason: diagnostics.batchPlanReason,
       kzgSchedulerBatchSplitCount: diagnostics.batchSplitCount,
       kzgSchedulerBatchFallbackCount: diagnostics.batchFallbackCount,
+      kzgSchedulerBatchTimeoutCount: diagnostics.batchTimeoutCount,
+      kzgSchedulerSafeMaxBatchMdus: diagnostics.safeMaxBatchMdus,
+      kzgSchedulerRetriedBatchSizes: diagnostics.retriedBatchSizes,
       kzgSchedulerOwner: diagnostics.owner,
     },
   }
@@ -174,7 +185,7 @@ export class UserMduKzgScheduler {
   private readonly concurrency: number
   private readonly now: () => number
   private readonly batchEnabled: boolean
-  private readonly batchConstraints: NormalizedUserMduKzgBatchConstraints
+  private batchConstraints: NormalizedUserMduKzgBatchConstraints
   private queue: QueuedTask[] = []
   private active = 0
   private completed = 0
@@ -182,6 +193,10 @@ export class UserMduKzgScheduler {
   private fallbackCount = 0
   private batchSplitCount = 0
   private batchFallbackCount = 0
+  private batchTimeoutCount = 0
+  private adaptiveBatchCapMdus: number | null = null
+  private adaptiveBatchCapReason: string | null = null
+  private lastRetriedBatchSizes: number[] = []
   private lastBatchSize: number | null = null
   private lastBatchBlobs: number | null = null
   private lastBatchBytes: number | null = null
@@ -212,6 +227,10 @@ export class UserMduKzgScheduler {
       fallbackCount: this.fallbackCount,
       batchSplitCount: this.batchSplitCount,
       batchFallbackCount: this.batchFallbackCount,
+      batchTimeoutCount: this.batchTimeoutCount,
+      safeMaxBatchMdus: this.effectiveBatchConstraints().maxBatchMdus,
+      adaptiveBatchCapReason: this.adaptiveBatchCapReason,
+      lastRetriedBatchSizes: [...this.lastRetriedBatchSizes],
       lastBatchSize: this.lastBatchSize,
       lastBatchBlobs: this.lastBatchBlobs,
       lastBatchBytes: this.lastBatchBytes,
@@ -220,6 +239,34 @@ export class UserMduKzgScheduler {
       lastQueueWaitMs: this.lastQueueWaitMs,
       lastTotalMs: this.lastTotalMs,
     }
+  }
+
+  setAdaptiveBatchCap(maxBatchMdus: number | null, reason?: string): void {
+    if (maxBatchMdus === null) {
+      this.adaptiveBatchCapMdus = null
+      this.adaptiveBatchCapReason = null
+      return
+    }
+    const normalized = Math.floor(Number(maxBatchMdus))
+    if (!Number.isFinite(normalized) || normalized <= 0) return
+    this.adaptiveBatchCapMdus = Math.max(1, Math.min(this.batchConstraints.maxBatchMdus, normalized))
+    this.adaptiveBatchCapReason = reason ?? null
+  }
+
+  private effectiveBatchConstraints(): NormalizedUserMduKzgBatchConstraints {
+    if (!this.adaptiveBatchCapMdus) return this.batchConstraints
+    return {
+      ...this.batchConstraints,
+      maxBatchMdus: Math.max(1, Math.min(this.batchConstraints.maxBatchMdus, this.adaptiveBatchCapMdus)),
+    }
+  }
+
+  private reduceAdaptiveBatchCapAfterTimeout(batchSize: number, retrySizes: number[]): void {
+    const retryCap = Math.max(1, ...retrySizes)
+    const currentCap = this.adaptiveBatchCapMdus ?? this.batchConstraints.maxBatchMdus
+    const nextCap = Math.max(1, Math.min(currentCap, retryCap, batchSize - 1 || 1))
+    this.adaptiveBatchCapMdus = nextCap
+    this.adaptiveBatchCapReason = `reduced after WebGPU batch timeout at ${batchSize} user MDU(s)`
   }
 
   enqueue(task: UserMduKzgSchedulerTask): Promise<UserMduBrowserKzgResult> {
@@ -273,6 +320,7 @@ export class UserMduKzgScheduler {
     meta: BatchMeta,
     position: number,
   ): UserMduKzgSchedulerDiagnostics {
+    const effectiveConstraints = this.effectiveBatchConstraints()
     return {
       sequence: item.task.sequence,
       queueWaitMs: Math.max(0, startedAtMs - item.enqueuedAtMs),
@@ -287,12 +335,15 @@ export class UserMduKzgScheduler {
       batchBlobs: meta.plan.blobs,
       batchBytes: meta.plan.bytes,
       batchEstimatedMemoryBytes: meta.plan.estimatedMemoryBytes,
-      batchMaxMdus: this.batchConstraints.maxBatchMdus,
-      batchMaxBlobs: this.batchConstraints.maxBatchBlobs,
-      batchMaxBytes: this.batchConstraints.maxBatchBytes,
+      batchMaxMdus: effectiveConstraints.maxBatchMdus,
+      batchMaxBlobs: effectiveConstraints.maxBatchBlobs,
+      batchMaxBytes: effectiveConstraints.maxBatchBytes,
       batchPlanReason: meta.plan.reason,
       batchSplitCount: this.batchSplitCount - meta.splitCountAtStart,
       batchFallbackCount: this.batchFallbackCount - meta.fallbackCountAtStart,
+      batchTimeoutCount: this.batchTimeoutCount,
+      safeMaxBatchMdus: effectiveConstraints.maxBatchMdus,
+      retriedBatchSizes: this.lastRetriedBatchSizes.join(','),
       owner: OWNER,
     }
   }
@@ -306,7 +357,8 @@ export class UserMduKzgScheduler {
   private collectReadyBatch(first: QueuedTask, firstExpansion: UserMduUncommittedExpansion): { batch: BatchItem[]; plan: UserMduKzgBatchPlan } {
     const batch: BatchItem[] = [{ queued: first, expansion: firstExpansion }]
     let acceptedFromQueue = 0
-    let plan = planUserMduKzgBatch([firstExpansion], this.batchConstraints)
+    const constraints = this.effectiveBatchConstraints()
+    let plan = planUserMduKzgBatch([firstExpansion], constraints)
 
     if (!this.batchEnabled || !first.task.commitBatch) {
       return { batch, plan }
@@ -316,7 +368,7 @@ export class UserMduKzgScheduler {
       if (!queued.task.commitBatch || queued.task.signal?.aborted) break
       if (queued.expansionState.status !== 'fulfilled') break
       const candidateExpansions = [...batch.map((item) => item.expansion), queued.expansionState.value]
-      const candidatePlan = planUserMduKzgBatch(candidateExpansions, this.batchConstraints)
+      const candidatePlan = planUserMduKzgBatch(candidateExpansions, constraints)
       if (candidatePlan.count !== candidateExpansions.length) {
         plan = candidatePlan.count === batch.length ? candidatePlan : plan
         break
@@ -385,6 +437,12 @@ export class UserMduKzgScheduler {
       const [leftCount, rightCount] = splitUserMduKzgBatch(batch.length)
       if (leftCount <= 0 || rightCount <= 0) {
         return Promise.all(batch.map((item) => this.commitSingle(item, startedAtMs, meta, errorMessage(error))))
+      }
+      const retrySizes = [leftCount, rightCount].filter((value) => value > 0)
+      this.lastRetriedBatchSizes = retrySizes
+      if (isWebGpuKzgCommitTimeoutError(error)) {
+        this.batchTimeoutCount += 1
+        this.reduceAdaptiveBatchCapAfterTimeout(batch.length, retrySizes)
       }
       const left = batch.slice(0, leftCount)
       const right = batch.slice(leftCount)

--- a/polystore-website/src/lib/uploadStatus.test.ts
+++ b/polystore-website/src/lib/uploadStatus.test.ts
@@ -73,6 +73,14 @@ test('normalizeKzgBackendStatus surfaces browser KZG scheduler diagnostics', () 
     kzgSchedulerBatchBytes: 50_331_648,
     kzgSchedulerBatchSplitCount: 1,
     kzgSchedulerBatchFallbackCount: 0,
+    kzgSchedulerBatchTimeoutCount: 1,
+    kzgSchedulerSafeMaxBatchMdus: 2,
+    kzgWebGpuCommitTimeoutCount: 2,
+    kzgWebGpuBatchTooLargeCount: 1,
+    kzgWebGpuLastTimeoutBlobs: 384,
+    kzgWebGpuLastTimeoutBytes: 50_331_648,
+    kzgWebGpuLastTimeoutBatchMdus: 4,
+    kzgWebGpuLastTimeoutRetryable: true,
   })
 
   assert.equal(status.schedulerQueueWaitMs, 12)
@@ -86,6 +94,34 @@ test('normalizeKzgBackendStatus surfaces browser KZG scheduler diagnostics', () 
   assert.equal(status.schedulerBatchBytes, 50_331_648)
   assert.equal(status.schedulerBatchSplitCount, 1)
   assert.equal(status.schedulerBatchFallbackCount, null)
+  assert.equal(status.schedulerBatchTimeoutCount, 1)
+  assert.equal(status.schedulerSafeMaxBatchMdus, 2)
+  assert.equal(status.webGpuCommitTimeoutCount, 2)
+  assert.equal(status.webGpuBatchTooLargeCount, 1)
+  assert.equal(status.webGpuLastTimeoutBlobs, 384)
+  assert.equal(status.webGpuLastTimeoutBytes, 50_331_648)
+  assert.equal(status.webGpuLastTimeoutBatchMdus, 4)
+  assert.equal(status.webGpuLastTimeoutRetryable, true)
+})
+
+test('normalizeKzgBackendStatus surfaces worker-side browser KZG batch split diagnostics', () => {
+  const status = normalizeKzgBackendStatus({
+    rustCommitBackend: 'webgpu-msm',
+    kzgCommitBackend: 'webgpu',
+    kzgSchedulerBatchSplitCount: 0,
+    kzgSchedulerBatchTimeoutCount: 0,
+    browserKzgBatchSize: 4,
+    browserKzgBatchBlobs: 384,
+    browserKzgBatchBytes: 50_331_648,
+    browserKzgBatchSplitCount: 1,
+    browserKzgBatchTimeoutCount: 1,
+  })
+
+  assert.equal(status.schedulerBatchSize, 4)
+  assert.equal(status.schedulerBatchBlobs, 384)
+  assert.equal(status.schedulerBatchBytes, 50_331_648)
+  assert.equal(status.schedulerBatchSplitCount, 1)
+  assert.equal(status.schedulerBatchTimeoutCount, 1)
 })
 
 test('patchUploadPipelineStatus preserves nested state and records elapsed time', () => {

--- a/polystore-website/src/lib/uploadStatus.ts
+++ b/polystore-website/src/lib/uploadStatus.ts
@@ -42,6 +42,12 @@ export type KzgBackendStatus = {
   calibrationStatus: string | null
   calibrationSource: string | null
   calibrationCacheKey: string | null
+  webGpuCommitTimeoutCount: number | null
+  webGpuBatchTooLargeCount: number | null
+  webGpuLastTimeoutBlobs: number | null
+  webGpuLastTimeoutBytes: number | null
+  webGpuLastTimeoutBatchMdus: number | null
+  webGpuLastTimeoutRetryable: boolean | null
   schedulerQueueWaitMs: number | null
   schedulerTotalMs: number | null
   schedulerQueueDepth: number | null
@@ -53,6 +59,8 @@ export type KzgBackendStatus = {
   schedulerBatchBytes: number | null
   schedulerBatchSplitCount: number | null
   schedulerBatchFallbackCount: number | null
+  schedulerBatchTimeoutCount: number | null
+  schedulerSafeMaxBatchMdus: number | null
   probeTimeoutMs: number | null
   commitTimeoutMs: number | null
   minBlobs: number | null
@@ -138,6 +146,18 @@ export type KzgDiagnosticsInput = {
   workerKzgWebGpuCalibrationSource?: string
   kzgWebGpuCalibrationCacheKey?: string
   workerKzgWebGpuCalibrationCacheKey?: string
+  kzgWebGpuCommitTimeoutCount?: number
+  workerKzgWebGpuCommitTimeoutCount?: number
+  kzgWebGpuBatchTooLargeCount?: number
+  workerKzgWebGpuBatchTooLargeCount?: number
+  kzgWebGpuLastTimeoutBlobs?: number
+  workerKzgWebGpuLastTimeoutBlobs?: number
+  kzgWebGpuLastTimeoutBytes?: number
+  workerKzgWebGpuLastTimeoutBytes?: number
+  kzgWebGpuLastTimeoutBatchMdus?: number
+  workerKzgWebGpuLastTimeoutBatchMdus?: number
+  kzgWebGpuLastTimeoutRetryable?: boolean
+  workerKzgWebGpuLastTimeoutRetryable?: boolean
   kzgSchedulerQueueWaitMs?: number
   workerKzgSchedulerQueueWaitMs?: number
   kzgSchedulerTotalMs?: number
@@ -152,14 +172,28 @@ export type KzgDiagnosticsInput = {
   workerKzgSchedulerFallbackCount?: number
   kzgSchedulerBatchSize?: number
   workerKzgSchedulerBatchSize?: number
+  browserKzgBatchSize?: number
+  workerBrowserKzgBatchSize?: number
   kzgSchedulerBatchBlobs?: number
   workerKzgSchedulerBatchBlobs?: number
+  browserKzgBatchBlobs?: number
+  workerBrowserKzgBatchBlobs?: number
   kzgSchedulerBatchBytes?: number
   workerKzgSchedulerBatchBytes?: number
+  browserKzgBatchBytes?: number
+  workerBrowserKzgBatchBytes?: number
   kzgSchedulerBatchSplitCount?: number
   workerKzgSchedulerBatchSplitCount?: number
+  browserKzgBatchSplitCount?: number
+  workerBrowserKzgBatchSplitCount?: number
   kzgSchedulerBatchFallbackCount?: number
   workerKzgSchedulerBatchFallbackCount?: number
+  kzgSchedulerBatchTimeoutCount?: number
+  workerKzgSchedulerBatchTimeoutCount?: number
+  browserKzgBatchTimeoutCount?: number
+  workerBrowserKzgBatchTimeoutCount?: number
+  kzgSchedulerSafeMaxBatchMdus?: number
+  workerKzgSchedulerSafeMaxBatchMdus?: number
   kzgWebGpuProbeTimeoutMs?: number
   workerKzgWebGpuProbeTimeoutMs?: number
   kzgWebGpuCommitTimeoutMs?: number
@@ -198,6 +232,12 @@ export const PENDING_KZG_BACKEND_STATUS: KzgBackendStatus = {
   calibrationStatus: null,
   calibrationSource: null,
   calibrationCacheKey: null,
+  webGpuCommitTimeoutCount: null,
+  webGpuBatchTooLargeCount: null,
+  webGpuLastTimeoutBlobs: null,
+  webGpuLastTimeoutBytes: null,
+  webGpuLastTimeoutBatchMdus: null,
+  webGpuLastTimeoutRetryable: null,
   schedulerQueueWaitMs: null,
   schedulerTotalMs: null,
   schedulerQueueDepth: null,
@@ -209,6 +249,8 @@ export const PENDING_KZG_BACKEND_STATUS: KzgBackendStatus = {
   schedulerBatchBytes: null,
   schedulerBatchSplitCount: null,
   schedulerBatchFallbackCount: null,
+  schedulerBatchTimeoutCount: null,
+  schedulerSafeMaxBatchMdus: null,
   probeTimeoutMs: null,
   commitTimeoutMs: null,
   minBlobs: null,
@@ -282,17 +324,50 @@ export function normalizeKzgBackendStatus(input?: KzgDiagnosticsInput | null): K
     calibrationStatus,
     calibrationSource,
     calibrationCacheKey,
+    webGpuCommitTimeoutCount: firstNumber(input.kzgWebGpuCommitTimeoutCount, input.workerKzgWebGpuCommitTimeoutCount),
+    webGpuBatchTooLargeCount: firstNumber(input.kzgWebGpuBatchTooLargeCount, input.workerKzgWebGpuBatchTooLargeCount),
+    webGpuLastTimeoutBlobs: firstNumber(input.kzgWebGpuLastTimeoutBlobs, input.workerKzgWebGpuLastTimeoutBlobs),
+    webGpuLastTimeoutBytes: firstNumber(input.kzgWebGpuLastTimeoutBytes, input.workerKzgWebGpuLastTimeoutBytes),
+    webGpuLastTimeoutBatchMdus: firstNumber(input.kzgWebGpuLastTimeoutBatchMdus, input.workerKzgWebGpuLastTimeoutBatchMdus),
+    webGpuLastTimeoutRetryable: firstBoolean(input.kzgWebGpuLastTimeoutRetryable, input.workerKzgWebGpuLastTimeoutRetryable),
     schedulerQueueWaitMs: firstNumber(input.kzgSchedulerQueueWaitMs, input.workerKzgSchedulerQueueWaitMs),
     schedulerTotalMs: firstNumber(input.kzgSchedulerTotalMs, input.workerKzgSchedulerTotalMs),
     schedulerQueueDepth: firstNumber(input.kzgSchedulerDepthAtEnqueue, input.workerKzgSchedulerDepthAtEnqueue),
     schedulerActive: firstNumber(input.kzgSchedulerActiveAtEnqueue, input.workerKzgSchedulerActiveAtEnqueue),
     schedulerMaxQueueDepth: firstNumber(input.kzgSchedulerMaxQueueDepth, input.workerKzgSchedulerMaxQueueDepth),
     schedulerFallbackCount: firstNumber(input.kzgSchedulerFallbackCount, input.workerKzgSchedulerFallbackCount),
-    schedulerBatchSize: firstNumber(input.kzgSchedulerBatchSize, input.workerKzgSchedulerBatchSize),
-    schedulerBatchBlobs: firstNumber(input.kzgSchedulerBatchBlobs, input.workerKzgSchedulerBatchBlobs),
-    schedulerBatchBytes: firstNumber(input.kzgSchedulerBatchBytes, input.workerKzgSchedulerBatchBytes),
-    schedulerBatchSplitCount: firstNumber(input.kzgSchedulerBatchSplitCount, input.workerKzgSchedulerBatchSplitCount),
+    schedulerBatchSize: firstNumber(
+      input.kzgSchedulerBatchSize,
+      input.workerKzgSchedulerBatchSize,
+      input.browserKzgBatchSize,
+      input.workerBrowserKzgBatchSize,
+    ),
+    schedulerBatchBlobs: firstNumber(
+      input.kzgSchedulerBatchBlobs,
+      input.workerKzgSchedulerBatchBlobs,
+      input.browserKzgBatchBlobs,
+      input.workerBrowserKzgBatchBlobs,
+    ),
+    schedulerBatchBytes: firstNumber(
+      input.kzgSchedulerBatchBytes,
+      input.workerKzgSchedulerBatchBytes,
+      input.browserKzgBatchBytes,
+      input.workerBrowserKzgBatchBytes,
+    ),
+    schedulerBatchSplitCount: firstNumber(
+      input.kzgSchedulerBatchSplitCount,
+      input.workerKzgSchedulerBatchSplitCount,
+      input.browserKzgBatchSplitCount,
+      input.workerBrowserKzgBatchSplitCount,
+    ),
     schedulerBatchFallbackCount: firstNumber(input.kzgSchedulerBatchFallbackCount, input.workerKzgSchedulerBatchFallbackCount),
+    schedulerBatchTimeoutCount: firstNumber(
+      input.kzgSchedulerBatchTimeoutCount,
+      input.workerKzgSchedulerBatchTimeoutCount,
+      input.browserKzgBatchTimeoutCount,
+      input.workerBrowserKzgBatchTimeoutCount,
+    ),
+    schedulerSafeMaxBatchMdus: firstNumber(input.kzgSchedulerSafeMaxBatchMdus, input.workerKzgSchedulerSafeMaxBatchMdus),
     probeTimeoutMs: firstNumber(input.kzgWebGpuProbeTimeoutMs, input.workerKzgWebGpuProbeTimeoutMs),
     commitTimeoutMs: firstNumber(input.kzgWebGpuCommitTimeoutMs, input.workerKzgWebGpuCommitTimeoutMs),
     minBlobs: firstNumber(input.kzgWebGpuMinBlobs, input.workerKzgWebGpuMinBlobs),

--- a/polystore-website/src/lib/worker-client.ts
+++ b/polystore-website/src/lib/worker-client.ts
@@ -3,6 +3,7 @@
 // This file provides a simple client API to interact with the gateway.worker.ts
 // It abstracts the message passing and Promise-based communication.
 import { DEFAULT_EXPANSION_HARDWARE_CONCURRENCY, pickExpansionWorkerCount } from './expansionWorkers'
+import { recommendedUserMduKzgBatchCapForWebGpuAdapter } from './upload/userMduKzgBatch'
 import { UserMduKzgScheduler } from './upload/userMduKzgScheduler'
 import type { UserMduBrowserKzgResult, UserMduUncommittedExpansion } from './upload/userMduBrowserKzg'
 
@@ -273,7 +274,20 @@ export interface ExpandedStripe {
       browserKzgBatchCommitMs?: number;
       browserKzgBatchRootMs?: number;
       browserKzgBatchSplitCount?: number;
+      browserKzgBatchTimeoutCount?: number;
     };
+}
+
+type KzgBackendStatusMessage = {
+  webgpu?: {
+    adapter?: {
+      vendor?: string
+      architecture?: string
+      device?: string
+      description?: string
+      isFallbackAdapter?: boolean
+    } | null
+  }
 }
 
 export type KzgCommitDiagnostics = {
@@ -291,6 +305,13 @@ export type KzgCommitDiagnostics = {
   kzgWebGpuCalibrationStatus?: string
   kzgWebGpuCalibrationSource?: string
   kzgWebGpuCalibrationCacheKey?: string
+  kzgWebGpuCommitTimeoutCount?: number
+  kzgWebGpuBatchTooLargeCount?: number
+  kzgWebGpuLastTimeoutBlobs?: number
+  kzgWebGpuLastTimeoutBytes?: number
+  kzgWebGpuLastTimeoutBatchMdus?: number
+  kzgWebGpuLastTimeoutRetryable?: boolean
+  kzgWebGpuLastTimeoutAdapterCacheKey?: string
   kzgSchedulerSequence?: number
   kzgSchedulerQueueWaitMs?: number
   kzgSchedulerCommitMs?: number
@@ -311,6 +332,9 @@ export type KzgCommitDiagnostics = {
   kzgSchedulerBatchPlanReason?: string
   kzgSchedulerBatchSplitCount?: number
   kzgSchedulerBatchFallbackCount?: number
+  kzgSchedulerBatchTimeoutCount?: number
+  kzgSchedulerSafeMaxBatchMdus?: number
+  kzgSchedulerRetriedBatchSizes?: string
   kzgSchedulerOwner?: string
   commitWorkerCount?: number
 }
@@ -390,6 +414,22 @@ export const workerClient = {
     const setupCopy = trustedSetupBytes.slice()
     const result = await sendMessageToWorker('initPolyStoreWasm', { trustedSetupBytes }, [trustedSetupBytes.buffer]) as string
     await initializeExpansionPool(setupCopy)
+    const platformHint = navigator.platform || navigator.userAgent || ''
+    const platformCap = recommendedUserMduKzgBatchCapForWebGpuAdapter(null, userMduKzgScheduler.getStatus().safeMaxBatchMdus, platformHint)
+    if (platformCap < userMduKzgScheduler.getStatus().safeMaxBatchMdus) {
+      userMduKzgScheduler.setAdaptiveBatchCap(platformCap, 'conservative WebGPU platform cap')
+    }
+    try {
+      const status = await sendMessageToWorker('getKzgBackendStatus', {}) as KzgBackendStatusMessage
+      const fallbackCap = userMduKzgScheduler.getStatus().safeMaxBatchMdus
+      const recommendedCap = recommendedUserMduKzgBatchCapForWebGpuAdapter(status?.webgpu?.adapter, fallbackCap, platformHint)
+      if (recommendedCap < fallbackCap) {
+        userMduKzgScheduler.setAdaptiveBatchCap(recommendedCap, 'conservative WebGPU adapter cap')
+      }
+    } catch {
+      // Status is best-effort. Split/retry still protects the upload path if the
+      // initial adapter-specific cap cannot be installed.
+    }
     return result
   },
 

--- a/polystore-website/src/workers/gateway.worker.ts
+++ b/polystore-website/src/workers/gateway.worker.ts
@@ -6,7 +6,11 @@
 // The `init` function loads the WASM binary.
 // The `Mdu0Builder` and `PolyStoreWasm` classes are exposed by wasm-bindgen.
 import init, { WasmMdu0Builder, PolyStoreWasm } from '../lib/polystoreCoreRuntime.js';
-import { createBrowserKzgCommitBackend, type KzgCommitBackend } from '../lib/kzgCommitBackend';
+import {
+    createBrowserKzgCommitBackend,
+    isWebGpuKzgCommitTimeoutError,
+    type KzgCommitBackend,
+} from '../lib/kzgCommitBackend';
 import {
     committedExpansionToUserMduBrowserKzgResult,
     commitUserMduBatchUncommittedWithBrowserKzg,
@@ -183,6 +187,7 @@ function committedFallbackReason(fallbackReason: unknown): string | undefined {
 async function commitUserMduBatchWithSplitting(
     expansions: UserMduUncommittedExpansion[],
     splitCount = { value: 0 },
+    timeoutCount = { value: 0 },
 ): Promise<UserMduBrowserKzgResult[]> {
     if (!polyStoreWasmInstance) throw new Error('PolyStoreWasm not initialized. Call initPolyStoreWasm first.');
     if (!kzgCommitBackend) throw new Error('PolyStoreWasm not initialized. Call initPolyStoreWasm first.');
@@ -197,14 +202,16 @@ async function commitUserMduBatchWithSplitting(
             perf: {
                 ...result.perf,
                 browserKzgBatchSplitCount: splitCount.value,
+                browserKzgBatchTimeoutCount: timeoutCount.value,
             },
         }));
     } catch (error) {
         if (expansions.length <= 1) throw error;
         splitCount.value += 1;
+        if (isWebGpuKzgCommitTimeoutError(error)) timeoutCount.value += 1;
         const mid = Math.ceil(expansions.length / 2);
-        const left = await commitUserMduBatchWithSplitting(expansions.slice(0, mid), splitCount);
-        const right = await commitUserMduBatchWithSplitting(expansions.slice(mid), splitCount);
+        const left = await commitUserMduBatchWithSplitting(expansions.slice(0, mid), splitCount, timeoutCount);
+        const right = await commitUserMduBatchWithSplitting(expansions.slice(mid), splitCount, timeoutCount);
         return [...left, ...right];
     }
 }
@@ -265,6 +272,11 @@ self.onmessage = async (event) => {
                     commitWorkersReady = Promise.resolve();
                 }
                 result = 'PolyStoreWasm initialized';
+                break;
+            }
+            case 'getKzgBackendStatus': {
+                if (!kzgCommitBackend) throw new Error('PolyStoreWasm not initialized. Call initPolyStoreWasm first.');
+                result = kzgCommitBackend.getStatus();
                 break;
             }
             case 'initMdu0Builder': {


### PR DESCRIPTION
## Summary

Closes #208. Implements adaptive browser WebGPU KZG batching for Mode 2 upload prep.

- Adds typed `WebGpuKzgCommitTimeoutError` diagnostics for bounded WebGPU commit timeouts.
- Treats retryable multi-MDU WebGPU timeouts as “batch too large” without opening the global WebGPU circuit or silently switching to WASM.
- Splits/retries timed-out batches through smaller WebGPU chunks, reduces the adaptive batch cap, and only falls back when a single-MDU retry still fails.
- Keeps single-MDU timeouts, device/probe failures, fallback adapters, and parity failures fail-closed/circuit-opening.
- Reinitializes retired timed-out committers safely so stale cleanup cannot destroy replacement committers or force silent WASM fallback.
- Surfaces timeout/split/retry/safe-cap diagnostics in worker perf, upload status, and FileSharder output.
- Applies conservative Apple/Metal/Mac WebGPU batch caps while retaining split/retry protection.

**Do not merge yet per requester instruction.**

## Tests

- `cd polystore-website && npm run test:unit` — 292 passed
- `cd polystore-website && npm run lint` — passed
- `cd polystore-website && npm run build:app` — passed
- Pi subagent review — PASS, no blocking findings after fixes

## Native Chrome/WebGPU benchmark

Native Chrome 148 with WebGPU enabled on macOS/Apple Metal:

- WebGPU preflight/adapter present: passed
- `perf:kzg-webgpu-msm` 1-blob smoke: WebGPU `webgpu-msm`, parity `true`, fallback adapter `false`
- 64 MiB no-gateway Mode 2 browser prep/upload smoke using native Chrome + WebGPU:
  - Final prepare run log: `/tmp/polystore_208_prepare_final2_K6NW8m/prepare.log`
  - `SPARSE_FILE_SIZE_BYTES=67108864`, `CAPTURE_PREPARE_PERF=1`
  - total prepare profile: ~86.0s
  - KZG backend: `webgpu` / `webgpu-msm`
  - circuit open: `false`
  - WebGPU fallback reason: `null`
  - commit timeout count / split count: `null` in the no-timeout run
- Full bundled upload smoke also passed earlier:
  - log: `/tmp/polystore_208_full_QP3EOe/full.log`
  - 36 artifacts uploaded in 3 bundled requests, fallbackCount 0



## Merge readiness

- Head SHA: `1d84c6d7221af6df99db697fe21959b206608a3e`
- GitHub CI: green / all checks passing at latest head
- Merge state: clean
- Review: Pi subagent review passed; no unresolved blocking findings known
- AI review requests: `@copilot review`, `@coderabbitai review`, and `@codex review` requested in PR comment; Codex connector responded that no Codex account is connected. No review threads are open.
- Merge policy: leave unmerged for human approval

