### PR TITLE
[codex] Harden PolyFS retrievable DA certificate RFC

### DIFF
--- a/rfcs/rfc-polyfs-da-lanes.md
+++ b/rfcs/rfc-polyfs-da-lanes.md
@@ -1,7 +1,8 @@
 # RFC: PolyFS DA Lanes and Availability Certificates
 
 **Status:** Proposed / research-track candidate
-**Scope:** Protocol, PolyFS, chain state, gateway APIs, storage economics
+**Scope:** Protocol, PolyFS, chain state, gateway APIs, provider-daemon
+attestations, retrieval economics
 **Depends on:**
 `whitepaper.md`,
 `rfcs/rfc-blob-alignment-and-striping.md`,
@@ -17,24 +18,40 @@
 
 ## 1. Summary
 
-This RFC proposes **PolyFS DA Lanes**: append-only publication streams backed by
-PolyStore deals that can produce explicit **Availability Certificates**.
+This RFC proposes **PolyFS DA Lanes** as an **attestation-first data
+availability service with native durable retrieval**.
 
 The intended product is not "current PolyStore storage deals are already a
 complete DA layer." The intended product is:
 
-> Applications publish erasure-coded batches to a PolyStore DA Lane, receive an
-> availability certificate under a documented sampling/attestation policy, and
-> keep the same data retrievable through PolyStore's paid, provable, repairable
-> storage layer.
+> Applications publish erasure-coded batches to a PolyStore DA Lane, receive a
+> compact Availability Certificate after protocol-selected provider-daemons
+> attest to the assigned data, and keep the same data retrievable through
+> PolyStore's paid, provable, repairable storage layer.
 
-This proposal keeps historical DA archival/retrieval as the near-term product
-wedge while defining the technical bridge toward publication-time availability
-and a full DAS research track.
+The first primary-DA path should be attestation-first, not sampling-first. It is
+closer to an EigenDA-shaped operator/quorum model than to a Celestia-shaped DAS
+chain. PolyStore's differentiation is that a certificate can bind publication
+availability to durable retrieval, repair, payment, and retained PolyFS
+generations.
+
+This RFC defines three certificate tiers:
+
+* `DA_CERT_FAST`: quorum attestation that assigned chunks were received,
+  verified, stored, and committed by provider-daemons.
+* `DA_CERT_RETRIEVABLE`: `DA_CERT_FAST` plus publication-time sample retrievals
+  served through PolyStore retrieval sessions before downstream acceptance.
+* `DA_CERT_RETAINED`: `DA_CERT_RETRIEVABLE` plus continuing retention, audit,
+  repair, and provider-rotation obligations through a declared window.
+
+`DA_CERT_RETRIEVABLE` is the flagship PolyStore target. It is the tier that
+makes the availability claim operationally useful: the data was not only
+attested, it was sampled as retrievable through the storage network that will
+serve it later.
 
 -----
 
-## 2. Motivation
+## 2. Design Posture
 
 DA systems answer a different question than archive systems.
 
@@ -44,38 +61,76 @@ DA systems answer a different question than archive systems.
   made available widely enough before downstream systems accepted that
   commitment?**
 
-PolyStore already has many primitives that map well to the second question:
+The market has two relevant protocol shapes.
 
-* pinned PolyFS generations and compare-and-swap root updates;
-* 128 KiB KZG-aligned blobs and 8 MiB MDUs;
-* RS(8,12) striping and accountable provider slots;
-* replicated metadata and witness MDUs;
-* chained proofs from a PolyFS root to served bytes;
-* mandatory retrieval sessions that pin deal, root, slot, range, payer, nonce,
-  and expiry;
-* public, sponsored, requester-funded, and protocol-funded retrieval flows;
-* synthetic liveness and provider-health accounting; and
+### 2.1 Sampling-first DA
+
+Sampling-first DA, represented by Celestia, Avail, and Ethereum PeerDAS-style
+designs, makes random sampling a core security mechanism. A light client or
+validator can sample encoded shares/cells and obtain confidence that the whole
+block or blob was published without downloading the full data.
+
+This model is strongest when the protocol itself owns consensus headers,
+sampling rules, reconstruction assumptions, and light-client semantics.
+
+PolyStore SHOULD NOT claim sampling-first security until it has a formal
+sampling network, probability model, encoding-correctness path, and light-client
+verification design.
+
+### 2.2 Attestation-first DA
+
+Attestation-first DA, represented by EigenDA-style designs, uses a selected
+operator set. A disperser encodes data, sends assigned chunks and proofs to
+operators, operators verify and store the chunks, and a quorum signs an
+availability statement. A rollup or bridge verifies the resulting certificate
+before accepting the batch.
+
+This model is the more natural primary-DA route for PolyStore because PolyStore
+already has:
+
+* provider-daemons with accountable storage obligations;
+* protocol-selected provider placement;
+* KZG-aligned blobs and 8 MiB MDUs;
+* RS(8,12)-style striping;
+* pinned PolyFS generations and compare-and-swap roots;
+* retrieval sessions that bind deal, root, range, payer, nonce, and expiry;
+* paid retrieval flows; and
 * repair and provider rotation.
 
-Those primitives make PolyStore a plausible substrate for a DA-style system, but
-they do not yet define the missing publication-time semantics: append-only
-batch ordering, public write admission, sample-coordinate grammar, delayed
-randomness, certificate state, and encoding-correctness evidence.
+### 2.3 PolyStore's DA shape
+
+PolyStore DA should be **attestation-first with retrieval-native hardening**.
+The first competitive claim should not be "cheapest or fastest generic DA." It
+should be:
+
+> PolyStore DA certificates bind publication-time availability to an accountable
+> retrieval and retention substrate.
+
+That claim is narrower, easier to defend, and more differentiated. It says the
+batch was not merely signed by a quorum. It also says the batch is mapped into a
+PolyFS generation, backed by storage deals, subject to retrieval sessions, and
+eligible for repair or retained access after certification.
 
 -----
 
 ## 3. Goals
 
-1. Define a formal product/protocol abstraction for DA publication on top of
-   PolyStore storage deals.
-2. Separate near-term append-only lane work from stronger DAS claims.
-3. Specify the chain objects and message shapes needed for DA lanes and
-   availability certificates.
-4. Reuse existing PolyStore primitives wherever possible.
-5. Make provider accountability, retrieval payment, and post-certification
-   repair first-class properties of the DA design.
-6. Identify the research questions that must be answered before PolyStore can
-   make strong light-client DAS claims.
+1. Define PolyStore DA as attestation-first primary DA with native durable
+   retrieval.
+2. Make `DA_CERT_FAST`, `DA_CERT_RETRIEVABLE`, and `DA_CERT_RETAINED` explicit
+   protocol tiers with different verification and service claims.
+3. Specify the chain objects and message shapes needed for DA lanes,
+   provider-daemon attestations, sample retrievals, failure evidence, and
+   Availability Certificates.
+4. Keep storage deals as the durable storage and economic substrate, not the DA
+   publication object itself.
+5. Define a compact certificate verification surface for rollups, bridge
+   contracts, and external applications.
+6. Reuse existing PolyStore primitives wherever possible.
+7. Make provider accountability, retrieval payment, post-certification repair,
+   and retained historical generations first-class properties of the design.
+8. Keep the future DAS/light-client path available without depending on that
+   stronger claim for the first product.
 
 -----
 
@@ -84,9 +139,10 @@ randomness, certificate state, and encoding-correctness evidence.
 This RFC does not:
 
 * claim current PolyStore deals are already a complete consensus DA layer;
-* replace the historical DA archive/retrieval strategy;
+* claim storage proofs alone are sufficient for primary DA;
+* claim Celestia-equivalent or PeerDAS-equivalent sampling security;
 * specify a final probability bound for every sampling profile;
-* define final slashing economics for DA certification failures;
+* define final slashing economics for all false attestation cases;
 * require a new consensus protocol for PolyStore;
 * require every storage provider to store every byte;
 * define an L1 bridge contract in detail; or
@@ -94,57 +150,38 @@ This RFC does not:
 
 -----
 
