### PR TITLE
devnet: add full stack rollout script

### DIFF
--- a/docs/devnet-polyfs-root-rollout.md
+++ b/docs/devnet-polyfs-root-rollout.md
@@ -21,7 +21,7 @@ It restarts services in this order:
 6. Preflight hub root service units with non-mutating, non-sudo `systemctl show`, including dry-runs, so a missing chain, faucet, or legacy router unit cannot abort after provider-daemons are already stopped.
 7. If `--restart-tunnels` is supplied, preflight tunnel user service units with non-mutating `systemctl --user show`.
 8. Resolve `provider-daemon` service managers with non-mutating unit checks, including dry-runs. The default `auto` mode resolves the local user-service provider layout; the checked-in root provider template must be selected explicitly with `POLYSTORE_PROVIDER_SERVICE_SCOPE=root`.
-9. Derive default provider health targets from known resolved service names unless `POLYSTORE_PROVIDER_BASES` is set. Unknown custom service names require explicit bases, and duplicate provider health bases fail before any service-stop mutation.
+9. Derive default provider health targets from known resolved service names unless `POLYSTORE_PROVIDER_BASES` is set. Unknown custom service names require explicit bases, and duplicate canonical provider health bases fail before any service-stop mutation.
 10. Preflight root service control. Live non-root runs must prove passwordless sudo authorization for the exact hub and root-managed `provider-daemon` `systemctl stop/start` actions before any `provider-daemon` is stopped.
 11. If `--restart-tunnels` is supplied, stop tunnel user services before taking down the devnet stack.
 12. Stop `provider-daemon` services from their resolved manager: user services such as `polystore-provider1.service` through `polystore-provider4.service`, or root services such as `polystore-gateway-provider.service`.
@@ -42,7 +42,7 @@ templates:
 - EVM JSON-RPC: `http://127.0.0.1:8545`
 - `user-gateway` via legacy router service: `http://127.0.0.1:8080`
 - Faucet: `http://127.0.0.1:8081`
-- `provider-daemon` services: derived from resolved provider service names. The four local user-provider layout maps `polystore-provider1.service` through `polystore-provider4.service` to `8091` through `8094`; the checked-in single root-provider template maps `polystore-gateway-provider.service` to `8091`. If a configured provider inventory resolves two services to the same health base, the rollout exits before stopping services.
+- `provider-daemon` services: derived from resolved provider service names. The four local user-provider layout maps `polystore-provider1.service` through `polystore-provider4.service` to `8091` through `8094`; the checked-in single root-provider template maps `polystore-gateway-provider.service` to `8091`. If a configured provider inventory resolves two services to the same canonical health base, including `localhost`/`127.0.0.1` aliases or omitted default ports, the rollout exits before stopping services.
 
 Override these with `POLYSTORE_RPC_BASE`, `POLYSTORE_LCD_BASE`,
 `POLYSTORE_EVM_BASE`, `POLYSTORE_ROUTER_BASE`, `POLYSTORE_FAUCET_BASE`, and
@@ -54,7 +54,7 @@ env binds the managed devnet `user-gateway` to another port such as `18080`, set
 Set `POLYSTORE_PROVIDER_BASES` when a host's provider ports do not follow the
 default known service-name mapping or when using custom provider service names.
 When set, it must provide exactly one base URL for each resolved
-`provider-daemon` service, and every base must be unique, so rollout
+`provider-daemon` service, and every canonical base must be unique, so rollout
 healthchecks cannot silently poll one surviving endpoint twice while skipping a
 restarted provider.
 

--- a/docs/devnet-polyfs-root-rollout.md
+++ b/docs/devnet-polyfs-root-rollout.md
@@ -18,7 +18,7 @@ It restarts services in this order:
 3. Preflight all build artifacts before stopping any service.
 4. Preflight the install plan. If a source artifact is already the target path, the later install step skips it instead of failing after services stop.
 5. Preflight root service control. Live non-root runs must prove `sudo -n systemctl` works before any `provider-daemon` is stopped.
-6. Resolve `provider-daemon` service managers. The default `auto` mode supports both the local user-service provider layout and the checked-in root provider template.
+6. Resolve `provider-daemon` service managers. The default `auto` mode resolves the local user-service provider layout; the checked-in root provider template must be selected explicitly with `POLYSTORE_PROVIDER_SERVICE_SCOPE=root`.
 7. Derive default provider health targets from the resolved service count unless `POLYSTORE_PROVIDER_BASES` is set.
 8. Stop `provider-daemon` services from their resolved manager: user services such as `polystore-provider1.service` through `polystore-provider4.service`, or root services such as `polystore-gateway-provider.service`.
 9. Stop hub services: `polystore-gateway-router.service` (legacy service alias for the `user-gateway` persona), `polystore-faucet.service`, then `polystorechaind.service`.
@@ -55,6 +55,9 @@ Provider service management is controlled by `POLYSTORE_PROVIDER_SERVICE_SCOPE`:
 - `root`: require every configured provider service to exist in the root systemd manager. With the checked-in provider template, use this with `POLYSTORE_PROVIDER_SERVICES=polystore-gateway-provider.service`.
 
 If a service name exists in both managers, `auto` exits before stopping services; set the scope explicitly for that host.
+The default `auto` inventory intentionally does not include the checked-in root
+provider template, because a loaded-but-unused root template can collide with
+the four user-provider devnet layout on port `8091`.
 
 ## State Policy
 

--- a/docs/devnet-polyfs-root-rollout.md
+++ b/docs/devnet-polyfs-root-rollout.md
@@ -21,7 +21,7 @@ It restarts services in this order:
 6. Preflight root service control. Live non-root runs must prove `sudo -n systemctl` works before any `provider-daemon` is stopped.
 7. Preflight hub root service units so a missing chain, faucet, or legacy router unit cannot abort after provider-daemons are already stopped.
 8. Resolve `provider-daemon` service managers. The default `auto` mode resolves the local user-service provider layout; the checked-in root provider template must be selected explicitly with `POLYSTORE_PROVIDER_SERVICE_SCOPE=root`.
-9. Derive default provider health targets from the resolved service count unless `POLYSTORE_PROVIDER_BASES` is set.
+9. Derive default provider health targets from known resolved service names unless `POLYSTORE_PROVIDER_BASES` is set. Unknown custom service names require explicit bases.
 10. Stop `provider-daemon` services from their resolved manager: user services such as `polystore-provider1.service` through `polystore-provider4.service`, or root services such as `polystore-gateway-provider.service`.
 11. Stop hub services: `polystore-gateway-router.service` (legacy service alias for the `user-gateway` persona), `polystore-faucet.service`, then `polystorechaind.service`.
 12. Install artifacts with backups and sha256 evidence.
@@ -39,7 +39,7 @@ templates:
 - EVM JSON-RPC: `http://127.0.0.1:8545`
 - `user-gateway` via legacy router service: `http://127.0.0.1:8080`
 - Faucet: `http://127.0.0.1:8081`
-- `provider-daemon` services: derived from resolved provider services, starting at `http://127.0.0.1:8091`. The four local user-provider layout resolves to `8091` through `8094`; the checked-in single root-provider template resolves to `8091`.
+- `provider-daemon` services: derived from resolved provider service names. The four local user-provider layout maps `polystore-provider1.service` through `polystore-provider4.service` to `8091` through `8094`; the checked-in single root-provider template maps `polystore-gateway-provider.service` to `8091`.
 
 Override these with `POLYSTORE_RPC_BASE`, `POLYSTORE_LCD_BASE`,
 `POLYSTORE_EVM_BASE`, `POLYSTORE_ROUTER_BASE`, `POLYSTORE_FAUCET_BASE`, and
@@ -49,9 +49,10 @@ Override these with `POLYSTORE_RPC_BASE`, `POLYSTORE_LCD_BASE`,
 env binds the managed devnet `user-gateway` to another port such as `18080`, set
 `POLYSTORE_ROUTER_BASE` explicitly before running the rollout.
 Set `POLYSTORE_PROVIDER_BASES` when a host's provider ports do not follow the
-default one-port-per-resolved-service sequence. When set, it must provide
-exactly one base URL for each resolved `provider-daemon` service so rollout
-healthchecks cannot silently skip a restarted provider.
+default known service-name mapping or when using custom provider service names.
+When set, it must provide exactly one base URL for each resolved
+`provider-daemon` service so rollout healthchecks cannot silently skip a
+restarted provider.
 
 Provider service management is controlled by `POLYSTORE_PROVIDER_SERVICE_SCOPE`:
 

--- a/docs/devnet-polyfs-root-rollout.md
+++ b/docs/devnet-polyfs-root-rollout.md
@@ -22,6 +22,19 @@ It restarts services in this order:
 
 Tunnel services are not restarted by default. Use `--restart-tunnels` only when endpoint or tunnel config changes.
 
+The default health endpoints match the current local devnet on this machine:
+
+- LCD: `http://127.0.0.1:1317`
+- Router gateway: `http://127.0.0.1:18080`
+- Faucet: `http://127.0.0.1:8081`
+- Providers: `http://127.0.0.1:8091` through `http://127.0.0.1:8094`
+
+Override these with `POLYSTORE_LCD_BASE`, `POLYSTORE_ROUTER_BASE`,
+`POLYSTORE_FAUCET_BASE`, and `POLYSTORE_PROVIDER_BASES` if a target machine uses
+different ports. The checked-in systemd template still documents `8080` as a
+generic router example; this machine's live `/etc/polystore` router env binds
+the managed devnet router to `18080`.
+
 ## State Policy
 
 The PolyFS root migration changes the trust root for new deals from the retired flat `manifest.bin` commitment to the MDU #0 PolyFS root. The rollout script is intentionally a binary/runtime rollout tool; it does not reset chain state and it does not silently migrate old committed deals.

--- a/docs/devnet-polyfs-root-rollout.md
+++ b/docs/devnet-polyfs-root-rollout.md
@@ -24,16 +24,19 @@ Tunnel services are not restarted by default. Use `--restart-tunnels` only when 
 
 The default health endpoints match the current local devnet on this machine:
 
+- RPC: `http://127.0.0.1:26657`
 - LCD: `http://127.0.0.1:1317`
+- EVM JSON-RPC: `http://127.0.0.1:8545`
 - Router gateway: `http://127.0.0.1:18080`
 - Faucet: `http://127.0.0.1:8081`
 - Providers: `http://127.0.0.1:8091` through `http://127.0.0.1:8094`
 
-Override these with `POLYSTORE_LCD_BASE`, `POLYSTORE_ROUTER_BASE`,
-`POLYSTORE_FAUCET_BASE`, and `POLYSTORE_PROVIDER_BASES` if a target machine uses
-different ports. The checked-in systemd template still documents `8080` as a
-generic router example; this machine's live `/etc/polystore` router env binds
-the managed devnet router to `18080`.
+Override these with `POLYSTORE_RPC_BASE`, `POLYSTORE_LCD_BASE`,
+`POLYSTORE_EVM_BASE`, `POLYSTORE_ROUTER_BASE`, `POLYSTORE_FAUCET_BASE`, and
+`POLYSTORE_PROVIDER_BASES` if a target machine uses different ports. The
+checked-in systemd template still documents `8080` as a generic router example;
+this machine's live `/etc/polystore` router env binds the managed devnet router
+to `18080`.
 
 ## State Policy
 

--- a/docs/devnet-polyfs-root-rollout.md
+++ b/docs/devnet-polyfs-root-rollout.md
@@ -104,3 +104,6 @@ that check without requiring a sudo prompt.
 Dry-runs and live runs both verify that all configured hub root service units
 are loaded. Live runs also verify that `curl` is available before any
 service-stop mutation.
+Final `systemctl is-active` status probes are best-effort evidence after the
+healthchecks have passed; a restricted sudoers policy for status commands should
+not mark an otherwise healthy rollout as failed.

--- a/docs/devnet-polyfs-root-rollout.md
+++ b/docs/devnet-polyfs-root-rollout.md
@@ -14,18 +14,20 @@ The script rebuilds as the configured run user, then installs:
 It restarts services in this order:
 
 1. Preflight source/target layout. Build mode refuses `--source-root == --target-root` so live artifacts are not overwritten while services are still running.
-2. Build artifacts as `--run-user`/`POLYSTORE_RUN_USER`; when invoked with `sudo`, this avoids root-owned Cargo/Go outputs in the source checkout.
-3. Preflight all build artifacts before stopping any service.
-4. Preflight the install plan. If a source artifact is already the target path, the later install step skips it instead of failing after services stop.
-5. Preflight root service control. Live non-root runs must prove `sudo -n systemctl` works before any `provider-daemon` is stopped.
-6. Resolve `provider-daemon` service managers. The default `auto` mode resolves the local user-service provider layout; the checked-in root provider template must be selected explicitly with `POLYSTORE_PROVIDER_SERVICE_SCOPE=root`.
-7. Derive default provider health targets from the resolved service count unless `POLYSTORE_PROVIDER_BASES` is set.
-8. Stop `provider-daemon` services from their resolved manager: user services such as `polystore-provider1.service` through `polystore-provider4.service`, or root services such as `polystore-gateway-provider.service`.
-9. Stop hub services: `polystore-gateway-router.service` (legacy service alias for the `user-gateway` persona), `polystore-faucet.service`, then `polystorechaind.service`.
-10. Install artifacts with backups and sha256 evidence.
-11. Start chain first.
-12. Start faucet and the `user-gateway` legacy router service.
-13. Start all resolved `provider-daemon` services, including provider4 when the local user-service layout is present.
+2. Preflight local command dependencies required for post-restart health polling, including `curl`.
+3. Build artifacts as `--run-user`/`POLYSTORE_RUN_USER`; when invoked with `sudo`, this avoids root-owned Cargo/Go outputs in the source checkout.
+4. Preflight all build artifacts before stopping any service.
+5. Preflight the install plan. If a source artifact is already the target path, the later install step skips it instead of failing after services stop.
+6. Preflight root service control. Live non-root runs must prove `sudo -n systemctl` works before any `provider-daemon` is stopped.
+7. Preflight hub root service units so a missing chain, faucet, or legacy router unit cannot abort after provider-daemons are already stopped.
+8. Resolve `provider-daemon` service managers. The default `auto` mode resolves the local user-service provider layout; the checked-in root provider template must be selected explicitly with `POLYSTORE_PROVIDER_SERVICE_SCOPE=root`.
+9. Derive default provider health targets from the resolved service count unless `POLYSTORE_PROVIDER_BASES` is set.
+10. Stop `provider-daemon` services from their resolved manager: user services such as `polystore-provider1.service` through `polystore-provider4.service`, or root services such as `polystore-gateway-provider.service`.
+11. Stop hub services: `polystore-gateway-router.service` (legacy service alias for the `user-gateway` persona), `polystore-faucet.service`, then `polystorechaind.service`.
+12. Install artifacts with backups and sha256 evidence.
+13. Start chain first.
+14. Start faucet and the `user-gateway` legacy router service.
+15. Start all resolved `provider-daemon` services, including provider4 when the local user-service layout is present.
 
 Tunnel services are not restarted by default. Use `--restart-tunnels` only when endpoint or tunnel config changes.
 
@@ -95,3 +97,5 @@ services are still running.
 In live non-root mode, the script also verifies passwordless `sudo systemctl`
 access before printing the service-stop plan. On this host, dry runs report that
 check without requiring a sudo prompt.
+Live runs also verify that all configured hub root service units are loaded and
+that `curl` is available before any service-stop mutation.

--- a/docs/devnet-polyfs-root-rollout.md
+++ b/docs/devnet-polyfs-root-rollout.md
@@ -18,10 +18,10 @@ It restarts services in this order:
 3. Build artifacts as `--run-user`/`POLYSTORE_RUN_USER`; when invoked with `sudo`, this avoids root-owned Cargo/Go outputs in the source checkout.
 4. Preflight all build artifacts before stopping any service.
 5. Preflight the install plan. If a source artifact is already the target path, the later install step skips it instead of failing after services stop.
-6. Preflight root service control. Live non-root runs must prove passwordless sudo authorization for the exact root `systemctl stop/start` actions before any `provider-daemon` is stopped.
-7. Preflight hub root service units with non-mutating `systemctl show`, including dry-runs, so a missing chain, faucet, or legacy router unit cannot abort after provider-daemons are already stopped.
-8. Resolve `provider-daemon` service managers. The default `auto` mode resolves the local user-service provider layout; the checked-in root provider template must be selected explicitly with `POLYSTORE_PROVIDER_SERVICE_SCOPE=root`.
-9. Derive default provider health targets from known resolved service names unless `POLYSTORE_PROVIDER_BASES` is set. Unknown custom service names require explicit bases.
+6. Preflight hub root service units with non-mutating `systemctl show`, including dry-runs, so a missing chain, faucet, or legacy router unit cannot abort after provider-daemons are already stopped.
+7. Resolve `provider-daemon` service managers. The default `auto` mode resolves the local user-service provider layout; the checked-in root provider template must be selected explicitly with `POLYSTORE_PROVIDER_SERVICE_SCOPE=root`.
+8. Derive default provider health targets from known resolved service names unless `POLYSTORE_PROVIDER_BASES` is set. Unknown custom service names require explicit bases.
+9. Preflight root service control. Live non-root runs must prove passwordless sudo authorization for the exact hub and root-managed `provider-daemon` `systemctl stop/start` actions before any `provider-daemon` is stopped.
 10. Stop `provider-daemon` services from their resolved manager: user services such as `polystore-provider1.service` through `polystore-provider4.service`, or root services such as `polystore-gateway-provider.service`.
 11. Stop hub services: `polystore-gateway-router.service` (legacy service alias for the `user-gateway` persona), `polystore-faucet.service`, then `polystorechaind.service`.
 12. Install artifacts with backups and sha256 evidence.
@@ -98,9 +98,9 @@ the stop plan and skipped during install. Without `--skip-build`, the script
 exits before building so it cannot partially overwrite live artifacts while
 services are still running.
 In live non-root mode, the script also verifies passwordless sudo authorization
-for the exact root `systemctl stop/start` actions before printing the
-service-stop plan. On this host, dry runs report that check without requiring a
-sudo prompt.
+for the exact hub and root-managed `provider-daemon` `systemctl stop/start`
+actions before printing the service-stop plan. On this host, dry runs report
+that check without requiring a sudo prompt.
 Dry-runs and live runs both verify that all configured hub root service units
 are loaded. Live runs also verify that `curl` is available before any
 service-stop mutation.

--- a/docs/devnet-polyfs-root-rollout.md
+++ b/docs/devnet-polyfs-root-rollout.md
@@ -30,8 +30,9 @@ It restarts services in this order:
 15. Start chain first.
 16. Start faucet and the `user-gateway` legacy router service.
 17. Start all resolved `provider-daemon` services, including provider4 when the local user-service layout is present.
+18. If `--restart-tunnels` is supplied, verify restarted tunnel user services are active before reporting `DONE`.
 
-Tunnel services are not restarted by default. Use `--restart-tunnels` only when endpoint or tunnel config changes. When enabled, tunnel user units must be loaded before any service-stop mutation, tunnel stop runs before the devnet stack is taken down, and tunnel stop/start failures are fatal because local healthchecks do not prove the public tunnel process restarted.
+Tunnel services are not restarted by default. Use `--restart-tunnels` only when endpoint or tunnel config changes. When enabled, tunnel user units must be loaded before any service-stop mutation, tunnel stop runs before the devnet stack is taken down, and tunnel stop/start plus post-restart `is-active` failures are fatal because local healthchecks do not prove the public tunnel process restarted.
 
 The default health endpoints match the checked-in local devnet and systemd
 templates:

--- a/docs/devnet-polyfs-root-rollout.md
+++ b/docs/devnet-polyfs-root-rollout.md
@@ -19,17 +19,18 @@ It restarts services in this order:
 4. Preflight all build artifacts before stopping any service.
 5. Preflight the install plan. If a source artifact is already the target path, the later install step skips it instead of failing after services stop.
 6. Preflight hub root service units with non-mutating, non-sudo `systemctl show`, including dry-runs, so a missing chain, faucet, or legacy router unit cannot abort after provider-daemons are already stopped.
-7. Resolve `provider-daemon` service managers. The default `auto` mode resolves the local user-service provider layout; the checked-in root provider template must be selected explicitly with `POLYSTORE_PROVIDER_SERVICE_SCOPE=root`.
-8. Derive default provider health targets from known resolved service names unless `POLYSTORE_PROVIDER_BASES` is set. Unknown custom service names require explicit bases.
-9. Preflight root service control. Live non-root runs must prove passwordless sudo authorization for the exact hub and root-managed `provider-daemon` `systemctl stop/start` actions before any `provider-daemon` is stopped.
-10. Stop `provider-daemon` services from their resolved manager: user services such as `polystore-provider1.service` through `polystore-provider4.service`, or root services such as `polystore-gateway-provider.service`.
-11. Stop hub services: `polystore-gateway-router.service` (legacy service alias for the `user-gateway` persona), `polystore-faucet.service`, then `polystorechaind.service`.
-12. Install artifacts with backups and sha256 evidence.
-13. Start chain first.
-14. Start faucet and the `user-gateway` legacy router service.
-15. Start all resolved `provider-daemon` services, including provider4 when the local user-service layout is present.
+7. If `--restart-tunnels` is supplied, preflight tunnel user service units with non-mutating `systemctl --user show`.
+8. Resolve `provider-daemon` service managers. The default `auto` mode resolves the local user-service provider layout; the checked-in root provider template must be selected explicitly with `POLYSTORE_PROVIDER_SERVICE_SCOPE=root`.
+9. Derive default provider health targets from known resolved service names unless `POLYSTORE_PROVIDER_BASES` is set. Unknown custom service names require explicit bases.
+10. Preflight root service control. Live non-root runs must prove passwordless sudo authorization for the exact hub and root-managed `provider-daemon` `systemctl stop/start` actions before any `provider-daemon` is stopped.
+11. Stop `provider-daemon` services from their resolved manager: user services such as `polystore-provider1.service` through `polystore-provider4.service`, or root services such as `polystore-gateway-provider.service`.
+12. Stop hub services: `polystore-gateway-router.service` (legacy service alias for the `user-gateway` persona), `polystore-faucet.service`, then `polystorechaind.service`.
+13. Install artifacts with backups and sha256 evidence.
+14. Start chain first.
+15. Start faucet and the `user-gateway` legacy router service.
+16. Start all resolved `provider-daemon` services, including provider4 when the local user-service layout is present.
 
