### PR TITLE
[codex] Guard SP endpoints and provider recovery

### DIFF
--- a/.env.testnet.public
+++ b/.env.testnet.public
@@ -17,6 +17,7 @@ POLYSTORE_TESTNET_SP1_ENDPOINT="/dns4/sp1.polynomialstore.com/tcp/443/https"
 POLYSTORE_TESTNET_SP2_ENDPOINT="/dns4/sp2.polynomialstore.com/tcp/443/https"
 POLYSTORE_TESTNET_SP3_ENDPOINT="/dns4/sp3.polynomialstore.com/tcp/443/https"
 POLYSTORE_TESTNET_PROVIDER_ENDPOINTS="$POLYSTORE_TESTNET_SP1_ENDPOINT,$POLYSTORE_TESTNET_SP2_ENDPOINT,$POLYSTORE_TESTNET_SP3_ENDPOINT"
+POLYSTORE_PROVIDER_MAINTENANCE_BOND="5stake"
 
 # Shared devnet gas-sponsor key for direct polystorechaind submission of user-signed EVM intents.
 POLYSTORE_TESTNET_TX_SENDER_KEY="faucet"

--- a/.env.testnet.public
+++ b/.env.testnet.public
@@ -9,6 +9,15 @@ POLYSTORE_TESTNET_LCD_BASE="https://lcd.polynomialstore.com"
 POLYSTORE_TESTNET_FAUCET_URL="https://faucet.polynomialstore.com/faucet"
 POLYSTORE_TESTNET_FAUCET_AUTH_TOKEN="11e7bb40b8629d639ae52945b709b76fa06f3411802411ee"
 
+# Canonical public storage-provider endpoints for the shared devnet. Provider
+# daemons may listen on 127.0.0.1 behind Caddy or Cloudflare Tunnel, but the
+# on-chain Provider.endpoints values for the shared stack must use these public
+# hostnames rather than loopback listener addresses.
+POLYSTORE_TESTNET_SP1_ENDPOINT="/dns4/sp1.polynomialstore.com/tcp/443/https"
+POLYSTORE_TESTNET_SP2_ENDPOINT="/dns4/sp2.polynomialstore.com/tcp/443/https"
+POLYSTORE_TESTNET_SP3_ENDPOINT="/dns4/sp3.polynomialstore.com/tcp/443/https"
+POLYSTORE_TESTNET_PROVIDER_ENDPOINTS="$POLYSTORE_TESTNET_SP1_ENDPOINT,$POLYSTORE_TESTNET_SP2_ENDPOINT,$POLYSTORE_TESTNET_SP3_ENDPOINT"
+
 # Shared devnet gas-sponsor key for direct polystorechaind submission of user-signed EVM intents.
 POLYSTORE_TESTNET_TX_SENDER_KEY="faucet"
 POLYSTORE_TESTNET_TX_SENDER_MNEMONIC="course what neglect valley visual ride common cricket bachelor rigid vessel mask actor pumpkin edit follow sorry used divorce odor ask exclude crew hole"

--- a/docs/TRUSTED_DEVNET_COLLABORATOR_PACKET_POLYNOMIALSTORE_COM.md
+++ b/docs/TRUSTED_DEVNET_COLLABORATOR_PACKET_POLYNOMIALSTORE_COM.md
@@ -16,15 +16,22 @@ Recommended public entry points:
 - Chain ID: `20260211` (`0x1352573`)
 
 Provider public endpoints (striped `2+1` baseline):
-- `https://sp1.polynomialstore.com` → provider `nil1jtqzjx7y9kh3un3a86u774mucsq4q3vshh8sr0`
-- `https://sp2.polynomialstore.com` → provider `nil1w98n98a8gnrwnyz62wfvya9wzvdr92uwz7dssk`
-- `https://sp3.polynomialstore.com` → provider `nil182f6qy5taazj5fa722p2ut4d0v5j2gkap0dprj`
+- `https://sp1.polynomialstore.com` -> provider `nil1d59tk5smpvkjrtvx5kep3uuvfflfg0e7qx36fq`
+- `https://sp2.polynomialstore.com` -> provider `nil15c5dmlaplgkdc3gumc62rwhsg9w0qauhmh28hw`
+- `https://sp3.polynomialstore.com` -> provider `nil1ggw66lserkfrdeax27nnq450yf7269w8p5ut6k`
 
 Provider ingress note:
 - These SP hostnames are expected to resolve directly to the provider host
   through DNS-only records, with Caddy terminating HTTPS and proxying to local
   provider-daemon ports. They should not be Cloudflare-proxied for normal bulk
   provider traffic.