-## 5. Market and Design Context
-
-The DA market is already a named category. Celestia, Ethereum PeerDAS, Avail,
-and EigenDA converge around the same primitive set: erasure coding, commitments,
-sampling or attestations, and a compact result that rollups or other execution
-systems can rely on.
-
-The market is not buying generic storage. It is buying assurances:
-
-* the data behind a batch was actually published;
-* withholding is detectable or economically costly;
-* light clients or validators do not need to download the whole batch;
-* downstream systems can reference a compact commitment or certificate; and
-* enough honest participants can recover the data during the relevant window.
-
-PolyStore's differentiated claim should therefore be narrow and stronger:
-
-> Most DA systems optimize publication. PolyStore can join publication-time
-> availability with long-lived, paid, provable retrieval.
-
-This RFC intentionally avoids claiming the broadest possible DA throughput or
-security model before the sampling math and encoding-correctness path are
-formalized.
-
------
-
-## 6. Terminology
+## 5. Terminology
 
 | Term | Meaning |
 |---|---|
 | **Deal** | Existing PolyStore storage/economic object. Deals remain the substrate for provider placement, escrow, retrieval policy, roots, and repair. |
-| **PolyFS generation** | Immutable committed content state identified by a PolyFS root. |
+| **PolyFS generation** | Immutable committed content state identified by a PolyFS root and generation. |
 | **DA Lane** | Append-only publication stream backed by one or more deals. |
 | **Batch** | One ordered publication unit in a DA Lane. |
+| **DABatchHeader** | DA-facing commitment and metadata that external systems verify or reference. |
 | **Publisher** | Account authorized to append a batch to a lane. |
-| **Availability Certificate** | Compact record that a batch passed a lane-defined availability policy. |
+| **Availability Certificate** | Compact record that a batch satisfied a named certificate policy. |
+| **`DA_CERT_FAST`** | Certificate tier based on provider-daemon quorum attestations. |
+| **`DA_CERT_RETRIEVABLE`** | Certificate tier based on quorum attestations plus publication-time retrieval samples. |
+| **`DA_CERT_RETAINED`** | Certificate tier based on retrievable certification plus ongoing retention, audit, and repair obligations. |
+| **Provider assignment** | Protocol-selected mapping from encoded cells/chunks to provider-daemons and backing deal slots. |
+| **Provider availability attestation** | Signed provider-daemon statement that assigned artifacts were received, verified, stored, and committed under a specific lane/batch/root/policy. |
 | **Sample coordinate** | Deterministic coordinate used to request and verify one availability sample. |
-| **Sampler** | Actor or protocol process that opens sample sessions and submits evidence. |
-| **user-gateway** | Optional client-side or service-side helper that stages, encodes, routes, and queries data. |
-| **provider-daemon** | Storage-provider runtime responsible for receiving shards, storing slot data, serving samples, and producing proofs. |
+| **Challenge window** | Bounded period during which certification samples or failure evidence can be submitted. |
+| **Retention window** | Period during which the lane claims certified data remains retrievable through the backing storage substrate. |
+| **user-gateway** | Optional client-side or service-side helper that stages, encodes, disperses, aggregates attestations, and queries data. |
+| **provider-daemon** | Storage-provider runtime responsible for receiving assigned artifacts, verifying them, storing slot data, serving samples, and producing proofs. |
 
 -----
 
-## 7. Design Principle
+## 6. Design Principle
 
-Deals and DA lanes should not be collapsed into one object.
+Deals and DA lanes MUST NOT be collapsed into one object.
 
 Deals answer:
 
 * who stores this content;
-* what root is current;
+* what root and generation are current or retained;
 * what retrieval policy applies;
 * how providers are paid or penalized;
 * how repairs are performed; and
@@ -154,18 +191,115 @@ DA lanes answer:
 
 * who may publish;
 * what order batches were appended in;
-* what batch roots and certificates exist;
-* what availability policy was used; and
+* what DA-facing batch roots exist;
+* which provider set and quorum policy certified each batch;
+* which certificate tier was issued;
+* which challenge and retention windows apply; and
 * how external systems reference a published batch.
 
 The lane is the publication abstraction. The deal is the storage and economic
-substrate.
+substrate. The Availability Certificate is the bridge between them.
 
 -----
 
-## 8. Proposed Chain Objects
+## 7. Certificate Tiers
 
-### 8.1 `DALane`
+### 7.1 `DA_CERT_FAST`
+
+`DA_CERT_FAST` is the attestation baseline.
+
+A batch MAY receive `DA_CERT_FAST` only after:
+
+* the batch has a canonical `DABatchHeader`;
+* encoded artifacts have been assigned to provider-daemons by a protocol policy;
+* each attesting provider-daemon has verified its assigned artifact against the
+  batch commitment and assignment;
+* each attesting provider-daemon has persisted the artifact under the declared
+  backing deal/generation/slot;
+* enough attestations satisfy the lane's `DAQuorumPolicy`; and
+* the backing deal roots required by the batch are committed or otherwise
+  blocked from mutation before certification.
+
+This tier is useful for low-latency acceptance paths. It does not by itself
+prove that any third party has retrieved a sample through PolyStore.
+
+### 7.2 `DA_CERT_RETRIEVABLE`
+
+`DA_CERT_RETRIEVABLE` is the primary PolyStore DA target.
+
+A batch MAY receive `DA_CERT_RETRIEVABLE` only after all `DA_CERT_FAST`
+conditions plus:
+
+* delayed-randomness sample coordinates are derived after artifact commitments
+  are fixed;
+* sample sessions are opened against the relevant historical PolyFS generation
+  and provider assignment;
+* assigned provider-daemons serve the challenged cells/ranges before expiry;
+* sample proofs bind the served bytes to the batch root, PolyFS generation,
+  assignment, provider, range, nonce, and retrieval-session id; and
+* the lane's certificate policy accepts the aggregate sample result.
+
+This tier says the data was attested and already sampled as retrievable through
+the same retrieval system that will serve it later.
+
+### 7.3 `DA_CERT_RETAINED`
+
+`DA_CERT_RETAINED` extends `DA_CERT_RETRIEVABLE` over a declared retention
+window.
+
+A batch MAY receive or maintain `DA_CERT_RETAINED` only while:
+
+* all segments remain inside active backing deal terms or renewed/migrated
+  equivalents;
+* retained historical generations remain addressable;
+* scheduled audits and public/protocol-funded retrieval samples satisfy lane
+  policy;
+* provider degradation triggers repair or replacement; and
+* the lane has enough escrow or fee policy support for continued retrieval and
+  repair obligations.
+
+Retention status is service health, not historical truth rewriting. A later
+retrieval failure MAY degrade or retire retained status, but it MUST NOT rewrite
+the fact that a lower-tier certificate was issued under a specific policy at a
+specific height.
+
+-----
+
+## 8. Publication Lifecycle
+
+1. **Lane creation.** The owner creates a `DALane` with writer, retrieval, fee,
+   quorum, certificate, and retention policies.
+2. **Batch submission.** A publisher submits a pending `DABatchHeader` and
+   storage-segment plan.
+3. **Canonical encoding.** The user-gateway or publisher converts the batch to
+   the lane's encoding profile and emits commitments/proofs.
+4. **Provider assignment.** The protocol selects provider-daemons and assigns
+   chunks/cells/slots according to `DAQuorumPolicy` and backing deal state.
+5. **Dispersal.** The user-gateway sends assigned artifacts to
+   provider-daemons.
+6. **Provider verification.** Provider-daemons verify headers, roots,
+   commitments, assigned coordinates, and local persistence requirements.
+7. **Provider attestation.** Provider-daemons submit signed
+   `ProviderAvailabilityAttestation` records.
+8. **Fast certification.** If the quorum policy passes, the lane may issue
+   `DA_CERT_FAST`.
+9. **Retrieval sampling.** If the requested tier is `DA_CERT_RETRIEVABLE` or
+   `DA_CERT_RETAINED`, delayed-randomness samples are opened as retrieval
+   sessions and proof results are submitted.
+10. **Retrievable certification.** If the sampling policy passes, the lane may
+    issue `DA_CERT_RETRIEVABLE`.
+11. **Retained service.** If the requested tier is `DA_CERT_RETAINED`, audits,
+    repair, and renewal/migration obligations continue through the retention
+    window.
+12. **External acceptance.** A rollup, bridge, or app verifies the compact
+    certificate and accepts or rejects the batch root according to its own
+    policy.
+
+-----
+
+## 9. Proposed Chain Objects
+
+### 9.1 `DALane`
 
 ```protobuf
 message DALane {
@@ -179,39 +313,71 @@ message DALane {
   string erasure_profile = 8;
   RetentionPolicy retention_policy = 9;
   FeePolicy fee_policy = 10;
-  CertificatePolicy certificate_policy = 11;
-  uint64 created_height = 12;
+  uint64 quorum_policy_id = 11;
+  uint64 certificate_policy_id = 12;
+  repeated CertificateTier allowed_tiers = 13;
+  uint64 created_height = 14;
 }
 ```
 
