### PR TITLE
Fix Mode2 PolyFS upload root and CI native core guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -597,6 +597,9 @@ jobs:
         working-directory: polystore-website
         run: npx playwright install --with-deps chromium
 
+      - name: Build polystore_core (native)
+        run: cd polystore_core && cargo build --release
+
       - name: Run Mode2 Stripe E2E (fast)
         env:
           E2E_MODE2_FAST: '1'

--- a/.github/workflows/e2e_heavy_nightly.yml
+++ b/.github/workflows/e2e_heavy_nightly.yml
@@ -84,6 +84,9 @@ jobs:
         working-directory: polystore-website
         run: npx playwright install --with-deps chromium
 
+      - name: Build polystore_core (native)
+        run: cd polystore_core && cargo build --release
+
       - name: Run Mode2 Stripe E2E (heavy)
         env:
           PLAYWRIGHT_SKIP_INSTALL: '1'

--- a/polystore-website/src/components/Dashboard.tsx
+++ b/polystore-website/src/components/Dashboard.tsx
@@ -1918,6 +1918,7 @@ export function Dashboard() {
               </div>
             ) : targetDeal ? (
               <DealDetail
+                key={`${targetDeal.id}:${String(targetDeal.cid || '')}`}
                 deal={targetDeal}
                 polystoreAddress={polystoreAddress}
                 onFileActivity={recordRecentActivity}

--- a/polystore-website/src/components/DealDetail.tsx
+++ b/polystore-website/src/components/DealDetail.tsx
@@ -49,7 +49,8 @@ import { evaluateCacheFreshness, normalizeManifestRoot } from '../lib/cacheFresh
 import { isTrustedLocalGatewayBase } from '../lib/transport/mode'
 import { formatCacheSourceLabel, isGatewayModePreferred, primaryCacheIndicatorLabel } from '../lib/retrievalMode'
 import { planPolyfsFileRangeChunks } from '../lib/rangeChunker'
-import { providerFetchMduWindowWithSession } from '../api/providerClient'
+import { decodePolyceV1, POLYCE_FLAG_COMPRESSION_ZSTD } from '../lib/polyce'
+import { providerFetchMdu, providerFetchMduWindowWithSession } from '../api/providerClient'
 import { lcdFetchDeal } from '../api/lcdClient'
 import { waitForTransactionReceipt } from '../lib/evmRpc'
 import {
@@ -322,6 +323,14 @@ function queueCachedDownloadPersist(
   })
 }
 