+- The on-chain provider endpoints for the shared stack must be the public
+  `/dns4/sp1.polynomialstore.com/tcp/443/https`,
+  `/dns4/sp2.polynomialstore.com/tcp/443/https`, and
+  `/dns4/sp3.polynomialstore.com/tcp/443/https` multiaddrs. Local loopback
+  listener addresses such as `/ip4/127.0.0.1/tcp/8091/http` are only reverse
+  proxy or tunnel origins and should not be left on active shared-devnet
+  provider records.
 - Runbook: `docs/networking/DIRECT_SP_HTTPS_RUNBOOK.md`
 
 ## What Collaborators Need From Hub Operator
@@ -120,7 +127,7 @@ Provider operator baseline:
 scripts/devnet_healthcheck.sh provider \
   --provider https://sp1.polynomialstore.com \
   --hub-lcd https://lcd.polynomialstore.com \
-  --provider-addr nil1jtqzjx7y9kh3un3a86u774mucsq4q3vshh8sr0
+  --provider-addr nil1d59tk5smpvkjrtvx5kep3uuvfflfg0e7qx36fq
 ```
 
 ## Reporting Template For Issues

--- a/docs/networking/DIRECT_SP_HTTPS_RUNBOOK.md
+++ b/docs/networking/DIRECT_SP_HTTPS_RUNBOOK.md
@@ -17,7 +17,8 @@ The current `polynomialstore.com` provider hostnames are expected to use:
   address.
 - Caddy listening on public TCP `443` on the provider host.
 - One public Let's Encrypt certificate covering all three SP hostnames.
-- Host-based Caddy reverse proxy:
+- Host-based Caddy reverse proxy to the local provider-daemon listeners, for
+  example:
   - `sp1.polynomialstore.com` -> `127.0.0.1:8091`
   - `sp2.polynomialstore.com` -> `127.0.0.1:8092`
   - `sp3.polynomialstore.com` -> `127.0.0.1:8093`
@@ -25,6 +26,22 @@ The current `polynomialstore.com` provider hostnames are expected to use:
   - `/dns4/sp1.polynomialstore.com/tcp/443/https`
   - `/dns4/sp2.polynomialstore.com/tcp/443/https`
   - `/dns4/sp3.polynomialstore.com/tcp/443/https`
+
+The `127.0.0.1:<port>` values above are private origin addresses only. Do not
+register them in `Provider.endpoints` for the shared devnet. If a recovery or
+chain refresh changes which local daemon serves a hostname, keep the on-chain
+endpoint as the matching `sp1`, `sp2`, or `sp3`
+`/dns4/.../tcp/443/https` hostname and update the reverse proxy or tunnel
+route to point that hostname at the correct daemon.
+
+Before submitting `register-provider` or `update-provider-endpoints`, verify
+the hostname-to-provider identity mapping:
+
+```bash
+curl -fsS https://sp1.polynomialstore.com/status | jq -r '.provider.address'
+curl -fsS https://sp2.polynomialstore.com/status | jq -r '.provider.address'
+curl -fsS https://sp3.polynomialstore.com/status | jq -r '.provider.address'
+```
 
 Do not commit the current provider host public IP address to the repo. Read it
 from Cloudflare DNS, the router/NAT configuration, or operator notes when
@@ -158,6 +175,13 @@ sudo caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile
 sudo systemctl restart caddy
 ```
 
+If this host is temporarily using Cloudflare Tunnel instead of direct DNS-only
+`A` records, the same identity rule applies: the tunnel ingress service may be
+`http://127.0.0.1:<port>`, but the chain endpoint must still be the public
+`/dns4/sp1.polynomialstore.com/tcp/443/https`,
+`/dns4/sp2.polynomialstore.com/tcp/443/https`, or
+`/dns4/sp3.polynomialstore.com/tcp/443/https` multiaddr.
+
 ## DNS Cutover
 
 Before cutover:
@@ -211,6 +235,19 @@ Expected:
 - HTTP status is `200`.
 - TLS verify result is `0`.
 - HTTP version is usually `2`.
+
+Also verify the chain records after any stack refresh:
+
+```bash
+curl -fsS https://lcd.polynomialstore.com/polystorechain/polystorechain/v1/providers \
+  | jq -r '.providers[] | [.address, (.draining // false), (.endpoints | join(","))] | @tsv'
+```
+
+Every non-draining shared-devnet SP should advertise one of the three
+`sp1`, `sp2`, or `sp3` `/dns4/.../tcp/443/https` endpoints. If a
+non-draining record advertises `/ip4/127.0.0.1/...`, update that provider
+with `update-provider-endpoints` from its local key or mark the extra provider
+draining if it is not one of the public three.
 
 ## Validating Cloudflare Slowdown
 
