### PR TITLE
fix(website): normalize upload wait times

### DIFF
--- a/polystore-website/src/components/FileSharder.tsx
+++ b/polystore-website/src/components/FileSharder.tsx
@@ -8,6 +8,7 @@ import { useDirectUpload } from '../hooks/useDirectUpload'; // New import
 import { useDirectCommit } from '../hooks/useDirectCommit'; // New import
 import { useBumpDealSetupSlot } from '../hooks/useBumpDealSetupSlot';
 import { appConfig } from '../config';
+import { formatDuration } from '../lib/duration';
 import { POLYFS_RECORD_PATH_MAX_BYTES, sanitizePolyfsRecordPath } from '../lib/polyfsPath';
 import {
   deleteDealDirectory,
@@ -412,12 +413,6 @@ function formatBytes(bytes: number) {
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
   if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(2)} MiB`;
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GiB`;
-}
-
-function formatDuration(ms: number) {
-  if (!Number.isFinite(ms) || ms < 0) return '—';
-  if (ms < 1000) return `${ms.toFixed(0)}ms`;
-  return `${(ms / 1000).toFixed(2)}s`;
 }
 
 function uploadToneForPhase(phase: UploadPipelinePhase): UploadStatusTone {

--- a/polystore-website/src/lib/duration.test.ts
+++ b/polystore-website/src/lib/duration.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { formatDuration } from './duration'
+
+test('formatDuration keeps sub-second timings in milliseconds', () => {
+  assert.equal(formatDuration(0), '0ms')
+  assert.equal(formatDuration(999.4), '999ms')
+})
+
+test('formatDuration uses compact seconds below one minute', () => {
+  assert.equal(formatDuration(1_000), '1s')
+  assert.equal(formatDuration(12_345), '12s')
+  assert.equal(formatDuration(59_400), '59s')
+  assert.equal(formatDuration(59_600), '1m')
+})
+
+test('formatDuration normalizes long waits to minutes and seconds', () => {
+  assert.equal(formatDuration(61_000), '1m 1s')
+  assert.equal(formatDuration(140_000), '2m 20s')
+  assert.equal(formatDuration(150_000), '2m 30s')
+  assert.equal(formatDuration(200_000), '3m 20s')
+  assert.equal(formatDuration(120_000), '2m')
+})
+
+test('formatDuration uses hours for very long waits', () => {
+  assert.equal(formatDuration(3_600_000), '1h')
+  assert.equal(formatDuration(3_725_000), '1h 2m 5s')
+})
+
+test('formatDuration rejects invalid durations', () => {
+  assert.equal(formatDuration(Number.NaN), '—')
+  assert.equal(formatDuration(-1), '—')
+})

--- a/polystore-website/src/lib/duration.ts
+++ b/polystore-website/src/lib/duration.ts
@@ -1,0 +1,21 @@
+export function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return '—'
+  if (ms < 1000) return `${ms.toFixed(0)}ms`
+
+  const totalSeconds = Math.round(ms / 1000)
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`
+  }
+
+  const totalMinutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  if (totalMinutes < 60) {
+    return seconds === 0 ? `${totalMinutes}m` : `${totalMinutes}m ${seconds}s`
+  }
+
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+  if (minutes === 0 && seconds === 0) return `${hours}h`
+  if (seconds === 0) return `${hours}h ${minutes}m`
+  return `${hours}h ${minutes}m ${seconds}s`
+}


### PR DESCRIPTION
## Summary

Closes #207.

- Adds a shared `formatDuration` helper for compact upload wait-time display.
- Formats long waits as minutes/seconds (for example `2m 20s`, `2m 30s`, `3m 20s`) instead of large raw second counts.
- Wires the FileSharder elapsed/ETA/current-op displays through the shared helper.
- Adds unit coverage for sub-second, seconds, minutes, and hour-scale durations.

## Tests

- `cd polystore-website && npx tsx --test src/lib/duration.test.ts` — passed
- `cd polystore-website && npm run test:unit` — 297 passed
- `cd polystore-website && npm run lint` — passed
- `cd polystore-website && npm run build:app` — passed

## Merge readiness

- Latest head: `4a3098e584ab42aad229c5ac3907f1e7301ca562`
- Scope: website-only display formatting; no protocol/storage changes
- Risk: low; presentation-only helper used by upload progress UI
- Merge policy: leave unmerged for human approval


- AI review requests: `@copilot review`, `@coderabbitai review`, and `@codex review` requested in PR comment; Codex connector responded that no Codex account is connected. No review threads are open.