-Notes:
+`current_lane_root` is the append-only root over batch descriptors. It is not
+necessarily the same value as a deal's current PolyFS root.
 
-* `backing_deal_ids` lets one lane start on one deal and later support sharded
-  or capacity-expanded layouts.
-* `current_lane_root` is the append-only root over batch descriptors, not
-  necessarily the same value as a deal's current PolyFS root.
-* `writer_policy` controls admission. It is separate from retrieval policy.
+### 9.2 `DAQuorumPolicy`
 
-### 8.2 `DABatch`
+```protobuf
+message DAQuorumPolicy {
+  uint64 quorum_policy_id = 1;
+  string assignment_policy = 2;
+  uint32 min_attesting_slots = 3;
+  uint32 min_reconstructable_slots = 4;
+  string stake_threshold = 5;
+  string capacity_threshold = 6;
+  string bandwidth_threshold = 7;
+  uint64 challenge_window_blocks = 8;
+  uint64 retention_window_blocks = 9;
+}
+```
+
+`min_attesting_slots` is the attestation threshold. `min_reconstructable_slots`
+is the reconstruction threshold, for example `K` in RS(K,N). Stake, capacity,
+and bandwidth thresholds are policy inputs and MUST be defined before they are
+used in a certificate claim.
+
+### 9.3 `DABatchHeader`
+
+```protobuf
+message DABatchHeader {
+  uint64 lane_id = 1;
+  uint64 batch_id = 2;
+  bytes batch_data_root = 3;
+  bytes previous_lane_root = 4;
+  bytes new_lane_root = 5;
+  string namespace_or_app_id = 6;
+  uint64 size_bytes = 7;
+  string encoding_profile = 8;
+  uint64 total_mdus = 9;
+  uint64 witness_mdus = 10;
+  uint64 publish_height = 11;
+  bytes domain_separator = 12;
+}
+```
+
+This is the external DA-facing object. Rollups and bridge contracts should not
+need to understand arbitrary PolyFS file metadata in order to verify it.
+
+### 9.4 `DABatch`
 
 ```protobuf
 message DABatch {
-  uint64 lane_id = 1;
-  uint64 batch_id = 2;
-  string publisher = 3;
-  bytes batch_data_root = 4;
-  bytes polyfs_root_or_segment_root = 5;
-  bytes previous_lane_root = 6;
-  bytes new_lane_root = 7;
-  string namespace_or_app_id = 8;
-  uint64 size_bytes = 9;
-  uint64 total_mdus = 10;
-  uint64 witness_mdus = 11;
-  string encoding_profile = 12;
-  BatchStatus status = 13;
-  uint64 publish_height = 14;
-  uint64 certificate_id = 15;
-  repeated DABatchStorageSegment storage_segments = 16;
+  DABatchHeader header = 1;
+  string publisher = 2;
+  bytes polyfs_root_or_segment_root = 3;
+  repeated DABatchStorageSegment storage_segments = 4;
+  repeated ProviderAssignment provider_assignments = 5;
+  BatchStatus status = 6;
+  CertificateTier requested_tier = 7;
+  uint64 certificate_id = 8;
 }
 
 message DABatchStorageSegment {
@@ -227,49 +393,168 @@ message DABatchStorageSegment {
 }
 ```
 
-`batch_data_root` is the external DA-facing root. `polyfs_root_or_segment_root`
-is the PolyStore storage-facing root or segment root used to retrieve and prove
-the underlying bytes. `storage_segments` is the authoritative lane-to-deal
-mapping for retrieval and sampling. It lets a lane expand across multiple
-backing deals while preserving enough information to open deal-scoped
-retrieval/sample sessions for `(lane_id, batch_id, range)` later. Each segment
-also binds the committed PolyFS generation and chain height that made the segment
-valid, so older certified batches remain addressable after a backing deal
-advances to a later root. `deal_end_block` snapshots the backing deal term used
-for retention validation. Certificates MUST NOT advertise retention past the
-minimum backing deal end block for their segments unless an on-chain renewal or
-migration updates the segment's backing term first.
+`storage_segments` is the authoritative lane-to-deal mapping for retrieval and
+sampling. Each segment binds the committed PolyFS generation and chain height
+that made the segment valid, so older certified batches remain addressable
+after a backing deal advances to a later root.
 
-### 8.3 `AvailabilityCertificate`
+`deal_end_block` snapshots the backing deal term used for retention validation.
+Certificates MUST NOT advertise retention past the minimum backing deal end
+block for their segments unless an on-chain renewal or migration updates the
+segment's backing term first.
+
+### 9.5 `ProviderAssignment`
+
+```protobuf
+message ProviderAssignment {
+  uint64 lane_id = 1;
+  uint64 batch_id = 2;
+  string provider = 3;
+  uint32 slot = 4;
+  uint64 deal_id = 5;
+  uint64 deal_generation = 6;
+  bytes polyfs_root_or_segment_root = 7;
+  uint64 first_mdu = 8;
+  uint64 mdu_count = 9;
+  uint64 logical_offset = 10;
+  uint64 length = 11;
+  bytes assignment_digest = 12;
+}
+```
+
+Assignments MUST be derived by protocol policy or verified against protocol
+policy. Publisher-selected friendly placement is not sufficient for primary DA.
+
+### 9.6 `ProviderAvailabilityAttestation`
+
+```protobuf
+message ProviderAvailabilityAttestation {
+  uint64 lane_id = 1;
+  uint64 batch_id = 2;
+  string provider = 3;
+  uint32 slot = 4;
+  bytes batch_data_root = 5;
+  bytes assignment_digest = 6;
+  bytes artifact_digest = 7;
+  bytes polyfs_root_or_segment_root = 8;
+  uint64 deal_id = 9;
+  uint64 deal_generation = 10;
+  uint64 challenge_window_end = 11;
+  uint64 retention_until = 12;
+  uint64 signed_height = 13;
+  bytes signature = 14;
+}
+```
+
+The signature MUST bind lane id, batch id, batch root, encoding profile,
+provider identity, assigned cell/chunk ranges, backing deal id, deal generation,
+PolyFS root or segment root, challenge window, retention window, chain height,
+and a domain separator.
+
+The attestation means:
+
+* the provider received its assigned artifact;
+* the provider verified the artifact against the assignment and batch
+  commitment according to the lane policy;
+* the provider persisted the artifact under the referenced deal/generation; and
+* the provider accepts challenge and retrieval obligations for the declared
+  windows.
+
+### 9.7 `DASampleChallenge`
+
+```protobuf
+message DASampleChallenge {
+  uint64 challenge_id = 1;
+  uint64 lane_id = 2;
+  uint64 batch_id = 3;
+  uint64 sample_policy_id = 4;
+  uint64 seed_height = 5;
+  bytes seed = 6;
+  string provider = 7;
+  uint32 slot = 8;
+  uint64 mdu_index = 9;
+  uint64 cell_or_leaf_index = 10;
+  uint64 byte_offset = 11;
+  uint64 byte_length = 12;
+  uint64 expiry_height = 13;
+}
+```
+
+The seed MUST be unknown until after artifacts and provider attestations are
+fixed. Challenges derived before commitment are vulnerable to grinding.
+
+### 9.8 `DASampleResult`
+
+```protobuf
+message DASampleResult {
+  uint64 challenge_id = 1;
+  uint64 retrieval_session_id = 2;
+  string provider = 3;
+  bytes served_digest = 4;
+  bytes proof_digest = 5;
+  uint64 served_height = 6;
+  SampleResultStatus status = 7;
+}
+```
+
+The sample proof MUST bind the retrieval session, provider, pinned root or
+segment root, historical deal generation, range, nonce, expiry, and served
+bytes/cell proof.
+
+### 9.9 `DAFailureEvidence`
+
+```protobuf
+message DAFailureEvidence {
+  uint64 evidence_id = 1;
+  uint64 lane_id = 2;
+  uint64 batch_id = 3;
+  string provider = 4;
+  FailureKind failure_kind = 5;
+  bytes attestation_digest = 6;
+  bytes challenge_digest = 7;
+  bytes proof_or_transcript = 8;
+  string submitter = 9;
+  uint64 submitted_height = 10;
+}
+```
+
+Failure evidence is used to fail pending certification, degrade retained
+service, slash or penalize providers, and trigger repair. The exact penalty
+schedule is policy-specific.
+
+### 9.10 `AvailabilityCertificate`
 
 ```protobuf
 message AvailabilityCertificate {
   uint64 certificate_id = 1;
   uint64 lane_id = 2;
   uint64 batch_id = 3;
-  bytes batch_data_root = 4;
-  bytes polyfs_root_or_segment_root = 5;
-  string erasure_profile = 6;
+  CertificateTier tier = 4;
+  bytes batch_data_root = 5;
+  bytes batch_header_digest = 6;
   bytes provider_set_hash = 7;
-  uint64 sample_policy_id = 8;
-  uint64 sample_seed_height = 9;
-  bytes sample_result_root = 10;
-  uint64 certified_height = 11;
-  uint64 retention_until = 12;
-  CertificateStatus status = 13;
+  uint64 quorum_policy_id = 8;
+  bytes quorum_result_root = 9;
+  bytes aggregate_signature_or_proof = 10;
+  uint64 sample_policy_id = 11;
+  uint64 sample_seed_height = 12;
+  bytes sample_result_root = 13;
+  uint64 certified_height = 14;
+  uint64 challenge_window_end = 15;
+  uint64 retention_until = 16;
+  CertificateStatus status = 17;
 }
 ```
 