@@ -355,7 +392,8 @@ HTTPS and Tunnel HTTPS use `/dns4/<host>/tcp/443/https`.
 
 - Do not assume `cloudflared-providers.service` carries live SP traffic. In the
   current deployment it is a fallback while DNS-only direct HTTPS is primary.
-- If `spN.polynomialstore.com` resolves to Cloudflare anycast IPs, the record is
+- If `sp1.polynomialstore.com`, `sp2.polynomialstore.com`, or
+  `sp3.polynomialstore.com` resolves to Cloudflare anycast IPs, the record is
   proxied or stale in a resolver cache.
 - If it resolves to the provider host public address but HTTPS fails, inspect
   Caddy first, then provider-daemon health on the local `809N` port.

--- a/docs/networking/PROVIDER_ENDPOINTS.md
+++ b/docs/networking/PROVIDER_ENDPOINTS.md
@@ -35,6 +35,21 @@ Important (current protocol behavior):
   - update the endpoint list with `update-provider-endpoints`
   - only create a new provider key if the chain explicitly rejects endpoint updates or you intentionally want a new identity
 
+Shared `polynomialstore.com` devnet rule:
+
+- The provider daemon may listen on `127.0.0.1:<port>` behind Caddy or
+  Cloudflare Tunnel, but `127.0.0.1` must not be registered on-chain for the
+  shared devnet.
+- Register the public SP hostname multiaddrs:
+  - `/dns4/sp1.polynomialstore.com/tcp/443/https`
+  - `/dns4/sp2.polynomialstore.com/tcp/443/https`
+  - `/dns4/sp3.polynomialstore.com/tcp/443/https`
+- `scripts/run_devnet_provider.sh` rejects loopback endpoints for the default
+  `polystore-public-testnet` profile. Use
+  `POLYSTORE_ALLOW_LOCAL_PROVIDER_ENDPOINTS=1` only for an isolated local
+  devnet where no remote user-gateway, website, or collaborator will resolve
+  the provider endpoint.
+
 ## Helper: Print Endpoint Multiaddrs
 
 From `polystore_gateway/`, you can generate the exact `--endpoint` values:
@@ -126,6 +141,27 @@ polystorechaind tx polystorechain update-provider-endpoints \
   --endpoint "/dns4/sp.example.com/tcp/443/https"
 ```
 
+For the current shared devnet hostnames, set the endpoint explicitly for the
+daemon identity that actually serves each hostname:
+
+```bash
+PROVIDER_KEY=<key-serving-sp1> PROVIDER_ENDPOINT="$POLYSTORE_TESTNET_SP1_ENDPOINT" \
+  ./scripts/run_devnet_provider.sh register
+PROVIDER_KEY=<key-serving-sp2> PROVIDER_ENDPOINT="$POLYSTORE_TESTNET_SP2_ENDPOINT" \
+  ./scripts/run_devnet_provider.sh register
+PROVIDER_KEY=<key-serving-sp3> PROVIDER_ENDPOINT="$POLYSTORE_TESTNET_SP3_ENDPOINT" \
+  ./scripts/run_devnet_provider.sh register
+```
+
+Do not assume `provider1` always maps to `sp1` after a recovery or chain
+refresh. Verify the route before registering:
+
+```bash
+curl -fsS https://sp1.polynomialstore.com/status | jq -r '.provider.address'
+curl -fsS https://sp2.polynomialstore.com/status | jq -r '.provider.address'
+curl -fsS https://sp3.polynomialstore.com/status | jq -r '.provider.address'
+```
+
 ## Type: cloudflare-tunnel (fallback when inbound ports are unavailable)
 
 Goal: expose the provider at `https://sp.example.com` without opening inbound ports.
@@ -194,6 +230,22 @@ polystorechaind tx polystorechain update-provider-endpoints \
   --yes \
   --endpoint "/dns4/sp.example.com/tcp/443/https"
 ```
+
+If a chain refresh already registered loopback endpoints, repair it in place
+with the same provider keys instead of resetting the chain:
+
+```bash
+polystorechaind tx polystorechain update-provider-endpoints \
+  --from <key-serving-sp1-or-sp2-or-sp3> \
+  --chain-id <chain-id> \
+  --yes \
+  --endpoint "/dns4/sp1.polynomialstore.com/tcp/443/https"
+```
+
+Then query the provider list and verify that every non-draining provider used
+by the shared stack advertises the matching `sp1`, `sp2`, or `sp3`
+`/dns4/.../tcp/443/https` endpoint. Extra loopback-only records should be
+drained or excluded from placement rather than left active.
 
 ## Future Work (Not Testnet-Blocking)
 

--- a/docs/networking/PROVIDER_ENDPOINTS.md
+++ b/docs/networking/PROVIDER_ENDPOINTS.md
@@ -162,6 +162,53 @@ curl -fsS https://sp2.polynomialstore.com/status | jq -r '.provider.address'
 curl -fsS https://sp3.polynomialstore.com/status | jq -r '.provider.address'
 ```
 
