### PR TITLE
core: add MDU #0 root-table verifier

### DIFF
--- a/polystore_core/src/ffi.rs
+++ b/polystore_core/src/ffi.rs
@@ -758,6 +758,144 @@ pub extern "C" fn polystore_compute_blob_proof(
     }
 }
 
+/// Computes the V2 MDU #0 root-table proof material for a target MDU root.
+///
+/// Inputs:
+/// - mdu0_bytes: full 8 MiB MDU #0 bytes.
+/// - mdu_index: target MDU index after MDU #0; valid range is 1..=65536.
+/// - target_mdu_root: 32-byte target MDU Merkle root.
+///
+/// Outputs:
+/// - out_root_table_du_commitment: 48-byte KZG commitment for the root-table DU.
+/// - out_root_table_du_merkle_proof: serialized Merkle path from that DU to polyfs_root.
+/// - out_root_table_du_merkle_proof_len: in/out capacity and actual length.
+/// - out_root_table_opening_proof: 48-byte KZG proof for the root-table cell.
+/// - out_root_table_opening_y: 32-byte opened field value for diagnostics/parity.
+#[unsafe(no_mangle)]
+pub extern "C" fn polystore_compute_mdu0_root_table_proof(
+    mdu0_bytes: *const u8,
+    mdu0_bytes_len: usize,
+    mdu_index: u64,
+    target_mdu_root: *const u8,
+    out_root_table_du_commitment: *mut u8,
+    out_root_table_du_merkle_proof: *mut u8,
+    out_root_table_du_merkle_proof_len: *mut usize,
+    out_root_table_opening_proof: *mut u8,
+    out_root_table_opening_y: *mut u8,
+) -> c_int {
+    let ctx = match KZG_CTX.get() {
+        Some(c) => c,
+        None => return -1, // Not initialized
+    };
+
+    if mdu0_bytes.is_null()
+        || target_mdu_root.is_null()
+        || out_root_table_du_commitment.is_null()
+        || out_root_table_du_merkle_proof.is_null()
+        || out_root_table_du_merkle_proof_len.is_null()
+        || out_root_table_opening_proof.is_null()
+        || out_root_table_opening_y.is_null()
+        || mdu0_bytes_len != crate::kzg::MDU_SIZE
+    {
+        return -2;
+    }
+
+    let mdu0_slice = unsafe { std::slice::from_raw_parts(mdu0_bytes, mdu0_bytes_len) };
+    let target_root_slice = unsafe { std::slice::from_raw_parts(target_mdu_root, 32) };
+
+    match ctx.compute_mdu0_root_table_proof(mdu0_slice, mdu_index, target_root_slice) {
+        Ok(proof) => {
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    proof.root_table_du_commitment.as_slice().as_ptr(),
+                    out_root_table_du_commitment,
+                    48,
+                );
+                std::ptr::copy_nonoverlapping(
+                    proof.root_table_opening_proof.as_slice().as_ptr(),
+                    out_root_table_opening_proof,
+                    48,
+                );
+                std::ptr::copy_nonoverlapping(
+                    proof.root_table_opening_y.as_slice().as_ptr(),
+                    out_root_table_opening_y,
+                    32,
+                );
+
+                let proof_len = proof.root_table_du_merkle_proof.len();
+                if *out_root_table_du_merkle_proof_len < proof_len {
+                    *out_root_table_du_merkle_proof_len = proof_len;
+                    return -7; // Buffer too small
+                }
+                std::ptr::copy_nonoverlapping(
+                    proof.root_table_du_merkle_proof.as_ptr(),
+                    out_root_table_du_merkle_proof,
+                    proof_len,
+                );
+                *out_root_table_du_merkle_proof_len = proof_len;
+            }
+            0
+        }
+        Err(_e) => {
+            #[cfg(feature = "debug-print")]
+            eprintln!("ERROR: Failed to compute MDU0 root-table proof");
+            -3
+        }
+    }
+}
+
+/// Verifies the V2 Hop 1 path:
+/// polyfs_root -> MDU #0 root-table DU commitment -> target MDU root.
+#[unsafe(no_mangle)]
+pub extern "C" fn polystore_verify_mdu0_root_table_proof(
+    polyfs_root: *const u8,
+    mdu_index: u64,
+    target_mdu_root: *const u8,
+    root_table_du_commitment: *const u8,
+    root_table_du_merkle_proof: *const u8,
+    root_table_du_merkle_proof_len: usize,
+    root_table_opening_proof: *const u8,
+) -> c_int {
+    let ctx = match KZG_CTX.get() {
+        Some(c) => c,
+        None => return -1, // Not initialized
+    };
+
+    if polyfs_root.is_null()
+        || target_mdu_root.is_null()
+        || root_table_du_commitment.is_null()
+        || root_table_du_merkle_proof.is_null()
+        || root_table_opening_proof.is_null()
+    {
+        return -2;
+    }
+
+    let polyfs_root_slice = unsafe { std::slice::from_raw_parts(polyfs_root, 32) };
+    let target_root_slice = unsafe { std::slice::from_raw_parts(target_mdu_root, 32) };
+    let du_commitment_slice = unsafe { std::slice::from_raw_parts(root_table_du_commitment, 48) };
+    let du_merkle_proof_slice = unsafe {
+        std::slice::from_raw_parts(root_table_du_merkle_proof, root_table_du_merkle_proof_len)
+    };
+    let opening_proof_slice = unsafe { std::slice::from_raw_parts(root_table_opening_proof, 48) };
+
+    match ctx.verify_mdu0_root_table_proof(
+        polyfs_root_slice,
+        mdu_index,
+        target_root_slice,
+        du_commitment_slice,
+        du_merkle_proof_slice,
+        opening_proof_slice,
+    ) {
+        Ok(true) => 1,
+        Ok(false) => 0,
+        Err(_e) => {
+            #[cfg(feature = "debug-print")]
+            eprintln!("ERROR: MDU0 root-table proof verification error");
+            -3
+        }
+    }
+}
+
 /// Verifies a "Triple Proof" (Chained Verification).
 ///
 /// Hop 1: Verify MDU Root is in Manifest (KZG).