-The certificate is historical. If later retrieval failures occur, they should
-be represented as service-health or degradation evidence. They should not
-rewrite the fact that a certificate was issued under a specific policy at a
-specific height.
+The certificate is historical. Later retrieval failures may degrade service
+status or retained status. They MUST NOT rewrite the fact that a certificate was
+issued under a specific tier, policy, provider set, and height.
 
 -----
 
-## 9. Proposed Messages
+## 10. Proposed Messages
 
-### 9.1 `MsgCreateDALane`
+### 10.1 `MsgCreateDALane`
 
 Creates an append-only lane backed by one or more existing deals.
 
@@ -277,32 +562,16 @@ Required checks:
 
 * sender is authorized to create the lane;
 * backing deals exist and are compatible with the lane's erasure profile;
-* retrieval policy is compatible with the intended public/sponsored sampling
-  behavior;
-* fee policy can fund publication, certification, and retrieval/audit costs; and
+* retrieval policy is compatible with public, sponsored, or requester-funded
+  sampling behavior;
+* fee policy can fund publication, certification, retrieval, audit, and repair
+  costs for the requested tiers;
+* quorum policy is a recognized protocol policy; and
 * certificate policy is a recognized protocol policy.
 
-### 9.2 `MsgAppendDABatch`
+### 10.2 `MsgAppendDABatch`
 
 Appends a pending batch to a lane.
-
-Required fields:
-
-* `lane_id`
-* `previous_lane_root`
-* `batch_data_root`
-* `polyfs_root_or_segment_root` as the storage-facing root/index commitment
-  for the batch;
-* `storage_segments`, with each segment binding `(deal_id,
-  polyfs_root_or_segment_root, logical_offset, length, first_mdu, mdu_count,
-  deal_generation, deal_root_height, deal_end_block)`;
-* `namespace_or_app_id`
-* `size_bytes`
-* `total_mdus`
-* `witness_mdus`
-* `encoding_profile`
-* publisher authorization
-* publication fee
 
 Required checks:
 
@@ -310,64 +579,69 @@ Required checks:
 * publisher satisfies `writer_policy`;
 * `previous_lane_root == lane.current_lane_root`;
 * batch size and fee satisfy lane policy;
+* requested tier is allowed by the lane;
 * every `storage_segments[*].deal_id` is one of the lane's backing deals;
 * `storage_segments` covers exactly `size_bytes` with no gaps, overlaps, or
-  zero-length segments, and the MDU ranges are compatible with `total_mdus` and
-  `witness_mdus`;
+  zero-length segments;
 * every segment's `(deal_id, deal_generation, polyfs_root_or_segment_root)` maps
   to a committed or pending-to-be-committed PolyFS root transition;
-* every segment's `deal_end_block` matches the backing deal state and is high
-  enough to satisfy the lane's required retention target, or the batch is marked
-  ineligible for certification until the segment is renewed or migrated;
-* backing deal root/segment state is known or staged for every segment;
-* duplicate batch roots are rejected unless a policy explicitly allows
-  idempotent retry; and
-* the batch enters `PENDING_DISPERSAL` or `PENDING_RANDOMNESS`, not
-  `CERTIFIED`.
+* every segment's `deal_end_block` matches backing deal state and is high enough
+  to satisfy the lane's requested retention target, or the batch remains
+  ineligible for the requested tier; and
+* the batch enters `PENDING_ASSIGNMENT`, not `CERTIFIED`.
 
-The top-level `polyfs_root_or_segment_root` is not a substitute for
-`storage_segments`. It can be retained as a compact storage-facing commitment for
-single-deal or indexed layouts, but the segment list is the canonical input for
-later retrieval and sampling sessions.
+### 10.3 `MsgAssignDAProviders`
 
-### 9.3 `MsgSubmitProviderReadiness`
+Records or verifies the provider assignment for a pending batch.
 
-Lets provider-daemons attest that they have staged their assigned artifacts for
-a pending batch.
+Required checks:
 
-The attestation should bind:
+* assignment policy matches `DAQuorumPolicy`;
+* assigned providers are active and eligible;
+* assigned slots/ranges are covered by backing deal state;
+* provider set hash is deterministic; and
+* assignments cannot be changed after the attestation window starts except by
+  explicit failure/replacement rules.
 
-* lane id;
-* batch id;
-* provider identity;
-* slot id;
-* expected root;
-* staged artifact digest;
-* artifact size;
-* expiry; and
-* provider signature.
+### 10.4 `MsgSubmitProviderAvailabilityAttestation`
 
-### 9.4 `MsgOpenDASampleSession`
+Submits a provider-daemon attestation for one assignment.
 
-Opens a sample session for one coordinate.
+Required checks:
 
-This MAY be implemented as a specialized retrieval session purpose rather than
-a fully separate object, but the semantic fields must include:
+* provider identity matches the assignment;
+* signature verifies under the provider key;
+* signed digest binds all fields required by this RFC;
+* artifact/root/generation state is compatible with the backing deal;
+* attestation arrives before the attestation deadline; and
+* duplicate or equivocated attestations are rejected or recorded as failure
+  evidence.
+
+### 10.5 `MsgOpenDASampleSession`
+
+Opens a sample session for one challenge coordinate.
+
+This SHOULD extend the mandatory retrieval-session architecture rather than
+creating a parallel payment/proof path.
+
+The semantic fields MUST include:
 
 * lane id;
 * batch id;
 * sample coordinate;
 * provider slot;
 * pinned PolyFS root or segment root;
-* payer/funding source;
+* historical deal generation;
+* payer or funding source;
 * nonce; and
 * expiry.
 
-### 9.5 `MsgSubmitDASampleProof`
+### 10.6 `MsgSubmitDASampleResult`
 
-Submits sample evidence for one session or a batch of sessions.
+Submits successful or failed sample evidence for one session or a batch of
+sessions.
 
-The proof must bind:
+The result MUST bind:
 
 * sample session;
 * sample coordinate;