+## Recovery After a Stack Refresh
+
+A refreshed local stack can leave two independent kinds of stale chain state:
+
+- endpoint drift: a live provider still advertises `/ip4/127.0.0.1/...` on-chain
+- health drift: a live provider is reachable and collateralized, but still has
+  old soft-fault `provider_delinquent` or `provider_degraded` health from prior
+  missed epochs
+
+Fix endpoint drift in place with `update-provider-endpoints`; do not reset the
+chain or rotate provider keys unless the identity is intentionally changing.
+
+Fix health drift with an authorized provider/operator maintenance top-up after
+the daemon is reachable and the provider has enough collateral headroom. The
+keeper treats this as a check-in and clears recoverable soft/degraded placement
+health, but it does not clear administrative states such as `Draining`, `Jailed`,
+or `Exited`.
+
+```bash
+CHAIN_MODULE="${POLYSTORE_CHAIN_MODULE:-nilchain}" # older local binaries may use polystorechain
+MAINTENANCE_BOND="${POLYSTORE_PROVIDER_MAINTENANCE_BOND:-5stake}"
+
+polystorechaind tx "$CHAIN_MODULE" add-provider-bond "$PROVIDER_ADDRESS" "$MAINTENANCE_BOND" \
+  --from "$PROVIDER_KEY" \
+  --chain-id "$CHAIN_ID" \
+  --node "$NODE_ADDR" \
+  --home "$POLYSTORE_HOME" \
+  --keyring-backend test \
+  --gas auto \
+  --gas-adjustment 1.6 \
+  --gas-prices "$POLYSTORE_GAS_PRICES" \
+  --yes
+```
+
+For the shared `polynomialstore.com` host, verify all public SPs are both
+reachable and eligible before retrying deal creation:
+
+```bash
+for host in sp1.polynomialstore.com sp2.polynomialstore.com sp3.polynomialstore.com; do
+  addr="$(curl -fsS "https://$host/status" | jq -r '.provider.address')"
+  curl -fsS "$POLYSTORE_TESTNET_LCD_BASE/polystorechain/polystorechain/v1/providers/$addr/health" |
+    jq --arg host "$host" '.health | {host: $host, address: .provider, lifecycle: .lifecycle_status, reason}'
+  curl -fsS "$POLYSTORE_TESTNET_LCD_BASE/polystorechain/polystorechain/v1/providers/$addr/collateral" |
+    jq '.collateral | {eligible_for_new_assignment, ineligibility_reason, assignment_headroom}'
+done
+```
+
 ## Type: cloudflare-tunnel (fallback when inbound ports are unavailable)
 
 Goal: expose the provider at `https://sp.example.com` without opening inbound ports.