-Tunnel services are not restarted by default. Use `--restart-tunnels` only when endpoint or tunnel config changes.
+Tunnel services are not restarted by default. Use `--restart-tunnels` only when endpoint or tunnel config changes. When enabled, tunnel user units must be loaded before any service-stop mutation, and tunnel stop/start failures are fatal because local healthchecks do not prove the public tunnel process restarted.
 
 The default health endpoints match the checked-in local devnet and systemd
 templates:
@@ -86,9 +87,10 @@ scripts/update_devnet_stack.sh --dry-run --skip-build
 ```
 
 This validates source layout, command dependencies, hub root unit inventory,
-provider health target derivation, and install preflight behavior, then prints
-the source commit, target paths, `provider-daemon` inventory, preflight artifact
-status, stop/start order, install paths, and healthcheck commands without
+optional tunnel user unit inventory, provider health target derivation, and
+install preflight behavior, then prints the source commit, target paths,
+`provider-daemon` inventory, preflight artifact status, stop/start order, install
+paths, and healthcheck commands without
 mutating services or files. If a required artifact is missing, the dry run exits
 before printing any service-stop plan, matching live rollout safety behavior.
 

--- a/docs/devnet-polyfs-root-rollout.md
+++ b/docs/devnet-polyfs-root-rollout.md
@@ -21,7 +21,7 @@ It restarts services in this order:
 6. Preflight hub root service units with non-mutating, non-sudo `systemctl show`, including dry-runs, so a missing chain, faucet, or legacy router unit cannot abort after provider-daemons are already stopped.
 7. If `--restart-tunnels` is supplied, preflight tunnel user service units with non-mutating `systemctl --user show`.
 8. Resolve `provider-daemon` service managers with non-mutating unit checks, including dry-runs. The default `auto` mode resolves the local user-service provider layout; the checked-in root provider template must be selected explicitly with `POLYSTORE_PROVIDER_SERVICE_SCOPE=root`.
-9. Derive default provider health targets from known resolved service names unless `POLYSTORE_PROVIDER_BASES` is set. Unknown custom service names require explicit bases, and duplicate canonical provider health bases fail before any service-stop mutation.
+9. Derive default provider health targets from known resolved service names unless `POLYSTORE_PROVIDER_BASES` is set. Unknown custom service names require explicit bases, and duplicate provider service names or duplicate canonical provider health bases fail before any service-stop mutation.
 10. Preflight root service control. Live non-root runs must prove passwordless sudo authorization for the exact hub and root-managed `provider-daemon` `systemctl stop/start` actions before any `provider-daemon` is stopped.
 11. If `--restart-tunnels` is supplied, stop tunnel user services before taking down the devnet stack.
 12. Stop `provider-daemon` services from their resolved manager: user services such as `polystore-provider1.service` through `polystore-provider4.service`, or root services such as `polystore-gateway-provider.service`.
@@ -42,7 +42,7 @@ templates:
 - EVM JSON-RPC: `http://127.0.0.1:8545`
 - `user-gateway` via legacy router service: `http://127.0.0.1:8080`
 - Faucet: `http://127.0.0.1:8081`
-- `provider-daemon` services: derived from resolved provider service names. The four local user-provider layout maps `polystore-provider1.service` through `polystore-provider4.service` to `8091` through `8094`; the checked-in single root-provider template maps `polystore-gateway-provider.service` to `8091`. If a configured provider inventory resolves two services to the same canonical health base, including `localhost`/`127.0.0.1` aliases or omitted default ports, the rollout exits before stopping services.
+- `provider-daemon` services: derived from resolved provider service names. The four local user-provider layout maps `polystore-provider1.service` through `polystore-provider4.service` to `8091` through `8094`; the checked-in single root-provider template maps `polystore-gateway-provider.service` to `8091`. If a configured provider inventory repeats a service name, or resolves two services to the same canonical health base including `localhost`/`127.0.0.1` aliases or omitted default ports, the rollout exits before stopping services.
 
 Override these with `POLYSTORE_RPC_BASE`, `POLYSTORE_LCD_BASE`,
 `POLYSTORE_EVM_BASE`, `POLYSTORE_ROUTER_BASE`, `POLYSTORE_FAUCET_BASE`, and
@@ -54,9 +54,9 @@ env binds the managed devnet `user-gateway` to another port such as `18080`, set
 Set `POLYSTORE_PROVIDER_BASES` when a host's provider ports do not follow the
 default known service-name mapping or when using custom provider service names.
 When set, it must provide exactly one base URL for each resolved
-`provider-daemon` service, and every canonical base must be unique, so rollout
-healthchecks cannot silently poll one surviving endpoint twice while skipping a
-restarted provider.
+`provider-daemon` service. Every configured service name and every canonical
+base must be unique, so rollout healthchecks cannot silently poll one surviving
+endpoint twice while skipping a restarted provider.
 
 Provider service management is controlled by `POLYSTORE_PROVIDER_SERVICE_SCOPE`:
 
@@ -91,7 +91,8 @@ scripts/update_devnet_stack.sh --dry-run --skip-build
 
 This validates source layout, command dependencies, hub root unit inventory,
 optional tunnel user unit inventory, `provider-daemon` unit inventory, provider
-health target derivation, and install preflight behavior, then prints the source
+service uniqueness, health target derivation, and install preflight behavior,
+then prints the source
 commit, target paths, `provider-daemon` inventory, preflight artifact status,
 stop/start order, install paths, and healthcheck commands without
 mutating services or files. If a required artifact is missing, the dry run exits

--- a/docs/devnet-polyfs-root-rollout.md
+++ b/docs/devnet-polyfs-root-rollout.md
@@ -20,17 +20,18 @@ It restarts services in this order:
 5. Preflight the install plan. If a source artifact is already the target path, the later install step skips it instead of failing after services stop.
 6. Preflight hub root service units with non-mutating, non-sudo `systemctl show`, including dry-runs, so a missing chain, faucet, or legacy router unit cannot abort after provider-daemons are already stopped.
 7. If `--restart-tunnels` is supplied, preflight tunnel user service units with non-mutating `systemctl --user show`.
-8. Resolve `provider-daemon` service managers. The default `auto` mode resolves the local user-service provider layout; the checked-in root provider template must be selected explicitly with `POLYSTORE_PROVIDER_SERVICE_SCOPE=root`.
+8. Resolve `provider-daemon` service managers with non-mutating unit checks, including dry-runs. The default `auto` mode resolves the local user-service provider layout; the checked-in root provider template must be selected explicitly with `POLYSTORE_PROVIDER_SERVICE_SCOPE=root`.
 9. Derive default provider health targets from known resolved service names unless `POLYSTORE_PROVIDER_BASES` is set. Unknown custom service names require explicit bases.
 10. Preflight root service control. Live non-root runs must prove passwordless sudo authorization for the exact hub and root-managed `provider-daemon` `systemctl stop/start` actions before any `provider-daemon` is stopped.
-11. Stop `provider-daemon` services from their resolved manager: user services such as `polystore-provider1.service` through `polystore-provider4.service`, or root services such as `polystore-gateway-provider.service`.
-12. Stop hub services: `polystore-gateway-router.service` (legacy service alias for the `user-gateway` persona), `polystore-faucet.service`, then `polystorechaind.service`.
-13. Install artifacts with backups and sha256 evidence.
-14. Start chain first.
-15. Start faucet and the `user-gateway` legacy router service.
-16. Start all resolved `provider-daemon` services, including provider4 when the local user-service layout is present.
+11. If `--restart-tunnels` is supplied, stop tunnel user services before taking down the devnet stack.
+12. Stop `provider-daemon` services from their resolved manager: user services such as `polystore-provider1.service` through `polystore-provider4.service`, or root services such as `polystore-gateway-provider.service`.
+13. Stop hub services: `polystore-gateway-router.service` (legacy service alias for the `user-gateway` persona), `polystore-faucet.service`, then `polystorechaind.service`.
+14. Install artifacts with backups and sha256 evidence.
+15. Start chain first.
+16. Start faucet and the `user-gateway` legacy router service.
+17. Start all resolved `provider-daemon` services, including provider4 when the local user-service layout is present.
 
-Tunnel services are not restarted by default. Use `--restart-tunnels` only when endpoint or tunnel config changes. When enabled, tunnel user units must be loaded before any service-stop mutation, and tunnel stop/start failures are fatal because local healthchecks do not prove the public tunnel process restarted.
+Tunnel services are not restarted by default. Use `--restart-tunnels` only when endpoint or tunnel config changes. When enabled, tunnel user units must be loaded before any service-stop mutation, tunnel stop runs before the devnet stack is taken down, and tunnel stop/start failures are fatal because local healthchecks do not prove the public tunnel process restarted.
 
 The default health endpoints match the checked-in local devnet and systemd
 templates:
@@ -87,10 +88,10 @@ scripts/update_devnet_stack.sh --dry-run --skip-build
 ```
 
 This validates source layout, command dependencies, hub root unit inventory,
-optional tunnel user unit inventory, provider health target derivation, and
-install preflight behavior, then prints the source commit, target paths,
-`provider-daemon` inventory, preflight artifact status, stop/start order, install
-paths, and healthcheck commands without
+optional tunnel user unit inventory, `provider-daemon` unit inventory, provider
+health target derivation, and install preflight behavior, then prints the source
+commit, target paths, `provider-daemon` inventory, preflight artifact status,
+stop/start order, install paths, and healthcheck commands without
 mutating services or files. If a required artifact is missing, the dry run exits
 before printing any service-stop plan, matching live rollout safety behavior.
 

--- a/docs/devnet-polyfs-root-rollout.md
+++ b/docs/devnet-polyfs-root-rollout.md
@@ -15,12 +15,13 @@ It restarts services in this order:
 
 1. Build artifacts as `--run-user`/`POLYSTORE_RUN_USER`; when invoked with `sudo`, this avoids root-owned Cargo/Go outputs in the source checkout.
 2. Preflight all build artifacts before stopping any service.
-3. Stop `provider-daemon` user services: `polystore-provider1.service` through `polystore-provider4.service`.
-4. Stop hub services: `polystore-gateway-router.service` (legacy service alias for the `user-gateway` persona), `polystore-faucet.service`, then `polystorechaind.service`.
-5. Install artifacts with backups and sha256 evidence.
-6. Start chain first.
-7. Start faucet and the `user-gateway` legacy router service.
-8. Start all `provider-daemon` services, including provider4.
+3. Preflight root service control. Live non-root runs must prove `sudo -n systemctl` works before any `provider-daemon` is stopped.
+4. Stop `provider-daemon` user services: `polystore-provider1.service` through `polystore-provider4.service`.
+5. Stop hub services: `polystore-gateway-router.service` (legacy service alias for the `user-gateway` persona), `polystore-faucet.service`, then `polystorechaind.service`.
+6. Install artifacts with backups and sha256 evidence.
+7. Start chain first.
+8. Start faucet and the `user-gateway` legacy router service.
+9. Start all `provider-daemon` services, including provider4.
 
 Tunnel services are not restarted by default. Use `--restart-tunnels` only when endpoint or tunnel config changes.
 
@@ -66,3 +67,7 @@ preflight artifact status, stop/start order, install paths, and healthcheck
 commands without mutating services or files. If a required artifact is missing,
 the dry run exits before printing any service-stop plan, matching live rollout
 safety behavior.
+
+In live non-root mode, the script also verifies passwordless `sudo systemctl`
+access before printing the service-stop plan. On this host, dry runs report that
+check without requiring a sudo prompt.

--- a/docs/devnet-polyfs-root-rollout.md
+++ b/docs/devnet-polyfs-root-rollout.md
@@ -13,12 +13,13 @@ The script rebuilds and installs:
 
 It restarts services in this order:
 
-1. Stop user providers: `polystore-provider1.service` through `polystore-provider4.service`.
-2. Stop hub services: `polystore-gateway-router.service`, `polystore-faucet.service`, then `polystorechaind.service`.
-3. Install artifacts with backups and sha256 evidence.
-4. Start chain first.
-5. Start faucet and router.
-6. Start all providers, including provider4.
+1. Preflight all build artifacts before stopping any service.
+2. Stop `provider-daemon` user services: `polystore-provider1.service` through `polystore-provider4.service`.
+3. Stop hub services: `polystore-gateway-router.service` (legacy service alias for the `user-gateway` persona), `polystore-faucet.service`, then `polystorechaind.service`.
+4. Install artifacts with backups and sha256 evidence.
+5. Start chain first.
+6. Start faucet and the `user-gateway` legacy router service.
+7. Start all `provider-daemon` services, including provider4.
 
 Tunnel services are not restarted by default. Use `--restart-tunnels` only when endpoint or tunnel config changes.
 
@@ -27,16 +28,17 @@ The default health endpoints match the current local devnet on this machine:
 - RPC: `http://127.0.0.1:26657`
 - LCD: `http://127.0.0.1:1317`
 - EVM JSON-RPC: `http://127.0.0.1:8545`
-- Router gateway: `http://127.0.0.1:18080`
+- `user-gateway` via legacy router service: `http://127.0.0.1:18080`
 - Faucet: `http://127.0.0.1:8081`
-- Providers: `http://127.0.0.1:8091` through `http://127.0.0.1:8094`
+- `provider-daemon` services: `http://127.0.0.1:8091` through `http://127.0.0.1:8094`
 
 Override these with `POLYSTORE_RPC_BASE`, `POLYSTORE_LCD_BASE`,
 `POLYSTORE_EVM_BASE`, `POLYSTORE_ROUTER_BASE`, `POLYSTORE_FAUCET_BASE`, and
 `POLYSTORE_PROVIDER_BASES` if a target machine uses different ports. The
-checked-in systemd template still documents `8080` as a generic router example;
-this machine's live `/etc/polystore` router env binds the managed devnet router
-to `18080`.
+`POLYSTORE_ROUTER_BASE` env name is a legacy compatibility alias for the
+`user-gateway` endpoint. The checked-in systemd template still documents `8080`
+as a generic router example; this machine's live `/etc/polystore` legacy router
+env binds the managed devnet `user-gateway` to `18080`.
 
 ## State Policy
 
@@ -58,4 +60,8 @@ Use:
 scripts/update_devnet_stack.sh --dry-run --skip-build
 ```
 
-This prints the source commit, target paths, provider inventory, stop/start order, install paths, and healthcheck commands without mutating services or files.
+This prints the source commit, target paths, `provider-daemon` inventory,
+preflight artifact status, stop/start order, install paths, and healthcheck
+commands without mutating services or files. If a required artifact is missing,
+the dry run exits before printing any service-stop plan, matching live rollout
+safety behavior.

--- a/docs/devnet-polyfs-root-rollout.md
+++ b/docs/devnet-polyfs-root-rollout.md
@@ -2,7 +2,7 @@
 
 Use `scripts/update_devnet_stack.sh` when rolling out proof-format-coupled changes to the local trusted devnet on this machine.
 
-The script rebuilds and installs:
+The script rebuilds as the configured run user, then installs:
 
 - `polystore_core/target/release/libpolystore_core.so`
 - `polystorechain/polystorechaind`
@@ -13,13 +13,14 @@ The script rebuilds and installs:
 
 It restarts services in this order:
 
-1. Preflight all build artifacts before stopping any service.
-2. Stop `provider-daemon` user services: `polystore-provider1.service` through `polystore-provider4.service`.
-3. Stop hub services: `polystore-gateway-router.service` (legacy service alias for the `user-gateway` persona), `polystore-faucet.service`, then `polystorechaind.service`.
-4. Install artifacts with backups and sha256 evidence.
-5. Start chain first.
-6. Start faucet and the `user-gateway` legacy router service.
-7. Start all `provider-daemon` services, including provider4.
+1. Build artifacts as `--run-user`/`POLYSTORE_RUN_USER`; when invoked with `sudo`, this avoids root-owned Cargo/Go outputs in the source checkout.
+2. Preflight all build artifacts before stopping any service.
+3. Stop `provider-daemon` user services: `polystore-provider1.service` through `polystore-provider4.service`.
+4. Stop hub services: `polystore-gateway-router.service` (legacy service alias for the `user-gateway` persona), `polystore-faucet.service`, then `polystorechaind.service`.
+5. Install artifacts with backups and sha256 evidence.
+6. Start chain first.
+7. Start faucet and the `user-gateway` legacy router service.
+8. Start all `provider-daemon` services, including provider4.
 
 Tunnel services are not restarted by default. Use `--restart-tunnels` only when endpoint or tunnel config changes.
 

--- a/docs/devnet-polyfs-root-rollout.md
+++ b/docs/devnet-polyfs-root-rollout.md
@@ -18,7 +18,7 @@ It restarts services in this order:
 3. Build artifacts as `--run-user`/`POLYSTORE_RUN_USER`; when invoked with `sudo`, this avoids root-owned Cargo/Go outputs in the source checkout.
 4. Preflight all build artifacts before stopping any service.
 5. Preflight the install plan. If a source artifact is already the target path, the later install step skips it instead of failing after services stop.
-6. Preflight root service control. Live non-root runs must prove `sudo -n systemctl` works before any `provider-daemon` is stopped.
+6. Preflight root service control. Live non-root runs must prove passwordless sudo authorization for the exact root `systemctl stop/start` actions before any `provider-daemon` is stopped.
 7. Preflight hub root service units with non-mutating `systemctl show`, including dry-runs, so a missing chain, faucet, or legacy router unit cannot abort after provider-daemons are already stopped.
 8. Resolve `provider-daemon` service managers. The default `auto` mode resolves the local user-service provider layout; the checked-in root provider template must be selected explicitly with `POLYSTORE_PROVIDER_SERVICE_SCOPE=root`.
 9. Derive default provider health targets from known resolved service names unless `POLYSTORE_PROVIDER_BASES` is set. Unknown custom service names require explicit bases.
@@ -97,9 +97,10 @@ artifact paths are supported only with `--skip-build`: they are reported before
 the stop plan and skipped during install. Without `--skip-build`, the script
 exits before building so it cannot partially overwrite live artifacts while
 services are still running.
-In live non-root mode, the script also verifies passwordless `sudo systemctl`
-access before printing the service-stop plan. On this host, dry runs report that
-check without requiring a sudo prompt.
+In live non-root mode, the script also verifies passwordless sudo authorization
+for the exact root `systemctl stop/start` actions before printing the
+service-stop plan. On this host, dry runs report that check without requiring a
+sudo prompt.
 Dry-runs and live runs both verify that all configured hub root service units
 are loaded. Live runs also verify that `curl` is available before any
 service-stop mutation.

--- a/docs/devnet-polyfs-root-rollout.md
+++ b/docs/devnet-polyfs-root-rollout.md
@@ -31,12 +31,13 @@ It restarts services in this order:
 
 Tunnel services are not restarted by default. Use `--restart-tunnels` only when endpoint or tunnel config changes.
 
-The default health endpoints match the current local devnet on this machine:
+The default health endpoints match the checked-in local devnet and systemd
+templates:
 
 - RPC: `http://127.0.0.1:26657`
 - LCD: `http://127.0.0.1:1317`
 - EVM JSON-RPC: `http://127.0.0.1:8545`
-- `user-gateway` via legacy router service: `http://127.0.0.1:18080`
+- `user-gateway` via legacy router service: `http://127.0.0.1:8080`
 - Faucet: `http://127.0.0.1:8081`
 - `provider-daemon` services: derived from resolved provider services, starting at `http://127.0.0.1:8091`. The four local user-provider layout resolves to `8091` through `8094`; the checked-in single root-provider template resolves to `8091`.
 
@@ -44,9 +45,9 @@ Override these with `POLYSTORE_RPC_BASE`, `POLYSTORE_LCD_BASE`,
 `POLYSTORE_EVM_BASE`, `POLYSTORE_ROUTER_BASE`, `POLYSTORE_FAUCET_BASE`, and
 `POLYSTORE_PROVIDER_BASES` if a target machine uses different ports. The
 `POLYSTORE_ROUTER_BASE` env name is a legacy compatibility alias for the
-`user-gateway` endpoint. The checked-in systemd template still documents `8080`
-as a generic router example; this machine's live `/etc/polystore` legacy router
-env binds the managed devnet `user-gateway` to `18080`.
+`user-gateway` endpoint. If a target host's live `/etc/polystore` legacy router
+env binds the managed devnet `user-gateway` to another port such as `18080`, set
+`POLYSTORE_ROUTER_BASE` explicitly before running the rollout.
 Set `POLYSTORE_PROVIDER_BASES` when a host's provider ports do not follow the
 default one-port-per-resolved-service sequence. When set, it must provide
 exactly one base URL for each resolved `provider-daemon` service so rollout

--- a/docs/devnet-polyfs-root-rollout.md
+++ b/docs/devnet-polyfs-root-rollout.md
@@ -18,7 +18,7 @@ It restarts services in this order:
 3. Build artifacts as `--run-user`/`POLYSTORE_RUN_USER`; when invoked with `sudo`, this avoids root-owned Cargo/Go outputs in the source checkout.
 4. Preflight all build artifacts before stopping any service.
 5. Preflight the install plan. If a source artifact is already the target path, the later install step skips it instead of failing after services stop.