@@ -375,114 +649,206 @@ The proof must bind:
 * relevant commitment;
 * PolyFS inclusion path;
 * KZG opening or equivalent cell proof; and
-* served sample bytes or cell data.
+* served sample bytes or cell data when successful.
 
-### 9.6 `MsgFinalizeAvailabilityCertificate`
+### 10.7 `MsgSubmitDAFailureEvidence`
+
+Submits failure evidence for attestation equivocation, invalid encoding,
+missing artifact, failed sample, stale backing root, or retained-service failure.
+
+Evidence MAY:
+
+* block certification for a pending batch;
+* slash or penalize a provider;
+* reduce provider service history;
+* mark retained service as degraded;
+* trigger repair or provider replacement; or
+* reward the evidence submitter.
+
+### 10.8 `MsgFinalizeAvailabilityCertificate`
 
 Finalizes or fails the pending batch after the lane's certificate policy is
 evaluated.
 
-Possible outcomes:
+Possible batch outcomes:
 
-* `CERTIFIED`
+* `CERTIFIED_FAST`
+* `CERTIFIED_RETRIEVABLE`
+* `CERTIFIED_RETAINED`
 * `FAILED`
 * `EXPIRED`
-
-The finalization transaction should record the sample policy, sample result
-root, provider set hash, and certified height.
 
 Required checks:
 
 * every segment's `(deal_id, deal_generation, polyfs_root_or_segment_root)` is
   committed in the backing deal state, with `deal_root_height` populated from
   that committed transition;
+* quorum attestations satisfy `DAQuorumPolicy`;
+* for `DA_CERT_RETRIEVABLE` and `DA_CERT_RETAINED`, sample results satisfy the
+  certificate policy;
 * `retention_until` is no greater than the minimum `deal_end_block` across the
-  batch's `storage_segments`;
-* `retention_until` satisfies the lane's retention policy; and
+  batch's `storage_segments`; and
 * if the lane retention target extends beyond any backing deal term, the batch
-  MUST remain uncertified until the affected segments are renewed, extended, or
-  migrated to a backing deal whose term covers the advertised retention.
+  remains uncertified for retained status until the affected segments are
+  renewed, extended, or migrated.
 
 -----
 
-## 10. State Machines
+## 11. State Machines
 
-### 10.1 Batch status
+### 11.1 Batch status
 
 ```text
-PENDING_DISPERSAL
-  -> PENDING_RANDOMNESS
-  -> SAMPLING
-      -> CERTIFIED
+PENDING_ASSIGNMENT
+  -> PENDING_DISPERSAL
+  -> PENDING_ATTESTATION
+      -> CERTIFIED_FAST
+          -> PENDING_RETRIEVAL_SAMPLES
+              -> CERTIFIED_RETRIEVABLE
+                  -> RETAINED_ACTIVE
+                      -> RETAINED_DEGRADED
+                      -> RETAINED_RETIRED
       -> FAILED
       -> EXPIRED
 ```
 
 Rules:
 
-* A batch MUST NOT become `CERTIFIED` before the delayed-randomness and
-  sampling/attestation policy has completed.
-* `CERTIFIED`, `FAILED`, and `EXPIRED` are sibling terminal outcomes of the
-  pending/sampling path. A certified batch MUST NOT later be rewritten as a
-  failed or expired batch.
-* A batch MUST NOT silently mutate after append. Any change creates a new batch
-  or an explicit failed/replaced status.
+* A batch MUST NOT become `CERTIFIED_FAST` before quorum attestations pass.
+* A batch MUST NOT become `CERTIFIED_RETRIEVABLE` before retrieval samples pass.
+* `CERTIFIED_FAST`, `CERTIFIED_RETRIEVABLE`, and `RETAINED_ACTIVE` are
+  historical certification achievements. Later service failures may degrade
+  retained service but must not rewrite prior certification facts.
 * A stale `previous_lane_root` MUST reject the append.
-* Expired pending batches MUST be visible so publication failures are
-  inspectable.
+* Expired pending batches MUST remain inspectable.
 
-### 10.2 Certificate status
+### 11.2 Certificate status
 
 ```text
 ISSUED
-  -> DEGRADED
+  -> SERVICE_DEGRADED
   -> RETIRED
 ```
 
-`DEGRADED` is optional in the first implementation. It is useful when later
-retrieval evidence shows the certified data is no longer meeting service
-expectations. Degradation does not mean the original certificate was invalid.
+`SERVICE_DEGRADED` is useful when later retrieval evidence shows the certified
+data is not meeting retained-service expectations. It does not mean the original
+certificate was invalid.
 
 -----
 
-## 11. Sampling Model
+## 12. External Verification Surface
+
+External rollups, bridge contracts, and applications should verify a compact
+object. They should not need to replay the full PolyStore retrieval protocol.
+
+The minimum verifier surface is:
+
+* `certificate_id`
+* `lane_id`
+* `batch_id`
+* `tier`
+* `batch_data_root`
+* `batch_header_digest`
+* `provider_set_hash`
+* `quorum_policy_id`
+* `aggregate_signature_or_proof`
+* `certified_height`
+* `challenge_window_end`
+* `retention_until`
+* bridge-facing domain separator
+
+A verifier MAY require `DA_CERT_FAST` for low-latency workflows,
+`DA_CERT_RETRIEVABLE` for dispute/proof/audit workflows, or
+`DA_CERT_RETAINED` when it needs continuing service through a longer window.
+
+-----
+
+## 13. Retrieval and Payment Semantics
+
+DA sampling MUST reuse the mandatory retrieval-session architecture wherever
+possible.
+
+Rules:
+
+* Sample sessions SHOULD be paid or explicitly protocol-funded.
+* Public lanes SHOULD allow third-party funded samples and retrievals.
+* A lane MUST NOT let third-party verification drain the publisher's escrow
+  unless the lane explicitly sponsors that behavior.
+* Samples, user reads, protocol audits, and repairs SHOULD feed one provider
+  service-history surface.
+* Post-certification retrieval failures SHOULD affect provider health and repair
+  state even when the original certificate remains historically valid.
+
+This is PolyStore's main differentiation: publication-time availability and
+long-lived retrieval accountability share one economic proof surface.
+
+### 13.1 Historical-generation sessions
+
+Current retrieval sessions are rooted in the backing deal's current committed
+PolyFS root. DA lanes need one additional mode because certified batch history is
+append-only while backing deals may continue to advance.
+
+For DA lane retrieval and sampling, the session opener MUST resolve
+`(lane_id, batch_id, range)` to the batch's `storage_segments`, then open a
+session against the recorded `(deal_id, deal_generation,
+polyfs_root_or_segment_root, logical_offset, length)` tuple. A historical
+segment is valid if:
+
+* the referenced batch is certified or still within an active certification
+  window;
+* the segment's `deal_root_height` proves that the root was committed for the
+  backing deal;
+* the requested byte range is covered by the segment list; and
+* the segment is still inside both the lane's retention window and the backing
+  deal term recorded by `deal_end_block`.
+
+Providers and user-gateways MUST keep DA-retained committed generations
+addressable by `(deal_id, deal_generation/root)` until the relevant retention
+window expires or the segment is explicitly migrated.
+
+If an implementation does not support historical-generation sessions, it MUST
+use immutable backing deals or otherwise ensure that every certified segment
+remains the current retrievable root for its full retention period.
+
+-----
+
+## 14. Sampling and Challenge Model
 
 The first research model should evaluate this profile:
 