--- a/polystorechain/x/polystorechain/keeper/msg_provider_bond.go
+++ b/polystorechain/x/polystorechain/keeper/msg_provider_bond.go
@@ -110,8 +110,8 @@ func (k msgServer) AddProviderBond(goCtx context.Context, msg *types.MsgAddProvi
 	if err := k.Providers.Set(ctx, providerAddr, provider); err != nil {
 		return nil, fmt.Errorf("failed to update provider bond: %w", err)
 	}
-	if err := k.clearResolvedProviderUnderbondedHealth(ctx, provider); err != nil {
-		return nil, fmt.Errorf("failed to clear resolved provider underbonded health: %w", err)
+	if err := k.clearResolvedProviderPlacementHealth(ctx, provider); err != nil {
+		return nil, fmt.Errorf("failed to clear resolved provider placement health: %w", err)
 	}
 
 	ctx.EventManager().EmitEvent(

--- a/polystorechain/x/polystorechain/keeper/provider_bond.go
+++ b/polystorechain/x/polystorechain/keeper/provider_bond.go
@@ -244,7 +244,17 @@ func overlayProviderBondHealth(health types.ProviderHealthState, provider types.
 	return health
 }
 
-func (k Keeper) clearResolvedProviderUnderbondedHealth(ctx sdk.Context, provider types.Provider) error {
+func recoverableProviderPlacementHealth(health types.ProviderHealthState) bool {
+	switch health.LifecycleStatus {
+	case types.ProviderLifecycleStatus_PROVIDER_LIFECYCLE_STATUS_DEGRADED,
+		types.ProviderLifecycleStatus_PROVIDER_LIFECYCLE_STATUS_DELINQUENT:
+	default:
+		return false
+	}
+	return health.Severity != types.EvidenceSeverity_EVIDENCE_SEVERITY_HARD
+}
+
+func (k Keeper) clearResolvedProviderPlacementHealth(ctx sdk.Context, provider types.Provider) error {
 	providerAddr := strings.TrimSpace(provider.Address)
 	if providerAddr == "" {
 		return nil
@@ -256,8 +266,10 @@ func (k Keeper) clearResolvedProviderUnderbondedHealth(ctx sdk.Context, provider
 		}
 		return err
 	}
-	if health.Reason != providerUnderbondedReason ||
-		health.LifecycleStatus != types.ProviderLifecycleStatus_PROVIDER_LIFECYCLE_STATUS_DELINQUENT {
+	if !recoverableProviderPlacementHealth(health) {
+		return nil
+	}
+	if reason := providerLifecyclePlacementIneligibility(providerLifecycleFromRegistration(provider)); reason != "" {
 		return nil
 	}
 	reason, err := k.providerAssignmentCollateralIneligibility(ctx, provider, 0)
@@ -269,10 +281,16 @@ func (k Keeper) clearResolvedProviderUnderbondedHealth(ctx sdk.Context, provider
 	}
 
 	health.LifecycleStatus = types.ProviderLifecycleStatus_PROVIDER_LIFECYCLE_STATUS_ACTIVE
-	health.Reason = "provider_bond_restored"
+	if health.Reason == providerUnderbondedReason {
+		health.Reason = "provider_bond_restored"
+		health.ConsequenceCeiling = "provider bond now satisfies collateral requirements"
+	} else {
+		health.Reason = "provider_operator_recovered"
+		health.ConsequenceCeiling = "authorized provider maintenance check-in restored placement eligibility"
+	}
 	health.EvidenceClass = types.EvidenceClass_EVIDENCE_CLASS_OPERATIONAL
 	health.Severity = types.EvidenceSeverity_EVIDENCE_SEVERITY_INFO
 	health.UpdatedHeight = ctx.BlockHeight()
-	health.ConsequenceCeiling = "provider bond now satisfies collateral requirements"
+	health.SoftFaultCount = 0
 	return k.ProviderHealthStates.Set(ctx, providerAddr, health)
 }

--- a/polystorechain/x/polystorechain/keeper/provider_bond_test.go
+++ b/polystorechain/x/polystorechain/keeper/provider_bond_test.go
@@ -407,6 +407,124 @@ func TestAddProviderBondClearsResolvedUnderbondedHealth(t *testing.T) {
 	require.Empty(t, after.Collateral.IneligibilityReason)
 }
 
+func TestAddProviderBondClearsRecoveredSoftProviderHealth(t *testing.T) {
+	bank := newTrackingBankKeeper()
+	f := initFixtureWithBankKeeper(t, bank)
+	msgServer := keeper.NewMsgServerImpl(f.keeper)
+	queryServer := keeper.NewQueryServerImpl(f.keeper)
+	ctx := sdk.UnwrapSDKContext(f.ctx).WithBlockHeight(20)
+
+	params := types.DefaultParams()
+	params.MinProviderBond = sdk.NewInt64Coin(sdk.DefaultBondDenom, 150)
+	params.AssignmentCollateralPerSlot = sdk.NewInt64Coin(sdk.DefaultBondDenom, 5)
+	require.NoError(t, f.keeper.Params.Set(ctx, params))
+
+	provider := makePolicyTestAddr(t, f, 0xA1)
+	providerAddr, err := sdk.AccAddressFromBech32(provider)
+	require.NoError(t, err)
+	bank.setAccountBalance(providerAddr, sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 155)))
+
+	_, err = msgServer.RegisterProvider(ctx, &types.MsgRegisterProvider{
+		Creator:      provider,
+		Capabilities: "General",
+		TotalStorage: 1_000_000_000,
+		Endpoints:    testProviderEndpoints,
+		Bond:         sdk.NewInt64Coin(sdk.DefaultBondDenom, 150),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, f.keeper.ProviderHealthStates.Set(ctx, provider, types.ProviderHealthState{
+		Provider:           provider,
+		LifecycleStatus:    types.ProviderLifecycleStatus_PROVIDER_LIFECYCLE_STATUS_DELINQUENT,
+		Reason:             "provider_delinquent",
+		EvidenceClass:      types.EvidenceClass_EVIDENCE_CLASS_CHAIN_MEASURABLE_SOFT,
+		Severity:           types.EvidenceSeverity_EVIDENCE_SEVERITY_DELINQUENT,
+		LastEvidenceCaseId: 99,
+		LastDealId:         7,
+		LastSlot:           1,
+		LastEpochId:        4,
+		UpdatedHeight:      19,
+		SoftFaultCount:     42,
+		HardFaultCount:     1,
+		RepairEventCount:   5,
+		ConsequenceCeiling: "repair and reward exclusion; no soft-fault slash by default",
+	}))
+
+	before, err := queryServer.GetProviderHealth(ctx, &types.QueryGetProviderHealthRequest{Address: provider})
+	require.NoError(t, err)
+	require.Equal(t, types.ProviderLifecycleStatus_PROVIDER_LIFECYCLE_STATUS_DELINQUENT, before.Health.LifecycleStatus)
+	require.Equal(t, uint64(42), before.Health.SoftFaultCount)
+
+	_, err = msgServer.AddProviderBond(ctx, &types.MsgAddProviderBond{
+		Creator:  provider,
+		Provider: provider,
+		Bond:     sdk.NewInt64Coin(sdk.DefaultBondDenom, 5),
+	})
+	require.NoError(t, err)
+
+	health, err := queryServer.GetProviderHealth(ctx, &types.QueryGetProviderHealthRequest{Address: provider})
+	require.NoError(t, err)
+	require.Equal(t, types.ProviderLifecycleStatus_PROVIDER_LIFECYCLE_STATUS_ACTIVE, health.Health.LifecycleStatus)
+	require.Equal(t, "provider_operator_recovered", health.Health.Reason)
+	require.Equal(t, uint64(0), health.Health.SoftFaultCount)
+	require.Equal(t, uint64(1), health.Health.HardFaultCount)
+	require.Equal(t, uint64(5), health.Health.RepairEventCount)
+
+	collateral, err := queryServer.GetProviderCollateral(ctx, &types.QueryGetProviderCollateralRequest{Address: provider})
+	require.NoError(t, err)
+	require.True(t, collateral.Collateral.EligibleForNewAssignment)
+	require.Empty(t, collateral.Collateral.IneligibilityReason)
+}
+
+func TestAddProviderBondDoesNotClearAdministrativeProviderHealth(t *testing.T) {
+	bank := newTrackingBankKeeper()
+	f := initFixtureWithBankKeeper(t, bank)
+	msgServer := keeper.NewMsgServerImpl(f.keeper)
+	queryServer := keeper.NewQueryServerImpl(f.keeper)
+	ctx := sdk.UnwrapSDKContext(f.ctx).WithBlockHeight(20)
+
+	provider := makePolicyTestAddr(t, f, 0xA1)
+	providerAddr, err := sdk.AccAddressFromBech32(provider)
+	require.NoError(t, err)
+	bank.setAccountBalance(providerAddr, sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 155)))
+
+	_, err = msgServer.RegisterProvider(ctx, &types.MsgRegisterProvider{
+		Creator:      provider,
+		Capabilities: "General",
+		TotalStorage: 1_000_000_000,
+		Endpoints:    testProviderEndpoints,
+		Bond:         sdk.NewInt64Coin(sdk.DefaultBondDenom, 150),
+	})
+	require.NoError(t, err)
+
+	record, err := f.keeper.Providers.Get(ctx, provider)
+	require.NoError(t, err)
+	record.Status = "Jailed"
+	require.NoError(t, f.keeper.Providers.Set(ctx, provider, record))
+	require.NoError(t, f.keeper.ProviderHealthStates.Set(ctx, provider, types.ProviderHealthState{
+		Provider:           provider,
+		LifecycleStatus:    types.ProviderLifecycleStatus_PROVIDER_LIFECYCLE_STATUS_JAILED,
+		Reason:             "hard_fault_jailed",
+		EvidenceClass:      types.EvidenceClass_EVIDENCE_CLASS_CHAIN_MEASURABLE_SOFT,
+		Severity:           types.EvidenceSeverity_EVIDENCE_SEVERITY_DELINQUENT,
+		SoftFaultCount:     42,
+		ConsequenceCeiling: "jailed until height 50",
+	}))
+
+	_, err = msgServer.AddProviderBond(ctx, &types.MsgAddProviderBond{
+		Creator:  provider,
+		Provider: provider,
+		Bond:     sdk.NewInt64Coin(sdk.DefaultBondDenom, 5),
+	})
+	require.NoError(t, err)
+
+	health, err := queryServer.GetProviderHealth(ctx, &types.QueryGetProviderHealthRequest{Address: provider})
+	require.NoError(t, err)
+	require.Equal(t, types.ProviderLifecycleStatus_PROVIDER_LIFECYCLE_STATUS_JAILED, health.Health.LifecycleStatus)
+	require.Equal(t, "provider_jailed", health.Health.Reason)
+	require.Equal(t, uint64(42), health.Health.SoftFaultCount)
+}
+
 func TestWithdrawProviderBondRetainsLockAwareAssignmentCollateral(t *testing.T) {
 	bank := newTrackingBankKeeper()
 	f := initFixtureWithBankKeeper(t, bank)

--- a/scripts/run_devnet_provider.sh
+++ b/scripts/run_devnet_provider.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 #   PROVIDER_KEY=provider1 OPERATOR_ADDRESS=<0x...|nil1...> ./scripts/run_devnet_provider.sh pair
 #   PROVIDER_KEY=provider1 OPERATOR_ADDRESS=<0x...|nil1...> ./scripts/run_devnet_provider.sh link
 #   PROVIDER_KEY=provider1 OPERATOR_ADDRESS=<0x...|nil1...> ./scripts/run_devnet_provider.sh bootstrap
-#   PROVIDER_KEY=provider1 PROVIDER_ENDPOINT="/ip4/<ip>/tcp/8091/http" ./scripts/run_devnet_provider.sh register
+#   PROVIDER_KEY=provider1 PROVIDER_ENDPOINT="/dns4/sp1.polynomialstore.com/tcp/443/https" ./scripts/run_devnet_provider.sh register
 #   PROVIDER_KEY=provider1 PROVIDER_LISTEN=":8091" ./scripts/run_devnet_provider.sh start
 #   PROVIDER_KEY=provider1 ./scripts/run_devnet_provider.sh print-config
 #   PROVIDER_KEY=provider1 ./scripts/run_devnet_provider.sh doctor
@@ -33,7 +33,7 @@ Examples:
   PROVIDER_KEY=provider1 OPERATOR_ADDRESS=<0x...|nil1...> ./scripts/run_devnet_provider.sh pair
   PROVIDER_KEY=provider1 OPERATOR_ADDRESS=<0x...|nil1...> ./scripts/run_devnet_provider.sh link
   PROVIDER_KEY=provider1 OPERATOR_ADDRESS=<0x...|nil1...> ./scripts/run_devnet_provider.sh bootstrap
-  PROVIDER_KEY=provider1 PROVIDER_ENDPOINT="/ip4/<ip>/tcp/8091/http" ./scripts/run_devnet_provider.sh register
+  PROVIDER_KEY=provider1 PROVIDER_ENDPOINT="/dns4/sp1.polynomialstore.com/tcp/443/https" ./scripts/run_devnet_provider.sh register
   PROVIDER_KEY=provider1 PROVIDER_LISTEN=":8091" ./scripts/run_devnet_provider.sh start
   PROVIDER_KEY=provider1 ./scripts/run_devnet_provider.sh print-config
   PROVIDER_KEY=provider1 ./scripts/run_devnet_provider.sh doctor
@@ -49,6 +49,8 @@ Notes:
   - register defaults to POLYSTORE_PROVIDER_REGISTRATION_BOND=200stake so providers
     satisfy the calibrated devnet minimum bond profile; set it empty to omit --bond.
   - EXPECTED_PROVIDER_ADDRESS (or POLYSTORE_EXPECTED_PROVIDER_ADDRESS) can enforce identity safety.
+  - On polystore-public-testnet, register public /dns4/.../https SP hostnames. Loopback
+    endpoints are rejected unless POLYSTORE_ALLOW_LOCAL_PROVIDER_ENDPOINTS=1 is set.
 USAGE
 }
 
@@ -86,6 +88,7 @@ PROVIDER_CAPABILITIES="${PROVIDER_CAPABILITIES:-General}"
 PROVIDER_TOTAL_STORAGE="${PROVIDER_TOTAL_STORAGE:-1099511627776}" # 1 TiB default
 PROVIDER_REGISTRATION_BOND="${POLYSTORE_PROVIDER_REGISTRATION_BOND-${POLYSTORE_PROVIDER_BOND-200stake}}"
 PROVIDER_ENDPOINTS_RAW="${PROVIDER_ENDPOINTS:-${PROVIDER_ENDPOINT:-}}"
+ALLOW_LOCAL_PROVIDER_ENDPOINTS="${POLYSTORE_ALLOW_LOCAL_PROVIDER_ENDPOINTS:-0}"
 BOOTSTRAP_ALLOW_PARTIAL="${BOOTSTRAP_ALLOW_PARTIAL:-0}"
 EXPECTED_PROVIDER_ADDRESS_RAW="${EXPECTED_PROVIDER_ADDRESS:-${POLYSTORE_EXPECTED_PROVIDER_ADDRESS:-}}"
 
@@ -112,6 +115,47 @@ json_escape() {
 
 have_cmd() {
   command -v "$1" >/dev/null 2>&1
+}
+
+provider_endpoint_is_loopback() {
+  local endpoint="$1"
+
+  case "$endpoint" in
+    /ip4/127.*/*|/ip4/0.0.0.0/*|/dns4/localhost/*|/dns4/127.*/*|/dns4/0.0.0.0/*|/dns6/localhost/*|/ip6/::1/*|/ip6/0:0:0:0:0:0:0:1/*)
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
+validate_provider_endpoints_for_profile() {
+  local context="$1"
+  local endpoints endpoint
+
+  if [[ "$NETWORK_PROFILE" != *public-testnet* ]]; then
+    return 0
+  fi
+  if [[ "$ALLOW_LOCAL_PROVIDER_ENDPOINTS" == "1" ]]; then
+    return 0
+  fi
+
+  IFS=',' read -r -a endpoints <<<"$PROVIDER_ENDPOINTS_RAW"
+  for endpoint in "${endpoints[@]}"; do
+    endpoint="$(echo "$endpoint" | xargs)"
+    if [[ -z "$endpoint" ]]; then
+      continue
+    fi
+    if provider_endpoint_is_loopback "$endpoint"; then
+      echo "ERROR: refusing loopback provider endpoint on $NETWORK_PROFILE during $context: $endpoint" >&2
+      echo "       Register the public SP hostname multiaddr instead, for example:" >&2
+      echo "       /dns4/sp1.polynomialstore.com/tcp/443/https" >&2
+      echo "       /dns4/sp2.polynomialstore.com/tcp/443/https" >&2
+      echo "       /dns4/sp3.polynomialstore.com/tcp/443/https" >&2
+      echo "       127.0.0.1 is only the local listener or reverse-proxy origin. Set POLYSTORE_ALLOW_LOCAL_PROVIDER_ENDPOINTS=1 only for isolated local devnets." >&2
+      exit 2
+    fi
+  done
 }
 
 amount_is_positive() {
@@ -1181,9 +1225,10 @@ register_provider() {
   assert_expected_provider_address
 
   if [ -z "$PROVIDER_ENDPOINTS_RAW" ]; then
-    echo "ERROR: set PROVIDER_ENDPOINT (or PROVIDER_ENDPOINTS) to a reachable multiaddr, e.g. /ip4/1.2.3.4/tcp/8091/http" >&2
+    echo "ERROR: set PROVIDER_ENDPOINT (or PROVIDER_ENDPOINTS) to a reachable public multiaddr, e.g. /dns4/sp1.polynomialstore.com/tcp/443/https" >&2
     exit 1
   fi
+  validate_provider_endpoints_for_profile "register"
 
   local addr
   addr="$(provider_addr)"
@@ -1421,6 +1466,9 @@ bootstrap_provider() {
   fi
   if [ -z "$PROVIDER_ENDPOINTS_RAW" ]; then
     missing+=("PROVIDER_ENDPOINT")
+  fi
+  if [ -n "$PROVIDER_ENDPOINTS_RAW" ]; then
+    validate_provider_endpoints_for_profile "bootstrap"
   fi
 
   if [ "${#missing[@]}" -gt 0 ] && [ "$BOOTSTRAP_ALLOW_PARTIAL" != "1" ]; then


### PR DESCRIPTION
## Summary
- require shared devnet SP registrations to use the public sp1/sp2/sp3.polynomialstore.com endpoint multiaddrs instead of loopback addresses
- document in-place endpoint repair and post-refresh provider health recovery checks
- let an authorized add-provider-bond maintenance top-up clear recovered soft/degraded provider health once collateral and registration state are healthy

## Validation
- go test -mod=mod ./x/polystorechain/keeper
- bash -n scripts/run_devnet_provider.sh scripts/load_testnet_public_env.sh scripts/update_devnet_stack.sh
- shellcheck scripts/run_devnet_provider.sh
- git diff --check

## Live devnet notes
- Updated active public provider endpoints on-chain to sp1/sp2/sp3 hostnames without resetting chain state.
- Topped up the three active public providers by 500stake each; remaining create-deal blocker is stale provider_delinquent soft-fault health.
- Built and installed the updated /opt/polystore/polystorechain/polystorechaind binary with a backup under /opt/polystore/backups/manual-provider-health-20260629-083137/.
- This shell cannot restart root unit polystorechaind.service non-interactively; after that unit is restarted, rerun the 5stake maintenance top-ups to clear provider health and restore deal eligibility.