### PR TITLE
docs: freeze MDU #0 PolyFS root contract

### DIFF
--- a/notes/mode2-artifacts-v1.md
+++ b/notes/mode2-artifacts-v1.md
@@ -37,6 +37,13 @@ For each provider slot `slot` (0..N-1), where `N = K + M`, store:
   - length = `rows * BLOB_SIZE`
   - where `rows = 64 / K` and `BLOB_SIZE = 128 KiB`
 
+## Optional / Debug Files
+
+Files in this section MUST be excluded from required-artifact conformance
+checks and golden-vector required-file lists. They may be present to help
+transition or visualization, but canonical PolyFS-root validation must succeed
+without them.
+
 ### Legacy Flat Manifest Blob
 
 - `manifest.bin`

--- a/notes/mode2-artifacts-v1.md
+++ b/notes/mode2-artifacts-v1.md
@@ -6,11 +6,11 @@ The goal is that the **gateway** and the **browser/WASM** implementation can pro
 
 ## Directory Roots
 
-- **Gateway (disk):** `polystore_gateway/uploads/deals/<deal_id>/<manifest_root_key>/`
+- **Gateway (disk):** `polystore_gateway/uploads/deals/<deal_id>/<polyfs_root_key>/`
 - **Browser (OPFS):** `OPFS:/deal-<deal_id>/`
 
-`manifest_root_key` is a filesystem-safe key derived from the 48-byte manifest root:
-- canonical form `0x<96 hex chars>`
+`polyfs_root_key` is a filesystem-safe key derived from the 32-byte PolyFS root:
+- canonical form `0x<64 hex chars>`
 - key form: lowercased hex **without** the `0x` prefix
 
 ## Required Files (within the directory)
@@ -37,10 +37,12 @@ For each provider slot `slot` (0..N-1), where `N = K + M`, store:
   - length = `rows * BLOB_SIZE`
   - where `rows = 64 / K` and `BLOB_SIZE = 128 KiB`
 
-### Manifest Blob
+### Legacy Flat Manifest Blob
 
 - `manifest.bin`
-  - 128 KiB manifest blob produced alongside the 48-byte manifest commitment (the on-chain `manifest_root`)
+  - Legacy alpha/debug artifact produced alongside the retired 48-byte flat manifest commitment.
+  - New PolyFS-root deals MUST NOT require this file for fetch, proof generation, repair, or trust-root validation.
+  - If retained during transition, it must be clearly treated as cache/debug data rather than canonical committed state.
 
 ## Determinism Rules
 
@@ -81,7 +83,6 @@ This matches the leaf index mapping used for proofs:
 Golden vectors live in `testdata/mode2-artifacts-v1/` and define expected SHA-256 hashes for:
 - `mdu_0.bin`, witness MDUs
 - all shard files
-- `manifest.bin`
+- any retained legacy/debug `manifest.bin`
 
 These vectors are used by Rust, Go, and web unit tests to enforce deterministic outputs and cross-implementation parity.
-

--- a/notes/mode2-framing.md
+++ b/notes/mode2-framing.md
@@ -25,14 +25,16 @@ Key point: PolyFS defines the *logical bytes*; Mode 2 defines how each 8 MiB SP�
 
 The chain does not commit to “file hash = X” directly. It commits to a structure that implies all file bytes are fixed:
 
-- `Deal.manifest_root` (48B KZG) commits to a vector of per‑MDU roots.
+- `Deal.polyfs_root` (32B Merkle root) commits to MDU #0, the PolyFS super-manifest.
+- MDU #0 contains a root table whose first 16 DUs commit to the roots of MDUs after MDU #0.
 - For each MDU index, there is an `mdu_root` (Merkle root over blob commitments).
 - Each blob commitment (48B KZG) commits to 128 KiB blob bytes.
 
 A proof (Triple Proof / `ChainedProof`) establishes:
-1) the per‑MDU root is part of `Deal.manifest_root`
-2) the blob commitment is included in the per‑MDU Merkle tree
-3) the served blob bytes match the blob commitment
+1) the relevant MDU #0 root-table DU commitment is included in `Deal.polyfs_root`
+2) that root-table DU opens to the target per-MDU root
+3) the blob commitment is included in the target per-MDU Merkle tree
+4) the served blob bytes match the blob commitment
 
 So “what proofs commit to” means: what byte-objects are bound into these roots such that a provider can be held accountable (reward/slash) for them.
 
@@ -53,9 +55,10 @@ Mode 2 relies on fully replicated metadata so any repairer can know “what the 
 
 - **MDU #0 (PolyFS super-manifest):** file table + root table (points to the other MDUs)
 - **Witness MDUs:** packed array of expected 48-byte blob commitments for each *data-bearing* SP‑MDU (see §6 and §5 Design A)
-- **Manifest openings material:** enough information to produce Hop‑1 openings against on-chain `Deal.manifest_root`.
-  - In devnet today this is commonly stored as `manifest.bin` (the 128 KiB manifest blob).
-  - Protocol requirement: provers/repairers must be able to obtain Hop‑1 openings deterministically from replicated metadata, not by contacting the user.
+- **Root-table opening material:** enough information to produce Hop 1b openings from the MDU #0 root table.
+  - In alpha devnet this was commonly stored as `manifest.bin` (the 128 KiB flat-manifest blob).
+  - For the PolyFS root contract, `manifest.bin` is legacy/cache only and is not part of the canonical trust root.
+  - Protocol requirement: provers/repairers must be able to obtain root-table openings deterministically from replicated MDU #0 metadata, not by contacting the user.
 
 ### 4.2 Witness sizing
 
@@ -66,8 +69,8 @@ Witness size formula:
 - Witness MDUs `W = ceil(witness_bytes / 8 MiB)`
 
 Root table capacity constraint (PolyFS V1):
-- RootTable in MDU #0 is 2 MiB of 32-byte roots → max `65,536` roots.
-- Therefore the slab must satisfy: `1 + W + S <= 65,536`.
+- RootTable in MDU #0 is 2 MiB of 32-byte root field bindings -> max `65,536` roots for MDU #1 onward.
+- Therefore the slab must satisfy: `W + S <= 65,536`, or `total_mdus = 1 + W + S <= 65,537`.
 - This is why “512 GiB logical minus a few MDUs” happens (metadata consumes some root slots).
 
 ## 5) How parity is bound into the committed state
@@ -155,11 +158,11 @@ For **metadata** MDUs (`slab_mdu_index <= W`):
 
 1) **Parity accountability:** Design A is the current target, but must be explicitly adopted for Mode 2.
 
-2) **Hop‑1 openings source-of-truth:** specify how provers obtain manifest openings (and what is replicated).
+2) **Hop 1b openings source-of-truth:** specify the exact prover-side root-table opening material and cache format.
 
 3) **Parameter flexibility beyond `K | 64`:** if arbitrary `K` is desired (not dividing 64), the system needs an explicit padding/packing rule (out of scope for this note).
 
 4) **Sizing semantics:** clarify caps:
    - per-SP cap (e.g. 512 GiB) vs client-visible logical cap