-* data is encoded into `N` provider slots with `K`-of-`N`
-  reconstructability;
+* data is encoded into `N` provider slots with `K`-of-`N` reconstructability;
 * default candidate profile is RS(8,12), matching the current Mode 2 design;
 * each user-data MDU has sample coordinates derived from `(mdu_index,
-  leaf_index, slot, row)`;
-* challenge seed is unknown until after staged upload and pending batch
-  publication;
-* protocol or third-party samplers open sample sessions for `s` coordinates;
+  leaf_index, slot, row)` or an equivalent cell grammar;
+* challenge seed is unknown until after staged upload, assignment, and provider
+  attestations are fixed;
+* protocol-funded or third-party samplers open retrieval sessions for `s`
+  coordinates;
 * provider-daemons return proof material before expiry; and
 * the certificate policy determines whether enough evidence exists to certify
-  the batch.
+  or retain the batch.
 
 Open policy questions:
 
 * Are sample coordinates uniform across all slots or weighted by capacity,
-  stake, bond, or provider reputation?
-* Does a certificate require readiness from all slots, at least `K` slots per
+  stake, bond, or provider service history?
+* Does `DA_CERT_FAST` require readiness from all slots, at least `K` slots per
   row, or a separate quorum threshold?
-* Does failure of a parity slot block certification or only create degraded
-  service health?
+* Does failure of a parity slot block retrievable certification or only create
+  degraded retained service?
 * Can any third party submit successful samples, or only selected samplers?
 * What confidence bound is advertised for a given batch size, sample count, and
   withholding strategy?
 
 The first production claim should be an explicitly named policy, such as:
 
-> Certified under PolyStore DA Lane Policy v0 with sample count S, delayed
-> randomness source R, provider set P, and confidence model M.
-
-It should not claim generic Celestia-equivalent DAS before the proof is written.
+> Certified as `DA_CERT_RETRIEVABLE` under PolyStore DA Lane Policy v0 with
+> quorum policy Q, sample count S, delayed randomness source R, provider set P,
+> and confidence model M.
 
 -----
 
-## 12. Encoding Correctness
+## 15. Encoding Correctness
 
 Encoding correctness is the deepest research requirement.
 
@@ -500,7 +866,7 @@ Candidate approaches:
 
 2. **Provider-side verification**
    * Provider-daemons verify assigned shards against a disperser proof or
-     deterministic reconstruction rule before readiness attestation.
+     deterministic reconstruction rule before attestation.
    * Moves more work to providers.
    * Gives readiness attestations more meaning.
 
@@ -510,7 +876,7 @@ Candidate approaches:
    * Needs formalization and test vectors for the exact PolyStore profile.
 
 4. **Validity proof**
-   * Publisher or disperser proves the encoded data is correctly derived.
+   * Publisher or user-gateway proves the encoded data is correctly derived.
    * Strongest certification surface.
    * Heaviest implementation and proving requirement.
 
@@ -520,94 +886,151 @@ check for RS(8,12).
 
 -----
 
-## 13. Retrieval and Payment Semantics
+## 16. Failure Semantics
 
-DA sampling should reuse the mandatory retrieval-session architecture wherever
-possible.
+### 16.1 Certification failure
 
-Rules:
+A pending batch MUST fail or expire if:
 
-* Sample sessions SHOULD be paid or explicitly protocol-funded.
-* Public lanes SHOULD allow third-party funded samples and retrievals.
-* A lane MUST NOT let third-party verification drain the publisher's escrow
-  unless the lane explicitly sponsors that behavior.
-* Samples, user reads, protocol audits, and repairs SHOULD feed one provider
-  service-history surface.
-* Post-certification retrieval failures SHOULD affect provider health and repair
-  state even when the original certificate remains historically valid.
+* the provider assignment cannot be derived or verified;
+* required providers do not attest before the deadline;
+* providers equivocate over roots, assignments, or artifact digests;
+* backing deal roots are not committed before finalization;
+* delayed-randomness samples fail for the requested tier;
+* invalid encoding evidence is accepted; or
+* the backing deal term cannot support the requested retention window.
 
-This is PolyStore's main differentiation: publication-time availability and
-long-lived retrieval accountability share one economic proof surface.
+### 16.2 Post-certification failure
 
-### 13.1 Historical-Generation Sessions
+Post-certification retrieval failures SHOULD:
 
-Current retrieval sessions are rooted in the backing deal's current committed
-PolyFS root. DA lanes need one additional mode because certified batch history is
-append-only while backing deals may continue to advance.
+* update provider service history;
+* trigger repair or provider replacement when possible;
+* degrade or retire retained service status; and
+* generate slashable or penalty-bearing evidence if the provider signed a false
+  attestation or violated a retained-service obligation.
 
-For DA lane retrieval and sampling, the session opener MUST resolve
-`(lane_id, batch_id, range)` to the batch's `storage_segments`, then open a
-session against the recorded `(deal_id, deal_generation,
-polyfs_root_or_segment_root, logical_offset, length)` tuple. A historical segment
-is valid if:
+Post-certification retrieval failures MUST NOT rewrite the historical fact that
+the certificate was issued under a specific policy at a specific height.
 
-* the referenced batch is `CERTIFIED` or still within an active certification
-  window;
-* the segment's `deal_root_height` proves that the root was committed for the
-  backing deal;
-* the requested byte range is covered by the segment list; and
-* the segment is still inside both the lane's retention window and the backing
-  deal term recorded by `deal_end_block`.
+### 16.3 Slashing and penalties
 
-This requires providers and gateways to keep DA-retained committed generations
-addressable by `(deal_id, deal_generation/root)` even when the deal's current
-root has moved forward. The current-root retrieval rule remains correct for
-ordinary mutable PolyFS reads; DA lane reads use the certificate and segment
-metadata as the authorization to open a historical-generation session.
+This RFC does not finalize slashing economics, but it requires that each
+certificate policy define:
 
-Historical-generation sessions MUST also obey the underlying deal/session
-constraints: the backing deal must still be active at session open, and the
-session expiry MUST be no later than both the lane retention deadline and the
-segment's `deal_end_block`. If a lane needs to retain a certified batch beyond
-the original backing deal term, the lane must renew the deal or migrate the
-segment before issuing or maintaining that retention claim.
-
-If an implementation does not support historical-generation sessions, it MUST use
-immutable backing deals or otherwise ensure that every certified segment remains
-the current retrievable root for its full retention period. That mode is simpler
-but less capacity-efficient, so it should be treated as a fallback rather than
-the preferred DA lane design.
+* what evidence is slashable;
+* who may submit evidence;
+* when evidence expires;
+* whether penalties apply to providers, publishers, user-gateways, or lane
+  escrows;
+* whether successful evidence submitters are rewarded; and
+* how repair is funded after a penalty event.
 
 -----
 
-## 14. Gateway and Provider Requirements
+## 17. Threat Model
 
-### 14.1 user-gateway
+### 17.1 Malicious publisher or user-gateway
+
+Risk: a publisher or user-gateway submits malformed, incomplete, or equivocated
+artifacts while trying to obtain a certificate.
+
+Required controls:
+
+* canonical `DABatchHeader`;
+* provider-daemon verification before attestation;
+* artifact digests in attestations;
+* delayed randomness after commitment; and
+* invalid-encoding evidence.
+
+### 17.2 Colluding providers
+
+Risk: assigned providers sign and answer narrow samples while withholding enough
+data to break reconstruction or future retrieval.
+
+Required controls:
+
+* protocol-selected provider assignment;
+* provider-set hash in certificates;
+* quorum policies with stake/capacity/bandwidth assumptions stated explicitly;
+* publication-time samples for `DA_CERT_RETRIEVABLE`; and
+* ongoing retained-service audits for `DA_CERT_RETAINED`.
+
+### 17.3 Sampling grinding
+
+Risk: sample coordinates are predictable and only those coordinates are made
+available.
+
+Required controls:
+
+* delayed randomness;
+* artifact commitments fixed before seed;
+* no artifact rewriting after seed; and
+* sample proofs bound to batch root, assignment, provider, and generation.
+
+### 17.4 Stale backing roots
+
+Risk: a certificate references a PolyFS root or generation that was never
+committed, is no longer addressable, or falls outside the backing deal term.
+
+Required controls:
+
+* finalization guard requiring committed roots;
+* `deal_generation`, `deal_root_height`, and `deal_end_block` in segments;
+* historical-generation retrieval sessions; and
+* renewal or migration before retained claims exceed backing terms.
+
+### 17.5 Retrieval liquidity failure
+
+Risk: samples are theoretically possible but no one can fund or route them in
+practice.
+
+Required controls:
+
+* protocol-funded or lane-funded sampling budgets;
+* public paid retrieval paths;
+* explicit escrow accounting; and
+* rate limits that prevent griefing without blocking honest verification.
+
+-----
+
+## 18. Gateway and Provider Requirements
+
+### 18.1 user-gateway
 
 The user-gateway should support:
 
 * batch packing;
 * deterministic erasure encoding;
 * append-only lane submission;
-* staged artifact upload;
+* protocol assignment lookup;
+* staged artifact dispersal;
+* attestation aggregation;
 * certificate polling;
-* range retrieval by `(lane_id, batch_id, range)`, including segment-generation
-  resolution;
+* sample-session opening or coordination;
+* range retrieval by `(lane_id, batch_id, range)`, including
+  segment-generation resolution;
 * namespace or application id lookup; and
-* proof bundle export.
+* certificate/proof bundle export for rollups and bridges.
 
-### 14.2 provider-daemon
+The user-gateway MUST be treated as untrusted by the protocol. It may aggregate
+and relay evidence, but certificates depend on provider-daemon attestations,
+chain checks, and sample results.
+
+### 18.2 provider-daemon
 
 The provider-daemon should support:
 
 * validating staged artifact headers;
 * rejecting stale expected roots before accepting large uploads;
-* binding stored artifacts to lane id, batch id, slot id, and root;
+* binding stored artifacts to lane id, batch id, slot id, assignment digest,
+  root, and generation;
+* verifying assigned artifacts before attestation;
 * keeping DA-retained committed generations addressable until their retention
   windows expire or their backing deal terms end;
 * surfacing renewal or migration requirements before a certified segment's
   backing deal term falls below the advertised retention window;
-* readiness attestation;
+* availability attestation;
 * sample serving;
 * sample proof construction;
 * repair participation; and
@@ -615,73 +1038,7 @@ The provider-daemon should support:
 
 -----
 
-## 15. Security Considerations
-
-### 15.1 Publisher withholding
-
-Risk: a publisher gets a batch certified while withholding enough data that
-reconstruction later fails.
-
-Required work:
-
-* model withholding under RS(8,12);
-* quantify sample counts against partial withholding;
-* define invalid encoding evidence;
-* define challenge windows; and
-* define submitter rewards or provider/publisher penalties.
-
-### 15.2 Provider collusion
-
-Risk: assigned providers answer samples but later fail broad retrieval.
-
-Required work:
-
-* quantify failure under slot concentration;
-* connect placement policy to anti-Sybil assumptions;
-* consider bond/stake/capacity weighting for certificate claims;
-* expose provider-set hash in certificates; and
-* treat later retrieval failures as economic evidence.
-
-### 15.3 Sampling grinding
-
-Risk: a publisher predicts sample coordinates and only makes those coordinates
-available.
-
-Required work:
-
-* use delayed randomness;
-* commit staged artifacts before the sample seed is known;
-* prevent artifact rewriting after seed;
-* bind samples to batch root and provider set; and
-* reject certification if artifact commitments are not fixed before randomness.
-
-### 15.4 Encoding fraud
-
-Risk: malformed parity makes samples pass but reconstruction fail.
-
-Required work:
-
-* define row-level reconstruction fraud proofs;
-* define compact parity commitment checks if possible;
-* require provider verification before readiness where feasible; and
-* produce canonical test vectors.
-
-### 15.5 Data equivocation
-
-Risk: a user-gateway or publisher serves inconsistent staged data to different
-providers.
-
-Required work:
-
-* bind uploads to lane id, batch id, expected root, provider slot, and artifact
-  digest;
-* require provider-daemons to verify staged headers;
-* include artifact digests in readiness attestations; and
-* make mismatches certificate-failing evidence.
-
------
-
-## 16. Compatibility and Migration
+## 19. Compatibility and Migration
 
 This proposal is additive.
 
@@ -695,69 +1052,105 @@ This proposal is additive.
 
 The main compatibility risk is root terminology. New DA-lane objects should use
 `polyfs_root` or `polyfs_segment_root` terminology. If legacy fields such as
-`manifest_root` are reused for transition, they must be documented as aliases
+`manifest_root` are reused during transition, they must be documented as aliases
 only.
 
 -----
 
-## 17. Phased Plan
+## 20. Implementation Roadmap
 
-### Phase 0: Research specification
-
-Deliverables:
-
-* sample-coordinate grammar;
-* certificate policy v0;
-* encoding-correctness proposal;
-* withholding probability model;
-* provider-collusion model;
-* sample-session economics; and
-* bridge/API requirements.
-
-Exit criteria:
-
-* one accepted research RFC or annex;
-* test-vector plan for encoding/proof verification;
-* clear claims and non-claims for public messaging.
-
-### Phase 1: Append-only lane prototype
+### Phase 0: RFC and tracker hardening
 
 Deliverables:
 
-* `DALane` state;
-* `DABatch` state;
-* `MsgCreateDALane`;
-* `MsgAppendDABatch`;
-* lane-level CAS;
-* batch root history;
-* user-gateway append API;
-* retrieval by `(lane_id, batch_id, range)`.
+* formal certificate tier semantics;
+* tracker issue with milestones and gates
+  (`https://github.com/Polynomialstore/polystore/issues/231`);
+* implementation boundaries for chain, user-gateway, provider-daemon, and
+  external verifier work; and
+* non-claim language for sampling-first DA.
 
 Exit criteria:
 