--- a/polystore_core/src/kzg.rs
+++ b/polystore_core/src/kzg.rs
@@ -827,6 +827,9 @@ impl KzgContext {
         if mdu_merkle_root.len() != 32 || challenged_kzg_commitment.len() != 48 {
             return Err(KzgError::InvalidDataLength);
         }
+        if merkle_proof_bytes.len() % 32 != 0 {
+            return Err(KzgError::InvalidDataLength);
+        }
 
         let leaf_hash = Blake2s256Hasher::hash(challenged_kzg_commitment);
 

--- a/polystore_core/src/kzg.rs
+++ b/polystore_core/src/kzg.rs
@@ -23,6 +23,9 @@ pub const MDU_SIZE: usize = 8 * 1024 * 1024;
 pub const SHARD_SIZE: usize = 1 * 1024 * 1024;
 pub const BLOB_SIZE: usize = 131072;
 pub const BLOBS_PER_MDU: usize = MDU_SIZE / BLOB_SIZE;
+pub const SCALARS_PER_BLOB: usize = BLOB_SIZE / 32;
+pub const MDU0_ROOT_TABLE_DUS: usize = 16;
+pub const MDU0_ROOT_TABLE_CAPACITY: u64 = (MDU0_ROOT_TABLE_DUS * SCALARS_PER_BLOB) as u64;
 
 pub type KzgCommitment = [u8; 48];
 pub type Bytes32 = [u8; 32];
@@ -86,8 +89,28 @@ pub enum KzgError {
     InvalidDataLength,
     #[error("Invalid MDU size")]
     InvalidMduSize,
+    #[error("Invalid MDU root-table index")]
+    InvalidMduIndex,
     #[error("Merkle Tree error: {0}")]
     MerkleTreeError(String),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RootTablePosition {
+    pub mdu_index: u64,
+    pub root_table_index: usize,
+    pub root_table_du: usize,
+    pub root_table_cell: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Mdu0RootTableProof {
+    pub position: RootTablePosition,
+    pub target_mdu_root: Bytes32,
+    pub root_table_du_commitment: Bytes48,
+    pub root_table_du_merkle_proof: Vec<u8>,
+    pub root_table_opening_proof: Bytes48,
+    pub root_table_opening_y: Bytes32,
 }
 
 #[derive(Clone)]
@@ -675,8 +698,7 @@ impl KzgContext {
         let mut blob_bytes = vec![0u8; BLOB_SIZE];
         for (i, root) in mdu_roots.iter().enumerate().take(4096) {
             let start = i * 32;
-            blob_bytes[start..start + 32]
-                .copy_from_slice(&scalar_to_bytes_be(&reduce_bytes32_to_scalar(root)));
+            blob_bytes[start..start + 32].copy_from_slice(&encode_mdu_root_for_root_table(root)?);
         }
 
         let commitment = self.blob_to_commitment(&blob_bytes)?;
@@ -699,11 +721,100 @@ impl KzgContext {
 
         let mut root_arr = [0u8; 32];
         root_arr.copy_from_slice(mdu_root_bytes);
-        let y = reduce_bytes32_to_scalar(&root_arr);
-        let y_bytes = scalar_to_bytes_be(&y);
+        let y_bytes = encode_mdu_root_for_root_table(&root_arr)?;
 
         let z_bytes = crate::utils::z_for_cell(mdu_index);
         self.verify_proof(manifest_commitment_bytes, &z_bytes, &y_bytes, proof_bytes)
+    }
+
+    pub fn compute_mdu0_root_table_proof(
+        &self,
+        mdu0_bytes: &[u8],
+        mdu_index: u64,
+        target_mdu_root_bytes: &[u8],
+    ) -> Result<Mdu0RootTableProof, KzgError> {
+        if mdu0_bytes.len() != MDU_SIZE || target_mdu_root_bytes.len() != 32 {
+            return Err(KzgError::InvalidDataLength);
+        }
+
+        let position = root_table_position_for_mdu_index(mdu_index)?;
+        let mut target_mdu_root = [0u8; 32];
+        target_mdu_root.copy_from_slice(target_mdu_root_bytes);
+        let expected_y = encode_mdu_root_for_root_table(&target_mdu_root)?;
+
+        let commitments = self.mdu_to_kzg_commitments(mdu0_bytes)?;
+        let root_table_du_commitment = commitments[position.root_table_du];
+
+        let leaves: Vec<[u8; 32]> = commitments
+            .iter()
+            .map(|c| Blake2s256Hasher::hash(c))
+            .collect();
+        let merkle_tree = MerkleTree::<Blake2s256Hasher>::from_leaves(&leaves);
+        let root_table_du_merkle_proof = merkle_tree.proof(&[position.root_table_du]).to_bytes();
+
+        let start = position.root_table_du * BLOB_SIZE;
+        let root_table_du_blob = &mdu0_bytes[start..start + BLOB_SIZE];
+        let z_bytes = crate::utils::z_for_cell(position.root_table_cell);
+        let (root_table_opening_proof, root_table_opening_y) =
+            self.compute_proof(root_table_du_blob, &z_bytes)?;
+
+        if root_table_opening_y != expected_y {
+            return Err(KzgError::Internal(
+                "root-table cell does not match target MDU root".into(),
+            ));
+        }
+
+        Ok(Mdu0RootTableProof {
+            position,
+            target_mdu_root,
+            root_table_du_commitment,
+            root_table_du_merkle_proof,
+            root_table_opening_proof,
+            root_table_opening_y,
+        })
+    }
+
+    pub fn verify_mdu0_root_table_proof(
+        &self,
+        polyfs_root_bytes: &[u8],
+        mdu_index: u64,
+        target_mdu_root_bytes: &[u8],
+        root_table_du_commitment_bytes: &[u8],
+        root_table_du_merkle_proof_bytes: &[u8],
+        root_table_opening_proof_bytes: &[u8],
+    ) -> Result<bool, KzgError> {
+        if polyfs_root_bytes.len() != 32
+            || target_mdu_root_bytes.len() != 32
+            || root_table_du_commitment_bytes.len() != 48
+            || root_table_opening_proof_bytes.len() != 48
+        {
+            return Err(KzgError::InvalidDataLength);
+        }
+
+        let position = root_table_position_for_mdu_index(mdu_index)?;
+
+        let merkle_ok = Self::verify_mdu_merkle_proof(
+            polyfs_root_bytes,
+            root_table_du_commitment_bytes,
+            position.root_table_du,
+            root_table_du_merkle_proof_bytes,
+            BLOBS_PER_MDU,
+        )?;
+        if !merkle_ok {
+            return Ok(false);
+        }
+
+        let mut target_mdu_root = [0u8; 32];
+        target_mdu_root.copy_from_slice(target_mdu_root_bytes);
+        let expected_y = encode_mdu_root_for_root_table(&target_mdu_root)?;
+        let z_bytes = crate::utils::z_for_cell(position.root_table_cell);
+
+        self.verify_proof(
+            root_table_du_commitment_bytes,
+            &z_bytes,
+            &expected_y,
+            root_table_opening_proof_bytes,
+        )
     }
 
     pub fn verify_mdu_merkle_proof(
@@ -739,6 +850,35 @@ impl KzgContext {
 
         Ok(merkle_proof.verify(root_array, &indices, &leaves, num_leaves))
     }
+}
+
+pub fn root_table_position_for_mdu_index(mdu_index: u64) -> Result<RootTablePosition, KzgError> {
+    if mdu_index == 0 || mdu_index > MDU0_ROOT_TABLE_CAPACITY {
+        return Err(KzgError::InvalidMduIndex);
+    }
+
+    let root_table_index_u64 = mdu_index - 1;
+    let root_table_index =
+        usize::try_from(root_table_index_u64).map_err(|_| KzgError::InvalidMduIndex)?;
+    let root_table_du = root_table_index / SCALARS_PER_BLOB;
+    let root_table_cell = root_table_index % SCALARS_PER_BLOB;
+
+    Ok(RootTablePosition {
+        mdu_index,
+        root_table_index,
+        root_table_du,
+        root_table_cell,
+    })
+}
+
+pub fn encode_mdu_root_for_root_table(mdu_root_bytes: &[u8]) -> Result<Bytes32, KzgError> {
+    if mdu_root_bytes.len() != 32 {
+        return Err(KzgError::InvalidDataLength);
+    }
+
+    let mut root = [0u8; 32];
+    root.copy_from_slice(mdu_root_bytes);
+    Ok(scalar_to_bytes_be(&reduce_bytes32_to_scalar(&root)))
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -1497,12 +1637,10 @@ fn webgpu_serialize_g1(point: &G1Affine) -> [u8; WEBGPU_G1_GPU_BYTES] {
     z_le[0] = 1;
 
     let mut out = [0u8; WEBGPU_G1_GPU_BYTES];
-    out[0..WEBGPU_FQ_GPU_BYTES]
-        .copy_from_slice(&webgpu_be_coord_to_gpu_limbs(&uncompressed[..48]));
+    out[0..WEBGPU_FQ_GPU_BYTES].copy_from_slice(&webgpu_be_coord_to_gpu_limbs(&uncompressed[..48]));
     out[WEBGPU_FQ_GPU_PADDED_BYTES..WEBGPU_FQ_GPU_PADDED_BYTES + WEBGPU_FQ_GPU_BYTES]
         .copy_from_slice(&webgpu_be_coord_to_gpu_limbs(&uncompressed[48..96]));
-    out[2 * WEBGPU_FQ_GPU_PADDED_BYTES
-        ..2 * WEBGPU_FQ_GPU_PADDED_BYTES + WEBGPU_FQ_GPU_BYTES]
+    out[2 * WEBGPU_FQ_GPU_PADDED_BYTES..2 * WEBGPU_FQ_GPU_PADDED_BYTES + WEBGPU_FQ_GPU_BYTES]
         .copy_from_slice(&webgpu_fq_bytes_to_13bit(&z_le));
     out
 }
@@ -1511,24 +1649,22 @@ fn webgpu_deserialize_g1(bytes: &[u8]) -> Result<G1Projective, KzgError> {
     if bytes.len() != WEBGPU_G1_GPU_BYTES {
         return Err(KzgError::InvalidDataLength);
     }
-    let z = &bytes[2 * WEBGPU_FQ_GPU_PADDED_BYTES
-        ..2 * WEBGPU_FQ_GPU_PADDED_BYTES + WEBGPU_FQ_GPU_BYTES];
+    let z = &bytes
+        [2 * WEBGPU_FQ_GPU_PADDED_BYTES..2 * WEBGPU_FQ_GPU_PADDED_BYTES + WEBGPU_FQ_GPU_BYTES];
     if z.iter().all(|byte| *byte == 0) {
         return Ok(G1Projective::identity());
     }
 
     let x_be = webgpu_gpu_limbs_to_be_coord(&bytes[0..WEBGPU_FQ_GPU_BYTES]);
     let y_be = webgpu_gpu_limbs_to_be_coord(
-        &bytes[WEBGPU_FQ_GPU_PADDED_BYTES
-            ..WEBGPU_FQ_GPU_PADDED_BYTES + WEBGPU_FQ_GPU_BYTES],
+        &bytes[WEBGPU_FQ_GPU_PADDED_BYTES..WEBGPU_FQ_GPU_PADDED_BYTES + WEBGPU_FQ_GPU_BYTES],
     );
     let mut uncompressed = [0u8; 96];
     uncompressed[..48].copy_from_slice(&x_be);
     uncompressed[48..].copy_from_slice(&y_be);
 
     let affine: Option<G1Affine> = Option::from(G1Affine::from_uncompressed(&uncompressed));
-    let affine = affine
-        .ok_or(KzgError::Internal("Invalid WebGPU G1 point".into()))?;
+    let affine = affine.ok_or(KzgError::Internal("Invalid WebGPU G1 point".into()))?;
     Ok(G1Projective::from(affine))
 }
 

--- a/polystore_core/tests/mdu0_root_table_test.rs
+++ b/polystore_core/tests/mdu0_root_table_test.rs
@@ -2,6 +2,7 @@ use polystore_core::kzg::{
     BLOB_SIZE, BLOBS_PER_MDU, KzgContext, MDU_SIZE, MDU0_ROOT_TABLE_CAPACITY,
     encode_mdu_root_for_root_table, root_table_position_for_mdu_index,
 };
+use std::ffi::CString;
 use std::path::PathBuf;
 use std::time::Instant;
 
@@ -31,6 +32,11 @@ fn polyfs_root_for_mdu0(ctx: &KzgContext, mdu0: &[u8]) -> [u8; 32] {
     let commitments = ctx.mdu_to_kzg_commitments(mdu0).unwrap();
     assert_eq!(commitments.len(), BLOBS_PER_MDU);
     ctx.create_mdu_merkle_root(&commitments).unwrap()
+}
+
+fn init_ffi_context() {
+    let path = CString::new(trusted_setup_path().to_str().unwrap()).unwrap();
+    assert_eq!(polystore_core::ffi::polystore_init(path.as_ptr()), 0);
 }
 
 #[test]
@@ -258,6 +264,83 @@ fn old_flat_manifest_boundary_fails_while_mdu0_path_passes() {
         )
         .unwrap();
     assert!(new_ok, "MDU #0 root-table path verifies mdu_index 4096");
+}
+
+#[test]
+fn ffi_mdu0_root_table_proof_round_trip_covers_high_index() {
+    init_ffi_context();
+
+    let mdu_index = 4097;
+    let target_root = test_root(0xab, mdu_index);
+    let mut mdu0 = vec![0u8; MDU_SIZE];
+    write_root_table_entry(&mut mdu0, mdu_index, &target_root);
+
+    let mut polyfs_root = [0u8; 32];
+    assert_eq!(
+        polystore_core::ffi::polystore_compute_mdu_merkle_root(
+            mdu0.as_ptr(),
+            mdu0.len(),
+            polyfs_root.as_mut_ptr(),
+        ),
+        0
+    );
+
+    let mut root_table_du_commitment = [0u8; 48];
+    let mut root_table_du_merkle_proof = [0u8; 6 * 32];
+    let mut root_table_du_merkle_proof_len = root_table_du_merkle_proof.len();
+    let mut root_table_opening_proof = [0u8; 48];
+    let mut root_table_opening_y = [0u8; 32];
+
+    assert_eq!(
+        polystore_core::ffi::polystore_compute_mdu0_root_table_proof(
+            mdu0.as_ptr(),
+            mdu0.len(),
+            mdu_index,
+            target_root.as_ptr(),
+            root_table_du_commitment.as_mut_ptr(),
+            root_table_du_merkle_proof.as_mut_ptr(),
+            &mut root_table_du_merkle_proof_len,
+            root_table_opening_proof.as_mut_ptr(),
+            root_table_opening_y.as_mut_ptr(),
+        ),
+        0
+    );
+    assert_eq!(root_table_du_merkle_proof_len, 6 * 32);
+    assert_eq!(
+        root_table_opening_y,
+        encode_mdu_root_for_root_table(&target_root).unwrap()
+    );
+
+    assert_eq!(
+        polystore_core::ffi::polystore_verify_mdu0_root_table_proof(
+            polyfs_root.as_ptr(),
+            mdu_index,
+            target_root.as_ptr(),
+            root_table_du_commitment.as_ptr(),
+            root_table_du_merkle_proof.as_ptr(),
+            root_table_du_merkle_proof_len,
+            root_table_opening_proof.as_ptr(),
+        ),
+        1
+    );
+
+    let mut undersized_merkle_proof = [0u8; 32];
+    let mut undersized_merkle_proof_len = undersized_merkle_proof.len();
+    assert_eq!(
+        polystore_core::ffi::polystore_compute_mdu0_root_table_proof(
+            mdu0.as_ptr(),
+            mdu0.len(),
+            mdu_index,
+            target_root.as_ptr(),
+            root_table_du_commitment.as_mut_ptr(),
+            undersized_merkle_proof.as_mut_ptr(),
+            &mut undersized_merkle_proof_len,
+            root_table_opening_proof.as_mut_ptr(),
+            root_table_opening_y.as_mut_ptr(),
+        ),
+        -7
+    );
+    assert_eq!(undersized_merkle_proof_len, 6 * 32);
 }
 
 #[test]

--- a/polystore_core/tests/mdu0_root_table_test.rs
+++ b/polystore_core/tests/mdu0_root_table_test.rs
@@ -169,6 +169,21 @@ fn mdu0_root_table_proof_rejects_tampering_and_invalid_indices() {
         .unwrap();
     assert!(!ok, "tampered MDU #0 DU merkle path must reject");
 
+    let mut malformed_merkle_proof = proof.root_table_du_merkle_proof.clone();
+    malformed_merkle_proof.push(0xff);
+    let malformed_result = ctx.verify_mdu0_root_table_proof(
+        &polyfs_root,
+        mdu_index,
+        &target_root,
+        &proof.root_table_du_commitment,
+        &malformed_merkle_proof,
+        &proof.root_table_opening_proof,
+    );
+    assert!(
+        malformed_result.is_err(),
+        "malformed MDU #0 DU merkle path length must reject"
+    );
+
     let mut tampered_target_root = target_root;
     tampered_target_root[0] ^= 0x01;
     let ok = ctx

--- a/polystore_core/tests/mdu0_root_table_test.rs
+++ b/polystore_core/tests/mdu0_root_table_test.rs
@@ -1,0 +1,352 @@
+use polystore_core::kzg::{
+    BLOB_SIZE, BLOBS_PER_MDU, KzgContext, MDU_SIZE, MDU0_ROOT_TABLE_CAPACITY,
+    encode_mdu_root_for_root_table, root_table_position_for_mdu_index,
+};
+use std::path::PathBuf;
+use std::time::Instant;
+
+fn trusted_setup_path() -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.pop();
+    path.push("demos");
+    path.push("kzg");
+    path.push("trusted_setup.txt");
+    path
+}
+
+fn test_root(tag: u8, mdu_index: u64) -> [u8; 32] {
+    let mut root = [tag; 32];
+    root[24..32].copy_from_slice(&mdu_index.to_be_bytes());
+    root
+}
+
+fn write_root_table_entry(mdu0: &mut [u8], mdu_index: u64, mdu_root: &[u8; 32]) {
+    let position = root_table_position_for_mdu_index(mdu_index).unwrap();
+    let encoded = encode_mdu_root_for_root_table(mdu_root).unwrap();
+    let offset = position.root_table_du * BLOB_SIZE + position.root_table_cell * 32;
+    mdu0[offset..offset + 32].copy_from_slice(&encoded);
+}
+
+fn polyfs_root_for_mdu0(ctx: &KzgContext, mdu0: &[u8]) -> [u8; 32] {
+    let commitments = ctx.mdu_to_kzg_commitments(mdu0).unwrap();
+    assert_eq!(commitments.len(), BLOBS_PER_MDU);
+    ctx.create_mdu_merkle_root(&commitments).unwrap()
+}
+
+#[test]
+fn root_table_position_boundaries() {
+    let first = root_table_position_for_mdu_index(1).unwrap();
+    assert_eq!(first.root_table_index, 0);
+    assert_eq!(first.root_table_du, 0);
+    assert_eq!(first.root_table_cell, 0);
+
+    let last_du0 = root_table_position_for_mdu_index(4096).unwrap();
+    assert_eq!(last_du0.root_table_index, 4095);
+    assert_eq!(last_du0.root_table_du, 0);
+    assert_eq!(last_du0.root_table_cell, 4095);
+
+    let first_du1 = root_table_position_for_mdu_index(4097).unwrap();
+    assert_eq!(first_du1.root_table_index, 4096);
+    assert_eq!(first_du1.root_table_du, 1);
+    assert_eq!(first_du1.root_table_cell, 0);
+
+    let near_cap = root_table_position_for_mdu_index(MDU0_ROOT_TABLE_CAPACITY).unwrap();
+    assert_eq!(near_cap.root_table_du, 15);
+    assert_eq!(near_cap.root_table_cell, 4095);
+
+    assert!(root_table_position_for_mdu_index(0).is_err());
+    assert!(root_table_position_for_mdu_index(MDU0_ROOT_TABLE_CAPACITY + 1).is_err());
+}
+
+#[test]
+fn mdu0_merkle_root_generation_covers_64_du_commitments() {
+    let ctx = KzgContext::load_from_file(trusted_setup_path()).unwrap();
+    let mut mdu0 = vec![0u8; MDU_SIZE];
+    write_root_table_entry(&mut mdu0, 1, &test_root(0x11, 1));
+    write_root_table_entry(&mut mdu0, 4097, &test_root(0x22, 4097));
+    write_root_table_entry(
+        &mut mdu0,
+        MDU0_ROOT_TABLE_CAPACITY,
+        &test_root(0x33, MDU0_ROOT_TABLE_CAPACITY),
+    );
+
+    let commitments = ctx.mdu_to_kzg_commitments(&mdu0).unwrap();
+    assert_eq!(commitments.len(), 64);
+    let polyfs_root = ctx.create_mdu_merkle_root(&commitments).unwrap();
+
+    let proof = ctx
+        .compute_mdu0_root_table_proof(&mdu0, 4097, &test_root(0x22, 4097))
+        .unwrap();
+    assert_eq!(proof.position.root_table_du, 1);
+    assert_eq!(proof.root_table_du_merkle_proof.len(), 6 * 32);
+
+    let ok = ctx
+        .verify_mdu0_root_table_proof(
+            &polyfs_root,
+            4097,
+            &test_root(0x22, 4097),
+            &proof.root_table_du_commitment,
+            &proof.root_table_du_merkle_proof,
+            &proof.root_table_opening_proof,
+        )
+        .unwrap();
+    assert!(ok);
+}
+
+#[test]
+fn valid_mdu0_root_table_proofs_cover_boundary_indices() {
+    let ctx = KzgContext::load_from_file(trusted_setup_path()).unwrap();
+    let indices = [1, 4096, 4097, MDU0_ROOT_TABLE_CAPACITY];
+    let mut mdu0 = vec![0u8; MDU_SIZE];
+    for (i, mdu_index) in indices.iter().copied().enumerate() {
+        write_root_table_entry(&mut mdu0, mdu_index, &test_root(0x40 + i as u8, mdu_index));
+    }
+    let polyfs_root = polyfs_root_for_mdu0(&ctx, &mdu0);
+
+    for (i, mdu_index) in indices.iter().copied().enumerate() {
+        let target_root = test_root(0x40 + i as u8, mdu_index);
+        let proof = ctx
+            .compute_mdu0_root_table_proof(&mdu0, mdu_index, &target_root)
+            .unwrap();
+
+        let ok = ctx
+            .verify_mdu0_root_table_proof(
+                &polyfs_root,
+                mdu_index,
+                &target_root,
+                &proof.root_table_du_commitment,
+                &proof.root_table_du_merkle_proof,
+                &proof.root_table_opening_proof,
+            )
+            .unwrap();
+        assert!(ok, "proof should verify for mdu_index {mdu_index}");
+    }
+}
+
+#[test]
+fn mdu0_root_table_proof_rejects_tampering_and_invalid_indices() {
+    let ctx = KzgContext::load_from_file(trusted_setup_path()).unwrap();
+    let mdu_index = 4097;
+    let target_root = test_root(0x77, mdu_index);
+    let mut mdu0 = vec![0u8; MDU_SIZE];
+    write_root_table_entry(&mut mdu0, mdu_index, &target_root);
+    let polyfs_root = polyfs_root_for_mdu0(&ctx, &mdu0);
+    let proof = ctx
+        .compute_mdu0_root_table_proof(&mdu0, mdu_index, &target_root)
+        .unwrap();
+
+    let mut tampered_polyfs_root = polyfs_root;
+    tampered_polyfs_root[0] ^= 0x01;
+    let ok = ctx
+        .verify_mdu0_root_table_proof(
+            &tampered_polyfs_root,
+            mdu_index,
+            &target_root,
+            &proof.root_table_du_commitment,
+            &proof.root_table_du_merkle_proof,
+            &proof.root_table_opening_proof,
+        )
+        .unwrap();
+    assert!(!ok, "tampered MDU #0 root must reject");
+
+    let mut tampered_merkle_proof = proof.root_table_du_merkle_proof.clone();
+    tampered_merkle_proof[0] ^= 0x01;
+    let ok = ctx
+        .verify_mdu0_root_table_proof(
+            &polyfs_root,
+            mdu_index,
+            &target_root,
+            &proof.root_table_du_commitment,
+            &tampered_merkle_proof,
+            &proof.root_table_opening_proof,
+        )
+        .unwrap();
+    assert!(!ok, "tampered MDU #0 DU merkle path must reject");
+
+    let mut tampered_target_root = target_root;
+    tampered_target_root[0] ^= 0x01;
+    let ok = ctx
+        .verify_mdu0_root_table_proof(
+            &polyfs_root,
+            mdu_index,
+            &tampered_target_root,
+            &proof.root_table_du_commitment,
+            &proof.root_table_du_merkle_proof,
+            &proof.root_table_opening_proof,
+        )
+        .unwrap();
+    assert!(!ok, "tampered target MDU root must reject");
+
+    let mut tampered_opening = proof.root_table_opening_proof;
+    tampered_opening[0] ^= 0x01;
+    let result = ctx.verify_mdu0_root_table_proof(
+        &polyfs_root,
+        mdu_index,
+        &target_root,
+        &proof.root_table_du_commitment,
+        &proof.root_table_du_merkle_proof,
+        &tampered_opening,
+    );
+    assert!(
+        !matches!(result, Ok(true)),
+        "tampered root-table KZG proof must reject"
+    );
+
+    let wrong_cell_result = ctx
+        .verify_mdu0_root_table_proof(
+            &polyfs_root,
+            mdu_index + 1,
+            &target_root,
+            &proof.root_table_du_commitment,
+            &proof.root_table_du_merkle_proof,
+            &proof.root_table_opening_proof,
+        )
+        .unwrap();
+    assert!(!wrong_cell_result, "wrong root-table cell must reject");
+
+    assert!(
+        ctx.verify_mdu0_root_table_proof(
+            &polyfs_root,
+            MDU0_ROOT_TABLE_CAPACITY + 1,
+            &target_root,
+            &proof.root_table_du_commitment,
+            &proof.root_table_du_merkle_proof,
+            &proof.root_table_opening_proof,
+        )
+        .is_err(),
+        "out-of-range root-table index must reject"
+    );
+}
+
+#[test]
+fn old_flat_manifest_boundary_fails_while_mdu0_path_passes() {
+    let ctx = KzgContext::load_from_file(trusted_setup_path()).unwrap();
+    let mdu_index = 4096;
+    let target_root = test_root(0x99, mdu_index);
+
+    let mut old_roots = vec![[0u8; 32]; 4097];
+    old_roots[mdu_index as usize] = target_root;
+    let (flat_commitment, flat_manifest_blob) =
+        ctx.compute_manifest_commitment(&old_roots).unwrap();
+    let (flat_proof, _) = ctx
+        .compute_proof(&flat_manifest_blob, &polystore_core::utils::z_for_cell(0))
+        .unwrap();
+    let old_ok = ctx
+        .verify_manifest_inclusion(
+            &flat_commitment,
+            &target_root,
+            mdu_index as usize,
+            &flat_proof,
+        )
+        .unwrap();
+    assert!(!old_ok, "old flat manifest verifier rejects mdu_index 4096");
+
+    let mut mdu0 = vec![0u8; MDU_SIZE];
+    write_root_table_entry(&mut mdu0, mdu_index, &target_root);
+    let polyfs_root = polyfs_root_for_mdu0(&ctx, &mdu0);
+    let proof = ctx
+        .compute_mdu0_root_table_proof(&mdu0, mdu_index, &target_root)
+        .unwrap();
+    let new_ok = ctx
+        .verify_mdu0_root_table_proof(
+            &polyfs_root,
+            mdu_index,
+            &target_root,
+            &proof.root_table_du_commitment,
+            &proof.root_table_du_merkle_proof,
+            &proof.root_table_opening_proof,
+        )
+        .unwrap();
+    assert!(new_ok, "MDU #0 root-table path verifies mdu_index 4096");
+}
+
+#[test]
+#[ignore = "prints local timing/proof-size evidence for issue #214 PR body"]
+fn performance_evidence_mdu0_root_table_verifier() {
+    let ctx = KzgContext::load_from_file(trusted_setup_path()).unwrap();
+    let small_index = 1u64;
+    let high_index = 4097u64;
+    let small_root = test_root(0xa1, small_index);
+    let high_root = test_root(0xa2, high_index);
+
+    let mut mdu0 = vec![0u8; MDU_SIZE];
+    write_root_table_entry(&mut mdu0, small_index, &small_root);
+    write_root_table_entry(&mut mdu0, high_index, &high_root);
+    let polyfs_root = polyfs_root_for_mdu0(&ctx, &mdu0);
+    let small_proof = ctx
+        .compute_mdu0_root_table_proof(&mdu0, small_index, &small_root)
+        .unwrap();
+    let high_proof = ctx
+        .compute_mdu0_root_table_proof(&mdu0, high_index, &high_root)
+        .unwrap();
+
+    let mut old_roots = vec![[0u8; 32]; 2];
+    old_roots[small_index as usize] = small_root;
+    let (flat_commitment, flat_manifest_blob) =
+        ctx.compute_manifest_commitment(&old_roots).unwrap();
+    let (flat_proof, _) = ctx
+        .compute_proof(
+            &flat_manifest_blob,
+            &polystore_core::utils::z_for_cell(small_index as usize),
+        )
+        .unwrap();
+
+    let iterations = 10u32;
+
+    let start = Instant::now();
+    for _ in 0..iterations {
+        assert!(
+            ctx.verify_manifest_inclusion(
+                &flat_commitment,
+                &small_root,
+                small_index as usize,
+                &flat_proof,
+            )
+            .unwrap()
+        );
+    }
+    let old_small_us = start.elapsed().as_micros() as f64 / f64::from(iterations);
+
+    let start = Instant::now();
+    for _ in 0..iterations {
+        assert!(
+            ctx.verify_mdu0_root_table_proof(
+                &polyfs_root,
+                small_index,
+                &small_root,
+                &small_proof.root_table_du_commitment,
+                &small_proof.root_table_du_merkle_proof,
+                &small_proof.root_table_opening_proof,
+            )
+            .unwrap()
+        );
+    }
+    let new_small_us = start.elapsed().as_micros() as f64 / f64::from(iterations);
+
+    let start = Instant::now();
+    for _ in 0..iterations {
+        assert!(
+            ctx.verify_mdu0_root_table_proof(
+                &polyfs_root,
+                high_index,
+                &high_root,
+                &high_proof.root_table_du_commitment,
+                &high_proof.root_table_du_merkle_proof,
+                &high_proof.root_table_opening_proof,
+            )
+            .unwrap()
+        );
+    }
+    let new_high_us = start.elapsed().as_micros() as f64 / f64::from(iterations);
+
+    let old_hop1_payload_bytes = 32 + 48;
+    let new_hop1_payload_bytes = 32 + 48 + small_proof.root_table_du_merkle_proof.len() + 48;
+
+    println!(
+        "old_flat_small_avg_us={old_small_us:.2} new_mdu0_small_avg_us={new_small_us:.2} new_mdu0_high_avg_us={new_high_us:.2}"
+    );
+    println!(
+        "old_hop1_payload_bytes={old_hop1_payload_bytes} new_hop1_payload_bytes={new_hop1_payload_bytes} delta_bytes={}",
+        new_hop1_payload_bytes as isize - old_hop1_payload_bytes as isize
+    );
+}


### PR DESCRIPTION
Part of #212.
Closes #214 after the stack is merged to `main`.

## Current Status (2026-06-23)

#219 / #213 has merged to `main`, and this PR is now retargeted to `main`.

Current head `342b0b9a` merges current `origin/main` (`27b31a7c`, including #219 and #223) into `core/mdu0-root-table-verifier`. The implementation code is unchanged from the reviewed core verifier head except for the final-base merge.

Local validation on `342b0b9a` passed:

```bash
cd polystore_core
cargo fmt --check
cargo test --test mdu0_root_table_test
cargo test
cd ..
git diff --check origin/main...HEAD
```

Results:

- `mdu0_root_table_test`: 6 passed, 1 ignored timing test.
- Full `polystore_core` suite: passed.
- Formatting and diff whitespace checks passed.

Current merge gate:

- Latest-head GitHub CI is green on `342b0b9a` after the final-base retarget.
- Codex GitHub review at `342b0b9a` found no major issues.
- Human review/approval and human merge are still required by repo policy.

## Scope

Adds the `polystore_core` V2 Hop 1 verifier surface for:

```text
polyfs_root -> MDU #0 root-table DU commitment -> target MDU root
```

Implemented:

- Root-table position helper for `mdu_index` values `1..=65536`.
- Deterministic `encode_mdu_root_for_root_table` helper matching the #213 `ReduceMduRootToFr` contract.
- Rust proof struct/helper for computing MDU #0 root-table proof material.
- Rust verifier for the MDU #0 Merkle hop plus root-table KZG opening.
- Rejection for malformed Merkle proof byte paths with non-32-byte remainders.
- C FFI entry points:
  - `polystore_compute_mdu0_root_table_proof`
  - `polystore_verify_mdu0_root_table_proof`
- Focused tests for boundaries, tampering, out-of-range rejection, malformed proof length, old flat-manifest boundary regression, and exported FFI compute/verify round trip.

Deliberately left out for downstream PRs:

- Proto/generated Go proof-shape changes (#215).
- Go FFI binding updates (#215).
- Gateway runtime proof generation and `manifest.bin` removal/quarantine (#216).
- Devnet rollout/update work (#217/#218).

## Boundary Evidence

Covered by `polystore_core/tests/mdu0_root_table_test.rs`:

- `mdu_index == 1` maps to DU 0 / cell 0.
- `mdu_index == 4096` maps to DU 0 / cell 4095.
- `mdu_index == 4097` maps to DU 1 / cell 0.
- `mdu_index == 65536` maps to DU 15 / cell 4095.
- `mdu_index == 0` and `65537` reject.
- Old flat manifest verifier rejects `mdu_index == 4096`; new MDU #0 path verifies it.
- A root-table DU Merkle proof with trailing non-32-byte garbage rejects.
- FFI round trip verifies a high-index `mdu_index == 4097` proof and reports the required Merkle-proof buffer length when the caller buffer is undersized.

## Performance Evidence

Command:

```bash
cargo test --release --manifest-path polystore_core/Cargo.toml --test mdu0_root_table_test performance_evidence_mdu0_root_table_verifier -- --ignored --nocapture
```

Observed on this machine:

| Case | Avg verify time |
| --- | ---: |
| Old flat Hop 1, small in-bound index | 3963.00 us |
| New MDU #0 Hop 1, small index | 4054.40 us |
| New MDU #0 Hop 1, `mdu_index == 4097` | 3942.80 us |

Payload note for Hop 1 material in this representation:

| Path | Bytes |
| --- | ---: |
| Old flat Hop 1 (`mdu_root` + manifest KZG proof) | 80 |
| New MDU #0 Hop 1 (`mdu_root` + DU commitment + MDU0 Merkle path + root-table KZG proof) | 320 |
| Delta | +240 |

The extra bytes are expected because the new path carries MDU #0 Merkle inclusion plus the root-table DU commitment.