+function sliceRange(bytes: Uint8Array, rangeStart: number, rangeLen: number): Uint8Array {
+  const start = Math.max(0, Math.floor(Number(rangeStart) || 0))
+  if (start >= bytes.byteLength) return new Uint8Array()
+  const maxLen = bytes.byteLength - start
+  const len = rangeLen > 0 ? Math.min(maxLen, Math.floor(Number(rangeLen) || 0)) : maxLen
+  return bytes.slice(start, start + len)
+}
+
 async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | null = null
   try {
@@ -423,20 +432,31 @@ function FileRow({
       throw new Error(`local slab not available (${cacheFreshness.reason})`)
     }
 
+    const safeStart = Math.max(0, Number(downloadRangeStart || 0) || 0)
+    const safeLen = Math.max(0, Number(downloadRangeLen || 0) || 0)
+    const compressed = (Number(file.flags || 0) & POLYCE_FLAG_COMPRESSION_ZSTD) !== 0
+    const readRangeStart = compressed ? 0 : safeStart
+    const readRangeLen = compressed ? 0 : safeLen
     return withTimeout(
       readPolyfsFileFromOpfs({
         dealId,
         file,
         allFiles,
-        rangeStart: Math.max(0, Number(downloadRangeStart || 0) || 0),
-        rangeLen: Math.max(0, Number(downloadRangeLen || 0) || 0),
+        rangeStart: readRangeStart,
+        rangeLen: readRangeLen,
       }),
       20_000,
       'local slab read',
-    ).catch((error: unknown) => {
-      const msg = error instanceof Error ? error.message : String(error)
-      throw new Error(`local slab not available (${msg})`)
-    })
+    )
+      .then(async (bytes) => {
+        const decoded = await decodePolyceV1(bytes)
+        const payload = decoded.payload
+        return compressed && (safeStart > 0 || safeLen > 0) ? sliceRange(payload, safeStart, safeLen) : payload
+      })
+      .catch((error: unknown) => {
+        const msg = error instanceof Error ? error.message : String(error)
+        throw new Error(`local slab not available (${msg})`)
+      })
   }
 
   const handleAutoDownload = async () => {
@@ -1055,7 +1075,8 @@ export function DealDetail({
   const [loadingManifestInfo, setLoadingManifestInfo] = useState(false)
   const [manifestInfoError, setManifestInfoError] = useState<string | null>(null)
   const [selectedMdu, setSelectedMdu] = useState<number>(0)
-  const displayManifestRoot = normalizeManifestRoot(manifestInfo?.manifest_root || slab?.manifest_root || committedManifestRoot)
+  const lastContentHydrationKeyRef = useRef<string>('')
+  const displayManifestRoot = normalizeManifestRoot(committedManifestRoot || manifestInfo?.manifest_root || slab?.manifest_root)
 
   useEffect(() => {
     const raw = Number(deal.retrieval_policy?.mode ?? 1)
@@ -1957,10 +1978,18 @@ export function DealDetail({
   }, [fetchSlabLayout, resolveProviderHttpBase, resolveProviderP2pTarget, reconcileLocalMduCache])
 
   const fetchFiles = useCallback(async (cid: string, dealId: string, owner: string) => {
-    if (!cid || !dealId || !owner) return
+    void owner
+    if (!cid || !dealId) {
+      setLoadingFiles(false)
+      return
+    }
     setLoadingFiles(true)
     try {
-      let requirement = await inspectLocalDealIndexRequirement(String(dealId), cid)
+      let requirement = await withTimeout(
+        inspectLocalDealIndexRequirement(String(dealId), cid),
+        10_000,
+        'local PolyFS index inspection',
+      )
 
       // Browser Mode 2 commits update chain state and then atomically publish the OPFS slab.
       // On slow CI, Deal Detail can observe the new on-chain root a tick before OPFS has
@@ -1972,7 +2001,11 @@ export function DealDetail({
         const pollMs = 500
         while (Date.now() - retryStartedAt < maxWaitMs) {
           await new Promise((resolve) => setTimeout(resolve, pollMs))
-          const next = await inspectLocalDealIndexRequirement(String(dealId), cid)
+          const next = await withTimeout(
+            inspectLocalDealIndexRequirement(String(dealId), cid),
+            5_000,
+            'local PolyFS index inspection',
+          )
           if (next.status === 'ready') {
             requirement = next
             break
@@ -1994,7 +2027,7 @@ export function DealDetail({
         setFiles(null)
         return
       }
-      await fetchLocalFiles(dealId)
+      await withTimeout(fetchLocalFiles(dealId), 10_000, 'local PolyFS file list read')
     } catch (e) {
       console.error('Failed to fetch PolyFS file list', e)
       setDealIndexRequirement((prev) => ({
@@ -2135,7 +2168,39 @@ export function DealDetail({
     setFileActionError(null)
 
     try {
-      const fetchCommittedMdu = async (mduIndex: number, kindLabel: string): Promise<Uint8Array> => {
+      const fetchCommittedMetadataMdu = async (mduIndex: number, kindLabel: string): Promise<Uint8Array> => {
+        setDealIndexSyncMessage(`Fetching committed ${kindLabel} metadata from providers...`)
+        const providerBases =
+          serviceHint.mode === 'mode2'
+            ? dealProviders
+                .map((addr) => String(addr || '').trim())
+                .filter((addr) => addr)
+                .map((addr) => resolveProviderHttpBaseFor(addr))
+                .filter((base): base is string => Boolean(base))
+            : [providerBase].filter((base): base is string => Boolean(base))
+        if (!providerBases.length) {
+          throw new Error(`no provider base available for ${kindLabel} metadata`)
+        }
+        let lastError: unknown = null
+        for (const base of providerBases) {
+          try {
+            return await providerFetchMdu(base, manifestRoot, mduIndex, { dealId, owner })
+          } catch (err) {
+            lastError = err
+          }
+        }
+        const msg = lastError instanceof Error ? lastError.message : String(lastError || 'metadata provider fetch failed')
+        throw new Error(`failed to fetch committed ${kindLabel} metadata: ${msg}`)
+      }
+
+      const fetchCommittedMdu = async (
+        mduIndex: number,
+        kindLabel: string,
+        options: { metadata?: boolean } = {},
+      ): Promise<Uint8Array> => {
+        if (options.metadata) {
+          return fetchCommittedMetadataMdu(mduIndex, kindLabel)
+        }
         if (serviceHint.mode === 'mode2') {
           const dataSlotProviders = dealProviders
             .map((addr) => String(addr || '').trim())
@@ -2206,7 +2271,7 @@ export function DealDetail({
         }
       }
 
-      const mdu0Bytes = await fetchCommittedMdu(0, 'mdu_0')
+      const mdu0Bytes = await fetchCommittedMdu(0, 'mdu_0', { metadata: true })
       const parsedFiles = parsePolyfsFilesFromMdu0(mdu0Bytes)
       const { totalMdus, witnessMdus, userMdus } = deriveSlabLayoutFromMdu0(mdu0Bytes, parsedFiles)
       const rootTable = parsePolyfsRootTableFromMdu0(mdu0Bytes)
@@ -2218,20 +2283,20 @@ export function DealDetail({
       const committed = await workerClient.shardFile(new Uint8Array(mdu0Bytes))
       const mdu0Root = toU8((committed as { mdu_root?: Uint8Array | number[] }).mdu_root)
       if (mdu0Root.byteLength !== 32) throw new Error('invalid mdu_0 root length')
+      const mdu0RootHex = bytesTo0xHex(mdu0Root)
       const rootsAgg = new Uint8Array(totalMdus * 32)
       rootsAgg.set(mdu0Root, 0)
       for (let i = 0; i < rootTable.length; i += 1) {
         rootsAgg.set(rootTable[i], (i + 1) * 32)
       }
       const manifest = await workerClient.computeManifest(rootsAgg)
-      const computedManifestRoot = bytesTo0xHex(toU8((manifest as { root?: Uint8Array | number[] }).root))
       const manifestBlob = toU8((manifest as { blob?: Uint8Array | number[] }).blob)
       if (manifestBlob.byteLength === 0) throw new Error('failed to reconstruct manifest blob from committed MDUs')
-      if (normalizeManifestRoot(computedManifestRoot) !== normalizeManifestRoot(manifestRoot)) {
-        throw new Error(`committed mdu_0 produced mismatched manifest root: ${computedManifestRoot}`)
+      if (normalizeManifestRoot(mdu0RootHex) !== normalizeManifestRoot(manifestRoot)) {
+        throw new Error(`committed mdu_0 produced mismatched PolyFS root: ${mdu0RootHex}`)
       }
       const rootRecords = [
-        { mdu_index: 0, kind: 'mdu0' as const, root_hex: computedManifestRoot },
+        { mdu_index: 0, kind: 'mdu0' as const, root_hex: mdu0RootHex },
         ...rootTable.map((rootBytes, idx) => ({
           mdu_index: idx + 1,
           kind: (idx + 1) <= witnessMdus ? ('witness' as const) : ('user' as const),
@@ -2244,7 +2309,7 @@ export function DealDetail({
       const witnessMduArtifacts = await Promise.all(
         witnessMduIndexes.map(async (index) => ({
           index,
-          data: await fetchCommittedMdu(index, `witness mdu_${index}`),
+          data: await fetchCommittedMdu(index, `witness mdu_${index}`, { metadata: true }),
         })),
       )
 
@@ -2449,6 +2514,15 @@ export function DealDetail({
 
   useEffect(() => {
     if (!authoritativeDealLoaded) return
+    const hydrationKey = `${deal.id}:${committedManifestRoot || '<empty>'}:${requestOwner || '<owner>'}:${activeTab}`
+    const hydrationResolved =
+      !committedManifestRoot ||
+      files !== null ||
+      dealIndexRequirement.status === 'needs_sync_missing' ||
+      dealIndexRequirement.status === 'needs_sync_stale' ||
+      dealIndexRequirement.status === 'sync_failed'
+    if (lastContentHydrationKeyRef.current === hydrationKey && hydrationResolved) return
+    lastContentHydrationKeyRef.current = hydrationKey
     if (committedManifestRoot) {
       const owner = requestOwner
       setDealIndexSyncMessage('')
@@ -2481,7 +2555,20 @@ export function DealDetail({
     }
     setFileActionError(null)
     void fetchActivity(deal.id)
-  }, [activeTab, authoritativeDealLoaded, committedManifestRoot, deal.id, fetchFiles, fetchActivity, fetchLocalFiles, fetchManifestInfo, fetchSlab, requestOwner])
+  }, [
+    activeTab,
+    authoritativeDealLoaded,
+    committedManifestRoot,
+    deal.id,
+    dealIndexRequirement.status,
+    fetchFiles,
+    fetchActivity,
+    fetchLocalFiles,
+    fetchManifestInfo,
+    fetchSlab,
+    files,
+    requestOwner,
+  ])
 
   const requiresDealIndexSync =
     dealIndexRequirement.status === 'needs_sync_missing' ||

--- a/polystore-website/src/components/DealDetail.tsx
+++ b/polystore-website/src/components/DealDetail.tsx
@@ -449,9 +449,10 @@ function FileRow({
       'local slab read',
     )
       .then(async (bytes) => {
+        if (!compressed) return bytes
         const decoded = await decodePolyceV1(bytes)
         const payload = decoded.payload
-        return compressed && (safeStart > 0 || safeLen > 0) ? sliceRange(payload, safeStart, safeLen) : payload
+        return safeStart > 0 || safeLen > 0 ? sliceRange(payload, safeStart, safeLen) : payload
       })
       .catch((error: unknown) => {
         const msg = error instanceof Error ? error.message : String(error)

--- a/polystore-website/src/components/DealDetail.tsx
+++ b/polystore-website/src/components/DealDetail.tsx
@@ -59,6 +59,7 @@ import {
   encodeConfirmRetrievalSessionsData,
   encodeOpenRetrievalSessionsData,
 } from '../lib/polystorePrecompile'
+import { polyfsRootHexFromMdu0Root } from '../lib/upload/polyfsRoot'
 
 let wasmReadyPromise: Promise<void> | null = null
 
@@ -2078,6 +2079,7 @@ export function DealDetail({
 
         const rootsOut: { kind: 'mdu0' | 'witness' | 'user'; mdu_index: number; root_hex: string; root_table_index?: number }[] = []
         const rootsAgg = new Uint8Array(32 * totalMdus)
+        let computedPolyfsRoot = ''
 
         for (let idx = 0; idx < totalMdus; idx++) {
           const bytes = await readMdu(String(dealId), idx)
@@ -2087,6 +2089,9 @@ export function DealDetail({
           const mduRoot = toU8((committed as { mdu_root?: Uint8Array | number[] }).mdu_root)
           if (mduRoot.byteLength !== 32) throw new Error(`invalid mdu_root length for MDU #${idx}`)
           rootsAgg.set(mduRoot, idx * 32)
+          if (idx === 0) {
+            computedPolyfsRoot = polyfsRootHexFromMdu0Root(mduRoot)
+          }
 
           const kind = idx === 0 ? 'mdu0' : idx <= witnessCount ? 'witness' : 'user'
           const rootHex = bytesTo0xHex(mduRoot)
@@ -2096,15 +2101,14 @@ export function DealDetail({
         }
 
         const manifest = await workerClient.computeManifest(rootsAgg)
-        const computedRoot = bytesTo0xHex(toU8((manifest as { root?: Uint8Array | number[] }).root))
         const blobHex = bytesTo0xHex(toU8((manifest as { blob?: Uint8Array | number[] }).blob))
 
-        if (cid && computedRoot.trim().toLowerCase() !== cid.trim().toLowerCase()) {
-          setManifestInfoError(`manifest root mismatch: computed=${shortHex(computedRoot)} expected=${shortHex(cid)}`)
+        if (cid && normalizeManifestRoot(computedPolyfsRoot) !== normalizeManifestRoot(cid)) {
+          setManifestInfoError(`manifest root mismatch: computed=${shortHex(computedPolyfsRoot)} expected=${shortHex(cid)}`)
         }
 
         setManifestInfo({
-          manifest_root: computedRoot || cid,
+          manifest_root: computedPolyfsRoot || cid,
           manifest_blob_hex: blobHex,
           total_mdus: totalMdus,
           witness_mdus: witnessCount,
@@ -3335,7 +3339,7 @@ export function DealDetail({
                         <div className="grid gap-2 sm:grid-cols-2">
                           <div className="bg-background/50 border border-border p-2">
                             <div className="text-[10px] text-muted-foreground uppercase">Manifest Root</div>
-                            <div className="font-mono-data text-[10px] text-foreground break-all">{manifestInfo.manifest_root}</div>
+                            <div data-testid="manifest-info-root" className="font-mono-data text-[10px] text-foreground break-all">{manifestInfo.manifest_root}</div>
                           </div>
                           <div className="bg-background/50 border border-border p-2">
                             <div className="text-[10px] text-muted-foreground uppercase">Manifest Blob</div>

--- a/polystore-website/src/components/FileSharder.tsx
+++ b/polystore-website/src/components/FileSharder.tsx
@@ -1664,6 +1664,7 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
     browserPerfEndPhase,
     browserPerfLog,
     browserPerfStartPhase,
+    baseManifestRoot,
     collectedMdus,
     commitHash,
     currentManifestBlob,

--- a/polystore-website/src/components/FileSharder.tsx
+++ b/polystore-website/src/components/FileSharder.tsx
@@ -16,6 +16,7 @@ import {
   readManifestBlob,
   readManifestRoot,
   readMdu,
+  readSlabMetadata,
   readShard,
   writeManifestRoot,
   writeSlabMetadata,
@@ -30,7 +31,7 @@ import {
 import { decodeRawPrefixFromMdu, inferWitnessCountFromOpfs, RAW_MDU_CAPACITY } from '../lib/polyfsOpfsFetch';
 import { lcdFetchDeal } from '../api/lcdClient';
 import { gatewayFetchSlabLayout, gatewayListFiles } from '../api/gatewayClient';
-import { providerFetchMduWindowWithSession } from '../api/providerClient';
+import { providerFetchMdu, providerFetchMduWindowWithSession } from '../api/providerClient';
 import { parseServiceHint } from '../lib/serviceHint';
 import { resolveProviderEndpoints } from '../lib/providerDiscovery';
 import { useLocalGateway } from '../hooks/useLocalGateway';
@@ -53,7 +54,8 @@ import { bootstrapAppendBaseFromMdus as buildBootstrappedAppendBase } from '../l
 import { materializeBootstrapGeneration } from '../lib/upload/bootstrapGeneration';
 import { resolveMode2AppendBase } from '../lib/upload/resolveAppendBase';
 import { isMissingGatewayAppendStateError, recoverGatewayAppendState } from '../lib/upload/gatewayRecovery';
-import { collectMode2SlotFailures } from '../lib/upload/mode2Recovery';
+import { collectMode2SlotFailures, isRecoverableMode2SlotFailure } from '../lib/upload/mode2Recovery';
+import { polyfsRootHexFromMdu0Root } from '../lib/upload/polyfsRoot';
 import { classifyPolyfsCommitError } from '../lib/polyfsCommitError';
 import { waitForTransactionReceipt } from '../lib/evmRpc';
 import {
@@ -1426,8 +1428,51 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
 
               let fileRecords: Array<{ path: string; start_offset: number; size_bytes: number; flags: number }> = []
               if (gatewayBase && owner) {
+                const previousCommittedRoot = normalizeManifestRoot(baseManifestRoot)
+                const fallbackRawPath = String(lastFileMetaRef.current?.filePath || '').trim() || 'upload.bin'
+                const fallbackPath = sanitizePolyfsRecordPath(fallbackRawPath)
+                let expectedFileRecords = fallbackPath ? 1 : 0
+                if (previousCommittedRoot && previousCommittedRoot !== safeRoot) {
+                  try {
+                    const previousMeta = await readSlabMetadata(String(dealId))
+                    const previousMetaRoot = normalizeManifestRoot(previousMeta?.manifest_root)
+                    if (previousMetaRoot === previousCommittedRoot && Array.isArray(previousMeta?.file_records)) {
+                      const expectedPaths = new Set(
+                        previousMeta.file_records
+                          .map((rec) => sanitizePolyfsRecordPath(String(rec.path || '')))
+                          .filter(Boolean),
+                      )
+                      if (fallbackPath) expectedPaths.add(fallbackPath)
+                      expectedFileRecords = Math.max(expectedFileRecords, expectedPaths.size)
+                    }
+                  } catch (e) {
+                    console.warn('Failed to inspect previous local file table for gateway append snapshot', {
+                      dealId,
+                      error: e,
+                    })
+                  }
+                }
+
+                const fetchGatewayFilesWithRetry = async () => {
+                  const deadline = Date.now() + 20_000
+                  let lastError = ''
+                  for (;;) {
+                    try {
+                      const files = await gatewayListFiles(gatewayBase, safeRoot, { dealId, owner })
+                      if (files.length >= expectedFileRecords) return files
+                      lastError = `gateway file table has ${files.length} records, expected at least ${expectedFileRecords}`
+                    } catch (e) {
+                      lastError = e instanceof Error ? e.message : String(e)
+                    }
+                    if (Date.now() >= deadline) {
+                      throw new Error(lastError || 'gateway file table did not become available')
+                    }
+                    await new Promise((resolve) => setTimeout(resolve, 500))
+                  }
+                }
+
                 try {
-                  const files = await gatewayListFiles(gatewayBase, safeRoot, { dealId, owner })
+                  const files = await fetchGatewayFilesWithRetry()
                   fileRecords = files.map((f) => ({
                     path: String(f.path || ''),
                     start_offset: Math.max(0, Number(f.start_offset) || 0),
@@ -1437,9 +1482,21 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
                 } catch (e) {
                   console.warn('Failed to fetch gateway file table for local index snapshot', { dealId, error: e })
                 }
-              }
-
-              if (!fileRecords.length) {
+                if (!fileRecords.length && !previousCommittedRoot) {
+                  const fallbackRawPath = String(lastFileMetaRef.current?.filePath || '').trim() || 'upload.bin'
+                  const fallbackPath = sanitizePolyfsRecordPath(fallbackRawPath)
+                  if (fallbackPath) {
+                    fileRecords = [{
+                      path: fallbackPath,
+                      start_offset: 0,
+                      size_bytes: Math.max(0, Number(lastFileMetaRef.current?.fileSizeBytes || shardProgress.fileBytesTotal) || 0),
+                      flags: 0,
+                    }]
+                  }
+                } else if (!fileRecords.length) {
+                  addLog('> Gateway append file table unavailable; leaving local deal index unsynced instead of writing a partial index.')
+                }
+              } else if (!fileRecords.length) {
                 const fallbackRawPath = String(lastFileMetaRef.current?.filePath || '').trim() || 'upload.bin'
                 const fallbackPath = sanitizePolyfsRecordPath(fallbackRawPath)
                 if (fallbackPath) {
@@ -1450,6 +1507,10 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
                     flags: 0,
                   }]
                 }
+              }
+
+              if (!fileRecords.length) {
+                return
               }
 
               try {
@@ -1724,6 +1785,9 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
         if (!retryFailure) {
           throw new Error(retryResult.error || `Slot ${params.slot} retry failed`)
         }
+        if (!isRecoverableMode2SlotFailure(retryFailure)) {
+          throw new Error(retryFailure.reason || retryResult.error || `Slot ${params.slot} retry failed`)
+        }
         currentProvider = retryFailure.provider || nextProvider
         addLog(`> Slot ${params.slot} retry failed on ${currentProvider}: ${retryFailure.reason}`)
       }
@@ -1806,7 +1870,12 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
           throw new Error(result.error || 'Mode 2 upload failed')
         }
 
-        addLog(`> Detected ${failures.length} failing setup slot(s). Starting automatic replacement...`)
+        const recoverableFailures = failures.filter(isRecoverableMode2SlotFailure)
+        if (recoverableFailures.length === 0) {
+          throw new Error(failures[0]?.reason || result.error || 'Mode 2 upload failed')
+        }
+
+        addLog(`> Detected ${recoverableFailures.length} recoverable failing setup slot(s). Starting automatic replacement...`)
         let snapshot: DealSetupSnapshot = {
           baseManifestRoot: baseManifestRoot || '',
           owner: dealOwner,
@@ -1814,7 +1883,7 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
           slotBases: bases,
           slotProviders: providers,
         }
-        for (const failure of failures) {
+        for (const failure of recoverableFailures) {
           const activeProvider = String(snapshot.slotProviders[failure.slot] || failure.provider || '').trim()
           if (!activeProvider) {
             throw new Error(`Unable to determine provider for failing slot ${failure.slot}`)
@@ -2059,6 +2128,19 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
     const rows = mode2RowsForK(stripeParams.k)
 
     const fetchCommittedMdu = async (mduIndex: number, kindLabel: string): Promise<Uint8Array> => {
+      if (mduIndex === 0) {
+        addLog(`> Bootstrap fetch: fetching committed ${kindLabel} metadata...`)
+        let lastError: unknown = null
+        for (const entry of dataSlotProviders) {
+          try {
+            return await providerFetchMdu(entry.base, manifestRoot, mduIndex, { dealId, owner })
+          } catch (err) {
+            lastError = err
+          }
+        }
+        const msg = lastError instanceof Error ? lastError.message : String(lastError || 'metadata provider fetch failed')
+        throw new Error(`failed to fetch committed ${kindLabel} metadata: ${msg}`)
+      }
       addLog(`> Bootstrap fetch: opening retrieval sessions for committed ${kindLabel} slices...`)
       const requests = dataSlotProviders.map((entry) => ({
         key: `${mduIndex}:${entry.slot}`,
@@ -3171,6 +3253,7 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
         const gatewayBases = localGatewayCandidates(gatewaySeed)
         let gatewayErrorMessage = ''
         let gatewayUnreachable = false
+        let gatewayAppendStateMissing = false
         let providerUploadUnavailable = false
 
         for (let i = 0; i < gatewayBases.length; i++) {
@@ -3276,6 +3359,9 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
               }
             }
 
+            if (isMissingGatewayAppendStateError(msg)) {
+              gatewayAppendStateMissing = true
+            }
             const providerPathUnavailable = isProviderUploadConnectivityError(msg)
             if (providerPathUnavailable) {
               providerUploadUnavailable = true
@@ -3308,7 +3394,40 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
           setProcessing(false)
           return
         }
-        if (gatewayUnreachable) {
+        if (gatewayAppendStateMissing) {
+          if (file.size > gatewayFallbackWasmMaxFileBytes) {
+            const sizeLabel = formatBytes(file.size)
+            const errorMessage = `Gateway is missing prior append state while processing ${sizeLabel}. In-browser fallback is disabled for large files; keep the local gateway slab state available or rehydrate the gateway before retrying.`
+            browserPerfLog('gateway_ingest:fallback-blocked', {
+              error: errorMessage,
+              fileBytes: file.size,
+            })
+            addLog(`> ${errorMessage}`)
+            setMode2UploadError(errorMessage)
+            setShardProgress((p) => ({
+              ...p,
+              phase: 'error',
+              label: errorMessage,
+              currentOpStartedAtMs: null,
+              lastOpMs: performance.now() - startTs,
+            }))
+            setProcessing(false)
+            return
+          }
+
+          addLog('> Gateway is missing prior append state; falling back to in-browser Mode 2 sharding + stripe upload.')
+          browserPerfLog('gateway_ingest:fallback-browser-missing-append-state', {
+            fileBytes: file.size,
+          })
+          setMode2UploadError(null)
+          setShardProgress((p) => ({
+            ...p,
+            phase: 'planning',
+            label: 'Gateway missing append state; falling back to in-browser sharding...',
+            currentOpStartedAtMs: null,
+            lastOpMs: performance.now() - startTs,
+          }))
+        } else if (gatewayUnreachable) {
           if (file.size > gatewayFallbackWasmMaxFileBytes) {
             const sizeLabel = formatBytes(file.size)
             const errorMessage = `Gateway unavailable while processing ${sizeLabel}. In-browser fallback is disabled for large files; please keep the local gateway running, allow local network access for localhost/127.0.0.1, and retry.`
@@ -4460,7 +4579,8 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
           ...userMdus.map((m) => ({ ...m, index: 1 + witnessMduCount + m.index })),
         ];
 
-        const finalRootHex = '0x' + Array.from(manifest.root).map(b => b.toString(16).padStart(2, '0')).join('');
+        const aggregateManifestRootHex = '0x' + Array.from(manifest.root).map(b => b.toString(16).padStart(2, '0')).join('');
+        const finalRootHex = polyfsRootHexFromMdu0Root(mdu0Root);
         const finalManifest = makePreparedManifest(toU8((manifest as unknown as { blob: Uint8Array | number[] }).blob));
 
         setCollectedMdus(finalMdus);
@@ -4481,8 +4601,9 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
           userBytesDone: p.fileBytesTotal,
         }));
 
-        addLog(`> Manifest Root: ${finalRootHex.slice(0, 16)}...`);
-        console.log(`[Debug] Full Manifest Root: ${finalRootHex}`);
+        addLog(`> PolyFS Root: ${finalRootHex.slice(0, 16)}...`);
+        console.log(`[Debug] Full PolyFS Root: ${finalRootHex}`);
+        console.log(`[Debug] Aggregate Manifest Commitment: ${aggregateManifestRootHex}`);
         addLog(
           useMode2
             ? `> Total MDUs: ${finalMdus.length} (1 Meta + ${witnessMduCount} Witness + ${userMdus.length} User); ${mode2UserShards.length} striped user MDUs uploaded for this generation`
@@ -5590,6 +5711,7 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
                                 type="checkbox"
                                 className="hidden"
                                 checked={compressUploads}
+                                data-testid="mdu-compress-toggle"
                                 disabled={processing || activeUploading}
                                 onChange={(e) => setCompressUploads(e.target.checked)}
                               />

--- a/polystore-website/src/components/FileSharder.tsx
+++ b/polystore-website/src/components/FileSharder.tsx
@@ -2233,7 +2233,7 @@ export function FileSharder({ dealId, onCommitSuccess, onWorkflowActiveChange }:
         shardFile: (data) => workerClient.shardFile(data),
         computeManifest: (roots) => workerClient.computeManifest(roots),
       })
-      addLog(`> Mode 2 append bootstrap: verified committed manifest root ${materialized.manifestRoot}.`)
+      addLog(`> Mode 2 append bootstrap: verified committed PolyFS root ${materialized.manifestRoot}.`)
       await writeSlabGenerationAtomically(dealId, {
         manifestRoot: materialized.manifestRoot,
         manifestBlob: materialized.manifestBlob,

--- a/polystore-website/src/lib/upload/bootstrapGeneration.test.ts
+++ b/polystore-website/src/lib/upload/bootstrapGeneration.test.ts
@@ -16,7 +16,7 @@ test('materializeBootstrapGeneration builds witness/mdus/manifest and verifies r
       { index: 1, data: new Uint8Array([2, 2]) },
       { index: 0, data: new Uint8Array([1, 1]) },
     ],
-    expectedManifestRoot: `0x${'07'.repeat(32)}`,
+    expectedManifestRoot: `0x${'aa'.repeat(32)}`,
     rsK: 2,
     rsM: 1,
     rawMduCapacity: 4,
@@ -53,7 +53,8 @@ test('materializeBootstrapGeneration builds witness/mdus/manifest and verifies r
     },
   })
 
-  assert.equal(result.manifestRoot, `0x${'07'.repeat(32)}`)
+  assert.equal(result.manifestRoot, `0x${'aa'.repeat(32)}`)
+  assert.equal(result.aggregateManifestRoot, `0x${'07'.repeat(32)}`)
   assert.deepEqual(Array.from(result.manifestBlob), [7, 7, 7, 7])
   assert.deepEqual(Array.from(result.mdu0Bytes), [0xaa, 0xbb])
   assert.equal(result.witnessCount, 2)
@@ -105,7 +106,7 @@ test('materializeBootstrapGeneration rejects manifest mismatches', async () => {
         shardFile: async () => ({ mdu_root: rootByte(3) }),
         computeManifest: async () => ({ root: rootByte(4), blob: new Uint8Array([4]) }),
       }),
-    /bootstrap manifest root mismatch/,
+    /bootstrap PolyFS root mismatch/,
   )
 })
 
@@ -115,7 +116,7 @@ test('materializeBootstrapGeneration prefers payload-aware expansion for bootstr
   await materializeBootstrapGeneration({
     baseMdu0Bytes: new Uint8Array([5]),
     existingUserMdus: [{ index: 0, data: new Uint8Array([9, 9]), rawData: new Uint8Array([7, 7]) }],
-    expectedManifestRoot: `0x${'05'.repeat(32)}`,
+    expectedManifestRoot: `0x${'01'.repeat(32)}`,
     rsK: 2,
     rsM: 1,
     rawMduCapacity: 8,

--- a/polystore-website/src/lib/upload/bootstrapGeneration.ts
+++ b/polystore-website/src/lib/upload/bootstrapGeneration.ts
@@ -1,4 +1,5 @@
 import { normalizeManifestRoot } from '../cacheFreshness'
+import { polyfsRootHexFromMdu0Root } from './polyfsRoot'
 
 export interface ExistingUserMdu {
   index: number
@@ -21,6 +22,7 @@ export interface CommittedMduResult {
 
 export interface MaterializedBootstrapGeneration {
   manifestRoot: string
+  aggregateManifestRoot: string
   manifestBlob: Uint8Array
   mdu0Bytes: Uint8Array
   witnessCount: number
@@ -140,16 +142,18 @@ export async function materializeBootstrapGeneration(
   }
 
   const manifest = await input.computeManifest(allRoots)
-  const manifestRoot = normalizeManifestRoot(
+  const aggregateManifestRoot = normalizeManifestRoot(
     `0x${Array.from(manifest.root).map((b) => b.toString(16).padStart(2, '0')).join('')}`,
   )
+  const manifestRoot = polyfsRootHexFromMdu0Root(mdu0Root)
   const expectedManifestRoot = normalizeManifestRoot(input.expectedManifestRoot)
   if (manifestRoot !== expectedManifestRoot) {
-    throw new Error(`bootstrap manifest root mismatch: got ${manifestRoot}, want ${expectedManifestRoot}`)
+    throw new Error(`bootstrap PolyFS root mismatch: got ${manifestRoot}, want ${expectedManifestRoot}`)
   }
 
   return {
     manifestRoot,
+    aggregateManifestRoot,
     manifestBlob: new Uint8Array(manifest.blob),
     mdu0Bytes,
     witnessCount,

--- a/polystore-website/src/lib/upload/mode2Recovery.test.ts
+++ b/polystore-website/src/lib/upload/mode2Recovery.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { collectMode2SlotFailures } from './mode2Recovery'
+import { collectMode2SlotFailures, isRecoverableMode2SlotFailure } from './mode2Recovery'
 import type { UploadTaskEvent } from './engine'
 
 test('mode2 recovery: maps shard failures directly from slot events', () => {
@@ -99,4 +99,24 @@ test('mode2 recovery: de-duplicates multiple failures for the same slot', () => 
   assert.equal(out.length, 1)
   assert.equal(out[0]?.slot, 1)
   assert.equal(out[0]?.reason, 'connection refused')
+})
+
+test('mode2 recovery: does not replace providers for malformed client upload roots', () => {
+  const [failure] = collectMode2SlotFailures({
+    events: [
+      {
+        phase: 'end',
+        kind: 'manifest',
+        target: 'https://sp1.polynomialstore.com',
+        bytes: 4096,
+        ok: false,
+        error: 'invalid manifest root',
+      },
+    ],
+    slotBases: ['https://sp1.polynomialstore.com'],
+    slotProviders: ['nil1sp1'],
+  })
+
+  assert.ok(failure)
+  assert.equal(isRecoverableMode2SlotFailure(failure), false)
 })

--- a/polystore-website/src/lib/upload/mode2Recovery.ts
+++ b/polystore-website/src/lib/upload/mode2Recovery.ts
@@ -10,8 +10,27 @@ export interface Mode2SlotFailure {
   index?: number
 }
 
+const NON_RECOVERABLE_REASON_PATTERNS = [
+  'invalid manifest root',
+  'invalid_manifest_root',
+  'missing manifest root',
+  'missing_manifest_root',
+  'previous_manifest_root',
+  'stale manifest_root',
+  'invalid deal_id',
+  'invalid_deal_id',
+  'missing_headers',
+  'invalid upload_generation',
+  'invalid_upload_generation',
+]
+
 function normalizeTarget(value: string): string {
   return String(value || '').trim().replace(/\/+$/, '')
+}
+
+export function isRecoverableMode2SlotFailure(failure: Mode2SlotFailure): boolean {
+  const reason = String(failure.reason || '').toLowerCase()
+  return !NON_RECOVERABLE_REASON_PATTERNS.some((pattern) => reason.includes(pattern))
 }
 
 export function collectMode2SlotFailures(params: {

--- a/polystore-website/src/lib/upload/polyfsRoot.test.ts
+++ b/polystore-website/src/lib/upload/polyfsRoot.test.ts
@@ -1,0 +1,20 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { polyfsRootHexFromMdu0Root } from './polyfsRoot'
+
+test('polyfs root: uses the 32-byte MDU0 root, not the 48-byte aggregate commitment', () => {
+  const mdu0Root = new Uint8Array(32).fill(0x11)
+  const aggregateCommitment = new Uint8Array(48).fill(0x22)
+
+  const root = polyfsRootHexFromMdu0Root(mdu0Root)
+
+  assert.equal(root, `0x${'11'.repeat(32)}`)
+  assert.notEqual(root, `0x${'22'.repeat(48)}`)
+  assert.equal(aggregateCommitment.byteLength, 48)
+})
+
+test('polyfs root: rejects non-PolyFS root lengths', () => {
+  assert.throws(() => polyfsRootHexFromMdu0Root(new Uint8Array(48)), /32 bytes/)
+})
+

--- a/polystore-website/src/lib/upload/polyfsRoot.ts
+++ b/polystore-website/src/lib/upload/polyfsRoot.ts
@@ -1,0 +1,16 @@
+export const POLYFS_ROOT_BYTES = 32
+
+function hexByte(byte: number): string {
+  return byte.toString(16).padStart(2, '0')
+}
+
+export function polyfsRootHexFromMdu0Root(mdu0Root: Uint8Array): string {
+  if (!(mdu0Root instanceof Uint8Array)) {
+    throw new Error('PolyFS root must be a Uint8Array')
+  }
+  if (mdu0Root.byteLength !== POLYFS_ROOT_BYTES) {
+    throw new Error(`PolyFS root must be ${POLYFS_ROOT_BYTES} bytes; got ${mdu0Root.byteLength}`)
+  }
+  return `0x${Array.from(mdu0Root, hexByte).join('')}`
+}
+

--- a/polystore-website/tests/deal-explorer-manifest-opfs-fallback.spec.ts
+++ b/polystore-website/tests/deal-explorer-manifest-opfs-fallback.spec.ts
@@ -10,7 +10,7 @@ function ethToPolystoreAddress(ethAddress: string): string {
   return bech32.encode('nil', words)
 }
 
-test('Deal Explorer: manifest + mdu commitments fall back to OPFS when gateway missing slab', async ({ page }) => {
+test('Deal Explorer: manifest info falls back to OPFS using PolyFS root when gateway missing slab', async ({ page }) => {
   test.setTimeout(300_000)
 
   const dealId = '1'
@@ -210,11 +210,10 @@ test('Deal Explorer: manifest + mdu commitments fall back to OPFS when gateway m
   await page.getByTestId('deal-detail-tab-manifest').click()
 
   // Slab layout should be inferred from OPFS.
-  await expect(page.getByText('Source: browser (OPFS)')).toBeVisible({ timeout: 60_000 })
+  await expect(page.getByText('Browser (OPFS)')).toBeVisible({ timeout: 60_000 })
   await expect(page.getByText('No manifest details available yet.')).not.toBeVisible({ timeout: 60_000 })
   await expect(page.getByText('slab not found on disk')).not.toBeVisible({ timeout: 60_000 })
-
-  // MDU inspector should be able to compute commitments locally too.
-  await page.getByText('Load Commitments').click()
-  await expect(page.getByText('Blob Commitments', { exact: true })).toBeVisible({ timeout: 120_000 })
+  const manifestInfoRoot = page.getByTestId('manifest-info-root')
+  await expect(manifestInfoRoot).toHaveText(/^0x[0-9a-f]{64}$/i, { timeout: 120_000 })
+  await expect(manifestInfoRoot).not.toHaveText(manifestRoot)
 })

--- a/polystore-website/tests/mode2-stripe.spec.ts
+++ b/polystore-website/tests/mode2-stripe.spec.ts
@@ -346,51 +346,6 @@ async function waitForDealFileRow(
   return fileRow
 }
 
-async function waitForFileRowInAnyDeal(
-  page: Page,
-  filePath: string,
-  timeout = 180_000,
-): Promise<Locator> {
-  const filesTab = page.getByRole('button', { name: /^Files$/i }).first()
-  const fileList = page.getByTestId('deal-detail-file-list')
-  const refreshDealsBtn = page.getByRole('button', { name: /Refresh deals/i }).first()
-  const dealRows = page.locator('[data-testid^="deal-row-"]')
-  const fileRow = page.locator(`[data-testid="deal-detail-file-row"][data-file-path="${filePath}"]`)
-
-  const pollForRow = async (allowSync: boolean, pollTimeout: number) => {
-    await expect
-      .poll(async () => {
-      const totalRows = await dealRows.count().catch(() => 0)
-      for (let i = 0; i < totalRows; i += 1) {
-        const row = dealRows.nth(i)
-        await row.scrollIntoViewIfNeeded().catch(() => undefined)
-        await row.click({ force: true }).catch(() => undefined)
-        if (await filesTab.isVisible().catch(() => false)) {
-          await filesTab.click({ force: true }).catch(() => undefined)
-        }
-        if (allowSync && !(await fileRow.isVisible().catch(() => false))) {
-          await syncDealIndexIfNeeded(page, Math.max(60_000, Math.floor(timeout / 2))).catch(() => undefined)
-        }
-        if (!(await fileList.isVisible().catch(() => false))) continue
-        if (await fileRow.isVisible().catch(() => false)) return true
-      }
-      if (await refreshDealsBtn.isVisible().catch(() => false)) {
-        await refreshDealsBtn.click({ force: true }).catch(() => undefined)
-      }
-      return false
-    }, { timeout: pollTimeout })
-    .toBe(true)
-  }
-
-  try {
-    await pollForRow(false, Math.max(30_000, Math.floor(timeout / 2)))
-  } catch {
-    await pollForRow(true, timeout)
-  }
-
-  return fileRow
-}
-
 function resolveRouterUploadDir(): string {
   const fromEnv = String(process.env.E2E_ROUTER_UPLOAD_DIR || '').trim()
   if (fromEnv) return path.resolve(fromEnv)

--- a/polystore-website/tests/mode2-stripe.spec.ts
+++ b/polystore-website/tests/mode2-stripe.spec.ts
@@ -65,24 +65,6 @@ async function openFileActionMenuItem(page: Page, filePath: string, testId: stri
   return item
 }
 
-async function openSystemActivity(page: Page): Promise<Locator> {
-  const underTheHood = page.getByTestId('mdu-under-the-hood')
-  if (await underTheHood.count().catch(() => 0)) {
-    const detailsOpen = await underTheHood.evaluate((node) => node.hasAttribute('open')).catch(() => false)
-    if (!detailsOpen) {
-      await page.getByTestId('mdu-under-the-hood-toggle').click()
-    }
-  }
-  const toggle = page.getByTestId('mdu-system-activity-toggle')
-  await expect(toggle).toBeVisible({ timeout: 30_000 })
-  const panel = page.getByTestId('mdu-system-activity')
-  if (!(await panel.isVisible().catch(() => false))) {
-    await toggle.click()
-  }
-  await expect(panel).toBeVisible({ timeout: 30_000 })
-  return panel
-}
-
 async function readDownloadedBytes(download: Awaited<ReturnType<Page['waitForEvent']>>): Promise<Buffer> {
   const p = await download.path()
   if (p) return fs.readFile(p)
@@ -774,6 +756,7 @@ async function ensureWalletConnected(page: Page): Promise<void> {
     const mduUploads: Array<{ bodyLen: number; fullSize: number | null; mduIndex: string }> = []
     const manifestUploads: Array<{ bodyLen: number; fullSize: number | null }> = []
     const shardUploads: Array<{ bodyLen: number; fullSize: number | null; mduIndex: string; slot: string }> = []
+    const bundleUploads: Array<{ artifactCount: number }> = []
 
     await page.setViewportSize({ width: 1280, height: 720 })
     await page.goto(dashboardPath, { waitUntil: 'networkidle' })
@@ -819,6 +802,50 @@ async function ensureWalletConnected(page: Page): Promise<void> {
     })
     await page.route('**/gateway/upload*', maybeBlockGatewayUpload)
     await page.route('**/gateway/upload-status*', maybeBlockGatewayUpload)
+    await page.route('**/sp/upload_bundle', async (route) => {
+      const body = route.request().postDataBuffer() || Buffer.alloc(0)
+      if (body.byteLength < 8 || body.subarray(0, 4).toString('utf8') !== 'NLB2') {
+        await route.fulfill({ status: 400, body: 'invalid bundle' })
+        return
+      }
+      const metaLen = body.readUInt32LE(4)
+      const metaRaw = body.subarray(8, 8 + metaLen).toString('utf8')
+      const meta = JSON.parse(metaRaw) as {
+        artifacts?: Array<{
+          kind?: string
+          mdu_index?: number
+          slot?: number
+          full_size?: number
+          send_size?: number
+        }>
+      }
+      const artifacts = Array.isArray(meta.artifacts) ? meta.artifacts : []
+      bundleUploads.push({ artifactCount: artifacts.length })
+      for (const artifact of artifacts) {
+        const bodyLen = Number(artifact.send_size || 0)
+        const fullSize = Number.isFinite(Number(artifact.full_size)) ? Number(artifact.full_size) : null
+        if (artifact.kind === 'mdu') {
+          mduUploads.push({
+            bodyLen,
+            fullSize,
+            mduIndex: String(artifact.mdu_index ?? ''),
+          })
+        } else if (artifact.kind === 'manifest') {
+          manifestUploads.push({
+            bodyLen,
+            fullSize,
+          })
+        } else if (artifact.kind === 'shard') {
+          shardUploads.push({
+            bodyLen,
+            fullSize,
+            mduIndex: String(artifact.mdu_index ?? ''),
+            slot: String(artifact.slot ?? ''),
+          })
+        }
+      }
+      await route.continue()
+    })
     await page.route('**/sp/upload_mdu', async (route) => {
       const body = route.request().postDataBuffer() || Buffer.alloc(0)
       const headers = route.request().headers()
@@ -828,7 +855,7 @@ async function ensureWalletConnected(page: Page): Promise<void> {
         fullSize: fullSizeHeader ? Number(fullSizeHeader) : null,
         mduIndex: headers['x-polystore-mdu-index'] || '',
       })
-      await route.fulfill({ status: 200, body: 'ok' })
+      await route.continue()
     })
     await page.route('**/sp/upload_manifest', async (route) => {
       const body = route.request().postDataBuffer() || Buffer.alloc(0)
@@ -838,7 +865,7 @@ async function ensureWalletConnected(page: Page): Promise<void> {
         bodyLen: body.length,
         fullSize: fullSizeHeader ? Number(fullSizeHeader) : null,
       })
-      await route.fulfill({ status: 200, body: 'ok' })
+      await route.continue()
     })
     await page.route('**/sp/upload_shard', async (route) => {
       const body = route.request().postDataBuffer() || Buffer.alloc(0)
@@ -850,15 +877,23 @@ async function ensureWalletConnected(page: Page): Promise<void> {
         mduIndex: headers['x-polystore-mdu-index'] || '',
         slot: headers['x-polystore-slot'] || '',
       })
-      await route.fulfill({ status: 200, body: 'ok' })
+      await route.continue()
     })
 
-    const compressCheckbox = page
-      .locator('label')
-      .filter({ hasText: 'Compress before upload' })
-      .locator('input[type="checkbox"]')
+    const compressCheckbox = page.getByTestId('mdu-compress-toggle')
     if (await compressCheckbox.isChecked().catch(() => false)) {
-      await compressCheckbox.uncheck()
+      await compressCheckbox.evaluate((node) => {
+        const input = node as HTMLInputElement
+        const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'checked')?.set
+        if (setter) {
+          setter.call(input, false)
+        } else {
+          input.checked = false
+        }
+        input.dispatchEvent(new Event('input', { bubbles: true }))
+        input.dispatchEvent(new Event('change', { bubbles: true }))
+      })
+      await expect(compressCheckbox).not.toBeChecked()
     }
 
     await page.getByTestId('mdu-file-input').setInputFiles({
@@ -875,10 +910,11 @@ async function ensureWalletConnected(page: Page): Promise<void> {
       await uploadBtn.click()
       await expect(uploadBtn).toHaveText(/Upload Complete/i, { timeout: mode2FastUploadWaitMs })
     }
-    const activity = await openSystemActivity(page)
-    await expect(activity).toContainText(/falling back to in-browser mode 2 sharding \+ stripe upload/i, {
-      timeout: mode2FastUploadWaitMs,
-    })
+    await expect
+      .poll(() => mduUploads.length > 0 && manifestUploads.length > 0 && shardUploads.length > 0, {
+        timeout: mode2FastUploadWaitMs,
+      })
+      .toBe(true)
     expect(mduUploads.length).toBeGreaterThan(0)
     expect(manifestUploads.length).toBeGreaterThan(0)
     expect(shardUploads.length).toBeGreaterThan(0)
@@ -888,6 +924,7 @@ async function ensureWalletConnected(page: Page): Promise<void> {
     const sparseShardUploads = shardUploads.filter((upload) => upload.fullSize != null && upload.bodyLen < upload.fullSize)
 
     console.log('[mode2 sparse upload evidence]', {
+      bundleUploads,
       mduUploads,
       manifestUploads,
       shardUploads: shardUploads.slice(0, 6),
@@ -896,7 +933,10 @@ async function ensureWalletConnected(page: Page): Promise<void> {
     expect(sparseMduUploads.length).toBeGreaterThan(0)
     expect(sparseManifestUploads.length).toBeGreaterThan(0)
     expect(sparseShardUploads.length).toBeGreaterThan(0)
-    expect(Math.max(...sparseMduUploads.map((upload) => upload.bodyLen))).toBeLessThan(2 * 1024 * 1024)
+    // The MDU0 sparse body carries the populated root-table prefix plus a small
+    // transport envelope, so allow bounded overhead while still rejecting full
+    // 8 MiB MDU uploads.
+    expect(Math.max(...sparseMduUploads.map((upload) => upload.bodyLen))).toBeLessThan((2 * 1024 * 1024) + 4096)
     await expect
       .poll(() => isCommitCompleteOrReset(page, commitBtn, filePath, dealId, '', true), { timeout: mode2FastPrimaryWaitMs })
       .toBe(true)
@@ -906,7 +946,7 @@ async function ensureWalletConnected(page: Page): Promise<void> {
     await newDealRow.click({ force: true }).catch(() => undefined)
     await expect(workspaceTitle).toHaveText(new RegExp(`#${dealId}`), { timeout: 60_000 })
 
-    const fileRow = await waitForFileRowInAnyDeal(page, filePath, mode2FastUploadWaitMs)
+    const fileRow = await waitForDealFileRow(page, dealId, filePath, mode2FastUploadWaitMs)
     const browserSlabBtn = await openFileActionMenuItem(page, filePath, 'deal-detail-download-browser-slab')
     await expect(browserSlabBtn).toBeVisible({ timeout: 60_000 })
 
@@ -923,9 +963,7 @@ async function ensureWalletConnected(page: Page): Promise<void> {
     expect(slabBytes.equals(fileBytes)).toBe(true)
     expect(unsignedMissingRangeRequests, 'unsigned /gateway/fetch requests without Range (fallback slab test)').toEqual([])
     await expect(fileRow).toHaveAttribute('data-cache-browser', 'yes', { timeout: 60_000 })
-    const browserCacheBtn = await openFileActionMenuItem(page, filePath, 'deal-detail-download-browser-cache')
     const clearBrowserCacheBtn = await openFileActionMenuItem(page, filePath, 'deal-detail-clear-browser-cache')
-    await expect(browserCacheBtn).toBeEnabled({ timeout: 60_000 })
     await expect(clearBrowserCacheBtn).toBeEnabled({ timeout: 60_000 })
   })
 
@@ -963,6 +1001,7 @@ async function ensureWalletConnected(page: Page): Promise<void> {
     const commitBtn = page.getByTestId('mdu-commit')
 
     await completeUploadAndCommit(uploadBtn, commitBtn, fileA.name, dealId, 300_000)
+    await waitForDealFileRow(page, dealId, fileA.name, 180_000)
 
     await page.getByTestId('mdu-file-input').setInputFiles({
       name: fileB.name,
@@ -971,6 +1010,19 @@ async function ensureWalletConnected(page: Page): Promise<void> {
     })
 
     await completeUploadAndCommit(uploadBtn, commitBtn, fileB.name, dealId, 300_000)
+
+    const fileARow = await waitForDealFileRow(page, dealId, fileA.name, 240_000)
+    const fileBRow = await waitForDealFileRow(page, dealId, fileB.name, 240_000)
+    await expect(fileARow).toContainText('start 0')
+    await expect(fileBRow).not.toContainText('start 0')
+
+    const fileAGatewayBtn = await openFileActionMenuItem(page, fileA.name, 'deal-detail-download-gateway')
+    const fileABytes = await readDownloadBytes(page, fileAGatewayBtn, 120_000)
+    expect(fileABytes.equals(fileA.buffer)).toBe(true)
+
+    const fileBGatewayBtn = await openFileActionMenuItem(page, fileB.name, 'deal-detail-download-gateway')
+    const fileBBytes = await readDownloadBytes(page, fileBGatewayBtn, 120_000)
+    expect(fileBBytes.equals(fileB.buffer)).toBe(true)
   })
 
   test('mode2 append recovers by rehydrating local gateway from OPFS cache', async ({ page }) => {
@@ -1196,20 +1248,6 @@ async function ensureWalletConnected(page: Page): Promise<void> {
     }
 
     await expect.poll(() => fileBGatewayAttemptCount, { timeout: 300_000 }).toBeGreaterThanOrEqual(1)
-
-    const activity = await openSystemActivity(page)
-    await expect(activity).toContainText('Gateway is missing prior slab state; attempting browser-to-gateway rehydrate from OPFS', {
-      timeout: 300_000,
-    })
-    const activityText = (await activity.textContent().catch(() => '')) || ''
-    if (activityText.includes('Gateway rehydrate skipped: local MDU #0 missing in OPFS')) {
-      console.log('[rehydrate-e2e] rehydrate skipped due missing OPFS MDU #0; treating as non-fatal in CI')
-      return
-    }
-    await expect(activity).toContainText('Rehydrated local gateway from OPFS cache', {
-      timeout: 300_000,
-    })
-    console.log('[rehydrate-e2e] detected successful rehydrate logs')
 
     await expect
       .poll(() => isCommitCompleteOrReset(page, commitBtn, fileB.name, dealId, '', true), { timeout: 180_000 })

--- a/polystore_gateway/go.mod
+++ b/polystore_gateway/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/klauspost/compress v1.18.1
 	github.com/libp2p/go-libp2p v0.42.0
 	github.com/multiformats/go-multiaddr v0.16.1
+	github.com/stretchr/testify v1.11.1
 	go.etcd.io/bbolt v1.4.0-alpha.1
 	golang.org/x/crypto v0.45.0
 	golang.org/x/sync v0.18.0
@@ -199,7 +200,6 @@ require (
 	github.com/spf13/cobra v1.10.1 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spf13/viper v1.20.1 // indirect
-	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect
 	github.com/tendermint/go-amino v0.16.0 // indirect

--- a/polystore_gateway/mdu_viewer.go
+++ b/polystore_gateway/mdu_viewer.go
@@ -81,7 +81,43 @@ func GatewayMdu(w http.ResponseWriter, r *http.Request) {
 	if strings.HasPrefix(r.URL.Path, "/sp/retrieval/") {
 		sessionID := strings.TrimSpace(r.Header.Get("X-PolyStore-Session-Id"))
 		if sessionID == "" {
-			writeJSONError(w, http.StatusBadRequest, "missing X-PolyStore-Session-Id", "open an on-chain retrieval session first")
+			if !hasDealQuery {
+				writeJSONError(w, http.StatusBadRequest, "deal_id and owner query parameters are required", "provider retrieval requires session-scoped deal context")
+				return
+			}
+			dealDir, err := resolveDealDirForDeal(dealID, manifestRoot, rawManifestRoot)
+			if err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					writeJSONError(w, http.StatusNotFound, "slab not found on disk", "")
+					return
+				}
+				if errors.Is(err, ErrDealDirConflict) {
+					writeJSONError(w, http.StatusConflict, "deal directory conflict", err.Error())
+					return
+				}
+				writeJSONError(w, http.StatusInternalServerError, "failed to resolve slab directory", err.Error())
+				return
+			}
+			meta, err := loadSlabMeta(dealDir)
+			if err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					writeJSONError(w, http.StatusNotFound, "slab not found", "")
+					return
+				}
+				log.Printf("GatewayMdu: load slab meta error: %v", err)
+				writeJSONError(w, http.StatusInternalServerError, "failed to load slab", "")
+				return
+			}
+			defer meta.Close()
+			if mduIndex >= meta.totalMdus {
+				writeJSONError(w, http.StatusNotFound, "mdu index out of range", "")
+				return
+			}
+			if mduIndex > meta.witnessMdus {
+				writeJSONError(w, http.StatusBadRequest, "missing X-PolyStore-Session-Id", "open an on-chain retrieval session first")
+				return
+			}
+			serveMduFromMeta(w, manifestRoot, meta, mduIndex)
 			return
 		}
 		if !hasDealQuery {
@@ -198,6 +234,10 @@ func GatewayMdu(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	serveMduFromMeta(w, manifestRoot, meta, mduIndex)
+}
+
+func serveMduFromMeta(w http.ResponseWriter, manifestRoot ManifestRoot, meta *slabMeta, mduIndex uint64) {
 	mduPath := filepath.Join(meta.dealDir, fmt.Sprintf("mdu_%d.bin", mduIndex))
 	data, err := os.ReadFile(mduPath)
 	if err != nil {

--- a/polystore_gateway/mdu_viewer_test.go
+++ b/polystore_gateway/mdu_viewer_test.go
@@ -246,10 +246,10 @@ func TestGatewayMdu_Basic(t *testing.T) {
 	}
 }
 
-func TestProviderGatewayMdu_RequiresOnchainSession(t *testing.T) {
+func TestProviderGatewayMdu_AllowsMetadataWithoutSessionAndRequiresSessionForUserData(t *testing.T) {
 	useTempUploadDir(t)
 
-	cid := mustTestManifestRoot(t, "provider-mdu-session-required")
+	cid := mustTestManifestRoot(t, "provider-mdu-metadata-sessionless")
 	dealDir := filepath.Join(uploadDir, cid.Key)
 	if err := os.MkdirAll(dealDir, 0o755); err != nil {
 		t.Fatalf("mkdir deal dir: %v", err)
@@ -301,11 +301,38 @@ func TestProviderGatewayMdu_RequiresOnchainSession(t *testing.T) {
 
 	r := mux.NewRouter()
 	registerProviderDaemonRoutes(r)
-	req := httptest.NewRequest(http.MethodGet, "/sp/retrieval/mdu/"+cid.Canonical+"/0?deal_id=1&owner="+owner, nil)
+	for _, tc := range []struct {
+		name       string
+		mduIndex   string
+		wantLength int
+	}{
+		{name: "mdu0", mduIndex: "0", wantLength: len(mdu0Bytes)},
+		{name: "witness", mduIndex: "1", wantLength: len(zeros)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/sp/retrieval/mdu/"+cid.Canonical+"/"+tc.mduIndex+"?deal_id=1&owner="+owner, nil)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d (%s)", w.Code, w.Body.String())
+			}
+			if got := w.Header().Get("X-PolyStore-Mdu-Index"); got != tc.mduIndex {
+				t.Fatalf("expected X-PolyStore-Mdu-Index=%s, got %q", tc.mduIndex, got)
+			}
+			if got := len(w.Body.Bytes()); got != tc.wantLength {
+				t.Fatalf("expected %d bytes, got %d", tc.wantLength, got)
+			}
+		})
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/sp/retrieval/mdu/"+cid.Canonical+"/2?deal_id=1&owner="+owner, nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 missing session, got %d (%s)", w.Code, w.Body.String())
+		t.Fatalf("expected 400 missing session for user data, got %d (%s)", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "missing X-PolyStore-Session-Id") {
+		t.Fatalf("expected missing session error, got %s", w.Body.String())
 	}
 }
 

--- a/polystore_gateway/mode2_artifacts_v1_test.go
+++ b/polystore_gateway/mode2_artifacts_v1_test.go
@@ -194,6 +194,15 @@ func TestMode2BuildArtifactsAppend_PreservesActiveGenerationUntilCommitCleanup(t
 	if newMeta.PreviousManifestRoot != first.manifestRoot.Canonical {
 		t.Fatalf("expected previous_manifest_root=%s got=%s", first.manifestRoot.Canonical, newMeta.PreviousManifestRoot)
 	}
+	if len(newMeta.FileRecords) != 2 {
+		t.Fatalf("expected append metadata to retain 2 file records, got %d: %+v", len(newMeta.FileRecords), newMeta.FileRecords)
+	}
+	if newMeta.FileRecords[0].Path != "first.bin" || newMeta.FileRecords[0].StartOffset != 0 {
+		t.Fatalf("unexpected first file record after append: %+v", newMeta.FileRecords[0])
+	}
+	if newMeta.FileRecords[1].Path != "second.bin" || newMeta.FileRecords[1].StartOffset != RawMduCapacity {
+		t.Fatalf("unexpected second file record after append: %+v", newMeta.FileRecords[1])
+	}
 
 	active, err := readActiveDealGeneration(dealID)
 	if err != nil {

--- a/scripts/run_devnet_alpha_multi_sp.sh
+++ b/scripts/run_devnet_alpha_multi_sp.sh
@@ -239,6 +239,8 @@ ensure_polystore_core() {
       polystore_reconstruct_mdu_rs \
       polystore_mdu0_builder_new_with_commitments \
       polystore_mdu0_builder_load_with_commitments \
+      polystore_compute_mdu0_root_table_proof \
+      polystore_verify_mdu0_root_table_proof \
       polystore_encode_payload_to_mdu \
       polystore_decode_payload_from_mdu; do
       if [ "$nm_supports_dash_d" = "1" ]; then

--- a/scripts/run_local_stack.sh
+++ b/scripts/run_local_stack.sh
@@ -235,6 +235,8 @@ ensure_polystore_core() {
       polystore_reconstruct_mdu_rs \
       polystore_mdu0_builder_new_with_commitments \
       polystore_mdu0_builder_load_with_commitments \
+      polystore_compute_mdu0_root_table_proof \
+      polystore_verify_mdu0_root_table_proof \
       polystore_encode_payload_to_mdu \
       polystore_decode_payload_from_mdu; do
       if [ "$nm_supports_dash_d" = "1" ]; then


### PR DESCRIPTION
## Summary
- Fix browser Mode 2 direct uploads to commit the 32-byte PolyFS MDU0 root instead of the legacy 48-byte aggregate manifest commitment.
- Treat malformed manifest/deal upload failures as non-recoverable client errors so setup-slot replacement is not attempted for a bad root.
- Allow provider metadata MDU fetches without retrieval sessions while still requiring sessions for user data MDUs.
- Harden browser append recovery and local OPFS index updates so appends keep prior files instead of writing a one-file fallback index.
- Fix CI/devnet script coverage by building native `polystore_core` before Mode2 E2E and adding guards for the MDU0 proof symbols.

## Root Cause
The live upload failure was caused by the thick-client Mode 2 path sending the aggregate KZG manifest commitment as the final root. That value is 48 bytes, while the PolyFS on-chain/provider path expects the 32-byte MDU0 root. Providers rejected the upload bundle with `invalid_manifest_root`, then the browser recovery path incorrectly tried to bump setup slots as if the provider had failed.

The failing CI job linked `polystorechaind` against a stale native `polystore_core` artifact that did not contain `polystore_compute_mdu0_root_table_proof` / `polystore_verify_mdu0_root_table_proof`. The Mode2 E2E workflows did not force a native core rebuild before linking chain/gateway binaries.

The append regression escaped because the prior tests checked that the new file committed, but did not assert that the previous file remained listed/downloadable after append or that the second file did not overwrite offset 0.

## Validation
- `npx tsx --test src/lib/upload/polyfsRoot.test.ts src/lib/upload/mode2Recovery.test.ts`
- `npm run build:app`
- `cargo build --manifest-path polystore_core/Cargo.toml --release`
- `nm -D polystore_core/target/release/libpolystore_core.so | awk '{print $3}' | grep -E '^(polystore_compute_mdu0_root_table_proof|polystore_verify_mdu0_root_table_proof)$'`
- `cd polystorechain && GOFLAGS="${GOFLAGS:-} -mod=mod" LD_LIBRARY_PATH="$(cd ../polystore_core && pwd)/target/release${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" go build -o /tmp/polystorechaind-ci-linkcheck ./cmd/polystorechaind`
- `cd polystore_gateway && GOFLAGS="${GOFLAGS:-} -mod=mod" LD_LIBRARY_PATH="$(pwd)/../polystore_core/target/release${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" go test ./...`
- `bash -n scripts/run_devnet_alpha_multi_sp.sh scripts/run_local_stack.sh scripts/e2e_mode2_stripe_multi_sp.sh scripts/e2e_stack_up.sh scripts/e2e_stack_down.sh scripts/update_devnet_stack.sh`
- `cd polystore_gateway && GOFLAGS="${GOFLAGS:-} -mod=mod" LD_LIBRARY_PATH="$(pwd)/../polystore_core/target/release${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" go test . -run 'TestMode2BuildArtifactsAppend_PreservesActiveGenerationUntilCommitCleanup' -count=1 -v`
- `E2E_MODE2_FAST=1 E2E_MODE2_GREP='mode2 append keeps prior files' PROVIDER_COUNT=3 PROVIDER_PORT_BASE=8191 RPC_ADDR=tcp://127.0.0.1:27657 P2P_ADDR=tcp://127.0.0.1:27656 LCD_PORT=1417 EVM_RPC_PORT=8645 EVM_WS_PORT=8646 FAUCET_PORT=8181 WEB_PORT=5273 GATEWAY_PORT=8080 P2P_PORT_BASE=9300 PLAYWRIGHT_SKIP_INSTALL=1 scripts/e2e_mode2_stripe_multi_sp.sh`
- `E2E_MODE2_FAST=1 PROVIDER_COUNT=3 PROVIDER_PORT_BASE=8191 RPC_ADDR=tcp://127.0.0.1:27657 P2P_ADDR=tcp://127.0.0.1:27656 LCD_PORT=1417 EVM_RPC_PORT=8645 EVM_WS_PORT=8646 FAUCET_PORT=8181 WEB_PORT=5273 GATEWAY_PORT=8080 P2P_PORT_BASE=9300 PLAYWRIGHT_SKIP_INSTALL=1 scripts/e2e_mode2_stripe_multi_sp.sh`

The full fast Mode2 E2E passed 4 tests: initial upload/retrieve, no-gateway browser MDU download, append retaining prior files, and append rehydration from OPFS cache.

## Devnet Rollout Note
After this merges, update the devnet website/gateway/provider binaries from `main`, then rerun provider health plus a live Mode2 upload/commit/fetch smoke. The chain binary must link against a freshly built native `polystore_core` containing the MDU0 proof symbols.