### PR TITLE
Preserve deal detail upload continuity

### DIFF
--- a/polystore-website/src/components/Dashboard.tsx
+++ b/polystore-website/src/components/Dashboard.tsx
@@ -1918,7 +1918,7 @@ export function Dashboard() {
               </div>
             ) : targetDeal ? (
               <DealDetail
-                key={`${targetDeal.id}:${String(targetDeal.cid || '')}`}
+                key={`${targetDeal.id}:${String(targetDeal.owner || '')}`}
                 deal={targetDeal}
                 polystoreAddress={polystoreAddress}
                 onFileActivity={recordRecentActivity}

--- a/polystore-website/src/components/DealDetail.tsx
+++ b/polystore-website/src/components/DealDetail.tsx
@@ -2889,7 +2889,7 @@ export function DealDetail({
                     </div>
                   )}
 
-                      {loadingFiles ? (
+                      {loadingFiles && (!files || files.length === 0) ? (
                         <div className="nil-tab-panel text-xs text-muted-foreground">Loading file table…</div>
                       ) : requiresDealIndexSync ? (
                         <div

--- a/polystore-website/tests/mode2-stripe.spec.ts
+++ b/polystore-website/tests/mode2-stripe.spec.ts
@@ -83,7 +83,18 @@ async function openFileActionMenuItem(page: Page, filePath: string, testId: stri
   const item = page.locator(`[data-testid="${testId}"][data-file-path="${filePath}"]`)
   if (await item.isVisible().catch(() => false)) return item
   await expect(menuButton).toBeVisible({ timeout: 60_000 })
-  await menuButton.click({ force: true })
+  await menuButton.scrollIntoViewIfNeeded().catch(() => undefined)
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    if (attempt === 0) {
+      await menuButton.click({ force: true })
+    } else {
+      await menuButton.evaluate((button) => {
+        if (button instanceof HTMLElement) button.click()
+      })
+    }
+    if (await item.isVisible().catch(() => false)) return item
+    await page.waitForTimeout(250)
+  }
   await expect(item).toBeVisible({ timeout: 30_000 })
   return item
 }
@@ -238,19 +249,20 @@ async function isCommitCompleteOrReset(
   dealId: string,
   initialManifestRoot: string,
   allowReset: boolean,
+  allowFileRowCompletion = true,
 ): Promise<boolean> {
   if (dealId) {
     const currentManifest = await readDealManifestRoot(page, dealId)
     if (currentManifest && currentManifest !== initialManifestRoot) return true
   }
-  if (expectedFilePath) {
+  if (allowFileRowCompletion && expectedFilePath) {
     if (await hasDealFileRow(page, expectedFilePath)) return true
   }
   const panelState = await page.getByTestId('mdu-upload-card').getAttribute('data-panel-state').catch(() => null)
-  if (panelState === 'success') return true
+  if (allowFileRowCompletion && panelState === 'success') return true
   const text = ((await commitBtn.textContent().catch(() => '')) || '').trim()
   if (/Committed!/i.test(text)) return true
-  if (allowReset && (await isUploaderResetToInitialState(page))) return true
+  if (allowFileRowCompletion && allowReset && (await isUploaderResetToInitialState(page))) return true
   return false
 }
 
@@ -260,21 +272,45 @@ async function completeUploadAndCommit(
   expectedFilePath: string,
   dealId: string,
   timeout = 300_000,
+  options: { allowFileRowCompletion?: boolean } = {},
 ): Promise<void> {
   const page = uploadBtn.page()
+  const allowFileRowCompletion = options.allowFileRowCompletion ?? true
   await waitForUploadControls(uploadBtn, commitBtn, timeout).catch(() => undefined)
   const initialManifestRoot = dealId ? await readDealManifestRoot(page, dealId) : ''
 
   const deadline = Date.now() + timeout
   while (Date.now() < deadline) {
-    if (await isCommitCompleteOrReset(page, commitBtn, expectedFilePath, dealId, initialManifestRoot, true)) return
+    if (
+      await isCommitCompleteOrReset(
+        page,
+        commitBtn,
+        expectedFilePath,
+        dealId,
+        initialManifestRoot,
+        true,
+        allowFileRowCompletion,
+      )
+    ) return
 
     const commitCount = await commitBtn.count().catch(() => 0)
     const commitEnabled = commitCount > 0 && (await commitBtn.isEnabled().catch(() => false))
     if (commitEnabled) {
       await commitBtn.click()
       await expect
-        .poll(() => isCommitCompleteOrReset(page, commitBtn, expectedFilePath, dealId, initialManifestRoot, true), { timeout: 180_000 })
+        .poll(
+          () =>
+            isCommitCompleteOrReset(
+              page,
+              commitBtn,
+              expectedFilePath,
+              dealId,
+              initialManifestRoot,
+              true,
+              allowFileRowCompletion,
+            ),
+          { timeout: 180_000 },
+        )
         .toBe(true)
       return
     }
@@ -286,20 +322,52 @@ async function completeUploadAndCommit(
       await uploadBtn.click({ force: true })
       await expect
         .poll(async () => {
-          if (await isCommitCompleteOrReset(page, commitBtn, expectedFilePath, dealId, initialManifestRoot, true)) return true
+          if (
+            await isCommitCompleteOrReset(
+              page,
+              commitBtn,
+              expectedFilePath,
+              dealId,
+              initialManifestRoot,
+              true,
+              allowFileRowCompletion,
+            )
+          ) return true
           const enabled = await commitBtn.isEnabled().catch(() => false)
           if (enabled) return true
           const text = ((await uploadBtn.textContent().catch(() => '')) || '').trim()
           return /Upload Complete/i.test(text)
         }, { timeout: 120_000 })
         .toBe(true)
-      if (await isCommitCompleteOrReset(page, commitBtn, expectedFilePath, dealId, initialManifestRoot, true)) return
+      if (
+        await isCommitCompleteOrReset(
+          page,
+          commitBtn,
+          expectedFilePath,
+          dealId,
+          initialManifestRoot,
+          true,
+          allowFileRowCompletion,
+        )
+      ) return
     }
     await page.waitForTimeout(500)
   }
 
   await expect
-    .poll(() => isCommitCompleteOrReset(page, commitBtn, expectedFilePath, dealId, initialManifestRoot, true), { timeout: 180_000 })
+    .poll(
+      () =>
+        isCommitCompleteOrReset(
+          page,
+          commitBtn,
+          expectedFilePath,
+          dealId,
+          initialManifestRoot,
+          true,
+          allowFileRowCompletion,
+        ),
+      { timeout: 180_000 },
+    )
     .toBe(true)
   await page.waitForTimeout(150)
 }
@@ -381,6 +449,74 @@ async function waitForDealFileRow(
   }
 
   return fileRow
+}
+
+async function installDealDetailContinuityProbe(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const root = document.querySelector('[data-testid="deal-detail"]')
+    if (!root) throw new Error('deal-detail root not found for continuity probe')
+
+    const probe = {
+      root,
+      rootReplaced: false,
+      loadingFileTableSeen: false,
+      observer: undefined as MutationObserver | undefined,
+    }
+
+    const scanLoadingState = () => {
+      if ((document.body.textContent || '').includes('Loading file table')) {
+        probe.loadingFileTableSeen = true
+      }
+    }
+
+    scanLoadingState()
+    probe.observer = new MutationObserver((records) => {
+      if (!document.contains(root)) {
+        probe.rootReplaced = true
+      }
+      for (const record of records) {
+        for (const node of Array.from(record.removedNodes)) {
+          if (node === root || (node instanceof Element && node.contains(root))) {
+            probe.rootReplaced = true
+          }
+        }
+      }
+      scanLoadingState()
+    })
+    probe.observer.observe(document.body, { childList: true, subtree: true, characterData: true })
+
+    ;(window as unknown as { __dealDetailContinuityProbe?: typeof probe }).__dealDetailContinuityProbe = probe
+  })
+}
+
+async function readDealDetailContinuityProbe(page: Page): Promise<{
+  rootReplaced: boolean
+  loadingFileTableSeen: boolean
+  fileRowCount: number
+}> {
+  return page.evaluate(() => {
+    const probe = (window as unknown as {
+      __dealDetailContinuityProbe?: {
+        root: Element
+        rootReplaced: boolean
+        loadingFileTableSeen: boolean
+        observer?: MutationObserver
+      }
+    }).__dealDetailContinuityProbe
+    if (!probe) throw new Error('deal-detail continuity probe was not installed')
+
+    const currentRoot = document.querySelector('[data-testid="deal-detail"]')
+    const rootReplaced = probe.rootReplaced || !document.contains(probe.root) || currentRoot !== probe.root
+    const loadingFileTableSeen =
+      probe.loadingFileTableSeen || (document.body.textContent || '').includes('Loading file table')
+    probe.observer?.disconnect()
+
+    return {
+      rootReplaced,
+      loadingFileTableSeen,
+      fileRowCount: document.querySelectorAll('[data-testid="deal-detail-file-row"]').length,
+    }
+  })
 }
 
 function resolveRouterUploadDir(): string {
@@ -996,6 +1132,7 @@ async function ensureWalletConnected(page: Page): Promise<void> {
 
     await completeUploadAndCommit(uploadBtn, commitBtn, fileA.name, dealId, 300_000)
     await waitForDealFileRow(page, dealId, fileA.name, 180_000)
+    await installDealDetailContinuityProbe(page)
 
     await page.getByTestId('mdu-file-input').setInputFiles({
       name: fileB.name,
@@ -1003,7 +1140,14 @@ async function ensureWalletConnected(page: Page): Promise<void> {
       buffer: fileB.buffer,
     })
 
-    await completeUploadAndCommit(uploadBtn, commitBtn, fileB.name, dealId, 300_000)
+    await completeUploadAndCommit(uploadBtn, commitBtn, fileB.name, dealId, 300_000, {
+      allowFileRowCompletion: false,
+    })
+
+    const continuity = await readDealDetailContinuityProbe(page)
+    expect(continuity.rootReplaced).toBe(false)
+    expect(continuity.loadingFileTableSeen).toBe(false)
+    expect(continuity.fileRowCount).toBeGreaterThanOrEqual(1)
 
     const fileARow = await waitForDealFileRow(page, dealId, fileA.name, 240_000)
     const fileBRow = await waitForDealFileRow(page, dealId, fileB.name, 240_000)


### PR DESCRIPTION
Closes #227

## Graph node

- Tracker: #227
- Implementation PR: this PR
- Devnet rollout: not required; this is frontend-only and does not change chain, gateway, provider, or deployed devnet binaries.

## Root cause

`Dashboard` keyed `DealDetail` by `deal.id:deal.cid`. A successful Mode 2 commit updates `cid` to the new manifest root, which changed the React key and forced a full `DealDetail` unmount/remount. During that remount, root-sensitive hydration could blank the Files section and show `Loading file table...` instead of updating the file list in place.

## Changes

- Keep `DealDetail` identity stable for the same selected deal by keying on stable deal identity/owner instead of the mutable manifest root.
- Keep existing file rows visible during a normal file table refresh when files are already loaded.
- Add a Playwright continuity probe around the second Mode 2 upload to assert the `DealDetail` root is not replaced and the Files section does not collapse to the loading-only state.
- Tighten the append helper so the second upload waits for the manifest-root/commit path, not merely the pre-existing file row.

## Test-first evidence

Before the implementation change, the new focused continuity assertion failed with:

```text
Expected: false
Received: true
at expect(continuity.rootReplaced).toBe(false)
```

That confirmed the regression was a real remount caused by the upload commit path.

## Local validation

```bash
E2E_LOCAL_STACK=1 E2E_MODE2_FAST=1 E2E_BASE_URL=http://127.0.0.1:5174 E2E_GATEWAY_BASE=http://127.0.0.1:18080 npm run test:e2e -- tests/mode2-stripe.spec.ts --grep 'mode2 append keeps prior files' --reporter=line
# 1 passed
```

```bash
E2E_LOCAL_STACK=1 E2E_MODE2_FAST=1 E2E_BASE_URL=http://127.0.0.1:5174 E2E_GATEWAY_BASE=http://127.0.0.1:18080 npm run test:e2e -- tests/mode2-stripe.spec.ts --grep 'mode2 deal → shard → upload → commit → retrieve' --reporter=line
# 1 passed
```

```bash
npm run build:app
# passed

npm run test:unit
# 300 pass, 0 fail

npm run lint
# passed
```

## Latest-head CI

Current head: `e8510c1c881b7961bd8b7630f7f2b5603121ab09`.

GitHub CI is fully green on latest head, including Website Build & Lint, Playwright E2E, E2E Mode2 Stripe (Fast 3 SPs), E2E Gateway Retrieval (Multi-SP), Browser Sparse Upload Proof, Native/WASM Parity, Gateway Absent, lifecycle gateway/no-gateway, ghost-repair, Website Node Integration, Go/Rust/Solidity suites, Tauri, and Workers preview.

Codex review on `e8510c1c88` reported no major issues. No reviewer findings or unresolved threads are present at closeout.

## Merge gates

- [x] Tracker linked
- [x] Focused continuity regression covered
- [x] Existing Mode 2 create/upload/download path covered
- [x] Local lint/unit/build gates passed
- [x] Latest-head CI green
- [x] AI/reviewer findings resolved or explicitly non-blocking