-   - RS overhead factor `N/K` and metadata overhead (Witness + MDU #0 + manifest openings material)
-   - RootTable ceiling `1 + W + S <= 65,536` for PolyFS V1
+   - RS overhead factor `N/K` and metadata overhead (Witness + MDU #0 + root-table opening material)
+   - RootTable ceiling `W + S <= 65,536` for PolyFS V1

--- a/notes/triple-proof.md
+++ b/notes/triple-proof.md
@@ -147,7 +147,8 @@ These are the MDUs that store the actual file content (raw bytes).
 
 5.  **Hop 2: Verify The Molecule (MDU Root -> Blob Commitment) [Merkle]**
     *   The prover supplies `Proof.blob_commitment` (48 bytes) and `Proof.merkle_path`.
-    *   *Merkle Check:* Verify `VerifyMerkle(Proof.mdu_root, Proof.blob_commitment, Proof.merkle_path)` (at `Proof.blob_index`).
+    *   *Merkle Check:* Select the target MDU root profile from the committed deal mode/profile and MDU kind, reject `Proof.blob_index` outside that profile's leaf count, then verify `VerifyMerkle(Proof.mdu_root, Proof.blob_commitment, Proof.merkle_path)` at `Proof.blob_index`.
+    *   *Leaf Count:* MDU #0, Witness MDUs, and Mode 1 replicated user MDUs use 64 leaves. Mode 2 striped user SP-MDUs use the slot-major `leaf_index` and `L = (K+M)*(64/K)` leaves from `rfcs/rfc-blob-alignment-and-striping.md` (96 leaves for the default `K=8`, `M=4` profile).
     *   **Note:** Witness MDUs are an acceleration structure for the prover to *find* `blob_commitment`; they are not required in the on-chain verification chain.
 
 6.  **Hop 3: Verify The Atom (Blob Commitment -> Data Byte) [KZG]**

--- a/notes/triple-proof.md
+++ b/notes/triple-proof.md
@@ -1,41 +1,43 @@
 # Technical Specification: The Triple Proof (PolyFS Volume Architecture)
 
-This mechanism enables the blockchain to verify a specific byte of data (e.g., inside file "video.mp4", MDU #500) while storing only a single 48-byte commitment (`Deal.manifest_root`) for the entire Deal.
+This mechanism enables the blockchain to verify a specific blob of data (e.g., inside file "video.mp4", MDU #500) while storing only a single deal root for the entire Deal.
 
-It uses a **Hybrid Merkle-KZG** architecture to support efficient filesystem mapping and petabyte scalability.
+It uses a **Hybrid Merkle-KZG** architecture to support efficient filesystem mapping and large slab verification.
+
+**Normative root contract:** `rfcs/rfc-polyfs-root-contract.md` is the source of truth for the MDU #0 trust root migration tracked by issue #212. This note describes the resulting architecture.
 
 ### 0. Naming & API Implications (PolyFS SSoT)
 
-*   **`manifest_root` is deal-level:** A 48-byte KZG commitment anchoring the entire slab (MDU #0 + Witness + User MDUs). Some codepaths may still label this as `cid` as a legacy alias. For REST APIs, it is encoded as **96 hex chars** (optional `0x` prefix) representing the 48-byte compressed G1 value. Gateways MUST normalize consistently:
-    *   Canonical string form for logs/responses: `0x` + lowercase hex (96 chars).
-    *   Canonical on-disk directory key `manifest_root_key`: lowercase hex **without** `0x` (96 chars), derived by decoding then re-encoding (not by string trimming alone).
-    *   Parsing must be strict: reject invalid compressed-point encodings and invalid subgroup points (return `400` in gateway APIs).
-*   **`file_path` is file-level:** The authoritative identifier for a file *within* a deal. Retrieval/proof APIs must be keyed by `(deal_id, manifest_root, file_path)` and resolved from PolyFS (`uploads/<manifest_root_key>/mdu_0.bin` + on-disk `mdu_*.bin`), with no fallback to `uploads/index.json` or “single-file deal” heuristics.
+*   **`polyfs_root` is deal-level:** A 32-byte Merkle root over the 64 KZG commitments of MDU #0. This root anchors the entire slab because MDU #0 contains the root table for all other MDUs. Some transitional codepaths may still label this value `manifest_root` or `cid`; those names are legacy aliases and MUST NOT imply the retired 48-byte flat-manifest KZG root.
+    *   Canonical string form for logs/responses: `0x` + lowercase hex (64 chars).
+    *   Canonical on-disk directory key `polyfs_root_key`: lowercase hex **without** `0x` (64 chars), derived by decoding then re-encoding (not by string trimming alone).
+    *   Parsing must be strict: reject non-hex, wrong-width, or legacy 96-hex roots for new committed deals (return `400` in gateway APIs).
+*   **`file_path` is file-level:** The authoritative identifier for a file *within* a deal. Retrieval/proof APIs must be keyed by `(deal_id, polyfs_root, file_path)` and resolved from PolyFS (`uploads/<polyfs_root_key>/mdu_0.bin` + on-disk `mdu_*.bin`), with no fallback to `uploads/index.json` or “single-file deal” heuristics.
     *   `file_path` MUST be unique within a deal. If an upload targets an existing `file_path`, the gateway must overwrite deterministically (update-in-place or tombstone + replace) so fetch/prove cannot return stale bytes.
     *   `GET /gateway/list-files/...` should return a deduplicated view (latest non-tombstone record per `file_path`). If the on-disk File Table contains ambiguous duplicates, fail fast with a clear non-200 (prefer `409`) until repaired.
 *   **`owner` is access control (gateway):** Gateway REST APIs that serve or prove deal content (e.g., `/gateway/fetch`, `/gateway/list-files`, `/gateway/prove-retrieval`) MUST require the deal owner (`owner`, PolyStore Chain bech32) alongside `deal_id` and verify `(deal_id, owner)` against chain state. Owner mismatches must return a clear non-200 (prefer `403`) as JSON.
 *   **`file_path` must be canonical:** Treat it as a relative, slash-separated path (no leading `/`, no `..` traversal, no `\\` separators, reject empty/whitespace-only). Gateways must decode **at most once** (URL query params are decoded by the HTTP stack; JSON bodies are already-decoded strings) and match case-sensitively against PolyFS File Table entries.
     *   Beware `+` vs `%20`: Go’s query parser treats `+` as space. Clients MUST use `%20` for spaces (JS `encodeURIComponent`) and servers should treat decoded strings as canonical.
-*   **Gateway error contract (target):** Missing/empty/unsafe `file_path` is a hard `400` with a remediation hint; tombstone/not-found is `404`; stale `manifest_root` (doesn’t match chain deal state, including the thin-provisioned “empty root” case) should be a clear non-200 (prefer `409`). Errors MUST be JSON (and set `Content-Type: application/json`) even when the success path is a byte stream.
+*   **Gateway error contract (target):** Missing/empty/unsafe `file_path` is a hard `400` with a remediation hint; tombstone/not-found is `404`; stale `polyfs_root` (doesn’t match chain deal state, including the thin-provisioned “empty root” case) should be a clear non-200 (prefer `409`). Errors MUST be JSON (and set `Content-Type: application/json`) even when the success path is a byte stream.
     *   If the PolyFS File Table is internally inconsistent (e.g., ambiguous duplicate `file_path` entries), the gateway should return a clear non-200 (prefer `409`) rather than serving potentially stale bytes.
 
 ### 1. The Data Model: "Elastic Filesystem on Slab"
 
 We treat the Deal as an **Elastic Volume** (Slab) with a structured layout: **Super-Manifest (MDU #0)**, followed by **Witness MDUs**, and then **User Data MDUs**.
 
-*   **Thin provisioning (no tiers):** Deals are created with `manifest_root = empty`, `size = 0`, `total_mdus = 0` until the first `MsgUpdateDealContent*` commits the initial slab root. Any sizing inputs (e.g., `max_user_mdus` used to size the Witness region) are devnet policy parameters, not user-selected tiers.
+*   **Thin provisioning (no tiers):** Deals are created with `polyfs_root = empty`, `size = 0`, `total_mdus = 0` until the first `MsgUpdateDealContent*` commits the initial slab root. Any sizing inputs (e.g., `max_user_mdus` used to size the Witness region) are devnet policy parameters, not user-selected tiers.
 *   **High-water mark:** Once enforced, `Deal.total_mdus` is the on-chain upper bound for valid `(mdu_index, ...)` challenges/receipts. Some gateway APIs may surface this as `allocated_length` / `total_mdus` in responses.
 
 #### A. On-Chain State (`Deal`)
 
-The blockchain stores a KZG commitment to the Manifest MDU and tracks the "High Water Mark" of the slab in MDUs.
+The blockchain stores `polyfs_root`, the Merkle root of MDU #0's 64 KZG commitments, and tracks the "High Water Mark" of the slab in MDUs.
 
 ```protobuf
 message Deal {
     uint64 id = 1;
-    // 48-byte KZG commitment (BLS12-381 G1, compressed) to the Manifest MDU.
-    // The Manifest MDU commits to the list of per-MDU roots (Hop 1).
-    bytes manifest_root = 2;
+    // 32-byte Merkle root over the 64 KZG commitments for MDU #0.
+    // MDU #0's root table commits to the list of per-MDU roots after MDU #0.
+    bytes polyfs_root = 2;
 
     // Current size of committed content in bytes (mutable).
     uint64 size = 3;
@@ -52,14 +54,15 @@ MDU #0 is an 8 MiB unit strictly partitioned into two regions:
 
 | Blob Range | Content | Format | Capacity |
 | :--- | :--- | :--- | :--- |
-| **0 - 15** | **Root Table** | `[Scalar; 65536]` | Roots for 512GB |
+| **0 - 15** | **Root Table** | `[Scalar; 65536]` | Roots for MDUs #1..#65536 |
 | **16 - 63** | **File Table** | Header + `[FileRecord; N]` | ~98k Files |
 
 **1. The Root Table (Blobs 0-15)**
 A contiguous array of 32-byte BLS12-381 Scalars.
-*   **Indexing:** `RootTable[i]` stores the per‑MDU root (Merkle root encoded as a scalar) for `MDU #(i+1)` in slab order. `RootTable[0]` refers to `MDU #1` (first Witness MDU) and `RootTable[W]` refers to `MDU #(W+1)` (first User Data MDU).
+*   **Indexing:** `RootTable[i]` stores the deterministic field binding for the per-MDU root of `MDU #(i+1)` in slab order. `RootTable[0]` refers to `MDU #1` (first Witness MDU) and `RootTable[W]` refers to `MDU #(W+1)` (first User Data MDU).
 *   **Addressing:** `Root(i)` is located at `Offset = i * 32` within the 2MB region of MDU #0.
-*   **Purpose:** The on-disk “map” for mounting the slab and generating proofs. The chain verifies proofs against `Deal.manifest_root` (the commitment), not by reading `RootTable` directly.
+*   **Encoding:** For each target MDU root, compute `mdu_root_fr = ReduceMduRootToFr(mdu_root)` and store `FrToBytesBE(mdu_root_fr)`. The exact reduction is frozen in `rfcs/rfc-polyfs-root-contract.md`; implementations must not silently choose a different reduction.
+*   **Purpose:** The on-disk "map" for mounting the slab and generating proofs. The chain verifies root-table openings against the MDU #0 DU commitment that is Merkle-included under `Deal.polyfs_root`, not by reading `RootTable` directly.
 
 **2. The File Table (Blobs 16-63)**
 A metadata region describing the files stored within the User Data Slab.
@@ -132,16 +135,21 @@ These are the MDUs that store the actual file content (raw bytes).
     *   If `Target_MDU_Index > 0` and `Target_MDU_Index <= W`: Witness MDU. Hop 2 is to find a Blob commitment for a Data MDU.
     *   If `Target_MDU_Index > W`: User Data MDU. Hop 2 is to find a Data Blob.
 
-3.  **Hop 1: Verify The Map (Deal Manifest -> Target MDU Root) [KZG]**
-    *   *KZG Check:* Verify `VerifyKZG(Deal.manifest_root, Proof.mdu_index, Proof.mdu_root_fr, Proof.manifest_opening)`.
-    *   *Result:* We now trust `Proof.mdu_root_fr` is the true root for `Proof.mdu_index`.
+3.  **Hop 1a: Verify The Super-Manifest DU (Deal Root -> Root-Table DU Commitment) [Merkle]**
+    *   Compute `root_table_index = Target_MDU_Index - 1`, `root_table_du = root_table_index / 4096`, and `root_table_cell = root_table_index % 4096`.
+    *   *Merkle Check:* Verify the supplied root-table DU commitment is included in `Deal.polyfs_root` at `root_table_du`.
 
-4.  **Hop 2: Verify The Molecule (MDU Root -> Blob Commitment) [Merkle]**
+4.  **Hop 1b: Verify The Map Cell (Root-Table DU -> Target MDU Root) [KZG]**
+    *   Derive `mdu_root_fr = ReduceMduRootToFr(Proof.mdu_root)`.
+    *   *KZG Check:* Verify the root-table DU KZG opening at `root_table_cell` returns `mdu_root_fr`.
+    *   *Result:* We now trust `Proof.mdu_root` is the true root for `Proof.mdu_index`.
+
+5.  **Hop 2: Verify The Molecule (MDU Root -> Blob Commitment) [Merkle]**
     *   The prover supplies `Proof.blob_commitment` (48 bytes) and `Proof.merkle_path`.
-    *   *Merkle Check:* Verify `VerifyMerkle(Proof.mdu_root_fr, Proof.blob_commitment, Proof.merkle_path)` (at `Proof.blob_index`).
+    *   *Merkle Check:* Verify `VerifyMerkle(Proof.mdu_root, Proof.blob_commitment, Proof.merkle_path)` (at `Proof.blob_index`).
     *   **Note:** Witness MDUs are an acceleration structure for the prover to *find* `blob_commitment`; they are not required in the on-chain verification chain.
 
-5.  **Hop 3: Verify The Atom (Blob Commitment -> Data Byte) [KZG]**
+6.  **Hop 3: Verify The Atom (Blob Commitment -> Data Byte) [KZG]**
     *   *KZG Check:* Verify `VerifyKZG(Proof.blob_commitment, Proof.z_value, Proof.y_value, Proof.kzg_opening_proof)`.
     *   *Result:* The data byte is valid.
 
@@ -150,11 +158,11 @@ These are the MDUs that store the actual file content (raw bytes).
 ### 3. Lifecycle & Filesystem Logic
 
 #### 3.1 Initialization (Lazy Fill)
-*   **CreateDeal (thin):** `manifest_root = empty`, `size = 0`, `total_mdus = 0`. No content challenges are meaningful until a root is committed.
+*   **CreateDeal (thin):** `polyfs_root = empty`, `size = 0`, `total_mdus = 0`. No content challenges are meaningful until a root is committed.
 *   **First Commit (gateway/provider):**
     1. Initialize a slab as `MDU #0 + W Witness MDUs` (all zero-filled/empty) plus any required User Data MDUs.
-    2. Compute the new `manifest_root`.
-*   **Chain:** User signs `MsgUpdateDealContent*` to set `Deal.manifest_root`, `Deal.size`, and advance `Deal.total_mdus` to reflect the committed slab. Challenges for newly added MDUs become valid when `mdu_index < total_mdus`.
+    2. Compute the new `polyfs_root`.
+*   **Chain:** User signs `MsgUpdateDealContent*` to set `Deal.polyfs_root`, `Deal.size`, and advance `Deal.total_mdus` to reflect the committed slab. Challenges for newly added MDUs become valid when `mdu_index < total_mdus`.
 
 #### 3.2 Sequential Write (Expansion)
 *   **Scenario:** User uploads 1GB file.
@@ -163,7 +171,7 @@ These are the MDUs that store the actual file content (raw bytes).
     2.  Updates `Root Table` in MDU #0 for these User Data MDUs.
     3.  Updates **Witness MDUs** with the KZG Blob Commitments for these User Data MDUs.
     4.  Appends `FileRecord` to `File Table` in MDU #0.
-*   **Chain:** User signs `MsgUpdateDealContent` updating `manifest_root`, `size`, and setting `total_mdus = 1 + W + 125`.
+*   **Chain:** User signs `MsgUpdateDealContent` updating `polyfs_root`, `size`, and setting `total_mdus = 1 + W + 125`.
 *   **Safety:** Challenges for newly added User Data MDUs are now valid (`mdu_index < total_mdus`).
 
 #### 3.3 Deletion & Fragmentation (Tombstones)

--- a/notes/triple-proof.md
+++ b/notes/triple-proof.md
@@ -134,11 +134,11 @@ raw payload capacity, not `user_data_mdus * 8 MiB`.
 1.  **Context Derivation:**
     *   From `Challenge`, derive `Target_MDU_Index` (the 0-indexed MDU number being challenged, starting from MDU #0).
     *   **Safety Check:** `Target_MDU_Index` must be < `Deal.total_mdus`.
-    *   **Content-proof Check:** Retrieval and liveness challenges MUST target `Target_MDU_Index > 0`. MDU #0 is the committed super-manifest itself; it is authenticated directly by `Deal.polyfs_root` and must not be looked up through the root table.
+    *   **Content-proof Check:** Retrieval and liveness challenges MUST target a user-data MDU: `Target_MDU_Index > W`. MDU #0 and Witness MDUs are metadata regions, not content-proof targets.
 
 2.  **Determine MDU Type:**
     *   If `Target_MDU_Index == 0`: reject this proof shape. A future metadata proof for bytes inside MDU #0 needs the separate direct path `Deal.polyfs_root -> MDU0.DU commitment -> KZG opening`, not the root-table path below.
-    *   If `Target_MDU_Index > 0` and `Target_MDU_Index <= W`: Witness MDU. Hop 2 is to find a Blob commitment for a Data MDU.
+    *   If `Target_MDU_Index > 0` and `Target_MDU_Index <= W`: reject this content-proof shape. Witness MDUs cache replicated metadata for proof generation; they must not satisfy retrieval or liveness challenges for user data.
     *   If `Target_MDU_Index > W`: User Data MDU. Hop 2 is to find a Data Blob.
 
 3.  **Hop 1a: Verify The Super-Manifest DU (Deal Root -> Root-Table DU Commitment) [Merkle]**

--- a/notes/triple-proof.md
+++ b/notes/triple-proof.md
@@ -109,9 +109,11 @@ struct FileRecordV1 {
 This contiguous block of MDUs (immediately following MDU #0) stores the KZG Blob Commitments required for Hop 2 of the Triple Proof.
 
 *   **Calculation of W (Number of Witness MDUs):**
-    *   For a *planned* maximum of `N_user_mdus`, total blob commitments = `N_user_mdus * 64`.
-    *   Total size of commitments = `N_user_mdus * 64 * 48 bytes`.
-    *   `W = ceil( (N_user_mdus * 64 * 48) / (8 * 1024 * 1024) )`.
+    *   For a *planned* maximum of `N_user_mdus`, total blob commitments = `N_user_mdus * commitments_per_user_mdu`.
+    *   `commitments_per_user_mdu` is the target MDU root profile leaf count selected by the committed deal mode/profile. Replicated user MDUs use 64. Mode 2 striped user SP-MDUs use `L = (K+M)*(64/K)`; the default `K=8`, `M=4` profile uses 96.
+    *   Total size of commitments = `N_user_mdus * commitments_per_user_mdu * 48 bytes`.
+    *   `W = ceil( (N_user_mdus * commitments_per_user_mdu * 48) / (8 * 1024 * 1024) )`.
+    *   A Mode 2 gateway/client MUST NOT reserve Witness MDUs with the old `N_user_mdus * 64` formula, because that omits parity-slot commitments and prevents proofs for leaves `64..95`.
     *   **Devnet note:** `N_user_mdus` is currently an off-chain input (e.g., a gateway/client parameter). The on-chain Deal does not store this reservation.
 *   **Structure:** Witness MDUs are a packed, contiguous array of 48-byte G1 Points (Compressed).
 *   **Indexing:** The `kzg_commitment` for `User_Data_MDU_X, Blob_Y` is located at a deterministic offset within the Witness MDUs.

--- a/notes/triple-proof.md
+++ b/notes/triple-proof.md
@@ -12,7 +12,7 @@ It uses a **Hybrid Merkle-KZG** architecture to support efficient filesystem map
     *   Canonical string form for logs/responses: `0x` + lowercase hex (64 chars).
     *   Canonical on-disk directory key `polyfs_root_key`: lowercase hex **without** `0x` (64 chars), derived by decoding then re-encoding (not by string trimming alone).
     *   Parsing must be strict: reject non-hex, wrong-width, or legacy 96-hex roots for new committed deals (return `400` in gateway APIs).
-*   **`file_path` is file-level:** The authoritative identifier for a file *within* a deal. Retrieval/proof APIs must be keyed by `(deal_id, polyfs_root, file_path)` and resolved from PolyFS (`uploads/<polyfs_root_key>/mdu_0.bin` + on-disk `mdu_*.bin`), with no fallback to `uploads/index.json` or “single-file deal” heuristics.
+*   **`file_path` is file-level:** The authoritative identifier for a file *within* a deal. Retrieval/proof APIs must be keyed by `(deal_id, polyfs_root, file_path)` and resolved from PolyFS (`uploads/deals/<deal_id>/<polyfs_root_key>/mdu_0.bin` + on-disk `mdu_*.bin`), with no fallback to `uploads/index.json` or “single-file deal” heuristics.
     *   `file_path` MUST be unique within a deal. If an upload targets an existing `file_path`, the gateway must overwrite deterministically (update-in-place or tombstone + replace) so fetch/prove cannot return stale bytes.
     *   `GET /gateway/list-files/...` should return a deduplicated view (latest non-tombstone record per `file_path`). If the on-disk File Table contains ambiguous duplicates, fail fast with a clear non-200 (prefer `409`) until repaired.
 *   **`owner` is access control (gateway):** Gateway REST APIs that serve or prove deal content (e.g., `/gateway/fetch`, `/gateway/list-files`, `/gateway/prove-retrieval`) MUST require the deal owner (`owner`, PolyStore Chain bech32) alongside `deal_id` and verify `(deal_id, owner)` against chain state. Owner mismatches must return a clear non-200 (prefer `403`) as JSON.
@@ -129,14 +129,15 @@ These are the MDUs that store the actual file content (raw bytes).
 1.  **Context Derivation:**
     *   From `Challenge`, derive `Target_MDU_Index` (the 0-indexed MDU number being challenged, starting from MDU #0).
     *   **Safety Check:** `Target_MDU_Index` must be < `Deal.total_mdus`.
+    *   **Content-proof Check:** Retrieval and liveness challenges MUST target `Target_MDU_Index > 0`. MDU #0 is the committed super-manifest itself; it is authenticated directly by `Deal.polyfs_root` and must not be looked up through the root table.
 
 2.  **Determine MDU Type:**
-    *   If `Target_MDU_Index == 0`: MDU #0 (Super-Manifest). Hop 2 is to find a Root within its Root Table.
+    *   If `Target_MDU_Index == 0`: reject this proof shape. A future metadata proof for bytes inside MDU #0 needs the separate direct path `Deal.polyfs_root -> MDU0.DU commitment -> KZG opening`, not the root-table path below.
     *   If `Target_MDU_Index > 0` and `Target_MDU_Index <= W`: Witness MDU. Hop 2 is to find a Blob commitment for a Data MDU.
     *   If `Target_MDU_Index > W`: User Data MDU. Hop 2 is to find a Data Blob.
 
 3.  **Hop 1a: Verify The Super-Manifest DU (Deal Root -> Root-Table DU Commitment) [Merkle]**
-    *   Compute `root_table_index = Target_MDU_Index - 1`, `root_table_du = root_table_index / 4096`, and `root_table_cell = root_table_index % 4096`.
+    *   Because `Target_MDU_Index == 0` was rejected above, compute `root_table_index = Target_MDU_Index - 1`, `root_table_du = root_table_index / 4096`, and `root_table_cell = root_table_index % 4096`.
     *   *Merkle Check:* Verify the supplied root-table DU commitment is included in `Deal.polyfs_root` at `root_table_du`.
 
 4.  **Hop 1b: Verify The Map Cell (Root-Table DU -> Target MDU Root) [KZG]**

--- a/notes/triple-proof.md
+++ b/notes/triple-proof.md
@@ -120,7 +120,10 @@ This contiguous block of MDUs (immediately following MDU #0) stores the KZG Blob
 
 #### D. MDU #(W+1)..(total_mdus-1): The User Data MDUs
 
-These are the MDUs that store the actual file content (raw bytes).
+These are the MDUs that store the actual file content after scalar packing.
+Each 8 MiB encoded user MDU carries `(8 MiB / 32) * 31 = 8,126,464`
+raw payload bytes. Content admission and `size_bytes` validation must use this
+raw payload capacity, not `user_data_mdus * 8 MiB`.
 
 ---
 

--- a/polystore_gateway/polystore-gateway-spec.md
+++ b/polystore_gateway/polystore-gateway-spec.md
@@ -26,12 +26,12 @@ The service wraps a mix of native libraries and CLI tools:
     *   **Witness MDUs:** Store the KZG Blobs required for Triple Proof verification (replicated metadata).
     *   **User Data MDUs:** Store the raw file content slices.
     *   Files are committed to a **deal-scoped directory** (recommended):
-        *   `uploads/deals/<deal_id>/<manifest_root_key>/`
-        *   where `manifest_root_key` is lowercase hex **without** `0x` (96 chars), derived by decoding the 48-byte `manifest_root` then re-encoding (not by string trimming alone).
+        *   `uploads/deals/<deal_id>/<polyfs_root_key>/`
+        *   where `polyfs_root_key` is lowercase hex **without** `0x` (64 chars), derived by decoding the 32-byte `polyfs_root` then re-encoding (not by string trimming alone).
         *   This avoids collisions across deals and allows multiple roots per deal over time.
         *   Any extra debug artifacts (e.g., shard JSON, `manifest_blob_hex`) are optional and must not be required for fetch/prove.
 *   **PolyFS is the Source of Truth (Target End State):**
-    *   The gateway MUST be able to list files, fetch bytes, and generate proofs by reading `uploads/deals/<deal_id>/<manifest_root_key>/mdu_0.bin` (File Table) and the on-disk `mdu_*.bin` slab — without any auxiliary index or in-memory state.
+    *   The gateway MUST be able to list files, fetch bytes, and generate proofs by reading `uploads/deals/<deal_id>/<polyfs_root_key>/mdu_0.bin` (File Table) and the on-disk `mdu_*.bin` slab — without any auxiliary index, in-memory state, or canonical `manifest.bin`.
 
 ---
 
@@ -40,7 +40,7 @@ The service wraps a mix of native libraries and CLI tools:
 ### 3.1 S3 Compatibility (Legacy)
 | Method | Path | Description |
 |:---|:---|:---|
-| `PUT` | `/api/v1/object/{key}` | **Legacy:** saves a raw object to disk for quick demos (not deal-backed). **Target:** treats `{key}` as a PolyFS `file_path` within a Deal and ingests it into PolyFS, returning `manifest_root` (legacy alias: `cid`). |
+| `PUT` | `/api/v1/object/{key}` | **Legacy:** saves a raw object to disk for quick demos (not deal-backed). **Target:** treats `{key}` as a PolyFS `file_path` within a Deal and ingests it into PolyFS, returning `polyfs_root` (legacy aliases during transition: `manifest_root`, `cid`). |
 | `GET` | `/api/v1/object/{key}` | **Legacy:** serves a raw object by filename. **Target:** resolves and streams from PolyFS by `file_path` (no `uploads/index.json` dependency). |
 
 #### 3.1.1 Path-Style S3 (Deal-Backed Buckets) — Devnet/Enterprise
@@ -54,7 +54,7 @@ The gateway also exposes a **minimal, path-style S3 surface** at the HTTP root f
 |:---|:---|:---|
 | `GET` | `/` | List buckets (on-chain deals) as `deal-<id>` names. |
 | `HEAD` | `/{bucket}` | Bucket existence check (Deal exists on chain). |
-| `GET` | `/{bucket}` | List objects (PolyFS file table) for the Deal’s current `manifest_root`. |
+| `GET` | `/{bucket}` | List objects (PolyFS file table) for the Deal’s current `polyfs_root`. |
 | `GET` / `HEAD` | `/{bucket}/{key...}` | Fetch an object from PolyFS by `file_path` (supports explicit `Range: bytes=start-end`). |
 | `PUT` | `/{bucket}/{key...}` | Upload an object, ingest via the striped RS path, upload to providers, and **commit** via `update-deal-content` (devnet: requires a faucet-authorized deal). |
 | `DELETE` | `/{bucket}/{key...}` | Not implemented yet (PolyFS tombstoning still needs wiring). |
@@ -62,24 +62,24 @@ The gateway also exposes a **minimal, path-style S3 surface** at the HTTP root f
 ### 3.2 Gateway (Web Frontend Support)
 These endpoints support the `polystore-website` "Thin Client" flow.
 
-**Naming note:** Some handlers and routes still name the path parameter `{cid}`. In all gateway APIs, `cid` is a **legacy alias** for the deal-level `manifest_root` (48-byte KZG commitment) — it is never a file identifier and must not be used as a lookup key into `uploads/index.json`.
+**Naming note:** Some handlers and routes still name the path parameter `{cid}` or `{manifest_root}`. In all gateway APIs for new deals, those names are **legacy aliases** for the deal-level `polyfs_root` (32-byte MDU #0 Merkle root). They are never file identifiers and must not be used as lookup keys into `uploads/index.json`.
 
 #### Data Ingestion
 *   **`POST /gateway/upload`**
     *   **Input:** Multipart form data (`file`, `owner`, optional `file_path`).
-*   **Logic:** Saves the file, then performs *canonical PolyFS ingest* (MDU #0 + Witness MDUs + User MDUs + `manifest_root`). Sharding/KZG uses `polystore_cli`; PolyFS table construction uses `polystore_core` FFI. Work is request-scoped: cancellation/timeouts propagate into `polystore_cli` subprocesses.
+*   **Logic:** Saves the file, then performs *canonical PolyFS ingest* (MDU #0 + Witness MDUs + User MDUs + `polyfs_root`). Sharding/KZG uses `polystore_cli`; PolyFS table construction uses `polystore_core` FFI. Work is request-scoped: cancellation/timeouts propagate into `polystore_cli` subprocesses.
     *   **Options:** Supports `deal_id` (append into an existing deal), `max_user_mdus` (devnet sizing hint for witness region), and `file_path` (PolyFS-relative destination path; default is a sanitized `filename`).
         *   **PolyFS path rules (target):** Decode at most once (HTTP frameworks already decode query/form values); reject empty/whitespace-only, leading `/`, `..` traversal, `\\` separators, NUL bytes, and control characters. Matching is case-sensitive and byte-exact (no `path.Clean` / no double-unescape).
         *   **Uniqueness (target):** `file_path` MUST be unique within a deal. If `deal_id` is provided and the target `file_path` already exists, the gateway MUST overwrite deterministically (update-in-place or tombstone + replace) so later fetch/prove cannot return stale bytes.
         *   **Encoding note:** Go’s query parser treats `+` as space. Clients should encode spaces as `%20` (JS `encodeURIComponent`) and servers should treat decoded strings as canonical.
-    *   **Output (target):** JSON `{ "manifest_root": "0x...", "size_bytes": 123, "file_size_bytes": 123, "total_mdus": 3, "witness_mdus": 1, "file_path": "dir/file.txt", "filename": "file.txt" }`.
-        *   **Compatibility:** Current responses may include legacy aliases: `cid == manifest_root` and `allocated_length == total_mdus`.
+    *   **Output (target):** JSON `{ "polyfs_root": "0x...", "size_bytes": 123, "file_size_bytes": 123, "total_mdus": 3, "witness_mdus": 1, "file_path": "dir/file.txt", "filename": "file.txt" }`.
+        *   **Compatibility:** Transitional responses may include legacy aliases: `manifest_root == polyfs_root`, `cid == polyfs_root`, and `allocated_length == total_mdus`.
     *   **Role:** Offloads canonical ingest and commitment generation from the browser (until thick-client parity is complete).
 
 *   **`POST /sp/upload_shard`** *(Striped Provider API)*
     *   **Input:** Raw shard bytes (body) with headers:
-        * `X-PolyStore-Deal-ID` (uint64), `X-PolyStore-Mdu-Index` (uint64), `X-PolyStore-Slot` (uint64), `X-PolyStore-Manifest-Root` (`0x` + 96 hex).
-    *   **Logic:** Stores the shard as `mdu_<index>_slot_<slot>.bin` under `uploads/<manifest_root_key>/`.
+        * `X-PolyStore-Deal-ID` (uint64), `X-PolyStore-Mdu-Index` (uint64), `X-PolyStore-Slot` (uint64), `X-PolyStore-PolyFS-Root` (`0x` + 64 hex). Legacy clients may send `X-PolyStore-Manifest-Root` only if it carries the 32-byte `polyfs_root` value.
+    *   **Logic:** Stores the shard as `mdu_<index>_slot_<slot>.bin` under `uploads/<polyfs_root_key>/`.
     *   **Role:** Slot-specific shard ingestion for the striped StripeReplica layout.
         *   **Provider is a dumb pipe:** the server does not need to understand layout variants beyond writing/serving bytes addressed by the headers.
         *   Metadata MDUs (MDU #0 + Witness) remain replicated to all slots via `/sp/upload_mdu`.
@@ -88,7 +88,7 @@ These endpoints support the `polystore-website` "Thin Client" flow.
     *   **Role:** Reduces browser direct-upload round trips by sending all Mode 2 artifacts for one provider in a single request. Support is optional; browsers MUST fall back to `/sp/upload_mdu`, `/sp/upload_shard`, and `/sp/upload_manifest` if the endpoint returns unsupported/invalid-bundle responses.
     *   **Content-Type:** `application/x.polystore-bundle-v2`.
     *   **Binary format:** `"NLB2"` magic (4 bytes), little-endian `uint32` metadata JSON length, metadata JSON, then artifact bodies concatenated in metadata order.
-    *   **Metadata JSON:** `{ "deal_id": uint64, "manifest_root": "0x...", "previous_manifest_root": "0x...", "upload_generation": "optional-devnet-id", "artifacts": [{ "part": "artifact_00", "kind": "mdu|shard|manifest", "mdu_index": uint64?, "slot": uint64?, "full_size": int64, "send_size": int64 }] }`.
+    *   **Metadata JSON:** `{ "deal_id": uint64, "polyfs_root": "0x...", "previous_polyfs_root": "0x...", "upload_generation": "optional-devnet-id", "artifacts": [{ "part": "artifact_00", "kind": "mdu|shard|legacy_manifest", "mdu_index": uint64?, "slot": uint64?, "full_size": int64, "send_size": int64 }] }`.
     *   **Sparse artifacts:** `send_size` MAY be smaller than `full_size`; providers write the prefix bytes and zero-extend/truncate the stored file to `full_size`, matching per-artifact `X-PolyStore-Full-Size` semantics.
     *   **Validation:** All artifacts in a bundle share the same deal/root/generation scope. Providers reject missing/invalid roots, too many artifacts, duplicate target filenames, malformed generation IDs, body length mismatches, and unexpected trailing bytes without committing partial files.
     *   **CORS:** Providers answer `OPTIONS /sp/upload_bundle` and allow `Content-Type` plus `X-PolyStore-*` headers so browser-only uploads remain gateway-optional.
@@ -96,12 +96,12 @@ These endpoints support the `polystore-website` "Thin Client" flow.
 *   **`POST /gateway/mirror_mdu` / `/gateway/mirror_manifest` / `/gateway/mirror_shard`** *(Gateway mirror helpers)*
     *   **Input:** Same headers/payloads as `/sp/upload_mdu`, `/sp/upload_manifest`, `/sp/upload_shard`.
     *   **Role:** Optional browser-side mirroring into a local user-gateway cache (used when the user-gateway is running in proxy mode and `/sp/*` endpoints are not exposed on that process).
-    *   **Generation semantics:** mirrored bytes are provisional generation artifacts until the signed chain swap succeeds; the current live generation remains bound to the current on-chain `manifest_root`.
+    *   **Generation semantics:** mirrored bytes are provisional generation artifacts until the signed chain swap succeeds; the current live generation remains bound to the current on-chain `polyfs_root`.
     *   **CAS preflight header:** artifact uploads may include `X-PolyStore-Previous-Manifest-Root` as an advisory expected-base root; stale values are rejected before the gateway/provider consumes upload bytes.
     *   **Devnet retention policy:** complete provisional generations older than 24 hours may be removed during startup/recovery cleanup if they were never promoted on-chain.
     *   **Operator control:** `POLYSTORE_PROVISIONAL_GENERATION_RETENTION_TTL` sets the age-based GC window for provisional generations; `0` disables this GC path.
     *   **Observability:** `/status` reports the effective TTL and generation counters via `polyfs_generation_*` fields, plus stale CAS preflight counters via `polyfs_cas_preflight_conflicts_*`.
-    *   **Inspection tooling:** `GET /gateway/deal-generations/{deal_id}` returns the local active/provisional/incomplete/invalid generations for a specific deal, including `previous_manifest_root`, age/classification, and on-disk bytes.
+    *   **Inspection tooling:** `GET /gateway/deal-generations/{deal_id}` returns the local active/provisional/incomplete/invalid generations for a specific deal, including `previous_polyfs_root` (legacy alias: `previous_manifest_root` during transition), age/classification, and on-disk bytes.
 
 #### Health & Status
 *   **`GET /health`**
@@ -115,28 +115,28 @@ These endpoints support the `polystore-website` "Thin Client" flow.
             *   Canonical contract: `notes/mode2-artifacts-v1.md`
 *   **`GET /gateway/deal-generations/{deal_id}`**
     *   **Role:** Operator/debug inspection endpoint for local PolyFS generation state by deal.
-    *   **Returns:** active pointer root, configured provisional retention TTL, and generation entries with status (`active`, `provisional_recent`, `provisional_expired`, `incomplete`, `invalid`), `previous_manifest_root`, file count, MDU counts, and bytes on disk.
+    *   **Returns:** active pointer root, configured provisional retention TTL, and generation entries with status (`active`, `provisional_recent`, `provisional_expired`, `incomplete`, `invalid`), `previous_polyfs_root`, file count, MDU counts, and bytes on disk.
 
 #### Deal Management (EVM Bridge, Optional Relay)
 *   **`POST /gateway/create-deal-evm`**
     *   **Input:** JSON `{ "intent": { ... }, "evm_signature": "0x..." }`.
 *   **Logic:** Forwards the intent to `polystorechaind tx polystorechain create-deal-from-evm`.
 *   **Role:** Relays user‑signed intents to the chain for clients that cannot call the precompile directly (MetaMask is the preferred path).
-    *   **Semantics (target):** Creates a **thin-provisioned** deal (`manifest_root = empty`, `size = 0`, `total_mdus = 0`) until the first `update-deal-content-evm` commit.
+    *   **Semantics (target):** Creates a **thin-provisioned** deal (`polyfs_root = empty`, `size = 0`, `total_mdus = 0`) until the first `update-deal-content-evm` commit.
         *   **No tiers:** Capacity-tier fields are deprecated and must not be required by the gateway; if accepted during transition they must be ignored.
 *   **`POST /gateway/update-deal-content-evm`**
     *   **Input:** JSON `{ "intent": { ... }, "evm_signature": "0x..." }`.
 *   **Logic:** Forwards to `polystorechaind tx polystorechain update-deal-content-evm`.
-*   **Role:** Commits the Deal `manifest_root` (returned from upload) to the on-chain deal when clients opt into the relay.
-    *   **CAS rule:** the signed intent MUST include `previous_manifest_root`, and relay/chain execution MUST reject the update if it does not match the current on-chain deal root.
+*   **Role:** Commits the Deal `polyfs_root` (returned from upload) to the on-chain deal when clients opt into the relay.
+    *   **CAS rule:** the signed intent MUST include `previous_polyfs_root`, and relay/chain execution MUST reject the update if it does not match the current on-chain deal root. `previous_manifest_root` may be accepted only as a transitional alias for a 32-byte `polyfs_root`.
 
 #### Data Retrieval & Proofs
-*   **`GET /gateway/plan-retrieval-session/{manifest_root}`**
+*   **`GET /gateway/plan-retrieval-session/{polyfs_root}`** *(legacy route name `{manifest_root}` may remain during transition)*
     *   **Query Params:** `deal_id`, `owner`, `file_path` (required; optional `range_start`, `range_len`).
     *   **Logic:** Resolves PolyFS offsets and returns a blob-range plan (`start_mdu_index`, `start_blob_index`, `blob_count`) plus the selected provider.
     *   **Role:** Planning helper for browser/CLI clients before they open a retrieval session on-chain.
 
-*   **`GET /gateway/fetch/{manifest_root}`**
+*   **`GET /gateway/fetch/{polyfs_root}`** *(legacy route name `{manifest_root}` may remain during transition)*
     *   **Query Params (target):** `deal_id`, `owner`, `file_path` (**required**).
     *   **Logic:**
         1.  Verifies `deal_id` exists on-chain and matches `owner`.
@@ -150,11 +150,11 @@ These endpoints support the `polystore-website` "Thin Client" flow.
         *   Invalid/unsafe `file_path` returns `400` (reject traversal `..`, absolute `/` prefix, `\\` separators, whitespace-only, NUL bytes, and control characters).
         *   Unknown `file_path` (or tombstone record) returns `404`.
         *   Duplicate/ambiguous `file_path` entries in the on-disk File Table should fail fast with a clear non-200 (prefer `409`) rather than serving potentially stale bytes.
-        *   `manifest_root` is a 48-byte compressed BLS12‑381 G1 commitment (96 hex chars; optional `0x` prefix). Invalid encodings and invalid subgroup points return `400`.
+        *   `polyfs_root` is a 32-byte MDU #0 Merkle root (64 hex chars; optional `0x` prefix). Invalid encodings and legacy 96-hex roots return `400` for new deals.
         *   Owner mismatch (or invalid owner format) should return a clear non-200 (prefer `403`) as JSON.
-        *   If `manifest_root` does not match the on-chain deal state for `deal_id`, return a clear non-200 (prefer `409`) to surface stale roots.
-        *   The gateway MUST canonicalize `manifest_root` consistently (decode → re-encode) for filesystem paths and logs to avoid duplicate deal directories.
-        *   The gateway resolves the file from `uploads/<manifest_root_key>/mdu_0.bin` (PolyFS File Table) and streams the requested bytes. Proof submission is performed separately via `/gateway/session-proof` or `/sp/session-proof`.
+        *   If `polyfs_root` does not match the on-chain deal state for `deal_id`, return a clear non-200 (prefer `409`) to surface stale roots.
+        *   The gateway MUST canonicalize `polyfs_root` consistently (decode -> re-encode) for filesystem paths and logs to avoid duplicate deal directories.
+        *   The gateway resolves the file from `uploads/<polyfs_root_key>/mdu_0.bin` (PolyFS File Table) and streams the requested bytes. Proof submission is performed separately via `/gateway/session-proof` or `/sp/session-proof`.
         *   Non-200 responses MUST be JSON with a short remediation hint (even though the success path is a byte stream) and set `Content-Type: application/json`, e.g. `{ "error": "...", "hint": "..." }`.
 
 *   **`POST /gateway/session-proof`**
@@ -169,48 +169,48 @@ These endpoints support the `polystore-website` "Thin Client" flow.
 
 *   **`GET /sp/shard`** *(Striped Provider API; internal)*
     *   **Headers:** `X‑PolyStore‑Gateway‑Auth: <shared token>` (**required**).
-    *   **Query Params:** `deal_id`, `manifest_root`, `mdu_index`, `slot`.
+    *   **Query Params:** `deal_id`, `polyfs_root` (legacy alias: `manifest_root` during transition), `mdu_index`, `slot`.
     *   **Logic:** Streams `mdu_<index>_slot_<slot>.bin` from the provider’s storage root.
     *   **Role:** Provider‑to‑provider shard reads used to reconstruct striped MDUs when local shards are missing. Browsers should fetch bytes via `/gateway/fetch/...` instead.
 
 *   **`POST /gateway/prove-retrieval`** *(Devnet helper; subject to change)*
-    *   **Input (target):** JSON `{ "deal_id": 123, "epoch_id": 1, "manifest_root": "0x...", "file_path": "video.mp4" }`.
+    *   **Input (target):** JSON `{ "deal_id": 123, "epoch_id": 1, "polyfs_root": "0x...", "file_path": "video.mp4" }`.
     *   **Logic (target):**
         1. Resolve the file from PolyFS (`mdu_0.bin` + on-disk slab) using `file_path`.
         2. Generate and submit `MsgProveLiveness` using the gateway/provider key.
     *   **Notes (target):** `file_path` in JSON is already an unescaped string; gateways must not URL-decode it again (no double-unescape).
     *   **Compatibility:** Legacy request bodies that only include `cid` are deprecated; do not rely on `uploads/index.json` lookups.
-        *   Missing/invalid params return `400`; tombstone/not-found returns `404`; stale `manifest_root` (doesn’t match chain deal state) should be a clear non-200 (prefer `409`).
+        *   Missing/invalid params return `400`; tombstone/not-found returns `404`; stale `polyfs_root` (doesn’t match chain deal state) should be a clear non-200 (prefer `409`).
         *   Non-200 responses should follow the same JSON error contract: `{ "error": "...", "hint": "..." }`.
 
-*   **`GET /gateway/list-files/{manifest_root}`**
+*   **`GET /gateway/list-files/{polyfs_root}`** *(legacy route name `{manifest_root}` may remain during transition)*
     *   **Query Params:** `deal_id`, `owner` (required for access control / deal-owner match).
-    *   **Logic:** Reads `uploads/<manifest_root_key>/mdu_0.bin`, parses the PolyFS File Table, and returns a deduplicated list of active files (latest non-tombstone record per `file_path`) plus computed total size.
-    *   **Response (target):** `{ "manifest_root": "0x...", "total_size_bytes": 123, "files": [{ "path": "dir/file.txt", "size_bytes": 123, "start_offset": 0, "flags": 0 }] }`.
+    *   **Logic:** Reads `uploads/<polyfs_root_key>/mdu_0.bin`, parses the PolyFS File Table, and returns a deduplicated list of active files (latest non-tombstone record per `file_path`) plus computed total size.
+    *   **Response (target):** `{ "polyfs_root": "0x...", "total_size_bytes": 123, "files": [{ "path": "dir/file.txt", "size_bytes": 123, "start_offset": 0, "flags": 0 }] }`.
     *   **Role:** The authoritative source for the Deal Explorer “Files (PolyFS)” list.
-    *   **Errors (target):** Missing/invalid params return `400`; owner mismatch returns a clear non-200 (prefer `403`); stale `manifest_root` should return a clear non-200 (prefer `409`).
+    *   **Errors (target):** Missing/invalid params return `400`; owner mismatch returns a clear non-200 (prefer `403`); stale `polyfs_root` should return a clear non-200 (prefer `409`).
 
-*   **`GET /gateway/slab/{manifest_root}`**
+*   **`GET /gateway/slab/{polyfs_root}`** *(legacy route name `{manifest_root}` may remain during transition)*
     *   **Query Params:** `deal_id`, `owner` (optional; enforced together for access control / deal-owner match).
-    *   **Logic:** Reads `uploads/<manifest_root_key>/mdu_0.bin` and the on-disk `mdu_*.bin` set to return a slab summary:
+    *   **Logic:** Reads `uploads/<polyfs_root_key>/mdu_0.bin` and the on-disk `mdu_*.bin` set to return a slab summary:
         * total MDUs, witness MDUs, user MDUs, and segment ranges (MDU #0 / Witness / User).
     *   **Role:** Powers the Deal Explorer “Manifest” tab to show the real slab layout (not the legacy shard JSON debug output).
 
-*   **`GET /gateway/manifest-info/{manifest_root}`**
+*   **`GET /gateway/manifest-info/{polyfs_root}`**
     *   **Query Params:** `deal_id`, `owner` (optional; enforced together for access control / deal-owner match).
     *   **Logic:** Returns *debug* manifest details needed for visualization:
-        * the ordered vector of per‑MDU roots committed by `manifest_root`,
-        * and (optionally) the manifest polynomial blob/openings if persisted by the gateway.
-    *   **Role:** Educational/visualization endpoint; **not** required for fetch/prove.
+        * the ordered vector of per-MDU roots committed through MDU #0,
+        * and (optionally) retained legacy flat-manifest debug data.
+    *   **Role:** Educational/visualization endpoint; **not** required for fetch/prove and not a canonical trust root.
 
-*   **`GET /gateway/mdu-kzg/{manifest_root}/{mdu_index}`**
+*   **`GET /gateway/mdu-kzg/{polyfs_root}/{mdu_index}`**
     *   **Query Params:** `deal_id`, `owner` (optional; enforced together for access control / deal-owner match).
     *   **Logic:** Returns the 64 blob commitments for the specified MDU index (derived from Witness MDUs) and the derived MDU root.
     *   **Role:** Educational/visualization endpoint; **not** required for fetch/prove.
 
 *   **`GET /gateway/manifest/{cid}`** *(Deprecated)*
     *   **Role:** Legacy debug endpoint for per-upload artifacts. It MUST NOT be required for fetch/prove flows and is expected to be removed once PolyFS-only flows are fully enforced.
-    *   **Compatibility:** If still present, `{cid}` MUST be treated as an alias for `manifest_root` only; callers should migrate to `/gateway/slab/{manifest_root}` and `/gateway/list-files/{manifest_root}`.
+    *   **Compatibility:** If still present, `{cid}` MUST be treated as an alias for `polyfs_root` only; callers should migrate to `/gateway/slab/{polyfs_root}` and `/gateway/list-files/{polyfs_root}`.
 
 ---
 
@@ -225,7 +225,7 @@ To facilitate the "Store Wars" Devnet without a full WASM client, `polystore_gat
 
 2.  **Triple Proof Generation:**
     *   Session‑proof submission uses on‑disk PolyFS slabs to build `ChainedProof` objects for the requested blob range.
-    *   **Target (PolyFS SSoT):** Proof inputs are derived from the on-disk slab (`uploads/<manifest_root_key>/mdu_0.bin` + `mdu_*.bin`) plus on-chain deal state — with **no dependency** on per-upload shard JSON, `manifest_blob_hex`, or `uploads/index.json`. Any such artifacts may exist for debugging but are non-normative.
+    *   **Target (PolyFS SSoT):** Proof inputs are derived from the on-disk slab (`uploads/<polyfs_root_key>/mdu_0.bin` + `mdu_*.bin`) plus on-chain deal state — with **no dependency** on per-upload shard JSON, `manifest_blob_hex`, legacy `manifest.bin`, or `uploads/index.json`. Any such artifacts may exist for debugging but are non-normative.
     *   **Gap:** In a production "Thick Client", the browser would generate or verify these proofs locally. Here, the Gateway can generate and relay them, effectively simulating a "perfect" SP.
 
 3.  **Local Storage:**

--- a/polystore_gateway/polystore-gateway-spec.md
+++ b/polystore_gateway/polystore-gateway-spec.md
@@ -79,7 +79,7 @@ These endpoints support the `polystore-website` "Thin Client" flow.
 *   **`POST /sp/upload_shard`** *(Striped Provider API)*
     *   **Input:** Raw shard bytes (body) with headers:
         * `X-PolyStore-Deal-ID` (uint64), `X-PolyStore-Mdu-Index` (uint64), `X-PolyStore-Slot` (uint64), `X-PolyStore-PolyFS-Root` (`0x` + 64 hex). Legacy clients may send `X-PolyStore-Manifest-Root` only if it carries the 32-byte `polyfs_root` value.
-    *   **Logic:** Stores the shard as `mdu_<index>_slot_<slot>.bin` under `uploads/<polyfs_root_key>/`.
+    *   **Logic:** Stores the shard as `mdu_<index>_slot_<slot>.bin` under `uploads/deals/<deal_id>/<polyfs_root_key>/`.
     *   **Role:** Slot-specific shard ingestion for the striped StripeReplica layout.
         *   **Provider is a dumb pipe:** the server does not need to understand layout variants beyond writing/serving bytes addressed by the headers.
         *   Metadata MDUs (MDU #0 + Witness) remain replicated to all slots via `/sp/upload_mdu`.
@@ -154,7 +154,7 @@ These endpoints support the `polystore-website` "Thin Client" flow.
         *   Owner mismatch (or invalid owner format) should return a clear non-200 (prefer `403`) as JSON.
         *   If `polyfs_root` does not match the on-chain deal state for `deal_id`, return a clear non-200 (prefer `409`) to surface stale roots.
         *   The gateway MUST canonicalize `polyfs_root` consistently (decode -> re-encode) for filesystem paths and logs to avoid duplicate deal directories.
-        *   The gateway resolves the file from `uploads/<polyfs_root_key>/mdu_0.bin` (PolyFS File Table) and streams the requested bytes. Proof submission is performed separately via `/gateway/session-proof` or `/sp/session-proof`.
+        *   The gateway resolves the file from `uploads/deals/<deal_id>/<polyfs_root_key>/mdu_0.bin` (PolyFS File Table) and streams the requested bytes. Proof submission is performed separately via `/gateway/session-proof` or `/sp/session-proof`.
         *   Non-200 responses MUST be JSON with a short remediation hint (even though the success path is a byte stream) and set `Content-Type: application/json`, e.g. `{ "error": "...", "hint": "..." }`.
 
 *   **`POST /gateway/session-proof`**
@@ -185,14 +185,14 @@ These endpoints support the `polystore-website` "Thin Client" flow.
 
 *   **`GET /gateway/list-files/{polyfs_root}`** *(legacy route name `{manifest_root}` may remain during transition)*
     *   **Query Params:** `deal_id`, `owner` (required for access control / deal-owner match).
-    *   **Logic:** Reads `uploads/<polyfs_root_key>/mdu_0.bin`, parses the PolyFS File Table, and returns a deduplicated list of active files (latest non-tombstone record per `file_path`) plus computed total size.
+    *   **Logic:** Reads `uploads/deals/<deal_id>/<polyfs_root_key>/mdu_0.bin`, parses the PolyFS File Table, and returns a deduplicated list of active files (latest non-tombstone record per `file_path`) plus computed total size.
     *   **Response (target):** `{ "polyfs_root": "0x...", "total_size_bytes": 123, "files": [{ "path": "dir/file.txt", "size_bytes": 123, "start_offset": 0, "flags": 0 }] }`.
     *   **Role:** The authoritative source for the Deal Explorer “Files (PolyFS)” list.
     *   **Errors (target):** Missing/invalid params return `400`; owner mismatch returns a clear non-200 (prefer `403`); stale `polyfs_root` should return a clear non-200 (prefer `409`).
 
 *   **`GET /gateway/slab/{polyfs_root}`** *(legacy route name `{manifest_root}` may remain during transition)*
     *   **Query Params:** `deal_id`, `owner` (optional; enforced together for access control / deal-owner match).
-    *   **Logic:** Reads `uploads/<polyfs_root_key>/mdu_0.bin` and the on-disk `mdu_*.bin` set to return a slab summary:
+    *   **Logic:** Reads `uploads/deals/<deal_id>/<polyfs_root_key>/mdu_0.bin` and the on-disk `mdu_*.bin` set to return a slab summary:
         * total MDUs, witness MDUs, user MDUs, and segment ranges (MDU #0 / Witness / User).
     *   **Role:** Powers the Deal Explorer “Manifest” tab to show the real slab layout (not the legacy shard JSON debug output).
 
@@ -225,7 +225,7 @@ To facilitate the "Store Wars" Devnet without a full WASM client, `polystore_gat
 
 2.  **Triple Proof Generation:**
     *   Session‑proof submission uses on‑disk PolyFS slabs to build `ChainedProof` objects for the requested blob range.
-    *   **Target (PolyFS SSoT):** Proof inputs are derived from the on-disk slab (`uploads/<polyfs_root_key>/mdu_0.bin` + `mdu_*.bin`) plus on-chain deal state — with **no dependency** on per-upload shard JSON, `manifest_blob_hex`, legacy `manifest.bin`, or `uploads/index.json`. Any such artifacts may exist for debugging but are non-normative.
+    *   **Target (PolyFS SSoT):** Proof inputs are derived from the deal-scoped on-disk slab (`uploads/deals/<deal_id>/<polyfs_root_key>/mdu_0.bin` + `mdu_*.bin`) plus on-chain deal state — with **no dependency** on per-upload shard JSON, `manifest_blob_hex`, legacy `manifest.bin`, or `uploads/index.json`. Any such artifacts may exist for debugging but are non-normative.
     *   **Gap:** In a production "Thick Client", the browser would generate or verify these proofs locally. Here, the Gateway can generate and relay them, effectively simulating a "perfect" SP.
 
 3.  **Local Storage:**

--- a/polystore_gateway/polystore-gateway-spec.md
+++ b/polystore_gateway/polystore-gateway-spec.md
@@ -204,8 +204,12 @@ These endpoints support the `polystore-website` "Thin Client" flow.
     *   **Role:** Educational/visualization endpoint; **not** required for fetch/prove and not a canonical trust root.
 
 *   **`GET /gateway/mdu-kzg/{polyfs_root}/{mdu_index}`**
-    *   **Query Params:** `deal_id`, `owner` (optional; enforced together for access control / deal-owner match).
-    *   **Logic:** Returns the 64 blob commitments for the specified MDU index (derived from Witness MDUs) and the derived MDU root.
+    *   **Query Params:** `deal_id`, `owner` (optional; enforced together for access control / deal-owner match), `mdu_kind` / profile selector if the kind cannot be inferred from the slab segment (`metadata`, `witness`, `replicated_user`, `mode2_user_sp_mdu`).
+    *   **Logic:** Returns the profile-selected blob commitments for the specified MDU index (derived from Witness MDUs for user-data MDUs) and the derived MDU root.
+        * The response MUST include the selected `mdu_kind`, `root_profile`, `leaf_count`, `commitments`, and `derived_mdu_root`.
+        * Replicated metadata/user MDUs use 64 leaves.
+        * Mode 2 striped user SP-MDUs use `leaf_count = (K + M) * (64 / K)`; the default `K=8,M=4` profile returns 96 commitments, not 64.
+        * Callers MUST compute/cross-check the MDU root with the returned `leaf_count`; truncating parity leaves produces a root that cannot match the committed MDU root.
     *   **Role:** Educational/visualization endpoint; **not** required for fetch/prove.
 
 *   **`GET /gateway/manifest/{cid}`** *(Deprecated)*

--- a/rfcs/rfc-blob-alignment-and-striping.md
+++ b/rfcs/rfc-blob-alignment-and-striping.md
@@ -125,7 +125,7 @@ This section defines the normative flow for a file "Life Cycle" in the striped l
 1.  **Routing:** Using the slot-major mapping, the chain computes `rows = 64 / K` and `slot = leaf_index / rows`. For default `K=8`, `rows = 8`, so `slot = 13 / 8 = 1`, therefore $SP_1$ is responsible.
 2.  **Lookup:** $SP_1$ reads local **Witness MDU** to find `Commitment #13` and sibling commitments.
 3.  **Proof Gen:**
-    *   **Hop 1:** Verify `MDU_Root` vs `Manifest`.
+    *   **Hop 1:** Verify `MDU_Root` through the MDU #0 root table anchored by `Deal.polyfs_root`.
     *   **Hop 2:** Verify `Commitment #13` vs `MDU_Root` (Merkle Proof using Witness data).
     *   **Hop 3:** Verify `Byte` vs `Commitment #13` (KZG Opening using local Data).
 4.  **Submit:** $SP_1$ sends the chained proof. Chain verifies without knowing about striping.

--- a/rfcs/rfc-content-encoding-and-compression.md
+++ b/rfcs/rfc-content-encoding-and-compression.md
@@ -51,7 +51,7 @@ For each file payload (plaintext):
 ### 3.2 Download pipeline (normative)
 
 1) Retrieve ciphertext bytes (session-gated).
-2) Verify proofs against `Deal.manifest_root`.
+2) Verify proofs against `Deal.polyfs_root` (the MDU #0 PolyFS root).
 3) Decrypt to recover wrapped bytes.
 4) Parse header and:
    - if `encoding == NONE`: return payload bytes,

--- a/rfcs/rfc-data-granularity-and-economics.md
+++ b/rfcs/rfc-data-granularity-and-economics.md
@@ -24,8 +24,8 @@ PolyStore faces a fundamental architectural tension between Scalability and Perf
 ## 2. The Financial Container: Thin-Provisioned Deals (No Tiers)
 PolyStore uses a **thin-provisioned** Deal container model:
 
-*   `MsgCreateDeal*` creates a Deal with `manifest_root = empty`, `size = 0` (and `total_mdus = 0` until first commit).
-*   `MsgUpdateDealContent*` commits content and advances the Deal’s `manifest_root`, `size`, and `total_mdus`.
+*   `MsgCreateDeal*` creates a Deal with `polyfs_root = empty`, `size = 0` (and `total_mdus = 0` until first commit).
+*   `MsgUpdateDealContent*` commits content and advances the Deal’s `polyfs_root`, `size`, and `total_mdus`.
 *   There is **no user-selected capacity tier** and no on-chain `DealSize` enum.
 
 ### 2.1 Governance Policy
@@ -102,7 +102,7 @@ The maximum batch size is bounded by the Deal’s committed content (`Deal.size`
 ## 6. Implementation Directives
 1.  **Core Cryptography:** Hardcode `MDU_SIZE = 8,388,608` in `polystore_core`.
 2.  **Chain Logic (Thin Provisioning):**
-    *   `MsgCreateDeal*` initializes `size = 0`, `manifest_root = empty`, `total_mdus = 0` (until first content commit).
+    *   `MsgCreateDeal*` initializes `size = 0`, `polyfs_root = empty`, `total_mdus = 0` (until first content commit).
     *   `MsgUpdateDealContent*` enforces `size ≤ MAX_DEAL_BYTES` and advances the committed state.
     *   Remove `DealSize` / `size_tier` from request payloads and EIP-712 typed-data in all clients.
 3.  **Client SDK:** Implement `GetRange()` as the primary retrieval method. The SDK should default to requesting the largest necessary range (up to the remaining file span) to minimize $\text{Gas}_{Orch}$ costs for the user.

--- a/rfcs/rfc-mandatory-retrieval-sessions-and-batching.md
+++ b/rfcs/rfc-mandatory-retrieval-sessions-and-batching.md
@@ -74,7 +74,7 @@ Before serving bytes, the serving node MUST validate (by querying chain state):
 
 1) `session.status == OPEN` and `current_height <= session.expires_at`
 2) `session.deal_id == requested_deal_id`
-3) `session.manifest_root == Deal.manifest_root` (content pin)
+3) `session.polyfs_root == Deal.polyfs_root` (content pin; legacy field names may remain during migration but must carry the 32-byte PolyFS root)
 4) **Provider binding**
    - For legacy full-replica compatibility, `session.provider` MUST be a member of `Deal.providers[]`.
    - For striped deals, `session.slot` MUST match the slot assignment for the provider serving the bytes.

--- a/rfcs/rfc-mode2-onchain-state.md
+++ b/rfcs/rfc-mode2-onchain-state.md
@@ -2,7 +2,7 @@
 
 **Status:** Implemented in devnet / migration cleanup pending
 **Scope:** Chain protocol state (`polystorechain/`)
-**Depends on:** `spec.md` §6.2, §8.3–§8.4; `rfcs/rfc-blob-alignment-and-striping.md`
+**Depends on:** `spec.md` §6.2, §8.3–§8.4; `rfcs/rfc-blob-alignment-and-striping.md`; `rfcs/rfc-polyfs-root-contract.md`
 **Motivation:** Appendix B #2 (striped encoding), #6 (write semantics beyond append-only; near-term constraints)
 
 ---
@@ -32,13 +32,13 @@ This RFC freezes a **concrete on-chain representation** for the striped layout a
 
 ### 1.2 Generations
 - **Generation:** a monotonically increasing counter `current_gen`
-- Every on-chain content commit that changes `Deal.manifest_root` MUST increment `current_gen`.
+- Every on-chain content commit that changes the deal root (`Deal.polyfs_root`; legacy alias `Deal.manifest_root` during migration) MUST increment `current_gen`.
 - Reads are always defined against the **current generation**.
 
 ### 1.3 Slab accounting fields (naming freeze)
 For chain policy and bounds checks we freeze:
 - `size_bytes`: total logical bytes of file contents in PolyFS (sum of non-tombstone file lengths)
-- `total_mdus`: total number of committed MDU roots in the Manifest commitment (includes metadata + witness + user MDUs)
+- `total_mdus`: total number of committed MDUs in the PolyFS slab (includes MDU #0 + witness + user MDUs)
 - `witness_mdus`: number of witness MDUs committed after MDU #0 (metadata region size)
 - `user_mdus = total_mdus - 1 - witness_mdus` (derived; must be non-negative)
 
@@ -92,7 +92,7 @@ message Deal {
   repeated DealSlot mode2_slots = 16;      // length N, slot-ordered
 
   // --- Generation / write coordination ---
-  uint64 current_gen = 17; // increments on every manifest_root change
+  uint64 current_gen = 17; // increments on every polyfs_root change
 
   // --- Slab accounting (bounds + policy) ---
   uint64 total_mdus = 14;     // already exists; MUST be set on first content commit
@@ -117,15 +117,15 @@ message Deal {
 At `MsgCreateDeal*` time:
 - `mode2_profile` and `mode2_slots` are derived from the request (legacy: parsed from `service_hint`)
 - `current_gen = 0`
-- `manifest_root = empty`, `size_bytes = 0`, `total_mdus = 0`, `witness_mdus = 0`
+- `polyfs_root = empty`, `size_bytes = 0`, `total_mdus = 0`, `witness_mdus = 0`
 
-### 3.2 UpdateDealContent (commit new manifest)
+### 3.2 UpdateDealContent (commit new PolyFS root)
 At `MsgUpdateDealContent*` time:
-- Validate `manifest_root` format (already implemented)
+- Validate `polyfs_root` format (32-byte MDU #0 Merkle root; see `rfcs/rfc-polyfs-root-contract.md`)
 - Require `size_bytes > 0`
 - Require `total_mdus > 0` and `witness_mdus >= 0` (new fields in message; see §4)
 - Set:
-  - `Deal.manifest_root = new`
+  - `Deal.polyfs_root = new`
   - `Deal.size_bytes = new`
   - `Deal.total_mdus = new_total_mdus`
   - `Deal.witness_mdus = new_witness_mdus`
@@ -217,4 +217,3 @@ Remaining cleanup:
 1. Add or document the migration/backfill path for older deals that predate typed striped state.
 2. Decide when schema/wire names like `mode2_profile` and `mode2_slots` can be renamed or formally frozen as compatibility identifiers.
 3. Keep the gap report authoritative for overlay elasticity, which is still not modeled end-to-end in typed slot state.
-

--- a/rfcs/rfc-mode2-onchain-state.md
+++ b/rfcs/rfc-mode2-onchain-state.md
@@ -128,6 +128,8 @@ At `MsgUpdateDealContent*` time:
   - `total_mdus = 1 + witness_mdus + user_mdus`
   - `witness_mdus < total_mdus`
   - `user_mdus = total_mdus - 1 - witness_mdus`
+  - if `size_bytes > 0`, require `user_mdus >= 1`
+  - require `size_bytes <= user_mdus * RawMduPayloadBytes`, where `RawMduPayloadBytes = (8 MiB / 32) * 31 = 8,126,464`
   - `witness_mdus + user_mdus <= 65,536`
   - equivalently, `total_mdus <= 65,537`
   - reject the commit if these bounds would let a verifier derive `root_table_du >= 16`

--- a/rfcs/rfc-mode2-onchain-state.md
+++ b/rfcs/rfc-mode2-onchain-state.md
@@ -124,6 +124,13 @@ At `MsgUpdateDealContent*` time:
 - Validate `polyfs_root` format (32-byte MDU #0 Merkle root; see `rfcs/rfc-polyfs-root-contract.md`)
 - Require `size_bytes > 0`
 - Require `total_mdus > 0` and `witness_mdus >= 0` (new fields in message; see §4)
+- Enforce the MDU #0 root-table capacity invariant from `rfcs/rfc-polyfs-root-contract.md`:
+  - `total_mdus = 1 + witness_mdus + user_mdus`
+  - `witness_mdus < total_mdus`
+  - `user_mdus = total_mdus - 1 - witness_mdus`
+  - `witness_mdus + user_mdus <= 65,536`
+  - equivalently, `total_mdus <= 65,537`
+  - reject the commit if these bounds would let a verifier derive `root_table_du >= 16`
 - Set:
   - `Deal.polyfs_root = new`
   - `Deal.size_bytes = new`

--- a/rfcs/rfc-mode2-onchain-state.md
+++ b/rfcs/rfc-mode2-onchain-state.md
@@ -130,6 +130,7 @@ At `MsgUpdateDealContent*` time:
   - `user_mdus = total_mdus - 1 - witness_mdus`
   - if `size_bytes > 0`, require `user_mdus >= 1`
   - require `size_bytes <= user_mdus * RawMduPayloadBytes`, where `RawMduPayloadBytes = (8 MiB / 32) * 31 = 8,126,464`
+  - if `user_mdus > 0`, require `witness_mdus >= ceil(user_mdus * target_mdu_leaf_count(mode2_profile) * 48 / 8 MiB)` so the committed Witness region covers every user-MDU blob commitment required by the selected root profile
   - `witness_mdus + user_mdus <= 65,536`
   - equivalently, `total_mdus <= 65,537`
   - reject the commit if these bounds would let a verifier derive `root_table_du >= 16`

--- a/rfcs/rfc-polyfs-generation-cas-and-staged-writes.md
+++ b/rfcs/rfc-polyfs-generation-cas-and-staged-writes.md
@@ -22,28 +22,33 @@ This creates two distinct risks:
 
 ## Model
 Every PolyFS mutation is a generation swap:
-* base generation: `previous_manifest_root = H1`
-* proposed generation: `new_manifest_root = H2`
+* base generation: `previous_polyfs_root = H1`
+* proposed generation: `new_polyfs_root = H2`
+
+`previous_manifest_root` and `new_manifest_root` are legacy alpha aliases only
+during the issue #212 migration. For new deals they MUST carry the 32-byte
+`polyfs_root` value if accepted at all; they MUST NOT carry the retired 48-byte
+flat-manifest KZG root.
 
 The owner signs an update intent containing both values. The chain only accepts the mutation if the currently committed deal root is still `H1`.
 
 ## Normative Rules
 
 ### 1. Signed CAS
-* `previous_manifest_root` MUST be part of the owner-signed `MsgUpdateDealContent*` payload.
-* The chain MUST validate `previous_manifest_root == Deal.manifest_root` at execution time.
+* `previous_polyfs_root` MUST be part of the owner-signed `MsgUpdateDealContent*` payload.
+* The chain MUST validate `previous_polyfs_root == Deal.polyfs_root` at execution time.
 * If the comparison fails, the transaction MUST be rejected as stale.
-* Any provider- or gateway-supplied copy of `previous_manifest_root` is preflight/advisory only.
+* Any provider- or gateway-supplied copy of `previous_polyfs_root` is preflight/advisory only.
 
 ### 2. Browser and gateway bootstrap
-* A client MUST compare its local cached generation to on-chain `Deal.manifest_root` before preparing an append or rewrite.
+* A client MUST compare its local cached generation to on-chain `Deal.polyfs_root` before preparing an append or rewrite.
 * If the cache is missing or stale, the client MUST bootstrap the current committed generation from the retrieval path before mutating.
 * A client MUST NOT silently rebuild from empty state when a committed generation already exists.
 
 ### 3. Staged generations at providers/gateways
-* Uploaded bytes for `new_manifest_root` SHOULD be staged provisionally until the chain swap succeeds.
-* The currently committed generation `previous_manifest_root` MUST remain available while `new_manifest_root` is provisional.
-* Provider/gateway artifact ingest MAY accept an advisory expected-base header for the staged generation; the current reference header is `X-PolyStore-Previous-Manifest-Root`.
+* Uploaded bytes for `new_polyfs_root` SHOULD be staged provisionally until the chain swap succeeds.
+* The currently committed generation `previous_polyfs_root` MUST remain available while `new_polyfs_root` is provisional.
+* Provider/gateway artifact ingest MAY accept an advisory expected-base header for the staged generation; the preferred header is `X-PolyStore-Previous-PolyFS-Root`. The legacy `X-PolyStore-Previous-Manifest-Root` header may be accepted only as a 32-byte-root alias during transition.
 * If that expected-base header is present and stale, the provider/gateway SHOULD reject the upload before consuming artifact bytes.
 * A stale or failed chain swap MUST NOT delete or replace the current generation.
 
@@ -68,7 +73,7 @@ Current devnet reference policy:
 * the gateway exposes the effective retention window as `POLYSTORE_PROVISIONAL_GENERATION_RETENTION_TTL` and reports it in `/status` as `polyfs_generation_provisional_retention_ttl_seconds`
 * `POLYSTORE_PROVISIONAL_GENERATION_RETENTION_TTL=0` disables age-based provisional-generation GC
 * the gateway SHOULD expose stale CAS preflight pressure in `/status` so concurrent-writer / abandoned-upload churn is observable; the current reference keys are `polyfs_cas_preflight_conflicts_total`, `polyfs_cas_preflight_conflicts_legacy`, `polyfs_cas_preflight_conflicts_evm`, and `polyfs_cas_preflight_conflicts_upload`
-* the gateway SHOULD expose per-deal local generation inspection; the current reference endpoint is `GET /gateway/deal-generations/{deal_id}`, which returns active/provisional/incomplete/invalid classification plus `previous_manifest_root` and on-disk byte counts
+* the gateway SHOULD expose per-deal local generation inspection; the current reference endpoint is `GET /gateway/deal-generations/{deal_id}`, which returns active/provisional/incomplete/invalid classification plus `previous_polyfs_root` and on-disk byte counts
 
 ## Implementation Notes
 Current implementation anchors signed CAS at:

--- a/rfcs/rfc-polyfs-root-contract.md
+++ b/rfcs/rfc-polyfs-root-contract.md
@@ -74,7 +74,8 @@ MDU #0 is partitioned as:
 | 0..15 | 2 MiB | Root table |
 | 16..63 | 6 MiB | File table |
 
-The root table has 65,536 scalar cells. It stores roots for MDUs after MDU #0:
+The root table has 65,536 scalar cells. It stores roots for MDUs after MDU #0.
+Apply this mapping only after rejecting `mdu_index == 0`:
 
 ```text
 root_table_index = mdu_index - 1

--- a/rfcs/rfc-polyfs-root-contract.md
+++ b/rfcs/rfc-polyfs-root-contract.md
@@ -26,6 +26,22 @@ polyfs_root = MerkleRoot(
 Where each `DU` is a 128 KiB KZG blob and MDU #0 is the 8 MiB PolyFS
 super-manifest containing the root table and file table.
 
+The Merkle construction is part of the consensus contract:
+
+- The tree has exactly 64 leaves for every MDU root in this protocol version.
+- Leaf `i` is `BLAKE2s-256(kzg_commitment_i)`, where `kzg_commitment_i` is the
+  48-byte compressed KZG commitment for `DU[i]`.
+- Internal nodes are `BLAKE2s-256(left_child || right_child)`.
+- Leaves are ordered by increasing DU index and internal-node concatenation
+  preserves that left-to-right order.
+- No padding, empty-root value, or odd-leaf promotion is used for MDU roots,
+  because each MDU always contains exactly 64 DUs.
+
+The same Merkle construction authenticates:
+
+- `polyfs_root`, the root over MDU #0's 64 DU commitments.
+- Target MDU roots, the roots over a non-zero MDU's 64 DU commitments.
+
 ## 2. Root Field Semantics
 
 The canonical chain field for new deals is `polyfs_root`.
@@ -91,6 +107,19 @@ Therefore:
 
 The root table covers `mdu_index` values `1..65536` inclusive. MDU #0 is
 authenticated directly by `polyfs_root`, not by a root-table entry.
+
+Root-table KZG openings use the same 4096-cell blob evaluation domain as normal
+data blobs. For `root_table_cell = c`, the opening point is:
+
+```text
+z = omega^c mod FrModulus
+omega = 7^((FrModulus - 1) / 4096) mod FrModulus
+FrModulus = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001
+```
+
+`z` is encoded as a canonical 32-byte big-endian BLS12-381 scalar. Verifiers
+MUST NOT interpret `root_table_cell` as a raw integer field element or byte
+offset.
 
 ## 5. Root-Table Entry Encoding
 

--- a/rfcs/rfc-polyfs-root-contract.md
+++ b/rfcs/rfc-polyfs-root-contract.md
@@ -28,19 +28,33 @@ super-manifest containing the root table and file table.
 
 The Merkle construction is part of the consensus contract:
 
-- The tree has exactly 64 leaves for every MDU root in this protocol version.
 - Leaf `i` is `BLAKE2s-256(kzg_commitment_i)`, where `kzg_commitment_i` is the
-  48-byte compressed KZG commitment for `DU[i]`.
+  48-byte compressed KZG commitment for the corresponding DU/shard blob.
 - Internal nodes are `BLAKE2s-256(left_child || right_child)`.
-- Leaves are ordered by increasing DU index and internal-node concatenation
-  preserves that left-to-right order.
-- No padding, empty-root value, or odd-leaf promotion is used for MDU roots,
-  because each MDU always contains exactly 64 DUs.
+- Leaf ordering is profile-specific and internal-node concatenation preserves
+  that left-to-right order.
+- No padding, empty-root value, or odd-leaf promotion is used for committed MDU
+  roots. Every supported root profile has a fixed leaf count.
 
-The same Merkle construction authenticates:
+The supported root profiles are:
+
+| MDU kind | Leaf count | Leaf ordering |
+| --- | ---: | --- |
+| MDU #0 super-manifest | 64 | increasing DU index `0..63` |
+| Replicated metadata MDU, including Witness MDUs | 64 | increasing DU index `0..63` |
+| Mode 1 replicated user MDU | 64 | increasing DU index `0..63` |
+| Mode 2 striped user SP-MDU | `L = (K+M) * (64/K)` | slot-major `leaf_index` from `rfcs/rfc-blob-alignment-and-striping.md` |
+
+The default Mode 2 profile `K=8`, `M=4` therefore has `L=96` target-MDU
+leaves. Verifiers MUST select the target MDU root profile from the committed
+deal mode/profile and reject `blob_index` / `leaf_index` values outside that
+profile's fixed leaf count.
+
+This construction authenticates:
 
 - `polyfs_root`, the root over MDU #0's 64 DU commitments.
-- Target MDU roots, the roots over a non-zero MDU's 64 DU commitments.
+- Target MDU roots, whose leaf count and ordering are determined by their MDU
+  kind and the committed deal profile.
 
 ## 2. Root Field Semantics
 
@@ -130,7 +144,7 @@ not the raw root bytes interpreted ambiguously.
 For each target MDU root:
 
 ```text
-mdu_root       = 32-byte Merkle root over the target MDU's KZG commitments
+mdu_root       = 32-byte Merkle root over the target MDU's profile-selected KZG commitments
 mdu_root_fr    = ReduceMduRootToFr(mdu_root)
 root_table_cell_bytes = FrToBytesBE(mdu_root_fr)
 ```
@@ -170,6 +184,9 @@ The proof must carry, or allow the verifier to derive:
 - target blob commitment
 - Merkle path from target blob commitment to `mdu_root`
 - `blob_index` / Mode 2 `leaf_index`
+- target MDU root profile, derived from the committed deal mode/profile and MDU
+  kind, so the verifier can validate the Hop 2 Merkle path against the correct
+  fixed leaf count
 - blob KZG opening point and value
 
 Synthetic liveness challenges target user data MDUs, not MDU #0 or Witness MDUs.
@@ -229,6 +246,10 @@ Challenge positions remain blob-oriented:
 
 For Mode 2, `blob_index` is interpreted as the slot-major `leaf_index` defined
 in `rfcs/rfc-blob-alignment-and-striping.md`.
+
+Verifiers MUST reject challenges whose `blob_index` is outside the target MDU
+root profile's leaf count. For the default Mode 2 profile, this means
+`blob_index < 96`; for replicated 64-DU roots, this means `blob_index < 64`.
 
 Retrieval sessions continue to pin the current deal root. After migration, that
 pin is `polyfs_root`, not the old 48-byte flat `manifest_root`.

--- a/rfcs/rfc-polyfs-root-contract.md
+++ b/rfcs/rfc-polyfs-root-contract.md
@@ -30,11 +30,15 @@ The Merkle construction is part of the consensus contract:
 
 - Leaf `i` is `BLAKE2s-256(kzg_commitment_i)`, where `kzg_commitment_i` is the
   48-byte compressed KZG commitment for the corresponding DU/shard blob.
-- Internal nodes are `BLAKE2s-256(left_child || right_child)`.
+- Internal nodes with both children are `BLAKE2s-256(left_child || right_child)`.
 - Leaf ordering is profile-specific and internal-node concatenation preserves
   that left-to-right order.
-- No padding, empty-root value, or odd-leaf promotion is used for committed MDU
-  roots. Every supported root profile has a fixed leaf count.
+- No padding, duplicated-last-leaf rule, or empty-root value is used for
+  committed MDU roots. Every supported root profile has a fixed leaf count.
+- For non-power-of-two fixed leaf counts, if a level has an unpaired final node,
+  carry that node unchanged into the next level. Proof generation omits a
+  sibling for that level, and verification must use the profile's fixed leaf
+  count to reconstruct the same carry-forward path.
 
 The supported root profiles are:
 
@@ -229,6 +233,20 @@ Because Witness MDUs consume root-table slots, the maximum user bytes are below
 Witness MDUs are replicated proof-generation metadata. They cache target blob
 commitments so providers can build Hop 2 proofs without contacting the original
 client.
+
+Witness sizing MUST budget the target root profile's leaf count, not a
+hard-coded 64 commitments per user MDU. For a uniform user-data profile:
+
+```text
+commitments_per_user_mdu = target_mdu_leaf_count(profile)
+witness_commitment_bytes = user_mdu_count * commitments_per_user_mdu * 48
+W = ceil(witness_commitment_bytes / 8 MiB)
+```
+
+For the default Mode 2 profile `K=8`, `M=4`,
+`commitments_per_user_mdu == 96`. A gateway/client that reserves only
+`user_mdu_count * 64` commitments for those slabs underallocates Witness MDUs
+and cannot generate proofs for parity-slot leaves `64..95`.
 
 Witness MDUs are not an independent trust root. The trust chain remains:
 

--- a/rfcs/rfc-polyfs-root-contract.md
+++ b/rfcs/rfc-polyfs-root-contract.md
@@ -1,0 +1,221 @@
+# RFC: PolyFS Root Contract (MDU #0 Trust Root)
+
+**Status:** Accepted for issue #213; implementation pending.
+**Scope:** Deal root semantics, MDU #0 root-table proof shape, legacy alpha behavior, and devnet migration policy.
+**Depends on:** `notes/triple-proof.md`, `rfcs/rfc-blob-alignment-and-striping.md`, `rfcs/rfc-mode2-onchain-state.md`
+
+## 1. Summary
+
+New PolyStore content commits MUST use MDU #0 as the deal trust root.
+
+The previous alpha path committed a separate 128 KiB `manifest.bin` blob whose
+cells contained per-MDU roots. That path is capped at 4096 MDU roots and is no
+longer the canonical protocol for new deals.
+
+The canonical committed root is now:
+
+```text
+polyfs_root = MerkleRoot(
+  KZG(MDU0.DU[0]),
+  KZG(MDU0.DU[1]),
+  ...,
+  KZG(MDU0.DU[63])
+)
+```
+
+Where each `DU` is a 128 KiB KZG blob and MDU #0 is the 8 MiB PolyFS
+super-manifest containing the root table and file table.
+
+## 2. Root Field Semantics
+
+The canonical chain field for new deals is `polyfs_root`.
+
+- `polyfs_root` is the 32-byte Merkle root of the 64 KZG commitments for MDU #0.
+- Empty thin-provisioned deals use an empty root (`len(polyfs_root) == 0`) until
+  the first content commit.
+- A committed deal MUST have `len(polyfs_root) == 32`.
+- The old `manifest_root` name is a legacy alpha alias for the retired flat
+  manifest KZG commitment and MUST NOT be used as the consensus meaning for new
+  deals.
+
+Downstream implementation may reuse the existing protobuf field number during
+the devnet clean break, but the schema, JSON, docs, CLI, gateway responses, and
+EIP-712/session hashing must treat the field as `polyfs_root` after migration.
+
+REST and local storage encodings:
+
+- Canonical string form: `0x` plus 64 lowercase hex characters.
+- Directory key form: 64 lowercase hex characters without `0x`.
+- Legacy 96-hex roots are invalid for new committed deals unless a deliberately
+  versioned legacy inspection path is being used.
+
+## 3. Legacy Alpha Behavior
+
+For the proof-format migration tracked by issue #212, PolyStore will use a clean
+devnet break:
+
+- New deals MUST NOT commit the old 48-byte flat `manifest.bin` KZG root.
+- New liveness and retrieval proofs MUST NOT use direct flat-manifest openings.
+- Old alpha deals with 48-byte roots are unsupported after the migration unless
+  a later PR explicitly adds a versioned legacy verifier.
+- `manifest.bin` MAY remain as a debug/cache artifact during transition, but it
+  is not canonical and must not be required to fetch or prove new deals.
+
+Devnet rollout MUST either reset state at the proof-format boundary or document
+an explicit migration. It must not silently keep old committed deals under new
+root semantics.
+
+## 4. MDU #0 Root Table
+
+MDU #0 is partitioned as:
+
+| DU range | Bytes | Purpose |
+| --- | ---: | --- |
+| 0..15 | 2 MiB | Root table |
+| 16..63 | 6 MiB | File table |
+
+The root table has 65,536 scalar cells. It stores roots for MDUs after MDU #0:
+
+```text
+root_table_index = mdu_index - 1
+root_table_du    = root_table_index / 4096
+root_table_cell  = root_table_index % 4096
+```
+
+Therefore:
+
+- `mdu_index == 1` maps to `root_table_du == 0`, `root_table_cell == 0`.
+- `mdu_index == 4096` maps to `root_table_du == 0`, `root_table_cell == 4095`.
+- `mdu_index == 4097` maps to `root_table_du == 1`, `root_table_cell == 0`.
+
+The root table covers `mdu_index` values `1..65536` inclusive. MDU #0 is
+authenticated directly by `polyfs_root`, not by a root-table entry.
+
+## 5. Root-Table Entry Encoding
+
+KZG openings return field elements, while MDU roots are 32-byte Merkle roots.
+The protocol therefore stores a deterministic field binding for each MDU root,
+not the raw root bytes interpreted ambiguously.
+
+For each target MDU root:
+
+```text
+mdu_root       = 32-byte Merkle root over the target MDU's KZG commitments
+mdu_root_fr    = ReduceMduRootToFr(mdu_root)
+root_table_cell_bytes = FrToBytesBE(mdu_root_fr)
+```
+
+`ReduceMduRootToFr` is the BLS12-381 scalar reduction currently used by
+`polystore_core`: construct a 64-byte little-endian wide input whose low 32
+bytes are `mdu_root` reversed from big-endian order and whose high 32 bytes are
+zero, then call the BLS12-381 `Scalar::from_bytes_wide` reduction. `FrToBytesBE`
+is the canonical 32-byte big-endian scalar representation.
+
+Verifiers MUST derive `mdu_root_fr` from the supplied 32-byte `mdu_root` and
+compare that derived value to the root-table KZG opening result. Implementations
+MUST NOT silently reduce arbitrary bytes in different ways.
+
+## 6. Chained Proof V2 Shape
+
+The V2 proof path is:
+
+```text
+Deal.polyfs_root
+  -> Merkle inclusion of root-table DU commitment in MDU #0
+  -> KZG opening of root-table DU at root_table_cell
+  -> target MDU root
+  -> Merkle inclusion of target blob commitment in target MDU
+  -> KZG opening of target blob data
+```
+
+The proof must carry, or allow the verifier to derive:
+
+- `mdu_index`
+- `root_table_du`
+- `root_table_cell`
+- root-table DU KZG commitment
+- Merkle path from root-table DU commitment to `polyfs_root`
+- target `mdu_root`
+- root-table KZG opening proving `RootTable[root_table_index]`
+- target blob commitment
+- Merkle path from target blob commitment to `mdu_root`
+- `blob_index` / Mode 2 `leaf_index`
+- blob KZG opening point and value
+
+Synthetic liveness challenges target user data MDUs, not MDU #0 or Witness MDUs.
+If a future protocol path needs to prove bytes inside MDU #0 itself, it should
+use the direct `polyfs_root -> MDU0.DU commitment -> KZG opening` path and must
+be specified separately.
+
+## 7. Capacity Semantics
+
+MDU #0 authenticates itself through `polyfs_root`. Its root table authenticates
+up to 65,536 additional MDUs.
+
+Let:
+
+```text
+W = witness_mdus
+S = user_mdus
+total_mdus = 1 + W + S
+```
+
+The PolyFS V1 root-table cap is:
+
+```text
+W + S <= 65,536
+total_mdus <= 65,537
+```
+
+The public "512 GiB-class" capacity refers to logical user MDU slots before
+metadata overhead. Actual user capacity is:
+
+```text
+S * 8 MiB
+```
+
+Because Witness MDUs consume root-table slots, the maximum user bytes are below
+512 GiB whenever `W > 0`.
+
+## 8. Witness MDUs
+
+Witness MDUs are replicated proof-generation metadata. They cache target blob
+commitments so providers can build Hop 2 proofs without contacting the original
+client.
+
+Witness MDUs are not an independent trust root. The trust chain remains:
+
+```text
+polyfs_root -> MDU #0 root table -> target MDU root -> target blob commitment
+```
+
+## 9. Challenge And Session Semantics
+
+Challenge positions remain blob-oriented:
+
+```text
+(mdu_index, blob_index)
+```
+
+For Mode 2, `blob_index` is interpreted as the slot-major `leaf_index` defined
+in `rfcs/rfc-blob-alignment-and-striping.md`.
+
+Retrieval sessions continue to pin the current deal root. After migration, that
+pin is `polyfs_root`, not the old 48-byte flat `manifest_root`.
+
+This RFC does not introduce arbitrary byte-range proofs. Gateways and clients
+still resolve file paths and byte ranges into blob-aligned proof work.
+
+## 10. Implementation Stack
+
+The issue #212 stack must land in this order:
+
+1. Spec contract (`#213`)
+2. Core verifier (`#214`)
+3. Proto/chain verifier (`#215`)
+4. Gateway ingest/proofs (`#216`)
+5. Devnet rollout automation (`#217`, can start after this spec)
+6. E2E/devnet validation (`#218`)
+
+The sprint is complete only after the updated local devnet accepts a
+chain-verified proof for `mdu_index >= 4096` using the V2 proof path.

--- a/rfcs/rfc-polyfs-root-contract.md
+++ b/rfcs/rfc-polyfs-root-contract.md
@@ -207,7 +207,7 @@ Let:
 
 ```text
 W = witness_mdus
-S = user_mdus
+S = user_data_mdus
 total_mdus = 1 + W + S
 ```
 
@@ -218,15 +218,33 @@ W + S <= 65,536
 total_mdus <= 65,537
 ```
 
-The public "512 GiB-class" capacity refers to logical user MDU slots before
-metadata overhead. Actual user capacity is:
+`S` counts committed user-data MDU slots. It is not a raw byte count and it
+MUST NOT be used as `S * 8 MiB` for raw file admission.
+
+Each 8 MiB user MDU is an encoded scalar buffer. With the shared 31-byte
+payload into 32-byte scalar packing rule:
 
 ```text
-S * 8 MiB
+RawMduPayloadBytes = (8 MiB / 32) * 31 = 8,126,464 bytes
+EncodedUserSlabBytes = S * 8 MiB
+MaxRawPayloadBytes = S * RawMduPayloadBytes
 ```
 
-Because Witness MDUs consume root-table slots, the maximum user bytes are below
-512 GiB whenever `W > 0`.
+For a committed live file set with raw payload byte demand `P`, content commit
+validation MUST require:
+
+```text
+P <= MaxRawPayloadBytes
+```
+
+If a file set needs `RawMduPayloadBytes + 1` bytes, it requires at least two
+user-data MDUs and the corresponding root-table and Witness entries. A gateway
+or chain admission check that accepts the file set with `S = 1` because
+`P <= 8 MiB` is invalid.
+
+The public "512 GiB-class" capacity refers to encoded user MDU address space
+before metadata overhead. Raw payload capacity is lower due to scalar packing,
+and it is further reduced whenever Witness MDUs consume root-table slots.
 
 ## 8. Witness MDUs
 

--- a/rfcs/rfc-pricing-and-escrow-accounting.md
+++ b/rfcs/rfc-pricing-and-escrow-accounting.md
@@ -60,7 +60,7 @@ From Deal state:
 1. If `deal_creation_fee > 0`, transfer `deal_creation_fee` from creator → fee collector.
 2. If `initial_escrow_amount > 0`, transfer `initial_escrow_amount` from creator → module account.
 3. Initialize deal with:
-   - `manifest_root = empty`
+   - `polyfs_root = empty`
    - `size_bytes = 0`
    - `total_mdus = 0` (until first commit; see `rfcs/rfc-mode2-onchain-state.md`)
    - `escrow_balance = initial_escrow_amount`
@@ -118,7 +118,7 @@ Let:
 
 **Must-fail conditions:**
 - `Deal.escrow_balance < total` → reject
-- `manifest_root` must match `Deal.manifest_root` (pin)
+- `polyfs_root` must match `Deal.polyfs_root` (pin)
 
 **Accounting at open:**
 1. Burn `base_fee` from module account (non-refundable).
@@ -196,4 +196,3 @@ elasticity_cost = base_stripe_cost * delta_replication
 - Storage lock-in: update content with increasing size charges `delta*duration*price` and rejects if insufficient funds.
 - Retrieval fees: open burns base fee, locks variable, completion burns cut + pays provider, cancel refunds variable.
 - Elasticity: scaling denied when exceeding `max_monthly_spend` or `escrow_balance`.
-

--- a/rfcs/rfc-retrieval-access-control-public-deals-and-vouchers.md
+++ b/rfcs/rfc-retrieval-access-control-public-deals-and-vouchers.md
@@ -1,9 +1,14 @@
 # RFC: Retrieval Access Control + Sponsored & Protocol Retrieval Sessions (Draft)
 
 **Status:** Implemented in devnet
-**Last updated:** 2026-01-23
+**Last updated:** 2026-06-21
 **Scope:** Chain (`polystorechain/`), Gateway/router (`polystore_gateway/`), Providers, UI (`polystore-website/`), and side projects (public explorers)
 **Hard constraints respected:** does **not** change storage lock‑in pricing or the settlement semantics of **owner‑paid** retrieval sessions in `rfcs/rfc-pricing-and-escrow-accounting.md`; no off-chain oracles; deterministic on-chain behavior.
+
+**Root contract dependency:** retrieval sessions pin the canonical 32-byte
+`Deal.polyfs_root` defined in `rfcs/rfc-polyfs-root-contract.md`. Legacy
+`manifest_root` field names may remain as wire/API aliases during migration, but
+they MUST carry the canonical PolyFS root after the MDU #0 migration.
 
 ---
 
@@ -122,7 +127,7 @@ Fields (conceptual):
 - `creator` (tx signer; pays)
 - `deal_id`
 - `provider` or `slot`
-- `manifest_root`
+- `polyfs_root`
 - `start_mdu_index`, `start_blob_index`, `blob_count`, `expires_at`
 - `auth` (oneof):
   - empty (public mode)
@@ -134,7 +139,7 @@ Handler semantics (normative):
 1) Enforce deal ACTIVE + term coupling:
    - `current_height < Deal.end_block`
    - `expires_at <= Deal.end_block`
-   - `manifest_root == Deal.manifest_root`
+   - `polyfs_root == Deal.polyfs_root`
 2) Enforce deal policy based on `Deal.retrieval_policy` (see §6.2).
 3) Compute `base_fee` and `variable_fee` using the same fee schedule and rounding rules as the frozen RFC.
 4) `total = base_fee + variable_fee`. If `max_total_fee` is set, reject unless `total <= max_total_fee`.
@@ -160,7 +165,7 @@ Fields (conceptual):
 - `purpose` (enum): `PROTOCOL_AUDIT | PROTOCOL_REPAIR`
 - `deal_id`
 - `provider` or `slot` (the *serving* provider/slot for the bytes being fetched)
-- `manifest_root`
+- `polyfs_root`
 - `start_mdu_index`, `start_blob_index`, `blob_count`, `expires_at`
 - `auth` (oneof):
   - `AuditTaskRef { epoch, task_id }` (deterministic audit assignment; see §6.3)
@@ -213,7 +218,7 @@ This budget funds:
 All opens MUST enforce:
 - `current_height < Deal.end_block` (deal ACTIVE)
 - `expires_at <= Deal.end_block`
-- `manifest_root == Deal.manifest_root`
+- `polyfs_root == Deal.polyfs_root`
 - provider/slot belongs to the deal assignment (for striped deals, slot binding must match the current assignment)
 
 ### 6.2 Policy checks for sponsored opens (`MsgOpenRetrievalSessionSponsored`)
@@ -238,7 +243,7 @@ A protocol audit session is only valid if it is bound to a deterministic audit a
 **Normative model (v1 hook):**
 - The chain maintains an `AuditTask` store keyed by `(epoch, task_id)`:
   - `assignee` (provider address)
-  - `deal_id`, `slot/provider`, `manifest_root`
+  - `deal_id`, `slot/provider`, `polyfs_root`
   - `(start_mdu_index, start_blob_index, blob_count)`
   - `expires_at` (bounded TTL)
 - `MsgOpenProtocolRetrievalSession(purpose=PROTOCOL_AUDIT, auth=AuditTaskRef{epoch, task_id})` MUST enforce:
@@ -280,7 +285,7 @@ A voucher is a signature from `voucher_signer` (default owner) authorizing a spe
 Voucher payload MUST include:
 
 - `deal_id`
-- `manifest_root`
+- `polyfs_root`
 - `provider/slot` binding (optional; if omitted, any assigned provider may be used)
 - `start_mdu_index`, `start_blob_index`, `blob_count` (or an explicit max blob_count)
 - `expires_at` (block height)


### PR DESCRIPTION
Part of #212.
Closes #213.

## Current Status (2026-06-22 14:01 UTC)

Head `9e3c2808` addresses the fresh review findings: the spec now requires minimum Witness coverage for committed user MDUs and rejects MDU #0 plus Witness MDUs as retrieval/liveness content-proof targets. The review threads are resolved.

Local validation: `git diff --check` passed.

Latest GitHub state is green: merge state is `CLEAN` with no pending or failed checks on head `9e3c2808`. Codex review returned no major issues on this current head: https://github.com/Polynomialstore/polystore/pull/219#issuecomment-4766837096. This PR still requires human review/approval before merge. Agents must not self-merge.

## Scope

This PR freezes the MDU #0 PolyFS root contract before the core, chain, gateway, and devnet rollout PRs start implementation.

It establishes:
- `polyfs_root` as the canonical new-deal root: 32-byte Merkle root over MDU #0's 64 KZG commitments, with exact BLAKE2s leaf/internal-node rules.
- Clean devnet break semantics: new deals must not commit the retired 48-byte flat `manifest.bin` KZG root.
- Root-table indexing for MDU indices `1..65536`, including the boundary examples `4096 -> DU 0 / cell 4095` and `4097 -> DU 1 / cell 0`, plus the exact roots-of-unity KZG opening point for each cell.
- Deterministic root-table cell encoding via `ReduceMduRootToFr(mdu_root)` and canonical big-endian scalar bytes.
- V2 proof path: `Deal.polyfs_root -> MDU #0 root-table DU -> target MDU root -> target blob commitment -> KZG data opening`.
- Capacity semantics: `W + S <= 65,536`, `total_mdus = 1 + W + S <= 65,537`.
- Gateway/API compatibility rules: legacy `manifest_root`/`cid` names may remain as aliases only when carrying the 32-byte PolyFS root.
- Devnet migration policy: reset or explicitly migrate; do not silently keep old 48-byte committed deals under the new semantics.

## Review Follow-Up

Head `bca12929` update: `rfcs/rfc-mode2-onchain-state.md` now adds the raw payload commit gate to `MsgUpdateDealContent*`: when `size_bytes > 0`, require `user_mdus >= 1`, and require `size_bytes <= user_mdus * RawMduPayloadBytes` with `RawMduPayloadBytes = 8,126,464`.

Head `003e6cbf` update: the RFC defines raw payload capacity for user-data MDUs. `S` counts committed user-data MDU slots, `RawMduPayloadBytes = (8 MiB / 32) * 31 = 8,126,464`, `EncodedUserSlabBytes = S * 8 MiB`, and content commit validation must enforce raw payload demand `P <= MaxRawPayloadBytes`. `notes/triple-proof.md` now carries the same raw-capacity warning.

Head `6e7e4d9a` update: `manifest.bin` is now moved out of required artifacts into an optional/debug section, and required-artifact conformance plus golden-vector required-file lists must exclude it. `/gateway/mdu-kzg` is now profile-aware: responses must include `mdu_kind`, `root_profile`, `leaf_count`, `commitments`, and `derived_mdu_root`. For default Mode 2 `K=8,M=4`, user SP-MDU roots return 96 commitments, not 64.

Head `9c1a9b21` update: the spec defines the Merkle reduction rule for fixed non-power-of-two target root profiles and corrects Witness MDU sizing for Mode 2. For default `K=8,M=4`, Mode 2 user SP-MDU roots have 96 leaves; an unpaired final node at any Merkle level is carried unchanged to the next level, duplicate-last padding is forbidden, and verification must use the profile fixed leaf count. Witness sizing now budgets `target_mdu_leaf_count(profile)`, so default Mode 2 reserves 96 commitments per user SP-MDU and covers parity-slot leaves `64..95`.

All current Codex review threads are resolved with evidence replies. Latest-head CI is green on `9e3c2808`: https://github.com/Polynomialstore/polystore/actions/runs/27940544893. Codex review returned no major issues on `9e3c2808`: https://github.com/Polynomialstore/polystore/pull/219#issuecomment-4766837096. Previous green head was `bca12929`: https://github.com/Polynomialstore/polystore/actions/runs/27936967974.

Heads `005d0ab6`, `99c4de74`, and `1eb1fbcd` addressed earlier Codex review findings:

- MDU #0 is now explicitly rejected before root-table lookup in `notes/triple-proof.md`, and the normative RFC says to apply `mdu_index - 1` only after rejecting `mdu_index == 0`.
- Gateway fetch/list/slab/proof storage paths now remain deal-scoped as `uploads/deals/<deal_id>/<polyfs_root_key>/...`, avoiding cross-deal lifecycle collisions for identical roots.
- `MsgUpdateDealContent*` now explicitly enforces the MDU #0 root-table capacity invariant: `witness_mdus < total_mdus`, `witness_mdus + user_mdus <= 65,536`, `total_mdus <= 65,537`, and no verifier-derived `root_table_du >= 16`.
- The Merkle construction is normative: leaf hash is `BLAKE2s-256` over each 48-byte compressed KZG commitment; internal nodes with both children use `BLAKE2s-256(left || right)`; fixed non-power-of-two profiles carry an unpaired final node unchanged.
- Root-table KZG openings are frozen as `z = omega^root_table_cell mod FrModulus`, using the 4096-cell BLS12-381 roots-of-unity domain and 32-byte big-endian scalar encoding.

Remaining merge gates are human review/approval and authorized merge. Agents should not self-merge this PR.

## Deliberate Non-Scope

Implementation code/protobuf/generated Go still contains old `manifest_root` names and 48-byte checks. That is intentionally left to the dependent implementation tickets:
- #214: `polystore_core` verifier and fixtures.
- #215: proto/chain validation, field semantics, EIP-712/session hashing, and generated code.
- #216: gateway ingest/proof generation/API compatibility.
- #217: local devnet reset/rollout automation.
- #218: high-index end-to-end validation and closeout.

## Validation

Docs/spec-only PR; no runtime benchmarks required.

Local checks run on head `f9b7ab37` before the final bounds fix:
- `git diff --check`
- `git diff --cached --check`
- `rg -n 'manifest_root == Deal\.manifest_root|96 hex chars|manifest_root_key|48-byte flat manifest|committed a separate 128 KiB `manifest\.bin`|Deal\.manifest_root \(48B|previous committed manifest root|uploads/<polyfs_root_key>|Target_MDU_Index == 0\`: MDU #0|root_table_index = Target_MDU_Index - 1' rfcs notes polystore_gateway/polystore-gateway-spec.md -g '*.md'`

The remaining targeted search hits are intentional legacy descriptions in the new compatibility contract, plus the guarded `Target_MDU_Index - 1` line that now follows an explicit zero-index rejection.

Additional local checks run on head `005d0ab6`:
- `git diff --check`
- `rg -n 'root_table_du >= 16|witness_mdus \+ user_mdus <= 65,536|total_mdus <= 65,537|witness_mdus < total_mdus' rfcs/rfc-mode2-onchain-state.md rfcs/rfc-polyfs-root-contract.md notes/triple-proof.md`

Additional local check run on head `99c4de74`:
- `git diff --check`

Additional local check run on head `9c1a9b21`:
- `git diff --check`

Additional local check run on head `6e7e4d9a`:
- `git diff --check`

Additional local check run on head `003e6cbf`:
- `git diff --check`

Additional local check run on head `bca12929`:
- `git diff --check`

Latest-head CI is green for `bca12929`: https://github.com/Polynomialstore/polystore/actions/runs/27936967974.
Latest-head CI is green for `1eb1fbcd`: https://github.com/Polynomialstore/polystore/actions/runs/27932865676.
Latest-head CI is green for `99c4de74`: https://github.com/Polynomialstore/polystore/actions/runs/27929769588. The rerun recovered the earlier external crates.io/Foundry fetch failures.
Companion runs are green: https://github.com/Polynomialstore/polystore/actions/runs/27929769606 and https://github.com/Polynomialstore/polystore/actions/runs/27929769580
Previous head `005d0ab6` was green: https://github.com/Polynomialstore/polystore/actions/runs/27919899982