-* append-only storage lane works over existing deals;
-* no full DAS claim is made;
-* stale append and concurrent append tests pass.
+* this RFC clearly defines `DA_CERT_FAST`, `DA_CERT_RETRIEVABLE`, and
+  `DA_CERT_RETAINED`;
+* tracker issue exists and is linked from the RFC PR; and
+* no public messaging depends on full DAS claims.
 
-### Phase 2: Certificate MVP
+### Phase 1: `DA_CERT_FAST` MVP
 
 Deliverables:
 
-* provider readiness attestation;
-* delayed-randomness sample selection;
-* protocol-funded sample sessions;
-* `AvailabilityCertificate` state;
-* certificate query API;
-* failed and expired batch states;
-* provider health effects from failed samples.
+* `DABatchHeader`;
+* `DAQuorumPolicy`;
+* fixed provider assignment policy;
+* `ProviderAssignment`;
+* `ProviderAvailabilityAttestation`;
+* `AvailabilityCertificate` for `DA_CERT_FAST`;
+* query API; and
+* local devnet demo with one lane and fixed provider set.
 
 Exit criteria:
 
-* batches can move from pending to certified/failed/expired;
-* certificates expose policy and assumptions;
-* proof failures are attributable.
+* a batch moves from append to attested certificate;
+* invalid or missing provider attestations fail certification;
+* certificate verification surface is compact enough for a mock rollup verifier;
+* existing storage deal behavior is unchanged.
 
-### Phase 3: DAS hardening
+### Phase 2: `DA_CERT_RETRIEVABLE` MVP
+
+Deliverables:
+
+* delayed-randomness sample coordinate derivation;
+* DA sample retrieval sessions;
+* `DASampleChallenge`;
+* `DASampleResult`;
+* `sample_result_root`;
+* failed sample evidence; and
+* mock rollup verifier that can require retrievable tier.
+
+Exit criteria:
+
+* retrievable certification requires successful sample serving;
+* failed samples block retrievable certification;
+* sample proof transcripts bind provider, root, range, generation, session,
+  nonce, and expiry;
+* a demo can publish, certify retrievable, and reconstruct the batch later.
+
+### Phase 3: `DA_CERT_RETAINED`
+
+Deliverables:
+
+* retained-generation addressability;
+* scheduled audits;
+* repair/rotation hooks;
+* retained status transitions;
+* renewal or migration requirements; and
+* service-health dashboard/query surface.
+
+Exit criteria:
+
+* retained status degrades when service evidence fails;
+* repair restores retained service without rewriting the historical certificate;
+* backing deal terms cap advertised retention.
+
+### Phase 4: External integration
+
+Deliverables:
+
+* generic verifier SDK;
+* bridge-contract verifier sketch or prototype;
+* OP Stack alt-DA prototype or equivalent integration;
+* certificate polling;
+* fallback retrieval from PolyStore; and
+* proof bundle export.
+
+Exit criteria:
+
+* one live design partner demo can publish, certify, verify, retrieve, and
+  reconstruct a batch.
+
+### Phase 5: DAS research track
 
 Deliverables:
 