-6. Preflight hub root service units with non-mutating `systemctl show`, including dry-runs, so a missing chain, faucet, or legacy router unit cannot abort after provider-daemons are already stopped.
+6. Preflight hub root service units with non-mutating, non-sudo `systemctl show`, including dry-runs, so a missing chain, faucet, or legacy router unit cannot abort after provider-daemons are already stopped.
 7. Resolve `provider-daemon` service managers. The default `auto` mode resolves the local user-service provider layout; the checked-in root provider template must be selected explicitly with `POLYSTORE_PROVIDER_SERVICE_SCOPE=root`.
 8. Derive default provider health targets from known resolved service names unless `POLYSTORE_PROVIDER_BASES` is set. Unknown custom service names require explicit bases.
 9. Preflight root service control. Live non-root runs must prove passwordless sudo authorization for the exact hub and root-managed `provider-daemon` `systemctl stop/start` actions before any `provider-daemon` is stopped.
@@ -102,8 +102,8 @@ for the exact hub and root-managed `provider-daemon` `systemctl stop/start`
 actions before printing the service-stop plan. On this host, dry runs report
 that check without requiring a sudo prompt.
 Dry-runs and live runs both verify that all configured hub root service units
-are loaded. Live runs also verify that `curl` is available before any
-service-stop mutation.
+are loaded with non-mutating, non-sudo `systemctl show`. Live runs also verify
+that `curl` is available before any service-stop mutation.
 Final `systemctl is-active` status probes are best-effort evidence after the
 healthchecks have passed; a restricted sudoers policy for status commands should
 not mark an otherwise healthy rollout as failed.

--- a/docs/devnet-polyfs-root-rollout.md
+++ b/docs/devnet-polyfs-root-rollout.md
@@ -13,16 +13,17 @@ The script rebuilds as the configured run user, then installs:
 
 It restarts services in this order:
 
-1. Build artifacts as `--run-user`/`POLYSTORE_RUN_USER`; when invoked with `sudo`, this avoids root-owned Cargo/Go outputs in the source checkout.
-2. Preflight all build artifacts before stopping any service.
-3. Preflight the install plan. If a source artifact is already the target path, the later install step skips it instead of failing after services stop.
-4. Preflight root service control. Live non-root runs must prove `sudo -n systemctl` works before any `provider-daemon` is stopped.
-5. Stop `provider-daemon` user services: `polystore-provider1.service` through `polystore-provider4.service`.
-6. Stop hub services: `polystore-gateway-router.service` (legacy service alias for the `user-gateway` persona), `polystore-faucet.service`, then `polystorechaind.service`.
-7. Install artifacts with backups and sha256 evidence.
-8. Start chain first.
-9. Start faucet and the `user-gateway` legacy router service.
-10. Start all `provider-daemon` services, including provider4.
+1. Preflight source/target layout. Build mode refuses `--source-root == --target-root` so live artifacts are not overwritten while services are still running.
+2. Build artifacts as `--run-user`/`POLYSTORE_RUN_USER`; when invoked with `sudo`, this avoids root-owned Cargo/Go outputs in the source checkout.
+3. Preflight all build artifacts before stopping any service.
+4. Preflight the install plan. If a source artifact is already the target path, the later install step skips it instead of failing after services stop.
+5. Preflight root service control. Live non-root runs must prove `sudo -n systemctl` works before any `provider-daemon` is stopped.
+6. Stop `provider-daemon` user services: `polystore-provider1.service` through `polystore-provider4.service`.
+7. Stop hub services: `polystore-gateway-router.service` (legacy service alias for the `user-gateway` persona), `polystore-faucet.service`, then `polystorechaind.service`.
+8. Install artifacts with backups and sha256 evidence.
+9. Start chain first.
+10. Start faucet and the `user-gateway` legacy router service.
+11. Start all `provider-daemon` services, including provider4.
 
 Tunnel services are not restarted by default. Use `--restart-tunnels` only when endpoint or tunnel config changes.
 
@@ -70,7 +71,10 @@ the dry run exits before printing any service-stop plan, matching live rollout
 safety behavior.
 
 If `--source-root` and `--target-root` refer to the same live checkout, matching
-artifact paths are reported before the stop plan and skipped during install.
+artifact paths are supported only with `--skip-build`: they are reported before
+the stop plan and skipped during install. Without `--skip-build`, the script
+exits before building so it cannot partially overwrite live artifacts while
+services are still running.
 In live non-root mode, the script also verifies passwordless `sudo systemctl`
 access before printing the service-stop plan. On this host, dry runs report that
 check without requiring a sudo prompt.

--- a/docs/devnet-polyfs-root-rollout.md
+++ b/docs/devnet-polyfs-root-rollout.md
@@ -19,7 +19,7 @@ It restarts services in this order:
 4. Preflight all build artifacts before stopping any service.
 5. Preflight the install plan. If a source artifact is already the target path, the later install step skips it instead of failing after services stop.
 6. Preflight root service control. Live non-root runs must prove `sudo -n systemctl` works before any `provider-daemon` is stopped.
-7. Preflight hub root service units so a missing chain, faucet, or legacy router unit cannot abort after provider-daemons are already stopped.
+7. Preflight hub root service units with non-mutating `systemctl show`, including dry-runs, so a missing chain, faucet, or legacy router unit cannot abort after provider-daemons are already stopped.
 8. Resolve `provider-daemon` service managers. The default `auto` mode resolves the local user-service provider layout; the checked-in root provider template must be selected explicitly with `POLYSTORE_PROVIDER_SERVICE_SCOPE=root`.
 9. Derive default provider health targets from known resolved service names unless `POLYSTORE_PROVIDER_BASES` is set. Unknown custom service names require explicit bases.
 10. Stop `provider-daemon` services from their resolved manager: user services such as `polystore-provider1.service` through `polystore-provider4.service`, or root services such as `polystore-gateway-provider.service`.
@@ -85,11 +85,12 @@ Use:
 scripts/update_devnet_stack.sh --dry-run --skip-build
 ```
 
-This prints the source commit, target paths, `provider-daemon` inventory,
-preflight artifact status, stop/start order, install paths, and healthcheck
-commands without mutating services or files. If a required artifact is missing,
-the dry run exits before printing any service-stop plan, matching live rollout
-safety behavior.
+This validates source layout, command dependencies, hub root unit inventory,
+provider health target derivation, and install preflight behavior, then prints
+the source commit, target paths, `provider-daemon` inventory, preflight artifact
+status, stop/start order, install paths, and healthcheck commands without
+mutating services or files. If a required artifact is missing, the dry run exits
+before printing any service-stop plan, matching live rollout safety behavior.
 
 If `--source-root` and `--target-root` refer to the same live checkout, matching
 artifact paths are supported only with `--skip-build`: they are reported before
@@ -99,5 +100,6 @@ services are still running.
 In live non-root mode, the script also verifies passwordless `sudo systemctl`
 access before printing the service-stop plan. On this host, dry runs report that
 check without requiring a sudo prompt.
-Live runs also verify that all configured hub root service units are loaded and
-that `curl` is available before any service-stop mutation.
+Dry-runs and live runs both verify that all configured hub root service units
+are loaded. Live runs also verify that `curl` is available before any
+service-stop mutation.

--- a/docs/devnet-polyfs-root-rollout.md
+++ b/docs/devnet-polyfs-root-rollout.md
@@ -21,7 +21,7 @@ It restarts services in this order:
 6. Preflight hub root service units with non-mutating, non-sudo `systemctl show`, including dry-runs, so a missing chain, faucet, or legacy router unit cannot abort after provider-daemons are already stopped.
 7. If `--restart-tunnels` is supplied, preflight tunnel user service units with non-mutating `systemctl --user show`.
 8. Resolve `provider-daemon` service managers with non-mutating unit checks, including dry-runs. The default `auto` mode resolves the local user-service provider layout; the checked-in root provider template must be selected explicitly with `POLYSTORE_PROVIDER_SERVICE_SCOPE=root`.
-9. Derive default provider health targets from known resolved service names unless `POLYSTORE_PROVIDER_BASES` is set. Unknown custom service names require explicit bases.
+9. Derive default provider health targets from known resolved service names unless `POLYSTORE_PROVIDER_BASES` is set. Unknown custom service names require explicit bases, and duplicate provider health bases fail before any service-stop mutation.
 10. Preflight root service control. Live non-root runs must prove passwordless sudo authorization for the exact hub and root-managed `provider-daemon` `systemctl stop/start` actions before any `provider-daemon` is stopped.
 11. If `--restart-tunnels` is supplied, stop tunnel user services before taking down the devnet stack.
 12. Stop `provider-daemon` services from their resolved manager: user services such as `polystore-provider1.service` through `polystore-provider4.service`, or root services such as `polystore-gateway-provider.service`.
@@ -42,7 +42,7 @@ templates:
 - EVM JSON-RPC: `http://127.0.0.1:8545`
 - `user-gateway` via legacy router service: `http://127.0.0.1:8080`
 - Faucet: `http://127.0.0.1:8081`
-- `provider-daemon` services: derived from resolved provider service names. The four local user-provider layout maps `polystore-provider1.service` through `polystore-provider4.service` to `8091` through `8094`; the checked-in single root-provider template maps `polystore-gateway-provider.service` to `8091`.
+- `provider-daemon` services: derived from resolved provider service names. The four local user-provider layout maps `polystore-provider1.service` through `polystore-provider4.service` to `8091` through `8094`; the checked-in single root-provider template maps `polystore-gateway-provider.service` to `8091`. If a configured provider inventory resolves two services to the same health base, the rollout exits before stopping services.
 
 Override these with `POLYSTORE_RPC_BASE`, `POLYSTORE_LCD_BASE`,
 `POLYSTORE_EVM_BASE`, `POLYSTORE_ROUTER_BASE`, `POLYSTORE_FAUCET_BASE`, and
@@ -54,7 +54,8 @@ env binds the managed devnet `user-gateway` to another port such as `18080`, set
 Set `POLYSTORE_PROVIDER_BASES` when a host's provider ports do not follow the
 default known service-name mapping or when using custom provider service names.
 When set, it must provide exactly one base URL for each resolved
-`provider-daemon` service so rollout healthchecks cannot silently skip a
+`provider-daemon` service, and every base must be unique, so rollout
+healthchecks cannot silently poll one surviving endpoint twice while skipping a
 restarted provider.
 
 Provider service management is controlled by `POLYSTORE_PROVIDER_SERVICE_SCOPE`:

--- a/docs/devnet-polyfs-root-rollout.md
+++ b/docs/devnet-polyfs-root-rollout.md
@@ -1,0 +1,45 @@
+# PolyFS Root Devnet Rollout
+
+Use `scripts/update_devnet_stack.sh` when rolling out proof-format-coupled changes to the local trusted devnet on this machine.
+
+The script rebuilds and installs:
+
+- `polystore_core/target/release/libpolystore_core.so`
+- `polystorechain/polystorechaind`
+- `polystore_gateway/polystore_gateway`
+- `polystore_faucet/polystore_faucet`
+- `polystore_cli/target/release/polystore_cli`
+- `polystorechain/trusted_setup.txt`
+
+It restarts services in this order:
+
+1. Stop user providers: `polystore-provider1.service` through `polystore-provider4.service`.
+2. Stop hub services: `polystore-gateway-router.service`, `polystore-faucet.service`, then `polystorechaind.service`.
+3. Install artifacts with backups and sha256 evidence.
+4. Start chain first.
+5. Start faucet and router.
+6. Start all providers, including provider4.
+
+Tunnel services are not restarted by default. Use `--restart-tunnels` only when endpoint or tunnel config changes.
+
+## State Policy
+
+The PolyFS root migration changes the trust root for new deals from the retired flat `manifest.bin` commitment to the MDU #0 PolyFS root. The rollout script is intentionally a binary/runtime rollout tool; it does not reset chain state and it does not silently migrate old committed deals.
+
+When the chain/gateway proof-format PRs land, choose one of these policies before running live validation:
+
+- **Reset devnet state**: preferred for alpha if the committed root field is not backward-compatible.
+- **Explicit migration**: only if a migration script or chain upgrade handler exists and records old root to new root mapping.
+- **Explicit legacy versioning**: only if the chain verifier has a deliberate legacy path for old alpha deals.
+
+Do not treat green `/health` endpoints as proof-format compatibility. Final validation belongs in issue #218 and must include a new-format proof accepted by the local chain.
+
+## Dry Run
+
+Use:
+
+```bash
+scripts/update_devnet_stack.sh --dry-run --skip-build
+```
+
+This prints the source commit, target paths, provider inventory, stop/start order, install paths, and healthcheck commands without mutating services or files.

--- a/docs/devnet-polyfs-root-rollout.md
+++ b/docs/devnet-polyfs-root-rollout.md
@@ -18,12 +18,13 @@ It restarts services in this order:
 3. Preflight all build artifacts before stopping any service.
 4. Preflight the install plan. If a source artifact is already the target path, the later install step skips it instead of failing after services stop.
 5. Preflight root service control. Live non-root runs must prove `sudo -n systemctl` works before any `provider-daemon` is stopped.
-6. Stop `provider-daemon` user services: `polystore-provider1.service` through `polystore-provider4.service`.
-7. Stop hub services: `polystore-gateway-router.service` (legacy service alias for the `user-gateway` persona), `polystore-faucet.service`, then `polystorechaind.service`.
-8. Install artifacts with backups and sha256 evidence.
-9. Start chain first.
-10. Start faucet and the `user-gateway` legacy router service.
-11. Start all `provider-daemon` services, including provider4.
+6. Resolve `provider-daemon` service managers. The default `auto` mode supports both the local user-service provider layout and the checked-in root provider template.
+7. Stop `provider-daemon` services from their resolved manager: user services such as `polystore-provider1.service` through `polystore-provider4.service`, or root services such as `polystore-gateway-provider.service`.
+8. Stop hub services: `polystore-gateway-router.service` (legacy service alias for the `user-gateway` persona), `polystore-faucet.service`, then `polystorechaind.service`.
+9. Install artifacts with backups and sha256 evidence.
+10. Start chain first.
+11. Start faucet and the `user-gateway` legacy router service.
+12. Start all resolved `provider-daemon` services, including provider4 when the local user-service layout is present.
 
 Tunnel services are not restarted by default. Use `--restart-tunnels` only when endpoint or tunnel config changes.
 
@@ -43,6 +44,14 @@ Override these with `POLYSTORE_RPC_BASE`, `POLYSTORE_LCD_BASE`,
 `user-gateway` endpoint. The checked-in systemd template still documents `8080`
 as a generic router example; this machine's live `/etc/polystore` legacy router
 env binds the managed devnet `user-gateway` to `18080`.
+
+Provider service management is controlled by `POLYSTORE_PROVIDER_SERVICE_SCOPE`:
+
+- `auto` (default): resolve each default or configured provider service against user and root systemd managers before any stop/start action.
+- `user`: require every configured provider service to exist in the user systemd manager.
+- `root`: require every configured provider service to exist in the root systemd manager. With the checked-in provider template, use this with `POLYSTORE_PROVIDER_SERVICES=polystore-gateway-provider.service`.
+
+If a service name exists in both managers, `auto` exits before stopping services; set the scope explicitly for that host.
 
 ## State Policy
 

--- a/docs/devnet-polyfs-root-rollout.md
+++ b/docs/devnet-polyfs-root-rollout.md
@@ -46,7 +46,9 @@ Override these with `POLYSTORE_RPC_BASE`, `POLYSTORE_LCD_BASE`,
 as a generic router example; this machine's live `/etc/polystore` legacy router
 env binds the managed devnet `user-gateway` to `18080`.
 Set `POLYSTORE_PROVIDER_BASES` when a host's provider ports do not follow the
-default one-port-per-resolved-service sequence.
+default one-port-per-resolved-service sequence. When set, it must provide
+exactly one base URL for each resolved `provider-daemon` service so rollout
+healthchecks cannot silently skip a restarted provider.
 
 Provider service management is controlled by `POLYSTORE_PROVIDER_SERVICE_SCOPE`:
 

--- a/docs/devnet-polyfs-root-rollout.md
+++ b/docs/devnet-polyfs-root-rollout.md
@@ -19,12 +19,13 @@ It restarts services in this order:
 4. Preflight the install plan. If a source artifact is already the target path, the later install step skips it instead of failing after services stop.
 5. Preflight root service control. Live non-root runs must prove `sudo -n systemctl` works before any `provider-daemon` is stopped.
 6. Resolve `provider-daemon` service managers. The default `auto` mode supports both the local user-service provider layout and the checked-in root provider template.
-7. Stop `provider-daemon` services from their resolved manager: user services such as `polystore-provider1.service` through `polystore-provider4.service`, or root services such as `polystore-gateway-provider.service`.
-8. Stop hub services: `polystore-gateway-router.service` (legacy service alias for the `user-gateway` persona), `polystore-faucet.service`, then `polystorechaind.service`.
-9. Install artifacts with backups and sha256 evidence.
-10. Start chain first.
-11. Start faucet and the `user-gateway` legacy router service.
-12. Start all resolved `provider-daemon` services, including provider4 when the local user-service layout is present.
+7. Derive default provider health targets from the resolved service count unless `POLYSTORE_PROVIDER_BASES` is set.
+8. Stop `provider-daemon` services from their resolved manager: user services such as `polystore-provider1.service` through `polystore-provider4.service`, or root services such as `polystore-gateway-provider.service`.
+9. Stop hub services: `polystore-gateway-router.service` (legacy service alias for the `user-gateway` persona), `polystore-faucet.service`, then `polystorechaind.service`.
+10. Install artifacts with backups and sha256 evidence.
+11. Start chain first.
+12. Start faucet and the `user-gateway` legacy router service.
+13. Start all resolved `provider-daemon` services, including provider4 when the local user-service layout is present.
 
 Tunnel services are not restarted by default. Use `--restart-tunnels` only when endpoint or tunnel config changes.
 
@@ -35,7 +36,7 @@ The default health endpoints match the current local devnet on this machine:
 - EVM JSON-RPC: `http://127.0.0.1:8545`
 - `user-gateway` via legacy router service: `http://127.0.0.1:18080`
 - Faucet: `http://127.0.0.1:8081`
-- `provider-daemon` services: `http://127.0.0.1:8091` through `http://127.0.0.1:8094`
+- `provider-daemon` services: derived from resolved provider services, starting at `http://127.0.0.1:8091`. The four local user-provider layout resolves to `8091` through `8094`; the checked-in single root-provider template resolves to `8091`.
 
 Override these with `POLYSTORE_RPC_BASE`, `POLYSTORE_LCD_BASE`,
 `POLYSTORE_EVM_BASE`, `POLYSTORE_ROUTER_BASE`, `POLYSTORE_FAUCET_BASE`, and
@@ -44,6 +45,8 @@ Override these with `POLYSTORE_RPC_BASE`, `POLYSTORE_LCD_BASE`,
 `user-gateway` endpoint. The checked-in systemd template still documents `8080`
 as a generic router example; this machine's live `/etc/polystore` legacy router
 env binds the managed devnet `user-gateway` to `18080`.
+Set `POLYSTORE_PROVIDER_BASES` when a host's provider ports do not follow the
+default one-port-per-resolved-service sequence.
 
 Provider service management is controlled by `POLYSTORE_PROVIDER_SERVICE_SCOPE`:
 

--- a/docs/devnet-polyfs-root-rollout.md
+++ b/docs/devnet-polyfs-root-rollout.md
@@ -15,13 +15,14 @@ It restarts services in this order:
 
 1. Build artifacts as `--run-user`/`POLYSTORE_RUN_USER`; when invoked with `sudo`, this avoids root-owned Cargo/Go outputs in the source checkout.
 2. Preflight all build artifacts before stopping any service.
-3. Preflight root service control. Live non-root runs must prove `sudo -n systemctl` works before any `provider-daemon` is stopped.
-4. Stop `provider-daemon` user services: `polystore-provider1.service` through `polystore-provider4.service`.
-5. Stop hub services: `polystore-gateway-router.service` (legacy service alias for the `user-gateway` persona), `polystore-faucet.service`, then `polystorechaind.service`.
-6. Install artifacts with backups and sha256 evidence.
-7. Start chain first.
-8. Start faucet and the `user-gateway` legacy router service.
-9. Start all `provider-daemon` services, including provider4.
+3. Preflight the install plan. If a source artifact is already the target path, the later install step skips it instead of failing after services stop.
+4. Preflight root service control. Live non-root runs must prove `sudo -n systemctl` works before any `provider-daemon` is stopped.
+5. Stop `provider-daemon` user services: `polystore-provider1.service` through `polystore-provider4.service`.
+6. Stop hub services: `polystore-gateway-router.service` (legacy service alias for the `user-gateway` persona), `polystore-faucet.service`, then `polystorechaind.service`.
+7. Install artifacts with backups and sha256 evidence.
+8. Start chain first.
+9. Start faucet and the `user-gateway` legacy router service.
+10. Start all `provider-daemon` services, including provider4.
 
 Tunnel services are not restarted by default. Use `--restart-tunnels` only when endpoint or tunnel config changes.
 
@@ -68,6 +69,8 @@ commands without mutating services or files. If a required artifact is missing,
 the dry run exits before printing any service-stop plan, matching live rollout
 safety behavior.
 
+If `--source-root` and `--target-root` refer to the same live checkout, matching
+artifact paths are reported before the stop plan and skipped during install.
 In live non-root mode, the script also verifies passwordless `sudo systemctl`
 access before printing the service-stop plan. On this host, dry runs report that
 check without requiring a sudo prompt.

--- a/ops/systemd/README.md
+++ b/ops/systemd/README.md
@@ -49,6 +49,17 @@ sudo systemctl restart polystorechaind && sudo systemctl status --no-pager polys
 ./scripts/redeploy_polystorechaind.sh --verify-only
 ```
 
+### Full Devnet Stack Rollout
+
+For proof-format-coupled changes that must update the chain, gateway, faucet,
+CLI, runtime library, and all local providers together, use:
+
+- runbook: `docs/devnet-polyfs-root-rollout.md`
+- script: `scripts/update_devnet_stack.sh`
+
+The stack rollout script covers provider1 through provider4 and restarts tunnel
+services only when `--restart-tunnels` is supplied.
+
 4) Tail logs:
 
 ```bash

--- a/ops/systemd/README.md
+++ b/ops/systemd/README.md
@@ -1,6 +1,6 @@
 # systemd templates (Trusted Devnet Soft Launch)
 
-These are **templates** for running a long-lived hub + remote SP devnet using systemd.
+These are **templates** for running a long-lived hub plus remote `provider-daemon` devnet using systemd.
 
 Files:
 - `ops/systemd/*.service`: unit templates
@@ -51,14 +51,16 @@ sudo systemctl restart polystorechaind && sudo systemctl status --no-pager polys
 
 ### Full Devnet Stack Rollout
 
-For proof-format-coupled changes that must update the chain, gateway, faucet,
-CLI, runtime library, and all local providers together, use:
+For proof-format-coupled changes that must update the chain, `user-gateway`
+legacy router service, faucet, CLI, runtime library, and all local
+`provider-daemon` services together, use:
 
 - runbook: `docs/devnet-polyfs-root-rollout.md`
 - script: `scripts/update_devnet_stack.sh`
 