@@ -765,40 +1158,54 @@ Deliverables:
 * invalid-encoding evidence;
 * sample aggregation;
 * collusion simulations;
-* lane economics simulations;
-* bridgeable certificate verifier.
+* lane economics simulations; and
+* light-client sampling design if justified.
 
 Exit criteria:
 
-* credible security model for a named lane policy;
-* no unresolved overclaim in public positioning;
-* at least one design partner can evaluate the claim.
-
-### Phase 4: Rollup integration
-
-Deliverables:
-
-* generic DA client SDK;
-* OP Stack alt-DA prototype or equivalent integration;
-* certificate polling;
-* fallback retrieval from PolyStore;
-* archive continuity after DA window;
-* coverage/health dashboard.
-
-Exit criteria:
-
-* one live design partner demo;
-* end-to-end publish, certify, retrieve, and verify workflow.
+* stronger sampling-first claims are either supported by a formal model or kept
+  out of public positioning.
 
 -----
 
-## 18. Product Positioning
+## 21. Tests and Evidence
+
+Every implementation PR should state which certificate tier it affects.
+
+Minimum test categories:
+
+* append CAS and lane-root tests;
+* provider assignment determinism tests;
+* attestation signature/domain-separator tests;
+* quorum threshold pass/fail tests;
+* stale root and stale generation rejection tests;
+* failed sample rejection tests;
+* historical-generation retrieval tests;
+* retained-service degradation tests;
+* repair/rotation tests for retained status; and
+* external verifier fixtures for each certificate tier.
+
+Performance evidence should be added before production claims:
+
+* batch size;
+* encoding profile;
+* provider count;
+* attestation aggregation latency;
+* certification latency by tier;
+* sample count and sample-serving latency;
+* retrieval throughput after certification;
+* repair time after provider loss; and
+* bridge/verifier cost.
+
+-----
+
+## 22. Product Positioning
 
 Suggested name family:
 
 * PolyStore DA Lanes
 * PolyFS Availability Certificates
-* PolyStore Availability Service
+* PolyStore Retrievable DA
 * PolyDA, only after the security model is strong enough
 
 Suggested one-liner:
@@ -807,62 +1214,66 @@ Suggested one-liner:
 > availability certificate, and keep the same data retrievable through paid,
 > provable, repairable storage.
 
-Suggested technical claim before full DAS proof:
+Suggested technical claim for the first product:
 
-> PolyStore can evolve from historical DA retrieval into a publication and
-> retrieval layer where availability samples, user reads, repairs, and provider
-> accountability share one economic proof surface.
+> PolyStore DA is attestation-first DA with native durable retrieval: provider
+> attestations certify publication, while PolyFS generations, retrieval
+> sessions, and repair preserve access after acceptance.
 
 Suggested claim to avoid:
 
-> PolyStore is already a Celestia replacement.
+> PolyStore already provides sampling-first DA security.
 
 -----
 
-## 19. Open Questions
+## 23. Open Questions
 
-1. What is the exact confidence bound for sample counts under RS(8,12)?
-2. Should certificate policies be slot-weighted, stake-weighted, capacity
-   weighted, or bond weighted?
+1. What is the exact confidence bound for retrievable sample counts under
+   RS(8,12)?
+2. Should quorum policies be slot-weighted, stake-weighted, capacity-weighted,
+   bandwidth-weighted, or multi-dimensional?
 3. Can KZG homomorphism over the current RS parity construction support compact
    encoding-correctness checks?
-4. What is the minimum certificate shape that a rollup settlement contract can
-   use safely?
-5. How should post-certification retrieval failures degrade visible
-   certificate status?
-6. Should public paid sampling be rate-limited by lane policy, protocol policy,
-   or both?
-7. Does the 8 MiB MDU remain appropriate for small rollup batches, or should DA
+4. What aggregate signature or quorum-proof scheme minimizes bridge verifier
+   cost?
+5. What is the minimum `DA_CERT_RETRIEVABLE` certificate shape an external
+   settlement contract can verify safely?
+6. Which false attestation cases are slashable on-chain versus only
+   service-history penalties?
+7. How should public paid sampling be rate-limited by lane policy, protocol
+   policy, or both?
+8. Does the 8 MiB MDU remain appropriate for small rollup batches, or should DA
    lanes aggregate many small batches into larger PolyFS segments?
-8. What retention and garbage-collection policy should DA-retained historical
+9. What retention and garbage-collection policy should DA-retained historical
    generations use relative to provisional-generation cleanup?
-9. Which external integration should be first: OP Stack alt-DA, a generic SDK,
-   or a source-DA archive bridge?
-10. What exact language is allowed in marketing before the Phase 3 proof work
-    is complete?
+10. Which external integration should be first: OP Stack alt-DA, a generic SDK,
+    or a source-DA archive bridge?
 
 -----
 
-## 20. Recommendation
+## 24. Recommendation
 
-Adopt PolyFS DA Lanes as a formal research and protocol direction.
+Adopt PolyFS DA Lanes as an attestation-first DA direction with
+`DA_CERT_RETRIEVABLE` as the flagship target.
 
 The recommended sequencing is:
 
 1. Keep historical DA archive/retrieval as the near-term commercial wedge.
-2. Specify DA lanes as an additive layer over existing deals.
-3. Build append-only lane semantics before claiming full DAS.
-4. Add availability certificates with explicit assumptions.
-5. Use the DAS research track to earn stronger "DA layer" claims later.
+2. Implement `DA_CERT_FAST` as the smallest primary-DA certificate.
+3. Implement `DA_CERT_RETRIEVABLE` before making differentiated DA claims.
+4. Implement `DA_CERT_RETAINED` after retrievable certification and repair hooks
+   work in devnet.
+5. Keep sampling-first DAS as a research track rather than the first product
+   claim.
 
-This direction avoids the weak framing of cloning existing DA systems. It
-focuses PolyStore on the point where it can be genuinely differentiated:
-publication-time availability, long-term retrieval, repair, and economic
+This direction avoids cloning existing DA systems. It focuses PolyStore on the
+point where it can be differentiated: publication-time attestations,
+publication-time retrieval samples, long-term retrieval, repair, and economic
 accountability as one continuous system.
 
 -----
 
-## 21. References
+## 25. References
 
 Local:
 
@@ -885,8 +1296,6 @@ External:
   `https://docs.celestia.org/learn/celestia-101/data-availability/`
 * Ethereum EIP-7594 PeerDAS:
   `https://eips.ethereum.org/EIPS/eip-7594`
-* Teku PeerDAS docs:
-  `https://docs.teku.consensys.io/concepts/peer-das`
 * EigenDA overview:
   `https://docs.eigencloud.xyz/eigenda/core-concepts/overview`
 * Avail DA docs:


### PR DESCRIPTION
## Summary

- Hardens `rfcs/rfc-polyfs-da-lanes.md` around attestation-first PolyStore DA with native durable retrieval.
- Makes `DA_CERT_FAST`, `DA_CERT_RETRIEVABLE`, and `DA_CERT_RETAINED` the core certificate tiers.
- Adds protocol objects, messages, state machines, external verifier surface, failure semantics, threat model, and roadmap for the retrievable DA buildout.
- Links the implementation tracker: Refs #231.

## Why

PolyStore should not position the first DA path as sampling-first DAS. The more natural route is attestation-first DA where provider-daemon quorum attestations are strengthened by PolyStore-native retrieval sessions, retained generations, repair, and paid access.

`DA_CERT_RETRIEVABLE` is framed as the flagship target: a certificate that says the batch was attested and already sampled as retrievable through the same storage network that will serve it later.

## Validation

- `git diff --check`
- `LC_ALL=C rg -n "[^\\x00-\\x7F]" rfcs/rfc-polyfs-da-lanes.md` returned no hits.
- `rg -n "trustless|guaranteed availability|Celestia replacement|router|Track B|track B|track b|Track b" rfcs/rfc-polyfs-da-lanes.md` returned no hits.
- Search for sampling-first/full-DAS terms only found explicit non-claim guardrails.

## Notes

Docs/RFC only. No benchmarks are applicable for this PR.