-The stack rollout script covers provider1 through provider4 and restarts tunnel
-services only when `--restart-tunnels` is supplied.
+The stack rollout script covers `provider-daemon` services provider1 through
+provider4 and restarts tunnel services only when `--restart-tunnels` is
+supplied.
 
 4) Tail logs:
 

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -441,6 +441,11 @@ resolve_provider_service_scopes() {
           echo "       user LoadState=$(describe_load_state "$user_state"), root LoadState=$(describe_load_state "$root_state")." >&2
           exit 1
         fi
+
+        echo "ERROR: default provider-daemon service is not loaded in user or root systemd managers: $service" >&2
+        echo "       user LoadState=$(describe_load_state "$user_state"), root LoadState=$(describe_load_state "$root_state")." >&2
+        echo "       The default devnet inventory requires provider1-provider4; set POLYSTORE_PROVIDER_SERVICES explicitly for partial devnets." >&2
+        exit 1
       done
 
       if [[ "$found_any" -ne 1 ]]; then

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -25,6 +25,11 @@ Environment:
                                 Default: polystore-provider1..polystore-provider4.
   POLYSTORE_TUNNEL_SERVICES     Space-separated tunnel user services.
                                 Default: cloudflared-hub.service cloudflared-providers.service.
+  POLYSTORE_LCD_BASE            Hub LCD base URL (default: http://127.0.0.1:1317).
+  POLYSTORE_ROUTER_BASE         Router gateway base URL (default: http://127.0.0.1:18080).
+  POLYSTORE_FAUCET_BASE         Faucet base URL (default: http://127.0.0.1:8081).
+  POLYSTORE_PROVIDER_BASES      Space-separated provider gateway base URLs.
+                                Default: http://127.0.0.1:8091..8094.
   POLYSTORE_SKIP_BUILD=1        Same as --skip-build.
   POLYSTORE_DRY_RUN=1           Same as --dry-run.
   POLYSTORE_RESTART_TUNNELS=1   Same as --restart-tunnels.
@@ -89,6 +94,10 @@ fi
 read -r -a PROVIDER_SERVICES <<<"${POLYSTORE_PROVIDER_SERVICES:-polystore-provider1.service polystore-provider2.service polystore-provider3.service polystore-provider4.service}"
 read -r -a ROOT_SERVICES <<<"polystorechaind.service polystore-faucet.service polystore-gateway-router.service"
 read -r -a TUNNEL_SERVICES <<<"${POLYSTORE_TUNNEL_SERVICES:-cloudflared-hub.service cloudflared-providers.service}"
+LCD_BASE="${POLYSTORE_LCD_BASE:-http://127.0.0.1:1317}"
+ROUTER_BASE="${POLYSTORE_ROUTER_BASE:-http://127.0.0.1:18080}"
+FAUCET_BASE="${POLYSTORE_FAUCET_BASE:-http://127.0.0.1:8081}"
+read -r -a PROVIDER_BASES <<<"${POLYSTORE_PROVIDER_BASES:-http://127.0.0.1:8091 http://127.0.0.1:8092 http://127.0.0.1:8093 http://127.0.0.1:8094}"
 
 if [[ "$IS_ROOT" -ne 1 && "$(id -un)" != "$RUN_USER" ]]; then
   echo "ERROR: non-root update must run as POLYSTORE_RUN_USER=$RUN_USER." >&2
@@ -238,6 +247,10 @@ print_source_evidence() {
   fi
   echo "    provider services: ${PROVIDER_SERVICES[*]}"
   echo "    root services: ${ROOT_SERVICES[*]}"
+  echo "    lcd base: $LCD_BASE"
+  echo "    router base: $ROUTER_BASE"
+  echo "    faucet base: $FAUCET_BASE"
+  echo "    provider bases: ${PROVIDER_BASES[*]}"
   if [[ "$RESTART_TUNNELS" == "1" ]]; then
     echo "    tunnel services: ${TUNNEL_SERVICES[*]}"
   else
@@ -268,20 +281,18 @@ print_service_status() {
 }
 
 run_healthchecks() {
-  wait_http "LCD node_info" "http://127.0.0.1:1317/cosmos/base/tendermint/v1beta1/node_info" 90
-  wait_http "router gateway" "http://127.0.0.1:18080/health" 45
-  wait_http "faucet" "http://127.0.0.1:8081/health" 45
-  wait_http "provider1" "http://127.0.0.1:8091/health" 45
-  wait_http "provider2" "http://127.0.0.1:8092/health" 45
-  wait_http "provider3" "http://127.0.0.1:8093/health" 45
-  wait_http "provider4" "http://127.0.0.1:8094/health" 45
+  wait_http "LCD node_info" "$LCD_BASE/cosmos/base/tendermint/v1beta1/node_info" 90
+  wait_http "router gateway" "$ROUTER_BASE/health" 45
+  wait_http "faucet" "$FAUCET_BASE/health" 45
+  for i in "${!PROVIDER_BASES[@]}"; do
+    wait_http "provider$((i + 1))" "${PROVIDER_BASES[$i]}/health" 45
+  done
 
   echo "==> Running scripted healthchecks"
-  run_in_dir "$SOURCE_ROOT" scripts/devnet_healthcheck.sh hub --lcd http://127.0.0.1:1317 --gateway http://127.0.0.1:18080 --faucet http://127.0.0.1:8081
-  run_in_dir "$SOURCE_ROOT" scripts/devnet_healthcheck.sh provider --provider http://127.0.0.1:8091 --hub-lcd http://127.0.0.1:1317
-  run_in_dir "$SOURCE_ROOT" scripts/devnet_healthcheck.sh provider --provider http://127.0.0.1:8092 --hub-lcd http://127.0.0.1:1317
-  run_in_dir "$SOURCE_ROOT" scripts/devnet_healthcheck.sh provider --provider http://127.0.0.1:8093 --hub-lcd http://127.0.0.1:1317
-  run_in_dir "$SOURCE_ROOT" scripts/devnet_healthcheck.sh provider --provider http://127.0.0.1:8094 --hub-lcd http://127.0.0.1:1317
+  run_in_dir "$SOURCE_ROOT" scripts/devnet_healthcheck.sh hub --lcd "$LCD_BASE" --gateway "$ROUTER_BASE" --faucet "$FAUCET_BASE"
+  for provider_base in "${PROVIDER_BASES[@]}"; do
+    run_in_dir "$SOURCE_ROOT" scripts/devnet_healthcheck.sh provider --provider "$provider_base" --hub-lcd "$LCD_BASE"
+  done
 }
 
 print_source_evidence
@@ -306,15 +317,14 @@ install_with_backup "$SOURCE_ROOT/polystorechain/trusted_setup.txt" "$TARGET_ROO
 
 echo "==> Start order: chain -> faucet/router -> providers"
 root_systemctl start polystorechaind.service
-wait_http "LCD node_info" "http://127.0.0.1:1317/cosmos/base/tendermint/v1beta1/node_info" 90
+wait_http "LCD node_info" "$LCD_BASE/cosmos/base/tendermint/v1beta1/node_info" 90
 root_systemctl start polystore-faucet.service polystore-gateway-router.service
-wait_http "faucet" "http://127.0.0.1:8081/health" 45
-wait_http "router gateway" "http://127.0.0.1:18080/health" 45
+wait_http "faucet" "$FAUCET_BASE/health" 45
+wait_http "router gateway" "$ROUTER_BASE/health" 45
 user_systemctl start "${PROVIDER_SERVICES[@]}"
-wait_http "provider1" "http://127.0.0.1:8091/health" 45
-wait_http "provider2" "http://127.0.0.1:8092/health" 45
-wait_http "provider3" "http://127.0.0.1:8093/health" 45
-wait_http "provider4" "http://127.0.0.1:8094/health" 45
+for i in "${!PROVIDER_BASES[@]}"; do
+  wait_http "provider$((i + 1))" "${PROVIDER_BASES[$i]}/health" 45
+done
 if [[ "$RESTART_TUNNELS" == "1" ]]; then
   echo "==> Starting tunnel user services"
   user_systemctl start "${TUNNEL_SERVICES[@]}"

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -37,7 +37,8 @@ Environment:
                                 for compatibility (default: http://127.0.0.1:18080).
   POLYSTORE_FAUCET_BASE         Faucet base URL (default: http://127.0.0.1:8081).
   POLYSTORE_PROVIDER_BASES      Space-separated provider-daemon base URLs.
-                                Default: http://127.0.0.1:8091..8094.
+                                Default: one URL per resolved provider-daemon
+                                service, starting at http://127.0.0.1:8091.
   POLYSTORE_SKIP_BUILD=1        Same as --skip-build.
   POLYSTORE_DRY_RUN=1           Same as --dry-run.
   POLYSTORE_RESTART_TUNNELS=1   Same as --restart-tunnels.
@@ -141,7 +142,13 @@ LCD_BASE="${POLYSTORE_LCD_BASE:-http://127.0.0.1:1317}"
 EVM_BASE="${POLYSTORE_EVM_BASE:-http://127.0.0.1:8545}"
 ROUTER_BASE="${POLYSTORE_ROUTER_BASE:-http://127.0.0.1:18080}"
 FAUCET_BASE="${POLYSTORE_FAUCET_BASE:-http://127.0.0.1:8081}"
-read -r -a PROVIDER_BASES <<<"${POLYSTORE_PROVIDER_BASES:-http://127.0.0.1:8091 http://127.0.0.1:8092 http://127.0.0.1:8093 http://127.0.0.1:8094}"
+PROVIDER_BASES_FROM_ENV=0
+if [[ -n "${POLYSTORE_PROVIDER_BASES+x}" ]]; then
+  PROVIDER_BASES_FROM_ENV=1
+  read -r -a PROVIDER_BASES <<<"$POLYSTORE_PROVIDER_BASES"
+else
+  PROVIDER_BASES=()
+fi
 
 if [[ "$IS_ROOT" -ne 1 && "$(id -un)" != "$RUN_USER" ]]; then
   echo "ERROR: non-root update must run as POLYSTORE_RUN_USER=$RUN_USER." >&2
@@ -232,6 +239,17 @@ root_systemctl() {
   run_cmd sudo -n systemctl "$@"
 }
 
+set_default_provider_bases() {
+  local count="$1"
+  local i port
+
+  PROVIDER_BASES=()
+  for ((i = 0; i < count; i += 1)); do
+    port=$((8091 + i))
+    PROVIDER_BASES+=("http://127.0.0.1:$port")
+  done
+}
+
 user_unit_load_state() {
   local service="$1"
   if [[ "$IS_ROOT" -eq 1 ]]; then
@@ -313,6 +331,10 @@ resolve_provider_service_scopes() {
     if [[ "${#PROVIDER_ROOT_SERVICES[@]}" -gt 0 ]]; then
       echo "    DRY-RUN root manager: ${PROVIDER_ROOT_SERVICES[*]}"
     fi
+    if [[ "$PROVIDER_BASES_FROM_ENV" -ne 1 ]]; then
+      set_default_provider_bases "$((${#PROVIDER_USER_SERVICES[@]} + ${#PROVIDER_ROOT_SERVICES[@]}))"
+      echo "    DRY-RUN provider-daemon bases derived from resolved services: ${PROVIDER_BASES[*]}"
+    fi
     PROVIDER_SERVICE_SCOPES_RESOLVED=1
     return
   fi
@@ -372,6 +394,10 @@ resolve_provider_service_scopes() {
   fi
   if [[ "${#PROVIDER_ROOT_SERVICES[@]}" -gt 0 ]]; then
     echo "    root manager: ${PROVIDER_ROOT_SERVICES[*]}"
+  fi
+  if [[ "$PROVIDER_BASES_FROM_ENV" -ne 1 ]]; then
+    set_default_provider_bases "$((${#PROVIDER_USER_SERVICES[@]} + ${#PROVIDER_ROOT_SERVICES[@]}))"
+    echo "    provider-daemon bases derived from resolved services: ${PROVIDER_BASES[*]}"
   fi
   PROVIDER_SERVICE_SCOPES_RESOLVED=1
 }
@@ -597,7 +623,11 @@ print_source_evidence() {
   echo "    evm base: $EVM_BASE"
   echo "    user-gateway base: $ROUTER_BASE (POLYSTORE_ROUTER_BASE legacy env alias)"
   echo "    faucet base: $FAUCET_BASE"
-  echo "    provider-daemon bases: ${PROVIDER_BASES[*]}"
+  if [[ "$PROVIDER_BASES_FROM_ENV" -eq 1 ]]; then
+    echo "    provider-daemon bases: ${PROVIDER_BASES[*]}"
+  else
+    echo "    provider-daemon bases: derived from resolved provider services"
+  fi
   if [[ "$RESTART_TUNNELS" == "1" ]]; then
     echo "    tunnel services: ${TUNNEL_SERVICES[*]}"
   else

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -538,6 +538,30 @@ preflight_root_services_loaded() {
   echo "    root services loaded: ${ROOT_SERVICES[*]}"
 }
 
+preflight_tunnel_services_loaded() {
+  local service load_state
+
+  if [[ "$RESTART_TUNNELS" != "1" ]]; then
+    return
+  fi
+
+  echo "==> Preflighting tunnel user service units"
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "    DRY-RUN: validating loaded tunnel user services with non-mutating systemctl --user show: ${TUNNEL_SERVICES[*]}"
+  fi
+
+  for service in "${TUNNEL_SERVICES[@]}"; do
+    load_state="$(user_unit_load_state "$service" || true)"
+    if ! unit_is_loaded "$load_state"; then
+      echo "ERROR: tunnel service $service is not loaded in the user systemd manager." >&2
+      echo "       LoadState=$(describe_load_state "$load_state"); fix the unit before stopping services." >&2
+      echo "       Unset --restart-tunnels if this rollout does not need tunnel restarts." >&2
+      exit 1
+    fi
+  done
+  echo "    tunnel services loaded: ${TUNNEL_SERVICES[*]}"
+}
+
 preflight_source_target_layout() {
   echo "==> Preflighting source/target layout"
   if [[ "$SKIP_BUILD" == "1" ]]; then
@@ -868,6 +892,7 @@ build_artifacts
 preflight_artifacts
 preflight_install_plan
 preflight_root_services_loaded
+preflight_tunnel_services_loaded
 resolve_provider_service_scopes
 preflight_root_service_control
 
@@ -877,7 +902,7 @@ root_systemctl stop polystore-gateway-router.service polystore-faucet.service
 root_systemctl stop polystorechaind.service
 if [[ "$RESTART_TUNNELS" == "1" ]]; then
   echo "==> Stopping tunnel user services"
-  user_systemctl stop "${TUNNEL_SERVICES[@]}" || true
+  user_systemctl stop "${TUNNEL_SERVICES[@]}"
 fi
 
 echo "==> Installing binaries and runtime inputs"

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -25,7 +25,9 @@ Environment:
                                 Default: polystore-provider1..polystore-provider4.
   POLYSTORE_TUNNEL_SERVICES     Space-separated tunnel user services.
                                 Default: cloudflared-hub.service cloudflared-providers.service.
+  POLYSTORE_RPC_BASE            Hub Tendermint RPC base URL (default: http://127.0.0.1:26657).
   POLYSTORE_LCD_BASE            Hub LCD base URL (default: http://127.0.0.1:1317).
+  POLYSTORE_EVM_BASE            Hub EVM JSON-RPC base URL (default: http://127.0.0.1:8545).
   POLYSTORE_ROUTER_BASE         Router gateway base URL (default: http://127.0.0.1:18080).
   POLYSTORE_FAUCET_BASE         Faucet base URL (default: http://127.0.0.1:8081).
   POLYSTORE_PROVIDER_BASES      Space-separated provider gateway base URLs.
@@ -45,17 +47,30 @@ SKIP_BUILD="${POLYSTORE_SKIP_BUILD:-0}"
 DRY_RUN="${POLYSTORE_DRY_RUN:-0}"
 RESTART_TUNNELS="${POLYSTORE_RESTART_TUNNELS:-0}"
 
+need_value() {
+  local flag="$1"
+  local value="${2:-}"
+  if [[ -z "$value" || "$value" == -* ]]; then
+    echo "ERROR: $flag requires a value" >&2
+    usage >&2
+    exit 2
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --source-root)
+      need_value "$@"
       SOURCE_ROOT="$2"
       shift 2
       ;;
     --target-root)
+      need_value "$@"
       TARGET_ROOT="$2"
       shift 2
       ;;
     --run-user)
+      need_value "$@"
       RUN_USER="$2"
       shift 2
       ;;
@@ -94,7 +109,9 @@ fi
 read -r -a PROVIDER_SERVICES <<<"${POLYSTORE_PROVIDER_SERVICES:-polystore-provider1.service polystore-provider2.service polystore-provider3.service polystore-provider4.service}"
 read -r -a ROOT_SERVICES <<<"polystorechaind.service polystore-faucet.service polystore-gateway-router.service"
 read -r -a TUNNEL_SERVICES <<<"${POLYSTORE_TUNNEL_SERVICES:-cloudflared-hub.service cloudflared-providers.service}"
+RPC_BASE="${POLYSTORE_RPC_BASE:-http://127.0.0.1:26657}"
 LCD_BASE="${POLYSTORE_LCD_BASE:-http://127.0.0.1:1317}"
+EVM_BASE="${POLYSTORE_EVM_BASE:-http://127.0.0.1:8545}"
 ROUTER_BASE="${POLYSTORE_ROUTER_BASE:-http://127.0.0.1:18080}"
 FAUCET_BASE="${POLYSTORE_FAUCET_BASE:-http://127.0.0.1:8081}"
 read -r -a PROVIDER_BASES <<<"${POLYSTORE_PROVIDER_BASES:-http://127.0.0.1:8091 http://127.0.0.1:8092 http://127.0.0.1:8093 http://127.0.0.1:8094}"
@@ -130,6 +147,17 @@ run_in_dir() {
     return 0
   fi
   (cd "$dir" && "$@")
+}
+
+goflags_with_mod() {
+  local current="${GOFLAGS:-}"
+  if [[ " $current " == *" -mod="* ]]; then
+    printf '%s' "$current"
+  elif [[ -n "$current" ]]; then
+    printf '%s -mod=mod' "$current"
+  else
+    printf '%s' "-mod=mod"
+  fi
 }
 
 user_systemctl() {
@@ -204,9 +232,9 @@ build_artifacts() {
 
   echo "==> Building coupled devnet artifacts"
   run_in_dir "$SOURCE_ROOT/polystore_core" cargo build --release
-  run_in_dir "$SOURCE_ROOT/polystorechain" env GOFLAGS="${GOFLAGS:-} -mod=mod" go build -o "$SOURCE_ROOT/polystorechain/polystorechaind" ./cmd/polystorechaind
-  run_in_dir "$SOURCE_ROOT/polystore_gateway" env GOFLAGS="${GOFLAGS:-} -mod=mod" go build -o "$SOURCE_ROOT/polystore_gateway/polystore_gateway" .
-  run_in_dir "$SOURCE_ROOT/polystore_faucet" env GOFLAGS="${GOFLAGS:-} -mod=mod" go build -o "$SOURCE_ROOT/polystore_faucet/polystore_faucet" .
+  run_in_dir "$SOURCE_ROOT/polystorechain" env GOFLAGS="$(goflags_with_mod)" go build -o "$SOURCE_ROOT/polystorechain/polystorechaind" ./cmd/polystorechaind
+  run_in_dir "$SOURCE_ROOT/polystore_gateway" env GOFLAGS="$(goflags_with_mod)" go build -o "$SOURCE_ROOT/polystore_gateway/polystore_gateway" .
+  run_in_dir "$SOURCE_ROOT/polystore_faucet" env GOFLAGS="$(goflags_with_mod)" go build -o "$SOURCE_ROOT/polystore_faucet/polystore_faucet" .
   run_in_dir "$SOURCE_ROOT/polystore_cli" cargo build --release
 }
 
@@ -247,7 +275,9 @@ print_source_evidence() {
   fi
   echo "    provider services: ${PROVIDER_SERVICES[*]}"
   echo "    root services: ${ROOT_SERVICES[*]}"
+  echo "    rpc base: $RPC_BASE"
   echo "    lcd base: $LCD_BASE"
+  echo "    evm base: $EVM_BASE"
   echo "    router base: $ROUTER_BASE"
   echo "    faucet base: $FAUCET_BASE"
   echo "    provider bases: ${PROVIDER_BASES[*]}"
@@ -289,7 +319,7 @@ run_healthchecks() {
   done
 
   echo "==> Running scripted healthchecks"
-  run_in_dir "$SOURCE_ROOT" scripts/devnet_healthcheck.sh hub --lcd "$LCD_BASE" --gateway "$ROUTER_BASE" --faucet "$FAUCET_BASE"
+  run_in_dir "$SOURCE_ROOT" scripts/devnet_healthcheck.sh hub --rpc "$RPC_BASE" --lcd "$LCD_BASE" --evm "$EVM_BASE" --gateway "$ROUTER_BASE" --faucet "$FAUCET_BASE"
   for provider_base in "${PROVIDER_BASES[@]}"; do
     run_in_dir "$SOURCE_ROOT" scripts/devnet_healthcheck.sh provider --provider "$provider_base" --hub-lcd "$LCD_BASE"
   done

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -17,7 +17,7 @@ Flags:
   --run-user USER         User that owns user systemd services (default: SUDO_USER or current user)
   --skip-build            Install existing artifacts without rebuilding
   --dry-run               Print actions without building, installing, or restarting
-  --restart-tunnels       Restart cloudflared user services after provider services
+  --restart-tunnels       Restart cloudflared user services after provider-daemon services
   -h, --help              Show this help
 
 Environment:
@@ -28,9 +28,10 @@ Environment:
   POLYSTORE_RPC_BASE            Hub Tendermint RPC base URL (default: http://127.0.0.1:26657).
   POLYSTORE_LCD_BASE            Hub LCD base URL (default: http://127.0.0.1:1317).
   POLYSTORE_EVM_BASE            Hub EVM JSON-RPC base URL (default: http://127.0.0.1:8545).
-  POLYSTORE_ROUTER_BASE         Router gateway base URL (default: http://127.0.0.1:18080).
+  POLYSTORE_ROUTER_BASE         user-gateway base URL; legacy env alias keeps router naming
+                                for compatibility (default: http://127.0.0.1:18080).
   POLYSTORE_FAUCET_BASE         Faucet base URL (default: http://127.0.0.1:8081).
-  POLYSTORE_PROVIDER_BASES      Space-separated provider gateway base URLs.
+  POLYSTORE_PROVIDER_BASES      Space-separated provider-daemon base URLs.
                                 Default: http://127.0.0.1:8091..8094.
   POLYSTORE_SKIP_BUILD=1        Same as --skip-build.
   POLYSTORE_DRY_RUN=1           Same as --dry-run.
@@ -224,6 +225,39 @@ install_with_backup() {
   sha256_if_present "$dst"
 }
 
+preflight_artifacts() {
+  local missing=0
+  local artifacts=(
+    "$SOURCE_ROOT/polystore_core/target/release/libpolystore_core.so"
+    "$SOURCE_ROOT/polystorechain/polystorechaind"
+    "$SOURCE_ROOT/polystore_gateway/polystore_gateway"
+    "$SOURCE_ROOT/polystore_faucet/polystore_faucet"
+    "$SOURCE_ROOT/polystore_cli/target/release/polystore_cli"
+    "$SOURCE_ROOT/polystorechain/trusted_setup.txt"
+  )
+
+  echo "==> Preflighting install artifacts before stopping services"
+  for artifact in "${artifacts[@]}"; do
+    if [[ -f "$artifact" ]]; then
+      sha256_if_present "$artifact"
+      continue
+    fi
+
+    missing=1
+    echo "MISSING $artifact" >&2
+  done
+
+  if [[ "$missing" -ne 0 ]]; then
+    if [[ "$DRY_RUN" == "1" ]]; then
+      echo "ERROR: missing install artifacts; dry-run aborting before service-stop plan" >&2
+      exit 1
+    fi
+
+    echo "ERROR: missing install artifacts; aborting before service stop" >&2
+    exit 1
+  fi
+}
+
 build_artifacts() {
   if [[ "$SKIP_BUILD" == "1" ]]; then
     echo "==> Skipping builds (--skip-build)"
@@ -273,14 +307,14 @@ print_source_evidence() {
     echo "    source status:"
     git -C "$SOURCE_ROOT" status --short || true
   fi
-  echo "    provider services: ${PROVIDER_SERVICES[*]}"
+  echo "    provider-daemon services: ${PROVIDER_SERVICES[*]}"
   echo "    root services: ${ROOT_SERVICES[*]}"
   echo "    rpc base: $RPC_BASE"
   echo "    lcd base: $LCD_BASE"
   echo "    evm base: $EVM_BASE"
-  echo "    router base: $ROUTER_BASE"
+  echo "    user-gateway base: $ROUTER_BASE (POLYSTORE_ROUTER_BASE legacy env alias)"
   echo "    faucet base: $FAUCET_BASE"
-  echo "    provider bases: ${PROVIDER_BASES[*]}"
+  echo "    provider-daemon bases: ${PROVIDER_BASES[*]}"
   if [[ "$RESTART_TUNNELS" == "1" ]]; then
     echo "    tunnel services: ${TUNNEL_SERVICES[*]}"
   else
@@ -312,10 +346,10 @@ print_service_status() {
 
 run_healthchecks() {
   wait_http "LCD node_info" "$LCD_BASE/cosmos/base/tendermint/v1beta1/node_info" 90
-  wait_http "router gateway" "$ROUTER_BASE/health" 45
+  wait_http "user-gateway (legacy router service)" "$ROUTER_BASE/health" 45
   wait_http "faucet" "$FAUCET_BASE/health" 45
   for i in "${!PROVIDER_BASES[@]}"; do
-    wait_http "provider$((i + 1))" "${PROVIDER_BASES[$i]}/health" 45
+    wait_http "provider-daemon$((i + 1))" "${PROVIDER_BASES[$i]}/health" 45
   done
 
   echo "==> Running scripted healthchecks"
@@ -327,9 +361,10 @@ run_healthchecks() {
 
 print_source_evidence
 build_artifacts
+preflight_artifacts
 
-echo "==> Stop order: providers -> router/faucet -> chain"
-user_systemctl stop "${PROVIDER_SERVICES[@]}" || true
+echo "==> Stop order: provider-daemons -> user-gateway/faucet -> chain"
+user_systemctl stop "${PROVIDER_SERVICES[@]}"
 root_systemctl stop polystore-gateway-router.service polystore-faucet.service
 root_systemctl stop polystorechaind.service
 if [[ "$RESTART_TUNNELS" == "1" ]]; then
@@ -345,15 +380,15 @@ install_with_backup "$SOURCE_ROOT/polystore_faucet/polystore_faucet" "$TARGET_RO
 install_with_backup "$SOURCE_ROOT/polystore_cli/target/release/polystore_cli" "$TARGET_ROOT/polystore_cli/target/release/polystore_cli" 755
 install_with_backup "$SOURCE_ROOT/polystorechain/trusted_setup.txt" "$TARGET_ROOT/polystorechain/trusted_setup.txt" 644
 
-echo "==> Start order: chain -> faucet/router -> providers"
+echo "==> Start order: chain -> faucet/user-gateway -> provider-daemons"
 root_systemctl start polystorechaind.service
 wait_http "LCD node_info" "$LCD_BASE/cosmos/base/tendermint/v1beta1/node_info" 90
 root_systemctl start polystore-faucet.service polystore-gateway-router.service
 wait_http "faucet" "$FAUCET_BASE/health" 45
-wait_http "router gateway" "$ROUTER_BASE/health" 45
+wait_http "user-gateway (legacy router service)" "$ROUTER_BASE/health" 45
 user_systemctl start "${PROVIDER_SERVICES[@]}"
 for i in "${!PROVIDER_BASES[@]}"; do
-  wait_http "provider$((i + 1))" "${PROVIDER_BASES[$i]}/health" 45
+  wait_http "provider-daemon$((i + 1))" "${PROVIDER_BASES[$i]}/health" 45
 done
 if [[ "$RESTART_TUNNELS" == "1" ]]; then
   echo "==> Starting tunnel user services"

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -34,7 +34,7 @@ Environment:
   POLYSTORE_LCD_BASE            Hub LCD base URL (default: http://127.0.0.1:1317).
   POLYSTORE_EVM_BASE            Hub EVM JSON-RPC base URL (default: http://127.0.0.1:8545).
   POLYSTORE_ROUTER_BASE         user-gateway base URL; legacy env alias keeps router naming
-                                for compatibility (default: http://127.0.0.1:18080).
+                                for compatibility (default: http://127.0.0.1:8080).
   POLYSTORE_FAUCET_BASE         Faucet base URL (default: http://127.0.0.1:8081).
   POLYSTORE_PROVIDER_BASES      Space-separated provider-daemon base URLs.
                                 Default: one URL per resolved provider-daemon
@@ -138,7 +138,7 @@ read -r -a TUNNEL_SERVICES <<<"${POLYSTORE_TUNNEL_SERVICES:-cloudflared-hub.serv
 RPC_BASE="${POLYSTORE_RPC_BASE:-http://127.0.0.1:26657}"
 LCD_BASE="${POLYSTORE_LCD_BASE:-http://127.0.0.1:1317}"
 EVM_BASE="${POLYSTORE_EVM_BASE:-http://127.0.0.1:8545}"
-ROUTER_BASE="${POLYSTORE_ROUTER_BASE:-http://127.0.0.1:18080}"
+ROUTER_BASE="${POLYSTORE_ROUTER_BASE:-http://127.0.0.1:8080}"
 FAUCET_BASE="${POLYSTORE_FAUCET_BASE:-http://127.0.0.1:8081}"
 PROVIDER_BASES_FROM_ENV=0
 if [[ -n "${POLYSTORE_PROVIDER_BASES+x}" ]]; then

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -39,7 +39,8 @@ Environment:
   POLYSTORE_PROVIDER_BASES      Space-separated provider-daemon base URLs.
                                 Default: one URL per resolved provider-daemon
                                 service, starting at http://127.0.0.1:8091.
-                                Duplicate canonical bases are rejected.
+                                Duplicate provider services and duplicate
+                                canonical bases are rejected.
   POLYSTORE_SKIP_BUILD=1        Same as --skip-build.
   POLYSTORE_DRY_RUN=1           Same as --dry-run.
   POLYSTORE_RESTART_TUNNELS=1   Same as --restart-tunnels.
@@ -139,6 +140,18 @@ elif [[ "$PROVIDER_SERVICE_SCOPE" == "root" ]]; then
 else
   PROVIDER_SERVICES=("${DEFAULT_USER_PROVIDER_SERVICES[@]}")
 fi
+declare -A SEEN_PROVIDER_SERVICES=()
+for provider_service in "${PROVIDER_SERVICES[@]}"; do
+  if [[ -n "${SEEN_PROVIDER_SERVICES[$provider_service]:-}" ]]; then
+    echo "ERROR: duplicate provider-daemon service: $provider_service" >&2
+    echo "       Each provider-daemon service may appear only once, so the rollout cannot stop/start one unit twice while healthchecking different provider bases." >&2
+    if [[ "$PROVIDER_SERVICES_FROM_ENV" -eq 1 ]]; then
+      echo "       Fix POLYSTORE_PROVIDER_SERVICES to list each provider-daemon service once." >&2
+    fi
+    exit 2
+  fi
+  SEEN_PROVIDER_SERVICES["$provider_service"]=1
+done
 read -r -a ROOT_SERVICES <<<"polystorechaind.service polystore-faucet.service polystore-gateway-router.service"
 read -r -a TUNNEL_SERVICES <<<"${POLYSTORE_TUNNEL_SERVICES:-cloudflared-hub.service cloudflared-providers.service}"
 RPC_BASE="${POLYSTORE_RPC_BASE:-http://127.0.0.1:26657}"

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -843,6 +843,21 @@ print_service_status() {
       sudo -n systemctl --no-pager --full status "${PROVIDER_ROOT_SERVICES[@]}" | sed -n '1,200p' || true
     fi
   fi
+
+  if [[ "$RESTART_TUNNELS" == "1" ]]; then
+    echo "==> Tunnel service activity"
+    if ! user_systemctl is-active "${TUNNEL_SERVICES[@]}"; then
+      echo "ERROR: tunnel service activity status probe failed after restart." >&2
+      return 1
+    fi
+    if [[ "$DRY_RUN" != "1" ]]; then
+      if [[ "$IS_ROOT" -eq 1 ]]; then
+        runuser -u "$RUN_USER" -- env XDG_RUNTIME_DIR="/run/user/$RUN_UID" systemctl --user --no-pager --full status "${TUNNEL_SERVICES[@]}" | sed -n '1,160p' || true
+      else
+        env XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$RUN_UID}" systemctl --user --no-pager --full status "${TUNNEL_SERVICES[@]}" | sed -n '1,160p' || true
+      fi
+    fi
+  fi
 }
 
 run_healthchecks() {

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -242,19 +242,42 @@ root_systemctl() {
   run_cmd sudo -n systemctl "$@"
 }
 
+provider_base_for_service() {
+  local service="$1"
+  local provider_index port
+
+  if [[ "$service" =~ ^polystore-provider([0-9]+)\.service$ ]]; then
+    provider_index="${BASH_REMATCH[1]}"
+    port=$((8090 + provider_index))
+    printf 'http://127.0.0.1:%s' "$port"
+    return 0
+  fi
+
+  if [[ "$service" == "polystore-gateway-provider.service" ]]; then
+    printf 'http://127.0.0.1:8091'
+    return 0
+  fi
+
+  return 1
+}
+
 set_default_provider_bases() {
-  local count="$1"
-  local i port
+  local service base
 
   PROVIDER_BASES=()
-  for ((i = 0; i < count; i += 1)); do
-    port=$((8091 + i))
-    PROVIDER_BASES+=("http://127.0.0.1:$port")
+  for service in "$@"; do
+    if ! base="$(provider_base_for_service "$service")"; then
+      echo "ERROR: cannot derive provider-daemon base URL for service: $service" >&2
+      echo "       Set POLYSTORE_PROVIDER_BASES with one URL per resolved provider-daemon service." >&2
+      exit 1
+    fi
+    PROVIDER_BASES+=("$base")
   done
 }
 
 resolve_provider_bases() {
   local expected_count="$1"
+  shift
   local actual_count="${#PROVIDER_BASES[@]}"
   local prefix=""
 
@@ -273,7 +296,7 @@ resolve_provider_bases() {
     return
   fi
 
-  set_default_provider_bases "$expected_count"
+  set_default_provider_bases "$@"
   echo "    ${prefix}provider-daemon bases derived from resolved services: ${PROVIDER_BASES[*]}"
 }
 
@@ -367,7 +390,7 @@ resolve_provider_service_scopes() {
     if [[ "${#PROVIDER_ROOT_SERVICES[@]}" -gt 0 ]]; then
       echo "    DRY-RUN root manager: ${PROVIDER_ROOT_SERVICES[*]}"
     fi
-    resolve_provider_bases "$((${#PROVIDER_USER_SERVICES[@]} + ${#PROVIDER_ROOT_SERVICES[@]}))"
+    resolve_provider_bases "$((${#PROVIDER_USER_SERVICES[@]} + ${#PROVIDER_ROOT_SERVICES[@]}))" "${PROVIDER_USER_SERVICES[@]}" "${PROVIDER_ROOT_SERVICES[@]}"
     PROVIDER_SERVICE_SCOPES_RESOLVED=1
     return
   fi
@@ -429,7 +452,7 @@ resolve_provider_service_scopes() {
   if [[ "${#PROVIDER_ROOT_SERVICES[@]}" -gt 0 ]]; then
     echo "    root manager: ${PROVIDER_ROOT_SERVICES[*]}"
   fi
-  resolve_provider_bases "$((${#PROVIDER_USER_SERVICES[@]} + ${#PROVIDER_ROOT_SERVICES[@]}))"
+  resolve_provider_bases "$((${#PROVIDER_USER_SERVICES[@]} + ${#PROVIDER_ROOT_SERVICES[@]}))" "${PROVIDER_USER_SERVICES[@]}" "${PROVIDER_ROOT_SERVICES[@]}"
   PROVIDER_SERVICE_SCOPES_RESOLVED=1
 }
 

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -39,6 +39,7 @@ Environment:
   POLYSTORE_PROVIDER_BASES      Space-separated provider-daemon base URLs.
                                 Default: one URL per resolved provider-daemon
                                 service, starting at http://127.0.0.1:8091.
+                                Duplicate bases are rejected.
   POLYSTORE_SKIP_BUILD=1        Same as --skip-build.
   POLYSTORE_DRY_RUN=1           Same as --dry-run.
   POLYSTORE_RESTART_TUNNELS=1   Same as --restart-tunnels.
@@ -275,9 +276,50 @@ set_default_provider_bases() {
   done
 }
 
+provider_base_duplicate_key() {
+  local base="$1"
+
+  while [[ "$base" == */ ]]; do
+    base="${base%/}"
+  done
+  printf '%s' "$base"
+}
+
+require_unique_provider_bases() {
+  local services=("$@")
+  local i j left_base right_base left_key right_key left_service right_service
+
+  for i in "${!PROVIDER_BASES[@]}"; do
+    left_base="${PROVIDER_BASES[$i]}"
+    left_key="$(provider_base_duplicate_key "$left_base")"
+    left_service="${services[$i]:-provider-daemon$((i + 1))}"
+
+    for ((j = i + 1; j < ${#PROVIDER_BASES[@]}; j++)); do
+      right_base="${PROVIDER_BASES[$j]}"
+      right_key="$(provider_base_duplicate_key "$right_base")"
+      right_service="${services[$j]:-provider-daemon$((j + 1))}"
+
+      if [[ "$left_key" != "$right_key" ]]; then
+        continue
+      fi
+
+      echo "ERROR: duplicate provider-daemon health base: $left_base" >&2
+      echo "       $left_service and $right_service both resolve to the same provider endpoint." >&2
+      echo "       Each provider-daemon service must have a unique health base so healthchecks cannot poll one surviving endpoint twice." >&2
+      if [[ "$PROVIDER_BASES_FROM_ENV" -eq 1 ]]; then
+        echo "       Fix POLYSTORE_PROVIDER_BASES to provide one unique base URL per resolved provider-daemon service." >&2
+      else
+        echo "       Set POLYSTORE_PROVIDER_BASES explicitly, or remove the duplicate provider service from POLYSTORE_PROVIDER_SERVICES." >&2
+      fi
+      exit 1
+    done
+  done
+}
+
 resolve_provider_bases() {
   local expected_count="$1"
   shift
+  local resolved_services=("$@")
   local actual_count="${#PROVIDER_BASES[@]}"
   local prefix=""
 
@@ -292,11 +334,13 @@ resolve_provider_bases() {
       exit 1
     fi
 
+    require_unique_provider_bases "${resolved_services[@]}"
     echo "    ${prefix}provider-daemon bases from POLYSTORE_PROVIDER_BASES: ${PROVIDER_BASES[*]}"
     return
   fi
 
   set_default_provider_bases "$@"
+  require_unique_provider_bases "${resolved_services[@]}"
   echo "    ${prefix}provider-daemon bases derived from resolved services: ${PROVIDER_BASES[*]}"
 }
 

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -522,6 +522,70 @@ same_install_path() {
   [[ "$(realpath -m "$src")" == "$(realpath -m "$dst")" ]]
 }
 
+preflight_install_destination() {
+  local src="$1"
+  local dst="$2"
+  local dst_dir backup_subdir backup_dir write_test
+
+  if same_install_path "$src" "$dst"; then
+    return 0
+  fi
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "    DRY-RUN: would verify target write access for $dst"
+    return 0
+  fi
+
+  dst_dir="$(dirname "$dst")"
+  backup_subdir="$(dirname "${dst#"$TARGET_ROOT"/}")"
+  backup_dir="$BACKUP_DIR/$backup_subdir"
+
+  if [[ -e "$dst" && ! -f "$dst" ]]; then
+    echo "ERROR: install target exists but is not a regular file: $dst" >&2
+    echo "       Fix the target path before stopping services." >&2
+    exit 1
+  fi
+
+  if ! mkdir -p "$dst_dir" "$backup_dir"; then
+    echo "ERROR: cannot create install/backup directories for $dst" >&2
+    echo "       dst_dir=$dst_dir backup_dir=$backup_dir" >&2
+    exit 1
+  fi
+
+  if [[ ! -w "$dst_dir" ]]; then
+    echo "ERROR: install target directory is not writable: $dst_dir" >&2
+    echo "       Fix permissions before stopping services." >&2
+    exit 1
+  fi
+
+  if [[ ! -w "$backup_dir" ]]; then
+    echo "ERROR: backup directory is not writable: $backup_dir" >&2
+    echo "       Fix permissions before stopping services." >&2
+    exit 1
+  fi
+
+  write_test="$backup_dir/.polystore-rollout-preflight-write-test"
+  if ! : >"$write_test"; then
+    echo "ERROR: cannot write backup preflight marker: $write_test" >&2
+    echo "       Fix permissions before stopping services." >&2
+    exit 1
+  fi
+  rm -f "$write_test"
+
+  if [[ -e "$dst" ]]; then
+    if [[ ! -r "$dst" ]]; then
+      echo "ERROR: existing install target cannot be read for backup: $dst" >&2
+      echo "       Fix permissions before stopping services." >&2
+      exit 1
+    fi
+    if [[ ! -w "$dst" ]]; then
+      echo "ERROR: existing install target is not writable for replacement: $dst" >&2
+      echo "       Fix permissions before stopping services." >&2
+      exit 1
+    fi
+  fi
+}
+
 install_with_backup() {
   local src="$1"
   local dst="$2"
@@ -631,7 +695,9 @@ preflight_install_plan() {
   for i in "${!sources[@]}"; do
     if same_install_path "${sources[$i]}" "${destinations[$i]}"; then
       echo "    source equals target; install will be skipped: ${destinations[$i]}"
+      continue
     fi
+    preflight_install_destination "${sources[$i]}" "${destinations[$i]}"
   done
 }
 

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -248,6 +248,30 @@ set_default_provider_bases() {
   done
 }
 
+resolve_provider_bases() {
+  local expected_count="$1"
+  local actual_count="${#PROVIDER_BASES[@]}"
+  local prefix=""
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    prefix="DRY-RUN "
+  fi
+
+  if [[ "$PROVIDER_BASES_FROM_ENV" -eq 1 ]]; then
+    if [[ "$actual_count" -ne "$expected_count" ]]; then
+      echo "ERROR: POLYSTORE_PROVIDER_BASES has $actual_count entries but $expected_count provider-daemon services were resolved." >&2
+      echo "       Provide exactly one base URL per provider-daemon service, or unset POLYSTORE_PROVIDER_BASES to derive defaults." >&2
+      exit 1
+    fi
+
+    echo "    ${prefix}provider-daemon bases from POLYSTORE_PROVIDER_BASES: ${PROVIDER_BASES[*]}"
+    return
+  fi
+
+  set_default_provider_bases "$expected_count"
+  echo "    ${prefix}provider-daemon bases derived from resolved services: ${PROVIDER_BASES[*]}"
+}
+
 user_unit_load_state() {
   local service="$1"
   if [[ "$IS_ROOT" -eq 1 ]]; then
@@ -328,10 +352,7 @@ resolve_provider_service_scopes() {
     if [[ "${#PROVIDER_ROOT_SERVICES[@]}" -gt 0 ]]; then
       echo "    DRY-RUN root manager: ${PROVIDER_ROOT_SERVICES[*]}"
     fi
-    if [[ "$PROVIDER_BASES_FROM_ENV" -ne 1 ]]; then
-      set_default_provider_bases "$((${#PROVIDER_USER_SERVICES[@]} + ${#PROVIDER_ROOT_SERVICES[@]}))"
-      echo "    DRY-RUN provider-daemon bases derived from resolved services: ${PROVIDER_BASES[*]}"
-    fi
+    resolve_provider_bases "$((${#PROVIDER_USER_SERVICES[@]} + ${#PROVIDER_ROOT_SERVICES[@]}))"
     PROVIDER_SERVICE_SCOPES_RESOLVED=1
     return
   fi
@@ -392,10 +413,7 @@ resolve_provider_service_scopes() {
   if [[ "${#PROVIDER_ROOT_SERVICES[@]}" -gt 0 ]]; then
     echo "    root manager: ${PROVIDER_ROOT_SERVICES[*]}"
   fi
-  if [[ "$PROVIDER_BASES_FROM_ENV" -ne 1 ]]; then
-    set_default_provider_bases "$((${#PROVIDER_USER_SERVICES[@]} + ${#PROVIDER_ROOT_SERVICES[@]}))"
-    echo "    provider-daemon bases derived from resolved services: ${PROVIDER_BASES[*]}"
-  fi
+  resolve_provider_bases "$((${#PROVIDER_USER_SERVICES[@]} + ${#PROVIDER_ROOT_SERVICES[@]}))"
   PROVIDER_SERVICE_SCOPES_RESOLVED=1
 }
 

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -467,13 +467,16 @@ resolve_provider_service_scopes() {
 }
 
 provider_systemctl() {
+  local status=0
+
   resolve_provider_service_scopes
   if [[ "${#PROVIDER_USER_SERVICES[@]}" -gt 0 ]]; then
-    user_systemctl "$@" "${PROVIDER_USER_SERVICES[@]}"
+    user_systemctl "$@" "${PROVIDER_USER_SERVICES[@]}" || status=$?
   fi
   if [[ "${#PROVIDER_ROOT_SERVICES[@]}" -gt 0 ]]; then
-    root_systemctl "$@" "${PROVIDER_ROOT_SERVICES[@]}"
+    root_systemctl "$@" "${PROVIDER_ROOT_SERVICES[@]}" || status=$?
   fi
+  return "$status"
 }
 
 preflight_required_tools() {
@@ -819,7 +822,9 @@ print_source_evidence() {
 
 print_service_status() {
   echo "==> Root service activity"
-  root_systemctl is-active "${ROOT_SERVICES[@]}"
+  if ! root_systemctl is-active "${ROOT_SERVICES[@]}"; then
+    echo "WARNING: root service activity status probe failed after healthchecks." >&2
+  fi
   if [[ "$DRY_RUN" != "1" ]]; then
     if [[ "$IS_ROOT" -eq 1 ]]; then
       systemctl --no-pager --full status "${ROOT_SERVICES[@]}" | sed -n '1,160p' || true
@@ -829,7 +834,9 @@ print_service_status() {
   fi
 
   echo "==> Provider service activity"
-  provider_systemctl is-active
+  if ! provider_systemctl is-active; then
+    echo "WARNING: provider-daemon activity status probe failed after healthchecks." >&2
+  fi
   if [[ "$DRY_RUN" != "1" ]]; then
     if [[ "${#PROVIDER_USER_SERVICES[@]}" -gt 0 && "$IS_ROOT" -eq 1 ]]; then
       runuser -u "$RUN_USER" -- env XDG_RUNTIME_DIR="/run/user/$RUN_UID" systemctl --user --no-pager --full status "${PROVIDER_USER_SERVICES[@]}" | sed -n '1,200p' || true

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -1,0 +1,326 @@
+#!/usr/bin/env bash
+#
+# Rebuild and roll out the local PolyStore devnet stack as one proof-format unit.
+# This script intentionally avoids git mutation. Run it from a checked-out branch
+# that already contains the code you want installed.
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/update_devnet_stack.sh [flags]
+
+Flags:
+  --source-root DIR       Source checkout (default: current repo)
+  --target-root DIR       Install root (default: /opt/polystore)
+  --run-user USER         User that owns user systemd services (default: SUDO_USER or current user)
+  --skip-build            Install existing artifacts without rebuilding
+  --dry-run               Print actions without building, installing, or restarting
+  --restart-tunnels       Restart cloudflared user services after provider services
+  -h, --help              Show this help
+
+Environment:
+  POLYSTORE_PROVIDER_SERVICES   Space-separated user services to restart.
+                                Default: polystore-provider1..polystore-provider4.
+  POLYSTORE_TUNNEL_SERVICES     Space-separated tunnel user services.
+                                Default: cloudflared-hub.service cloudflared-providers.service.
+  POLYSTORE_SKIP_BUILD=1        Same as --skip-build.
+  POLYSTORE_DRY_RUN=1           Same as --dry-run.
+  POLYSTORE_RESTART_TUNNELS=1   Same as --restart-tunnels.
+EOF
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_SOURCE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SOURCE_ROOT="${SOURCE_ROOT:-$DEFAULT_SOURCE_ROOT}"
+TARGET_ROOT="${TARGET_ROOT:-/opt/polystore}"
+RUN_USER="${POLYSTORE_RUN_USER:-${SUDO_USER:-$(id -un)}}"
+SKIP_BUILD="${POLYSTORE_SKIP_BUILD:-0}"
+DRY_RUN="${POLYSTORE_DRY_RUN:-0}"
+RESTART_TUNNELS="${POLYSTORE_RESTART_TUNNELS:-0}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --source-root)
+      SOURCE_ROOT="$2"
+      shift 2
+      ;;
+    --target-root)
+      TARGET_ROOT="$2"
+      shift 2
+      ;;
+    --run-user)
+      RUN_USER="$2"
+      shift 2
+      ;;
+    --skip-build)
+      SKIP_BUILD=1
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --restart-tunnels)
+      RESTART_TUNNELS=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown flag: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+RUN_UID="$(id -u "$RUN_USER")"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+BACKUP_DIR="$TARGET_ROOT/backups/update-$STAMP"
+IS_ROOT=0
+if [[ "$(id -u)" -eq 0 ]]; then
+  IS_ROOT=1
+fi
+
+read -r -a PROVIDER_SERVICES <<<"${POLYSTORE_PROVIDER_SERVICES:-polystore-provider1.service polystore-provider2.service polystore-provider3.service polystore-provider4.service}"
+read -r -a ROOT_SERVICES <<<"polystorechaind.service polystore-faucet.service polystore-gateway-router.service"
+read -r -a TUNNEL_SERVICES <<<"${POLYSTORE_TUNNEL_SERVICES:-cloudflared-hub.service cloudflared-providers.service}"
+
+if [[ "$IS_ROOT" -ne 1 && "$(id -un)" != "$RUN_USER" ]]; then
+  echo "ERROR: non-root update must run as POLYSTORE_RUN_USER=$RUN_USER." >&2
+  exit 1
+fi
+
+if [[ "$DRY_RUN" != "1" && ! -w "$TARGET_ROOT" ]]; then
+  echo "ERROR: $TARGET_ROOT is not writable by $(id -un)." >&2
+  echo "       Run with sudo or grant this user write access to the devnet install root." >&2
+  exit 1
+fi
+
+run_cmd() {
+  printf '+'
+  printf ' %q' "$@"
+  printf '\n'
+  if [[ "$DRY_RUN" == "1" ]]; then
+    return 0
+  fi
+  "$@"
+}
+
+run_in_dir() {
+  local dir="$1"
+  shift
+  printf '+ (cd %q &&' "$dir"
+  printf ' %q' "$@"
+  printf ')\n'
+  if [[ "$DRY_RUN" == "1" ]]; then
+    return 0
+  fi
+  (cd "$dir" && "$@")
+}
+
+user_systemctl() {
+  if [[ "$IS_ROOT" -eq 1 ]]; then
+    run_cmd runuser -u "$RUN_USER" -- env XDG_RUNTIME_DIR="/run/user/$RUN_UID" systemctl --user "$@"
+    return
+  fi
+
+  run_cmd env XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$RUN_UID}" systemctl --user "$@"
+}
+
+root_systemctl() {
+  if [[ "$IS_ROOT" -eq 1 ]]; then
+    run_cmd systemctl "$@"
+    return
+  fi
+
+  run_cmd sudo -n systemctl "$@"
+}
+
+sha256_if_present() {
+  local path="$1"
+  if [[ -f "$path" ]]; then
+    sha256sum "$path"
+  else
+    echo "MISSING $path"
+  fi
+}
+
+install_with_backup() {
+  local src="$1"
+  local dst="$2"
+  local mode="$3"
+
+  echo "==> Installing artifact"
+  echo "    src: $src"
+  echo "    dst: $dst"
+  echo "    mode: $mode"
+
+  if [[ ! -f "$src" ]]; then
+    if [[ "$DRY_RUN" == "1" ]]; then
+      echo "    DRY-RUN: source artifact is missing and would fail in live mode"
+      return 0
+    fi
+    echo "ERROR: source artifact missing: $src" >&2
+    exit 1
+  fi
+
+  sha256_if_present "$src"
+  if [[ -e "$dst" ]]; then
+    sha256_if_present "$dst"
+  fi
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "    DRY-RUN: would backup existing target and install"
+    return 0
+  fi
+
+  mkdir -p "$BACKUP_DIR/$(dirname "${dst#"$TARGET_ROOT"/}")" "$(dirname "$dst")"
+  if [[ -e "$dst" ]]; then
+    cp -p "$dst" "$BACKUP_DIR/${dst#"$TARGET_ROOT"/}"
+  fi
+  install -m "$mode" "$src" "$dst"
+  sha256_if_present "$dst"
+}
+
+build_artifacts() {
+  if [[ "$SKIP_BUILD" == "1" ]]; then
+    echo "==> Skipping builds (--skip-build)"
+    return
+  fi
+
+  echo "==> Building coupled devnet artifacts"
+  run_in_dir "$SOURCE_ROOT/polystore_core" cargo build --release
+  run_in_dir "$SOURCE_ROOT/polystorechain" env GOFLAGS="${GOFLAGS:-} -mod=mod" go build -o "$SOURCE_ROOT/polystorechain/polystorechaind" ./cmd/polystorechaind
+  run_in_dir "$SOURCE_ROOT/polystore_gateway" env GOFLAGS="${GOFLAGS:-} -mod=mod" go build -o "$SOURCE_ROOT/polystore_gateway/polystore_gateway" .
+  run_in_dir "$SOURCE_ROOT/polystore_faucet" env GOFLAGS="${GOFLAGS:-} -mod=mod" go build -o "$SOURCE_ROOT/polystore_faucet/polystore_faucet" .
+  run_in_dir "$SOURCE_ROOT/polystore_cli" cargo build --release
+}
+
+wait_http() {
+  local name="$1"
+  local url="$2"
+  local attempts="${3:-60}"
+
+  echo "==> Waiting for $name: $url"
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "    DRY-RUN: would poll $url"
+    return 0
+  fi
+
+  for _ in $(seq 1 "$attempts"); do
+    if curl -fsS --max-time 5 "$url" >/dev/null; then
+      echo "    OK: $name"
+      return 0
+    fi
+    sleep 2
+  done
+
+  echo "ERROR: $name did not become healthy at $url" >&2
+  return 1
+}
+
+print_source_evidence() {
+  echo "==> Source evidence"
+  echo "    source root: $SOURCE_ROOT"
+  echo "    target root: $TARGET_ROOT"
+  echo "    run user: $RUN_USER uid=$RUN_UID"
+  echo "    backup dir: $BACKUP_DIR"
+  if git -C "$SOURCE_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "    source commit: $(git -C "$SOURCE_ROOT" rev-parse HEAD)"
+    echo "    source branch: $(git -C "$SOURCE_ROOT" rev-parse --abbrev-ref HEAD)"
+    echo "    source status:"
+    git -C "$SOURCE_ROOT" status --short || true
+  fi
+  echo "    provider services: ${PROVIDER_SERVICES[*]}"
+  echo "    root services: ${ROOT_SERVICES[*]}"
+  if [[ "$RESTART_TUNNELS" == "1" ]]; then
+    echo "    tunnel services: ${TUNNEL_SERVICES[*]}"
+  else
+    echo "    tunnel services: skipped unless --restart-tunnels is supplied"
+  fi
+}
+
+print_service_status() {
+  echo "==> Root service activity"
+  root_systemctl is-active "${ROOT_SERVICES[@]}"
+  if [[ "$DRY_RUN" != "1" ]]; then
+    if [[ "$IS_ROOT" -eq 1 ]]; then
+      systemctl --no-pager --full status "${ROOT_SERVICES[@]}" | sed -n '1,160p' || true
+    else
+      sudo -n systemctl --no-pager --full status "${ROOT_SERVICES[@]}" | sed -n '1,160p' || true
+    fi
+  fi
+
+  echo "==> Provider service activity"
+  user_systemctl is-active "${PROVIDER_SERVICES[@]}"
+  if [[ "$DRY_RUN" != "1" ]]; then
+    if [[ "$IS_ROOT" -eq 1 ]]; then
+      runuser -u "$RUN_USER" -- env XDG_RUNTIME_DIR="/run/user/$RUN_UID" systemctl --user --no-pager --full status "${PROVIDER_SERVICES[@]}" | sed -n '1,200p' || true
+    else
+      env XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$RUN_UID}" systemctl --user --no-pager --full status "${PROVIDER_SERVICES[@]}" | sed -n '1,200p' || true
+    fi
+  fi
+}
+
+run_healthchecks() {
+  wait_http "LCD node_info" "http://127.0.0.1:1317/cosmos/base/tendermint/v1beta1/node_info" 90
+  wait_http "router gateway" "http://127.0.0.1:18080/health" 45
+  wait_http "faucet" "http://127.0.0.1:8081/health" 45
+  wait_http "provider1" "http://127.0.0.1:8091/health" 45
+  wait_http "provider2" "http://127.0.0.1:8092/health" 45
+  wait_http "provider3" "http://127.0.0.1:8093/health" 45
+  wait_http "provider4" "http://127.0.0.1:8094/health" 45
+
+  echo "==> Running scripted healthchecks"
+  run_in_dir "$SOURCE_ROOT" scripts/devnet_healthcheck.sh hub --lcd http://127.0.0.1:1317 --gateway http://127.0.0.1:18080 --faucet http://127.0.0.1:8081
+  run_in_dir "$SOURCE_ROOT" scripts/devnet_healthcheck.sh provider --provider http://127.0.0.1:8091 --hub-lcd http://127.0.0.1:1317
+  run_in_dir "$SOURCE_ROOT" scripts/devnet_healthcheck.sh provider --provider http://127.0.0.1:8092 --hub-lcd http://127.0.0.1:1317
+  run_in_dir "$SOURCE_ROOT" scripts/devnet_healthcheck.sh provider --provider http://127.0.0.1:8093 --hub-lcd http://127.0.0.1:1317
+  run_in_dir "$SOURCE_ROOT" scripts/devnet_healthcheck.sh provider --provider http://127.0.0.1:8094 --hub-lcd http://127.0.0.1:1317
+}
+
+print_source_evidence
+build_artifacts
+
+echo "==> Stop order: providers -> router/faucet -> chain"
+user_systemctl stop "${PROVIDER_SERVICES[@]}" || true
+root_systemctl stop polystore-gateway-router.service polystore-faucet.service
+root_systemctl stop polystorechaind.service
+if [[ "$RESTART_TUNNELS" == "1" ]]; then
+  echo "==> Stopping tunnel user services"
+  user_systemctl stop "${TUNNEL_SERVICES[@]}" || true
+fi
+
+echo "==> Installing binaries and runtime inputs"
+install_with_backup "$SOURCE_ROOT/polystore_core/target/release/libpolystore_core.so" "$TARGET_ROOT/polystore_core/target/release/libpolystore_core.so" 755
+install_with_backup "$SOURCE_ROOT/polystorechain/polystorechaind" "$TARGET_ROOT/polystorechain/polystorechaind" 755
+install_with_backup "$SOURCE_ROOT/polystore_gateway/polystore_gateway" "$TARGET_ROOT/polystore_gateway/polystore_gateway" 755
+install_with_backup "$SOURCE_ROOT/polystore_faucet/polystore_faucet" "$TARGET_ROOT/polystore_faucet/polystore_faucet" 755
+install_with_backup "$SOURCE_ROOT/polystore_cli/target/release/polystore_cli" "$TARGET_ROOT/polystore_cli/target/release/polystore_cli" 755
+install_with_backup "$SOURCE_ROOT/polystorechain/trusted_setup.txt" "$TARGET_ROOT/polystorechain/trusted_setup.txt" 644
+
+echo "==> Start order: chain -> faucet/router -> providers"
+root_systemctl start polystorechaind.service
+wait_http "LCD node_info" "http://127.0.0.1:1317/cosmos/base/tendermint/v1beta1/node_info" 90
+root_systemctl start polystore-faucet.service polystore-gateway-router.service
+wait_http "faucet" "http://127.0.0.1:8081/health" 45
+wait_http "router gateway" "http://127.0.0.1:18080/health" 45
+user_systemctl start "${PROVIDER_SERVICES[@]}"
+wait_http "provider1" "http://127.0.0.1:8091/health" 45
+wait_http "provider2" "http://127.0.0.1:8092/health" 45
+wait_http "provider3" "http://127.0.0.1:8093/health" 45
+wait_http "provider4" "http://127.0.0.1:8094/health" 45
+if [[ "$RESTART_TUNNELS" == "1" ]]; then
+  echo "==> Starting tunnel user services"
+  user_systemctl start "${TUNNEL_SERVICES[@]}"
+fi
+
+run_healthchecks
+print_service_status
+
+echo "DONE: PolyStore devnet stack updated. Backups are in $BACKUP_DIR"

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -570,13 +570,17 @@ preflight_artifacts() {
     fi
 
     missing=1
-    echo "MISSING $artifact" >&2
+    if [[ "$DRY_RUN" == "1" ]]; then
+      echo "DRY-RUN MISSING $artifact"
+    else
+      echo "MISSING $artifact" >&2
+    fi
   done
 
   if [[ "$missing" -ne 0 ]]; then
     if [[ "$DRY_RUN" == "1" ]]; then
-      echo "ERROR: missing install artifacts; dry-run aborting before service-stop plan" >&2
-      exit 1
+      echo "    DRY-RUN: missing artifacts would be produced by the build step or fail before service stop in live mode"
+      return
     fi
 
     echo "ERROR: missing install artifacts; aborting before service stop" >&2

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -427,6 +427,16 @@ provider_systemctl() {
   fi
 }
 
+preflight_required_tools() {
+  echo "==> Preflighting local command dependencies"
+  if ! command -v curl >/dev/null; then
+    echo "ERROR: curl is required for post-restart health polling before service mutation." >&2
+    echo "       Install curl or run from a host image that includes it." >&2
+    exit 1
+  fi
+  echo "    curl: $(command -v curl)"
+}
+
 preflight_root_service_control() {
   echo "==> Preflighting root service control before stopping services"
   if [[ "$IS_ROOT" -eq 1 ]]; then
@@ -444,6 +454,26 @@ preflight_root_service_control() {
     echo "       Re-run with sudo or configure passwordless sudo for systemctl service control." >&2
     exit 1
   fi
+}
+
+preflight_root_services_loaded() {
+  local service load_state
+
+  echo "==> Preflighting hub root service units"
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "    DRY-RUN: would require loaded root services: ${ROOT_SERVICES[*]}"
+    return
+  fi
+
+  for service in "${ROOT_SERVICES[@]}"; do
+    load_state="$(root_unit_load_state "$service" || true)"
+    if ! unit_is_loaded "$load_state"; then
+      echo "ERROR: hub root service $service was not found in the root systemd manager." >&2
+      echo "       Fix POLYSTORE root service inventory before stopping provider-daemon services." >&2
+      exit 1
+    fi
+  done
+  echo "    root services loaded: ${ROOT_SERVICES[*]}"
 }
 
 preflight_source_target_layout() {
@@ -694,10 +724,12 @@ run_healthchecks() {
 
 print_source_evidence
 preflight_source_target_layout
+preflight_required_tools
 build_artifacts
 preflight_artifacts
 preflight_install_plan
 preflight_root_service_control
+preflight_root_services_loaded
 resolve_provider_service_scopes
 
 echo "==> Stop order: provider-daemons -> user-gateway/faucet -> chain"

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -39,7 +39,7 @@ Environment:
   POLYSTORE_PROVIDER_BASES      Space-separated provider-daemon base URLs.
                                 Default: one URL per resolved provider-daemon
                                 service, starting at http://127.0.0.1:8091.
-                                Duplicate bases are rejected.
+                                Duplicate canonical bases are rejected.
   POLYSTORE_SKIP_BUILD=1        Same as --skip-build.
   POLYSTORE_DRY_RUN=1           Same as --dry-run.
   POLYSTORE_RESTART_TUNNELS=1   Same as --restart-tunnels.
@@ -278,10 +278,61 @@ set_default_provider_bases() {
 
 provider_base_duplicate_key() {
   local base="$1"
+  local scheme authority path host port
 
   while [[ "$base" == */ ]]; do
     base="${base%/}"
   done
+
+  if [[ "$base" =~ ^([A-Za-z][A-Za-z0-9+.-]*)://([^/]+)(/.*)?$ ]]; then
+    scheme="${BASH_REMATCH[1],,}"
+    authority="${BASH_REMATCH[2]}"
+    path="${BASH_REMATCH[3]:-}"
+
+    if [[ "$authority" =~ ^\[([^]]+)\](:([0-9]+))?$ ]]; then
+      host="${BASH_REMATCH[1],,}"
+      port="${BASH_REMATCH[3]:-}"
+      case "$host" in
+        ::1)
+          host="127.0.0.1"
+          ;;
+        *)
+          host="[$host]"
+          ;;
+      esac
+    elif [[ "$authority" =~ ^([^:]+):([0-9]+)$ ]]; then
+      host="${BASH_REMATCH[1],,}"
+      port="${BASH_REMATCH[2]}"
+    else
+      host="${authority,,}"
+      port=""
+    fi
+
+    case "$host" in
+      localhost|127.0.0.1)
+        host="127.0.0.1"
+        ;;
+    esac
+
+    if [[ -z "$port" ]]; then
+      case "$scheme" in
+        http)
+          port="80"
+          ;;
+        https)
+          port="443"
+          ;;
+      esac
+    fi
+
+    if [[ -n "$port" ]]; then
+      printf '%s://%s:%s%s' "$scheme" "$host" "$port" "$path"
+    else
+      printf '%s://%s%s' "$scheme" "$host" "$path"
+    fi
+    return
+  fi
+
   printf '%s' "$base"
 }
 
@@ -303,7 +354,7 @@ require_unique_provider_bases() {
         continue
       fi
 
-      echo "ERROR: duplicate provider-daemon health base: $left_base" >&2
+      echo "ERROR: duplicate provider-daemon health base: $left_base and $right_base" >&2
       echo "       $left_service and $right_service both resolve to the same provider endpoint." >&2
       echo "       Each provider-daemon service must have a unique health base so healthchecks cannot poll one surviving endpoint twice." >&2
       if [[ "$PROVIDER_BASES_FROM_ENV" -eq 1 ]]; then

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -100,6 +100,14 @@ while [[ $# -gt 0 ]]; do
 done
 
 RUN_UID="$(id -u "$RUN_USER")"
+if ! RUN_HOME="$(getent passwd "$RUN_USER" | cut -d: -f6)"; then
+  echo "ERROR: could not look up run user $RUN_USER." >&2
+  exit 1
+fi
+if [[ -z "$RUN_HOME" ]]; then
+  echo "ERROR: could not determine home directory for run user $RUN_USER." >&2
+  exit 1
+fi
 STAMP="$(date +%Y%m%d-%H%M%S)"
 BACKUP_DIR="$TARGET_ROOT/backups/update-$STAMP"
 IS_ROOT=0
@@ -148,6 +156,24 @@ run_in_dir() {
     return 0
   fi
   (cd "$dir" && "$@")
+}
+
+run_build_in_dir() {
+  local dir="$1"
+  shift
+
+  if [[ "$IS_ROOT" -eq 1 && "$RUN_USER" != "root" ]]; then
+    printf '+ (cd %q && runuser -u %q -- env HOME=%q XDG_RUNTIME_DIR=%q' "$dir" "$RUN_USER" "$RUN_HOME" "/run/user/$RUN_UID"
+    printf ' %q' "$@"
+    printf ')\n'
+    if [[ "$DRY_RUN" == "1" ]]; then
+      return 0
+    fi
+    (cd "$dir" && runuser -u "$RUN_USER" -- env HOME="$RUN_HOME" XDG_RUNTIME_DIR="/run/user/$RUN_UID" "$@")
+    return
+  fi
+
+  run_in_dir "$dir" "$@"
 }
 
 goflags_with_mod() {
@@ -265,11 +291,11 @@ build_artifacts() {
   fi
 
   echo "==> Building coupled devnet artifacts"
-  run_in_dir "$SOURCE_ROOT/polystore_core" cargo build --release
-  run_in_dir "$SOURCE_ROOT/polystorechain" env GOFLAGS="$(goflags_with_mod)" go build -o "$SOURCE_ROOT/polystorechain/polystorechaind" ./cmd/polystorechaind
-  run_in_dir "$SOURCE_ROOT/polystore_gateway" env GOFLAGS="$(goflags_with_mod)" go build -o "$SOURCE_ROOT/polystore_gateway/polystore_gateway" .
-  run_in_dir "$SOURCE_ROOT/polystore_faucet" env GOFLAGS="$(goflags_with_mod)" go build -o "$SOURCE_ROOT/polystore_faucet/polystore_faucet" .
-  run_in_dir "$SOURCE_ROOT/polystore_cli" cargo build --release
+  run_build_in_dir "$SOURCE_ROOT/polystore_core" cargo build --release
+  run_build_in_dir "$SOURCE_ROOT/polystorechain" env GOFLAGS="$(goflags_with_mod)" go build -o "$SOURCE_ROOT/polystorechain/polystorechaind" ./cmd/polystorechaind
+  run_build_in_dir "$SOURCE_ROOT/polystore_gateway" env GOFLAGS="$(goflags_with_mod)" go build -o "$SOURCE_ROOT/polystore_gateway/polystore_gateway" .
+  run_build_in_dir "$SOURCE_ROOT/polystore_faucet" env GOFLAGS="$(goflags_with_mod)" go build -o "$SOURCE_ROOT/polystore_faucet/polystore_faucet" .
+  run_build_in_dir "$SOURCE_ROOT/polystore_cli" cargo build --release
 }
 
 wait_http() {

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -205,6 +205,25 @@ root_systemctl() {
   run_cmd sudo -n systemctl "$@"
 }
 
+preflight_root_service_control() {
+  echo "==> Preflighting root service control before stopping services"
+  if [[ "$IS_ROOT" -eq 1 ]]; then
+    echo "    running as root; root systemd control is available"
+    return
+  fi
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "    DRY-RUN: would verify passwordless sudo for root systemd control"
+    return
+  fi
+
+  if ! sudo -n systemctl show --property=Version --value >/dev/null; then
+    echo "ERROR: passwordless sudo systemctl is required before stopping provider-daemon services." >&2
+    echo "       Re-run with sudo or configure passwordless sudo for systemctl service control." >&2
+    exit 1
+  fi
+}
+
 sha256_if_present() {
   local path="$1"
   if [[ -f "$path" ]]; then
@@ -388,6 +407,7 @@ run_healthchecks() {
 print_source_evidence
 build_artifacts
 preflight_artifacts
+preflight_root_service_control
 
 echo "==> Stop order: provider-daemons -> user-gateway/faucet -> chain"
 user_systemctl stop "${PROVIDER_SERVICES[@]}"

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -22,9 +22,9 @@ Flags:
 
 Environment:
   POLYSTORE_PROVIDER_SERVICES   Space-separated provider-daemon services to restart.
-                                Default: polystore-provider1..polystore-provider4
-                                plus the checked-in root provider template when
-                                POLYSTORE_PROVIDER_SERVICE_SCOPE=auto.
+                                Default: polystore-provider1..polystore-provider4,
+                                or the checked-in root provider template when
+                                POLYSTORE_PROVIDER_SERVICE_SCOPE=root.
   POLYSTORE_PROVIDER_SERVICE_SCOPE
                                 Provider service manager: auto, user, or root
                                 (default: auto).
@@ -130,8 +130,6 @@ if [[ -n "${POLYSTORE_PROVIDER_SERVICES+x}" ]]; then
   read -r -a PROVIDER_SERVICES <<<"$POLYSTORE_PROVIDER_SERVICES"
 elif [[ "$PROVIDER_SERVICE_SCOPE" == "root" ]]; then
   PROVIDER_SERVICES=("${DEFAULT_ROOT_PROVIDER_SERVICES[@]}")
-elif [[ "$PROVIDER_SERVICE_SCOPE" == "auto" ]]; then
-  PROVIDER_SERVICES=("${DEFAULT_USER_PROVIDER_SERVICES[@]}" "${DEFAULT_ROOT_PROVIDER_SERVICES[@]}")
 else
   PROVIDER_SERVICES=("${DEFAULT_USER_PROVIDER_SERVICES[@]}")
 fi
@@ -321,7 +319,6 @@ resolve_provider_service_scopes() {
           PROVIDER_USER_SERVICES=("${PROVIDER_SERVICES[@]}")
         else
           PROVIDER_USER_SERVICES=("${DEFAULT_USER_PROVIDER_SERVICES[@]}")
-          PROVIDER_ROOT_SERVICES=("${DEFAULT_ROOT_PROVIDER_SERVICES[@]}")
         fi
         ;;
     esac

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -498,11 +498,22 @@ preflight_root_service_control() {
     return
   fi
 
-  if ! sudo -n systemctl show --property=Version --value >/dev/null; then
-    echo "ERROR: passwordless sudo systemctl is required before stopping provider-daemon services." >&2
-    echo "       Re-run with sudo or configure passwordless sudo for systemctl service control." >&2
-    exit 1
+  preflight_root_systemctl_authorized stop polystore-gateway-router.service polystore-faucet.service
+  preflight_root_systemctl_authorized stop polystorechaind.service
+  preflight_root_systemctl_authorized start polystorechaind.service
+  preflight_root_systemctl_authorized start polystore-faucet.service polystore-gateway-router.service
+}
+
+preflight_root_systemctl_authorized() {
+  if sudo -n -l systemctl "$@" >/dev/null 2>&1; then
+    echo "    sudo authorization OK: systemctl $*"
+    return
   fi
+
+  echo "ERROR: passwordless sudo authorization is required before stopping provider-daemon services." >&2
+  echo "       Missing authorization for: systemctl $*" >&2
+  echo "       Re-run as root or configure passwordless sudo for the exact systemctl stop/start actions." >&2
+  exit 1
 }
 
 preflight_root_services_loaded() {

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -224,6 +224,20 @@ preflight_root_service_control() {
   fi
 }
 
+preflight_source_target_layout() {
+  echo "==> Preflighting source/target layout"
+  if [[ "$SKIP_BUILD" == "1" ]]; then
+    echo "    build skipped; source root may equal target root only for already-staged artifacts"
+    return
+  fi
+
+  if [[ "$(realpath -m "$SOURCE_ROOT")" == "$(realpath -m "$TARGET_ROOT")" ]]; then
+    echo "ERROR: refusing to build with --source-root equal to --target-root." >&2
+    echo "       Build from a separate checkout, or use --skip-build only after artifacts are already staged in place." >&2
+    exit 1
+  fi
+}
+
 sha256_if_present() {
   local path="$1"
   if [[ -f "$path" ]]; then
@@ -447,6 +461,7 @@ run_healthchecks() {
 }
 
 print_source_evidence
+preflight_source_target_layout
 build_artifacts
 preflight_artifacts
 preflight_install_plan

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -294,7 +294,16 @@ root_unit_load_state() {
 
 unit_is_loaded() {
   local load_state="$1"
-  [[ -n "$load_state" && "$load_state" != "not-found" ]]
+  [[ "$load_state" == "loaded" ]]
+}
+
+describe_load_state() {
+  local load_state="$1"
+  if [[ -n "$load_state" ]]; then
+    printf '%s' "$load_state"
+  else
+    printf 'unavailable'
+  fi
 }
 
 require_provider_service_loaded() {
@@ -309,7 +318,8 @@ require_provider_service_loaded() {
   fi
 
   if ! unit_is_loaded "$load_state"; then
-    echo "ERROR: provider-daemon service $service was not found in the $scope systemd manager." >&2
+    echo "ERROR: provider-daemon service $service is not loaded in the $scope systemd manager." >&2
+    echo "       LoadState=$(describe_load_state "$load_state"); fix the unit before stopping services." >&2
     exit 1
   fi
 }
@@ -394,13 +404,14 @@ resolve_provider_service_scopes() {
         fi
 
         if [[ "$PROVIDER_SERVICES_FROM_ENV" -eq 1 ]]; then
-          echo "ERROR: provider-daemon service not found in user or root systemd managers: $service" >&2
+          echo "ERROR: provider-daemon service is not loaded in user or root systemd managers: $service" >&2
+          echo "       user LoadState=$(describe_load_state "$user_state"), root LoadState=$(describe_load_state "$root_state")." >&2
           exit 1
         fi
       done
 
       if [[ "$found_any" -ne 1 ]]; then
-        echo "ERROR: no provider-daemon services were found in user or root systemd managers." >&2
+        echo "ERROR: no provider-daemon services were loaded in user or root systemd managers." >&2
         echo "       Set POLYSTORE_PROVIDER_SERVICES and POLYSTORE_PROVIDER_SERVICE_SCOPE for this host." >&2
         exit 1
       fi
@@ -468,7 +479,8 @@ preflight_root_services_loaded() {
   for service in "${ROOT_SERVICES[@]}"; do
     load_state="$(root_unit_load_state "$service" || true)"
     if ! unit_is_loaded "$load_state"; then
-      echo "ERROR: hub root service $service was not found in the root systemd manager." >&2
+      echo "ERROR: hub root service $service is not loaded in the root systemd manager." >&2
+      echo "       LoadState=$(describe_load_state "$load_state"); fix the unit before stopping services." >&2
       echo "       Fix POLYSTORE root service inventory before stopping provider-daemon services." >&2
       exit 1
     fi

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -578,12 +578,15 @@ preflight_artifacts() {
   done
 
   if [[ "$missing" -ne 0 ]]; then
-    if [[ "$DRY_RUN" == "1" ]]; then
+    if [[ "$DRY_RUN" == "1" && "$SKIP_BUILD" != "1" ]]; then
       echo "    DRY-RUN: missing artifacts would be produced by the build step or fail before service stop in live mode"
       return
     fi
 
     echo "ERROR: missing install artifacts; aborting before service stop" >&2
+    if [[ "$DRY_RUN" == "1" && "$SKIP_BUILD" == "1" ]]; then
+      echo "       --skip-build dry-runs require staged artifacts because no build step can produce them." >&2
+    fi
     exit 1
   fi
 }

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -21,8 +21,13 @@ Flags:
   -h, --help              Show this help
 
 Environment:
-  POLYSTORE_PROVIDER_SERVICES   Space-separated user services to restart.
-                                Default: polystore-provider1..polystore-provider4.
+  POLYSTORE_PROVIDER_SERVICES   Space-separated provider-daemon services to restart.
+                                Default: polystore-provider1..polystore-provider4
+                                plus the checked-in root provider template when
+                                POLYSTORE_PROVIDER_SERVICE_SCOPE=auto.
+  POLYSTORE_PROVIDER_SERVICE_SCOPE
+                                Provider service manager: auto, user, or root
+                                (default: auto).
   POLYSTORE_TUNNEL_SERVICES     Space-separated tunnel user services.
                                 Default: cloudflared-hub.service cloudflared-providers.service.
   POLYSTORE_RPC_BASE            Hub Tendermint RPC base URL (default: http://127.0.0.1:26657).
@@ -115,7 +120,20 @@ if [[ "$(id -u)" -eq 0 ]]; then
   IS_ROOT=1
 fi
 
-read -r -a PROVIDER_SERVICES <<<"${POLYSTORE_PROVIDER_SERVICES:-polystore-provider1.service polystore-provider2.service polystore-provider3.service polystore-provider4.service}"
+DEFAULT_USER_PROVIDER_SERVICES=(polystore-provider1.service polystore-provider2.service polystore-provider3.service polystore-provider4.service)
+DEFAULT_ROOT_PROVIDER_SERVICES=(polystore-gateway-provider.service)
+PROVIDER_SERVICES_FROM_ENV=0
+PROVIDER_SERVICE_SCOPE="${POLYSTORE_PROVIDER_SERVICE_SCOPE:-auto}"
+if [[ -n "${POLYSTORE_PROVIDER_SERVICES+x}" ]]; then
+  PROVIDER_SERVICES_FROM_ENV=1
+  read -r -a PROVIDER_SERVICES <<<"$POLYSTORE_PROVIDER_SERVICES"
+elif [[ "$PROVIDER_SERVICE_SCOPE" == "root" ]]; then
+  PROVIDER_SERVICES=("${DEFAULT_ROOT_PROVIDER_SERVICES[@]}")
+elif [[ "$PROVIDER_SERVICE_SCOPE" == "auto" ]]; then
+  PROVIDER_SERVICES=("${DEFAULT_USER_PROVIDER_SERVICES[@]}" "${DEFAULT_ROOT_PROVIDER_SERVICES[@]}")
+else
+  PROVIDER_SERVICES=("${DEFAULT_USER_PROVIDER_SERVICES[@]}")
+fi
 read -r -a ROOT_SERVICES <<<"polystorechaind.service polystore-faucet.service polystore-gateway-router.service"
 read -r -a TUNNEL_SERVICES <<<"${POLYSTORE_TUNNEL_SERVICES:-cloudflared-hub.service cloudflared-providers.service}"
 RPC_BASE="${POLYSTORE_RPC_BASE:-http://127.0.0.1:26657}"
@@ -129,6 +147,15 @@ if [[ "$IS_ROOT" -ne 1 && "$(id -un)" != "$RUN_USER" ]]; then
   echo "ERROR: non-root update must run as POLYSTORE_RUN_USER=$RUN_USER." >&2
   exit 1
 fi
+
+case "$PROVIDER_SERVICE_SCOPE" in
+  auto|user|root)
+    ;;
+  *)
+    echo "ERROR: POLYSTORE_PROVIDER_SERVICE_SCOPE must be auto, user, or root." >&2
+    exit 2
+    ;;
+esac
 
 if [[ "$DRY_RUN" != "1" && ! -w "$TARGET_ROOT" ]]; then
   echo "ERROR: $TARGET_ROOT is not writable by $(id -un)." >&2
@@ -203,6 +230,160 @@ root_systemctl() {
   fi
 
   run_cmd sudo -n systemctl "$@"
+}
+
+user_unit_load_state() {
+  local service="$1"
+  if [[ "$IS_ROOT" -eq 1 ]]; then
+    runuser -u "$RUN_USER" -- env XDG_RUNTIME_DIR="/run/user/$RUN_UID" systemctl --user show "$service" --property=LoadState --value 2>/dev/null
+    return
+  fi
+
+  env XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$RUN_UID}" systemctl --user show "$service" --property=LoadState --value 2>/dev/null
+}
+
+root_unit_load_state() {
+  local service="$1"
+  if [[ "$IS_ROOT" -eq 1 ]]; then
+    systemctl show "$service" --property=LoadState --value 2>/dev/null
+    return
+  fi
+
+  sudo -n systemctl show "$service" --property=LoadState --value 2>/dev/null
+}
+
+unit_is_loaded() {
+  local load_state="$1"
+  [[ -n "$load_state" && "$load_state" != "not-found" ]]
+}
+
+require_provider_service_loaded() {
+  local scope="$1"
+  local service="$2"
+  local load_state
+
+  if [[ "$scope" == "user" ]]; then
+    load_state="$(user_unit_load_state "$service" || true)"
+  else
+    load_state="$(root_unit_load_state "$service" || true)"
+  fi
+
+  if ! unit_is_loaded "$load_state"; then
+    echo "ERROR: provider-daemon service $service was not found in the $scope systemd manager." >&2
+    exit 1
+  fi
+}
+
+declare -a PROVIDER_USER_SERVICES=()
+declare -a PROVIDER_ROOT_SERVICES=()
+PROVIDER_SERVICE_SCOPES_RESOLVED=0
+
+resolve_provider_service_scopes() {
+  local service user_state root_state found_any=0
+
+  if [[ "$PROVIDER_SERVICE_SCOPES_RESOLVED" -eq 1 ]]; then
+    return
+  fi
+
+  PROVIDER_USER_SERVICES=()
+  PROVIDER_ROOT_SERVICES=()
+  echo "==> Resolving provider-daemon service managers"
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    case "$PROVIDER_SERVICE_SCOPE" in
+      user)
+        PROVIDER_USER_SERVICES=("${PROVIDER_SERVICES[@]}")
+        ;;
+      root)
+        PROVIDER_ROOT_SERVICES=("${PROVIDER_SERVICES[@]}")
+        ;;
+      auto)
+        if [[ "$PROVIDER_SERVICES_FROM_ENV" -eq 1 ]]; then
+          echo "    DRY-RUN: auto scope for explicit POLYSTORE_PROVIDER_SERVICES resolves in live mode"
+          PROVIDER_USER_SERVICES=("${PROVIDER_SERVICES[@]}")
+        else
+          PROVIDER_USER_SERVICES=("${DEFAULT_USER_PROVIDER_SERVICES[@]}")
+          PROVIDER_ROOT_SERVICES=("${DEFAULT_ROOT_PROVIDER_SERVICES[@]}")
+        fi
+        ;;
+    esac
+    if [[ "${#PROVIDER_USER_SERVICES[@]}" -gt 0 ]]; then
+      echo "    DRY-RUN user manager: ${PROVIDER_USER_SERVICES[*]}"
+    fi
+    if [[ "${#PROVIDER_ROOT_SERVICES[@]}" -gt 0 ]]; then
+      echo "    DRY-RUN root manager: ${PROVIDER_ROOT_SERVICES[*]}"
+    fi
+    PROVIDER_SERVICE_SCOPES_RESOLVED=1
+    return
+  fi
+
+  case "$PROVIDER_SERVICE_SCOPE" in
+    user)
+      for service in "${PROVIDER_SERVICES[@]}"; do
+        require_provider_service_loaded user "$service"
+      done
+      PROVIDER_USER_SERVICES=("${PROVIDER_SERVICES[@]}")
+      ;;
+    root)
+      for service in "${PROVIDER_SERVICES[@]}"; do
+        require_provider_service_loaded root "$service"
+      done
+      PROVIDER_ROOT_SERVICES=("${PROVIDER_SERVICES[@]}")
+      ;;
+    auto)
+      for service in "${PROVIDER_SERVICES[@]}"; do
+        user_state="$(user_unit_load_state "$service" || true)"
+        root_state="$(root_unit_load_state "$service" || true)"
+
+        if unit_is_loaded "$user_state" && unit_is_loaded "$root_state"; then
+          echo "ERROR: provider-daemon service $service exists in both user and root managers." >&2
+          echo "       Set POLYSTORE_PROVIDER_SERVICE_SCOPE=user or root for this rollout." >&2
+          exit 1
+        fi
+
+        if unit_is_loaded "$user_state"; then
+          PROVIDER_USER_SERVICES+=("$service")
+          found_any=1
+          continue
+        fi
+
+        if unit_is_loaded "$root_state"; then
+          PROVIDER_ROOT_SERVICES+=("$service")
+          found_any=1
+          continue
+        fi
+
+        if [[ "$PROVIDER_SERVICES_FROM_ENV" -eq 1 ]]; then
+          echo "ERROR: provider-daemon service not found in user or root systemd managers: $service" >&2
+          exit 1
+        fi
+      done
+
+      if [[ "$found_any" -ne 1 ]]; then
+        echo "ERROR: no provider-daemon services were found in user or root systemd managers." >&2
+        echo "       Set POLYSTORE_PROVIDER_SERVICES and POLYSTORE_PROVIDER_SERVICE_SCOPE for this host." >&2
+        exit 1
+      fi
+      ;;
+  esac
+
+  if [[ "${#PROVIDER_USER_SERVICES[@]}" -gt 0 ]]; then
+    echo "    user manager: ${PROVIDER_USER_SERVICES[*]}"
+  fi
+  if [[ "${#PROVIDER_ROOT_SERVICES[@]}" -gt 0 ]]; then
+    echo "    root manager: ${PROVIDER_ROOT_SERVICES[*]}"
+  fi
+  PROVIDER_SERVICE_SCOPES_RESOLVED=1
+}
+
+provider_systemctl() {
+  resolve_provider_service_scopes
+  if [[ "${#PROVIDER_USER_SERVICES[@]}" -gt 0 ]]; then
+    user_systemctl "$@" "${PROVIDER_USER_SERVICES[@]}"
+  fi
+  if [[ "${#PROVIDER_ROOT_SERVICES[@]}" -gt 0 ]]; then
+    root_systemctl "$@" "${PROVIDER_ROOT_SERVICES[@]}"
+  fi
 }
 
 preflight_root_service_control() {
@@ -409,6 +590,7 @@ print_source_evidence() {
     git -C "$SOURCE_ROOT" status --short || true
   fi
   echo "    provider-daemon services: ${PROVIDER_SERVICES[*]}"
+  echo "    provider-daemon service scope: $PROVIDER_SERVICE_SCOPE"
   echo "    root services: ${ROOT_SERVICES[*]}"
   echo "    rpc base: $RPC_BASE"
   echo "    lcd base: $LCD_BASE"
@@ -435,12 +617,17 @@ print_service_status() {
   fi
 
   echo "==> Provider service activity"
-  user_systemctl is-active "${PROVIDER_SERVICES[@]}"
+  provider_systemctl is-active
   if [[ "$DRY_RUN" != "1" ]]; then
-    if [[ "$IS_ROOT" -eq 1 ]]; then
-      runuser -u "$RUN_USER" -- env XDG_RUNTIME_DIR="/run/user/$RUN_UID" systemctl --user --no-pager --full status "${PROVIDER_SERVICES[@]}" | sed -n '1,200p' || true
-    else
-      env XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$RUN_UID}" systemctl --user --no-pager --full status "${PROVIDER_SERVICES[@]}" | sed -n '1,200p' || true
+    if [[ "${#PROVIDER_USER_SERVICES[@]}" -gt 0 && "$IS_ROOT" -eq 1 ]]; then
+      runuser -u "$RUN_USER" -- env XDG_RUNTIME_DIR="/run/user/$RUN_UID" systemctl --user --no-pager --full status "${PROVIDER_USER_SERVICES[@]}" | sed -n '1,200p' || true
+    elif [[ "${#PROVIDER_USER_SERVICES[@]}" -gt 0 ]]; then
+      env XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$RUN_UID}" systemctl --user --no-pager --full status "${PROVIDER_USER_SERVICES[@]}" | sed -n '1,200p' || true
+    fi
+    if [[ "${#PROVIDER_ROOT_SERVICES[@]}" -gt 0 && "$IS_ROOT" -eq 1 ]]; then
+      systemctl --no-pager --full status "${PROVIDER_ROOT_SERVICES[@]}" | sed -n '1,200p' || true
+    elif [[ "${#PROVIDER_ROOT_SERVICES[@]}" -gt 0 ]]; then
+      sudo -n systemctl --no-pager --full status "${PROVIDER_ROOT_SERVICES[@]}" | sed -n '1,200p' || true
     fi
   fi
 }
@@ -466,9 +653,10 @@ build_artifacts
 preflight_artifacts
 preflight_install_plan
 preflight_root_service_control
+resolve_provider_service_scopes
 
 echo "==> Stop order: provider-daemons -> user-gateway/faucet -> chain"
-user_systemctl stop "${PROVIDER_SERVICES[@]}"
+provider_systemctl stop
 root_systemctl stop polystore-gateway-router.service polystore-faucet.service
 root_systemctl stop polystorechaind.service
 if [[ "$RESTART_TUNNELS" == "1" ]]; then
@@ -490,7 +678,7 @@ wait_http "LCD node_info" "$LCD_BASE/cosmos/base/tendermint/v1beta1/node_info" 9
 root_systemctl start polystore-faucet.service polystore-gateway-router.service
 wait_http "faucet" "$FAUCET_BASE/health" 45
 wait_http "user-gateway (legacy router service)" "$ROUTER_BASE/health" 45
-user_systemctl start "${PROVIDER_SERVICES[@]}"
+provider_systemctl start
 for i in "${!PROVIDER_BASES[@]}"; do
   wait_http "provider-daemon$((i + 1))" "${PROVIDER_BASES[$i]}/health" 45
 done

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -502,6 +502,10 @@ preflight_root_service_control() {
   preflight_root_systemctl_authorized stop polystorechaind.service
   preflight_root_systemctl_authorized start polystorechaind.service
   preflight_root_systemctl_authorized start polystore-faucet.service polystore-gateway-router.service
+  if [[ "${#PROVIDER_ROOT_SERVICES[@]}" -gt 0 ]]; then
+    preflight_root_systemctl_authorized stop "${PROVIDER_ROOT_SERVICES[@]}"
+    preflight_root_systemctl_authorized start "${PROVIDER_ROOT_SERVICES[@]}"
+  fi
 }
 
 preflight_root_systemctl_authorized() {
@@ -861,9 +865,9 @@ preflight_required_tools
 build_artifacts
 preflight_artifacts
 preflight_install_plan
-preflight_root_service_control
 preflight_root_services_loaded
 resolve_provider_service_scopes
+preflight_root_service_control
 
 echo "==> Stop order: provider-daemons -> user-gateway/faucet -> chain"
 provider_systemctl stop

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -128,6 +128,11 @@ PROVIDER_SERVICE_SCOPE="${POLYSTORE_PROVIDER_SERVICE_SCOPE:-auto}"
 if [[ -n "${POLYSTORE_PROVIDER_SERVICES+x}" ]]; then
   PROVIDER_SERVICES_FROM_ENV=1
   read -r -a PROVIDER_SERVICES <<<"$POLYSTORE_PROVIDER_SERVICES"
+  if [[ "${#PROVIDER_SERVICES[@]}" -eq 0 ]]; then
+    echo "ERROR: POLYSTORE_PROVIDER_SERVICES was provided but no provider-daemon services were listed." >&2
+    echo "       Unset it to use the default provider inventory, or provide one or more service names." >&2
+    exit 2
+  fi
 elif [[ "$PROVIDER_SERVICE_SCOPE" == "root" ]]; then
   PROVIDER_SERVICES=("${DEFAULT_ROOT_PROVIDER_SERVICES[@]}")
 else

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -317,6 +317,11 @@ root_unit_load_state() {
     return
   fi
 
+  if [[ "$DRY_RUN" == "1" ]]; then
+    systemctl show "$service" --property=LoadState --value 2>/dev/null
+    return
+  fi
+
   sudo -n systemctl show "$service" --property=LoadState --value 2>/dev/null
 }
 
@@ -500,8 +505,7 @@ preflight_root_services_loaded() {
 
   echo "==> Preflighting hub root service units"
   if [[ "$DRY_RUN" == "1" ]]; then
-    echo "    DRY-RUN: would require loaded root services: ${ROOT_SERVICES[*]}"
-    return
+    echo "    DRY-RUN: validating loaded root services with non-mutating systemctl show: ${ROOT_SERVICES[*]}"
   fi
 
   for service in "${ROOT_SERVICES[@]}"; do

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -233,6 +233,12 @@ sha256_if_present() {
   fi
 }
 
+same_install_path() {
+  local src="$1"
+  local dst="$2"
+  [[ "$(realpath -m "$src")" == "$(realpath -m "$dst")" ]]
+}
+
 install_with_backup() {
   local src="$1"
   local dst="$2"
@@ -255,6 +261,15 @@ install_with_backup() {
   sha256_if_present "$src"
   if [[ -e "$dst" ]]; then
     sha256_if_present "$dst"
+  fi
+
+  if same_install_path "$src" "$dst"; then
+    if [[ "$DRY_RUN" == "1" ]]; then
+      echo "    DRY-RUN: source and target are the same path; install would be skipped"
+    else
+      echo "    source and target are the same path; skipping install"
+    fi
+    return 0
   fi
 
   if [[ "$DRY_RUN" == "1" ]]; then
@@ -301,6 +316,33 @@ preflight_artifacts() {
     echo "ERROR: missing install artifacts; aborting before service stop" >&2
     exit 1
   fi
+}
+
+preflight_install_plan() {
+  local sources=(
+    "$SOURCE_ROOT/polystore_core/target/release/libpolystore_core.so"
+    "$SOURCE_ROOT/polystorechain/polystorechaind"
+    "$SOURCE_ROOT/polystore_gateway/polystore_gateway"
+    "$SOURCE_ROOT/polystore_faucet/polystore_faucet"
+    "$SOURCE_ROOT/polystore_cli/target/release/polystore_cli"
+    "$SOURCE_ROOT/polystorechain/trusted_setup.txt"
+  )
+  local destinations=(
+    "$TARGET_ROOT/polystore_core/target/release/libpolystore_core.so"
+    "$TARGET_ROOT/polystorechain/polystorechaind"
+    "$TARGET_ROOT/polystore_gateway/polystore_gateway"
+    "$TARGET_ROOT/polystore_faucet/polystore_faucet"
+    "$TARGET_ROOT/polystore_cli/target/release/polystore_cli"
+    "$TARGET_ROOT/polystorechain/trusted_setup.txt"
+  )
+  local i
+
+  echo "==> Preflighting install plan before stopping services"
+  for i in "${!sources[@]}"; do
+    if same_install_path "${sources[$i]}" "${destinations[$i]}"; then
+      echo "    source equals target; install will be skipped: ${destinations[$i]}"
+    fi
+  done
 }
 
 build_artifacts() {
@@ -407,6 +449,7 @@ run_healthchecks() {
 print_source_evidence
 build_artifacts
 preflight_artifacts
+preflight_install_plan
 preflight_root_service_control
 
 echo "==> Stop order: provider-daemons -> user-gateway/faucet -> chain"

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -317,12 +317,7 @@ root_unit_load_state() {
     return
   fi
 
-  if [[ "$DRY_RUN" == "1" ]]; then
-    systemctl show "$service" --property=LoadState --value 2>/dev/null
-    return
-  fi
-
-  sudo -n systemctl show "$service" --property=LoadState --value 2>/dev/null
+  systemctl show "$service" --property=LoadState --value 2>/dev/null
 }
 
 unit_is_loaded() {

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -366,33 +366,8 @@ resolve_provider_service_scopes() {
   PROVIDER_USER_SERVICES=()
   PROVIDER_ROOT_SERVICES=()
   echo "==> Resolving provider-daemon service managers"
-
   if [[ "$DRY_RUN" == "1" ]]; then
-    case "$PROVIDER_SERVICE_SCOPE" in
-      user)
-        PROVIDER_USER_SERVICES=("${PROVIDER_SERVICES[@]}")
-        ;;
-      root)
-        PROVIDER_ROOT_SERVICES=("${PROVIDER_SERVICES[@]}")
-        ;;
-      auto)
-        if [[ "$PROVIDER_SERVICES_FROM_ENV" -eq 1 ]]; then
-          echo "    DRY-RUN: auto scope for explicit POLYSTORE_PROVIDER_SERVICES resolves in live mode"
-          PROVIDER_USER_SERVICES=("${PROVIDER_SERVICES[@]}")
-        else
-          PROVIDER_USER_SERVICES=("${DEFAULT_USER_PROVIDER_SERVICES[@]}")
-        fi
-        ;;
-    esac
-    if [[ "${#PROVIDER_USER_SERVICES[@]}" -gt 0 ]]; then
-      echo "    DRY-RUN user manager: ${PROVIDER_USER_SERVICES[*]}"
-    fi
-    if [[ "${#PROVIDER_ROOT_SERVICES[@]}" -gt 0 ]]; then
-      echo "    DRY-RUN root manager: ${PROVIDER_ROOT_SERVICES[*]}"
-    fi
-    resolve_provider_bases "$((${#PROVIDER_USER_SERVICES[@]} + ${#PROVIDER_ROOT_SERVICES[@]}))" "${PROVIDER_USER_SERVICES[@]}" "${PROVIDER_ROOT_SERVICES[@]}"
-    PROVIDER_SERVICE_SCOPES_RESOLVED=1
-    return
+    echo "    DRY-RUN: validating loaded provider-daemon services with non-mutating systemctl show"
   fi
 
   case "$PROVIDER_SERVICE_SCOPE" in
@@ -896,14 +871,15 @@ preflight_tunnel_services_loaded
 resolve_provider_service_scopes
 preflight_root_service_control
 
-echo "==> Stop order: provider-daemons -> user-gateway/faucet -> chain"
-provider_systemctl stop
-root_systemctl stop polystore-gateway-router.service polystore-faucet.service
-root_systemctl stop polystorechaind.service
 if [[ "$RESTART_TUNNELS" == "1" ]]; then
   echo "==> Stopping tunnel user services"
   user_systemctl stop "${TUNNEL_SERVICES[@]}"
 fi
+
+echo "==> Stop order: provider-daemons -> user-gateway/faucet -> chain"
+provider_systemctl stop
+root_systemctl stop polystore-gateway-router.service polystore-faucet.service
+root_systemctl stop polystorechaind.service
 
 echo "==> Installing binaries and runtime inputs"
 install_with_backup "$SOURCE_ROOT/polystore_core/target/release/libpolystore_core.so" "$TARGET_ROOT/polystore_core/target/release/libpolystore_core.so" 755


### PR DESCRIPTION
## Current Status (2026-06-22 14:21 UTC)

Head `0f68f67c` is the current ready-for-review head for `devnet/polyfs-root-rollout`.

- PR state: non-draft, merge state `CLEAN`.
- Latest-head CI: all 28 checks green on `0f68f67c`, including PolyStore CI, Playwright E2E, Repro Bug E2E, Workers build, Browser Sparse Upload Proof, Native/WASM parity, lifecycle gateway/no-gateway, Gateway Retrieval, Mode2 Stripe, Gateway Absent, Website Node Integration, and ghost-repair.
- Review threads: 0 unresolved.
- Final AI review: Codex clean response on `0f68f67c` at https://github.com/Polynomialstore/polystore/pull/223#issuecomment-4769344473; no major issues found.
- Live devnet restart: not performed. Run only after the selected #221 proof-format implementation is accepted or explicitly staged with this rollout branch for #224 validation.

## Summary

- Add tracked `scripts/update_devnet_stack.sh` for proof-format-coupled local devnet rollouts.
- Cover chain, faucet, `user-gateway` legacy router service, provider1-provider4, optional root-managed provider-daemon template, gateway, CLI, core shared library, and trusted setup artifacts.
- Add dry-run support, sha256/backup evidence, source/target safety checks, endpoint health polling, configurable endpoint bases, provider service-scope resolution, and opt-in tunnel restarts.
- Harden pre-stop gates so missing artifacts, missing `curl`, bad hub/provider/tunnel units, provider inventory mismatches, duplicate provider service names, duplicate canonical provider health bases, missing sudo authorization, and install-target permission problems fail before the devnet stack is stopped.
- Keep tunnel restarts opt-in; when requested, tunnel user units are preflighted and tunnel stop happens before the provider/user-gateway/faucet/chain stop sequence.
- Document PolyFS root rollout state policy and service-scope behavior in `docs/devnet-polyfs-root-rollout.md`.

## Validation

Local validation on this branch:

```sh
bash -n scripts/update_devnet_stack.sh
shellcheck scripts/update_devnet_stack.sh
git diff --check
scripts/update_devnet_stack.sh --dry-run
```

Focused fake-systemd/sudo validation covered:

- missing artifacts fail before any service-stop plan in `--dry-run --skip-build`;
- complete fake-artifact dry-run reaches the full stop/start and healthcheck plan without mutation;
- source-equals-target build mode is refused, while skip-build same-path installs are skipped safely;
- missing `curl`, missing hub units, bad provider scope, empty/short provider bases, empty provider-service overrides, masked/bad provider units, and missing sudo authorization fail before stack stop;
- provider1-provider4 are all required in the default auto inventory unless `POLYSTORE_PROVIDER_SERVICES` explicitly selects a partial devnet;
- explicit `polystore-provider4.service` maps to `http://127.0.0.1:8094`, and custom provider service names require explicit `POLYSTORE_PROVIDER_BASES`;
- dry-runs validate hub, provider-daemon, and optional tunnel unit `LoadState=loaded` using non-mutating `systemctl show` paths;
- non-root root-unit probes use non-sudo `systemctl show`; sudo remains scoped to exact stop/start authorizations;
- final `systemctl is-active` probes are best-effort after healthchecks, while stop/start failures remain fatal;
- `--restart-tunnels` missing tunnel units fail before stop, and simulated tunnel stop failure aborts before the core stack stop order.

Additional duplicate-provider validation covered:

- derived duplicate service mappings;
- explicit duplicate `POLYSTORE_PROVIDER_BASES`;
- canonical `localhost`/`127.0.0.1`/`[::1]` aliases;
- omitted default HTTP/HTTPS ports;
- duplicate `POLYSTORE_PROVIDER_SERVICES` entries with distinct bases, failing immediately with `ERROR: duplicate provider-daemon service`;
- normal unique `8091..8094` host dry-run.

Latest-head CI on `0f68f67c` is green:

- PolyStore CI: https://github.com/Polynomialstore/polystore/actions/runs/27958716066
- Playwright E2E: https://github.com/Polynomialstore/polystore/actions/runs/27958715666
- Repro Bug E2E: https://github.com/Polynomialstore/polystore/actions/runs/27958715702

## Live Restart

Not performed in this PR. This PR prepares the rollout mechanism. The live devnet update belongs in #218 after #221 and #223 are accepted or explicitly staged together.

When authorized, record exact source SHAs, artifact hashes, service status, endpoint health, high-index proof evidence, small lifecycle evidence, and rollback/reset decision. Endpoint health alone is not proof-format compatibility.

## Stack Notes

- Addresses #217.
- Supports #212 and #218 final rollout gates.
- PR #224 will run this script's rollout dry-run once this script is present in the selected validation branch.
- Human review/approval is still required. Do not self-merge.