### PR TITLE
[codex] Add rootless devnet handoff

### DIFF
--- a/docs/devnet-polyfs-root-rollout.md
+++ b/docs/devnet-polyfs-root-rollout.md
@@ -2,6 +2,12 @@
 
 Use `scripts/update_devnet_stack.sh` when rolling out proof-format-coupled changes to the local trusted devnet on this machine.
 
+For local machines, prefer the rootless hub layout documented in
+`docs/devnet-rootless-handoff.md`. After that one-time handoff,
+`scripts/update_devnet_stack.sh` can manage `polystorechaind`,
+`polystore-faucet`, and the `user-gateway` legacy router service with
+`systemctl --user`, avoiding sudo/root blockers during routine deploys.
+
 The script rebuilds as the configured run user, then installs:
 
 - `polystore_core/target/release/libpolystore_core.so`
@@ -18,14 +24,14 @@ It restarts services in this order:
 3. Build artifacts as `--run-user`/`POLYSTORE_RUN_USER`; when invoked with `sudo`, this avoids root-owned Cargo/Go outputs in the source checkout.
 4. Preflight all build artifacts before stopping any service.
 5. Preflight the install plan. If a source artifact is already the target path, the later install step skips it instead of failing after services stop.
-6. Preflight hub root service units with non-mutating, non-sudo `systemctl show`, including dry-runs, so a missing chain, faucet, or legacy router unit cannot abort after provider-daemons are already stopped.
+6. Preflight hub service units with non-mutating `systemctl show`, including dry-runs, so a missing chain, faucet, or legacy router unit cannot abort after provider-daemons are already stopped. Hub services can be resolved from the user or root systemd manager.
 7. If `--restart-tunnels` is supplied, preflight tunnel user service units with non-mutating `systemctl --user show`.
 8. Resolve `provider-daemon` service managers with non-mutating unit checks, including dry-runs. The default `auto` mode resolves the local user-service provider layout; the checked-in root provider template must be selected explicitly with `POLYSTORE_PROVIDER_SERVICE_SCOPE=root`.
 9. Derive default provider health targets from known resolved service names unless `POLYSTORE_PROVIDER_BASES` is set. Unknown custom service names require explicit bases, and duplicate provider service names or duplicate canonical provider health bases fail before any service-stop mutation.
-10. Preflight root service control. Live non-root runs must prove passwordless sudo authorization for the exact hub and root-managed `provider-daemon` `systemctl stop/start` actions before any `provider-daemon` is stopped.
+10. Preflight root service control only for services resolved from the root systemd manager. Live non-root runs must prove passwordless sudo authorization for exact root-managed `systemctl stop/start` actions before any `provider-daemon` is stopped. User-managed hub services do not require sudo.
 11. If `--restart-tunnels` is supplied, stop tunnel user services before taking down the devnet stack.
 12. Stop `provider-daemon` services from their resolved manager: user services such as `polystore-provider1.service` through `polystore-provider4.service`, or root services such as `polystore-gateway-provider.service`.
-13. Stop hub services: `polystore-gateway-router.service` (legacy service alias for the `user-gateway` persona), `polystore-faucet.service`, then `polystorechaind.service`.
+13. Stop hub services from their resolved manager: `polystore-gateway-router.service` (legacy service alias for the `user-gateway` persona), `polystore-faucet.service`, then `polystorechaind.service`.
 14. Install artifacts with backups and sha256 evidence.
 15. Start chain first.
 16. Start faucet and the `user-gateway` legacy router service.
@@ -69,6 +75,21 @@ The default `auto` inventory intentionally does not include the checked-in root
 provider template, because a loaded-but-unused root template can collide with
 the four user-provider devnet layout on port `8091`.
 
+Hub service management is controlled by `POLYSTORE_HUB_SERVICE_SCOPE`:
+
+- `auto` (default): resolve `polystorechaind.service`,
+  `polystore-faucet.service`, and `polystore-gateway-router.service` against
+  user and root systemd managers.
+- `user`: require all hub services to exist in the user systemd manager.
+- `root`: require all hub services to exist in the root systemd manager.
+
+If a hub service name exists in both managers, `auto` exits before stopping
+services; set the scope explicitly. On rootless local devnets, run:
+
+```bash
+POLYSTORE_HUB_SERVICE_SCOPE=user scripts/update_devnet_stack.sh
+```
+
 ## State Policy
 
 The PolyFS root migration changes the trust root for new deals from the retired flat `manifest.bin` commitment to the MDU #0 PolyFS root. The rollout script is intentionally a binary/runtime rollout tool; it does not reset chain state and it does not silently migrate old committed deals.
@@ -104,12 +125,13 @@ the stop plan and skipped during install. Without `--skip-build`, the script
 exits before building so it cannot partially overwrite live artifacts while
 services are still running.
 In live non-root mode, the script also verifies passwordless sudo authorization
-for the exact hub and root-managed `provider-daemon` `systemctl stop/start`
-actions before printing the service-stop plan. On this host, dry runs report
-that check without requiring a sudo prompt.
-Dry-runs and live runs both verify that all configured hub root service units
-are loaded with non-mutating, non-sudo `systemctl show`. Live runs also verify
-that `curl` is available before any service-stop mutation.
+for exact root-managed `systemctl stop/start` actions before printing the
+service-stop plan. On rootless hub devnets, this only applies to any
+root-managed `provider-daemon` services that remain. On this host, dry runs
+report that check without requiring a sudo prompt.
+Dry-runs and live runs both verify that all configured hub service units are
+loaded in their resolved systemd manager with non-mutating `systemctl show`.
+Live runs also verify that `curl` is available before any service-stop mutation.
 Final `systemctl is-active` status probes are best-effort evidence after the
 healthchecks have passed; a restricted sudoers policy for status commands should
 not mark an otherwise healthy rollout as failed.

--- a/docs/devnet-rootless-handoff.md
+++ b/docs/devnet-rootless-handoff.md
@@ -1,0 +1,70 @@
+# Devnet Rootless Handoff
+
+The trusted devnet should not require root for routine chain binary rollouts.
+Root should only be needed for machine-level ingress such as Caddy on `:443` or
+for the first handoff from root systemd units to user systemd units.
+
+## Why This Exists
+
+The local hub services bind only high ports:
+
+- `polystorechaind`: RPC/LCD/EVM ports such as `26657`, `1317`, `8545`, `8546`
+- `polystore-faucet`: local faucet port such as `8081`
+- `polystore-gateway-router`: local user-gateway port such as `8080`
+
+These services do not need root. If they run as root, every deploy can block on
+root-owned binaries, root-owned chain state, or unavailable sudo for
+`systemctl restart`.
+
+## One-Time Handoff
+
+Run this once from a repo checkout:
+
+```bash
+sudo -E scripts/devnet_rootless_handoff.sh --run-user "$USER"
+```
+
+The script:
+
+- stops, disables, and masks the root hub units by default
+- makes `/opt/polystore`, `/etc/polystore`, `/var/lib/nilstore`, and
+  `/var/lib/polystore` owned by the run user
+- installs the hub units into `~/.config/systemd/user`
+- enables lingering for the run user
+- starts the hub through `systemctl --user`
+
+Use `--dry-run` to inspect the plan first:
+
+```bash
+sudo -E scripts/devnet_rootless_handoff.sh --run-user "$USER" --dry-run
+```
+
+If you want to install user units without starting them, pass `--no-start`.
+
+## Routine Rollouts After Handoff
+
+After handoff, recurring stack updates should resolve the hub from the user
+systemd manager:
+
+```bash
+POLYSTORE_HUB_SERVICE_SCOPE=user scripts/update_devnet_stack.sh --dry-run --skip-build
+POLYSTORE_HUB_SERVICE_SCOPE=user scripts/update_devnet_stack.sh
+```
+
+When the root units are masked, `scripts/update_devnet_stack.sh` can also use
+the default `auto` mode and will resolve the hub services from the user manager.
+
+Useful service commands:
+
+```bash
+systemctl --user status polystorechaind.service polystore-faucet.service polystore-gateway-router.service
+systemctl --user restart polystorechaind.service
+journalctl --user -u polystorechaind.service -f
+```
+
+## Root Still Belongs Elsewhere
+
+This handoff does not try to manage privileged ingress. Caddy, DNS, and public
+`:443` routing are still host-level concerns and may remain root-managed. The
+goal is narrower: routine PolyStore devnet build/install/restart work should be
+owned by the same unprivileged user that runs agents and local deploy scripts.

--- a/ops/systemd/README.md
+++ b/ops/systemd/README.md
@@ -62,6 +62,25 @@ The stack rollout script covers `provider-daemon` services provider1 through
 provider4 and restarts tunnel services only when `--restart-tunnels` is
 supplied.
 
+### Rootless Local Devnet Handoff
+
+Routine local devnet deploys should not depend on root-owned hub services. For a
+machine that already has `polystorechaind`, `polystore-faucet`, and
+`polystore-gateway-router` installed as root units, run the one-time handoff:
+
+```bash
+sudo -E scripts/devnet_rootless_handoff.sh --run-user "$USER"
+```
+
+This moves the hub to user systemd units, chowns the devnet install/config/state
+paths, and masks the root hub units by default. Afterward, use:
+
+```bash
+POLYSTORE_HUB_SERVICE_SCOPE=user scripts/update_devnet_stack.sh
+```
+
+See `docs/devnet-rootless-handoff.md`.
+
 4) Tail logs:
 
 ```bash

--- a/scripts/devnet_rootless_handoff.sh
+++ b/scripts/devnet_rootless_handoff.sh
@@ -1,0 +1,414 @@
+#!/usr/bin/env bash
+#
+# One-time handoff for a local trusted devnet whose hub services were installed
+# as root systemd units. After this script succeeds, the chain, faucet, and
+# user-gateway run as user systemd services so normal deploys can restart them
+# without sudo.
+
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+RUN_USER="${POLYSTORE_RUN_USER:-${SUDO_USER:-}}"
+RUN_GROUP=""
+TARGET_ROOT="${POLYSTORE_TARGET_ROOT:-/opt/polystore}"
+CONFIG_ROOT="${POLYSTORE_CONFIG_ROOT:-/etc/polystore}"
+STATE_ROOTS=()
+HUB_SERVICES=(polystorechaind.service polystore-faucet.service polystore-gateway-router.service)
+DISABLE_ROOT=1
+MASK_ROOT=1
+ENABLE_USER=1
+START_USER=1
+DRY_RUN=0
+
+usage() {
+  cat <<'EOF'
+Usage:
+  sudo -E scripts/devnet_rootless_handoff.sh [flags]
+
+Purpose:
+  Move the local devnet hub from root systemd units to user systemd units.
+  This is intended as a one-time root action. Afterward, recurring deploys can
+  run scripts/update_devnet_stack.sh with POLYSTORE_HUB_SERVICE_SCOPE=user
+  (or auto, when root units are masked) and should not need root to restart hub
+  services or overwrite installed devnet artifacts.
+
+Flags:
+  --run-user USER        User that should own and run the devnet.
+                         Default: POLYSTORE_RUN_USER, then SUDO_USER.
+  --target-root DIR      Installed artifact tree to chown (default: /opt/polystore).
+  --config-root DIR      EnvironmentFile directory to chown (default: /etc/polystore).
+  --state-root DIR       State root to chown. Can be repeated.
+                         Defaults: /var/lib/nilstore and /var/lib/polystore.
+  --service UNIT         Hub service to move. Can be repeated.
+                         Defaults: polystorechaind, polystore-faucet,
+                         polystore-gateway-router.
+  --no-disable-root      Leave root units enabled.
+  --no-mask-root         Do not mask root units after disabling them.
+  --no-enable-user       Install user units but do not enable them.
+  --no-start             Do not start user units after installation.
+  --dry-run              Print commands without mutating services or files.
+  -h, --help             Show this help.
+
+Notes:
+  - Run this from the repo whose ops/systemd templates you want installed.
+  - Existing files under /etc/polystore are preserved and made readable by
+    RUN_USER. Missing env files are copied from ops/systemd/env/*.env, but the
+    script refuses to start services while template placeholders remain.
+  - Root units are masked by default so a future root systemctl start cannot
+    silently recreate root-owned runtime state. Use --no-mask-root if you need
+    a reversible transition without masking.
+EOF
+}
+
+log() {
+  printf '[%s] %s\n' "$SCRIPT_NAME" "$*"
+}
+
+die() {
+  printf '[%s] ERROR: %s\n' "$SCRIPT_NAME" "$*" >&2
+  exit 1
+}
+
+print_cmd() {
+  printf '+'
+  printf ' %q' "$@"
+  printf '\n'
+}
+
+run_cmd() {
+  print_cmd "$@"
+  if [[ "$DRY_RUN" -eq 0 ]]; then
+    "$@"
+  fi
+}
+
+run_user_cmd() {
+  local runtime_dir="/run/user/$RUN_UID"
+  print_cmd runuser -u "$RUN_USER" -- env "XDG_RUNTIME_DIR=$runtime_dir" "DBUS_SESSION_BUS_ADDRESS=unix:path=$runtime_dir/bus" "$@"
+  if [[ "$DRY_RUN" -eq 0 ]]; then
+    runuser -u "$RUN_USER" -- env "XDG_RUNTIME_DIR=$runtime_dir" "DBUS_SESSION_BUS_ADDRESS=unix:path=$runtime_dir/bus" "$@"
+  fi
+}
+
+parse_args() {
+  local custom_state_roots=0
+  local custom_services=0
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --run-user)
+        [[ $# -ge 2 ]] || die "--run-user requires a value"
+        RUN_USER="$2"
+        shift 2
+        ;;
+      --run-user=*)
+        RUN_USER="${1#*=}"
+        shift
+        ;;
+      --target-root)
+        [[ $# -ge 2 ]] || die "--target-root requires a value"
+        TARGET_ROOT="$2"
+        shift 2
+        ;;
+      --target-root=*)
+        TARGET_ROOT="${1#*=}"
+        shift
+        ;;
+      --config-root)
+        [[ $# -ge 2 ]] || die "--config-root requires a value"
+        CONFIG_ROOT="$2"
+        shift 2
+        ;;
+      --config-root=*)
+        CONFIG_ROOT="${1#*=}"
+        shift
+        ;;
+      --state-root)
+        [[ $# -ge 2 ]] || die "--state-root requires a value"
+        if [[ "$custom_state_roots" -eq 0 ]]; then
+          STATE_ROOTS=()
+          custom_state_roots=1
+        fi
+        STATE_ROOTS+=("$2")
+        shift 2
+        ;;
+      --state-root=*)
+        if [[ "$custom_state_roots" -eq 0 ]]; then
+          STATE_ROOTS=()
+          custom_state_roots=1
+        fi
+        STATE_ROOTS+=("${1#*=}")
+        shift
+        ;;
+      --service)
+        [[ $# -ge 2 ]] || die "--service requires a value"
+        if [[ "$custom_services" -eq 0 ]]; then
+          HUB_SERVICES=()
+          custom_services=1
+        fi
+        HUB_SERVICES+=("$2")
+        shift 2
+        ;;
+      --service=*)
+        if [[ "$custom_services" -eq 0 ]]; then
+          HUB_SERVICES=()
+          custom_services=1
+        fi
+        HUB_SERVICES+=("${1#*=}")
+        shift
+        ;;
+      --no-disable-root)
+        DISABLE_ROOT=0
+        MASK_ROOT=0
+        shift
+        ;;
+      --no-mask-root)
+        MASK_ROOT=0
+        shift
+        ;;
+      --no-enable-user)
+        ENABLE_USER=0
+        shift
+        ;;
+      --no-start)
+        START_USER=0
+        shift
+        ;;
+      --dry-run)
+        DRY_RUN=1
+        shift
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        die "unknown argument: $1"
+        ;;
+    esac
+  done
+
+  if [[ "${#STATE_ROOTS[@]}" -eq 0 ]]; then
+    STATE_ROOTS=(/var/lib/nilstore /var/lib/polystore)
+  fi
+}
+
+require_root_for_live_run() {
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    return
+  fi
+  if [[ "$(id -u)" -ne 0 ]]; then
+    die "live handoff must run as root; use sudo -E scripts/devnet_rootless_handoff.sh"
+  fi
+}
+
+resolve_run_user() {
+  [[ -n "$RUN_USER" ]] || die "could not infer run user; pass --run-user USER"
+  if ! id "$RUN_USER" >/dev/null 2>&1; then
+    die "run user does not exist: $RUN_USER"
+  fi
+  RUN_UID="$(id -u "$RUN_USER")"
+  RUN_GID="$(id -g "$RUN_USER")"
+  RUN_GROUP="$(id -gn "$RUN_USER")"
+  RUN_HOME="$(getent passwd "$RUN_USER" | cut -d: -f6)"
+  [[ -n "$RUN_HOME" ]] || die "could not determine home directory for $RUN_USER"
+  USER_SYSTEMD_DIR="$RUN_HOME/.config/systemd/user"
+}
+
+ensure_user_manager() {
+  log "Enabling lingering and checking the user systemd manager"
+  run_cmd loginctl enable-linger "$RUN_USER"
+  run_cmd systemctl start "user@$RUN_UID.service"
+
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    return
+  fi
+
+  if [[ ! -S "/run/user/$RUN_UID/bus" ]]; then
+    die "user systemd bus is not available at /run/user/$RUN_UID/bus; log in as $RUN_USER once and rerun"
+  fi
+}
+
+root_unit_exists() {
+  local unit="$1"
+  local load_state
+  load_state="$(systemctl show "$unit" --property=LoadState --value 2>/dev/null || true)"
+  [[ "$load_state" == "loaded" || "$load_state" == "masked" ]]
+}
+
+stop_root_units() {
+  local unit
+
+  if [[ "$DISABLE_ROOT" -ne 1 ]]; then
+    log "Skipping root unit disable/stop because --no-disable-root was supplied"
+    return
+  fi
+
+  log "Stopping and disabling root hub units"
+  for unit in "${HUB_SERVICES[@]}"; do
+    if [[ "$DRY_RUN" -eq 0 ]] && ! root_unit_exists "$unit"; then
+      log "Root unit not loaded or masked, skipping: $unit"
+      continue
+    fi
+    run_cmd systemctl stop "$unit"
+    run_cmd systemctl disable "$unit"
+    if [[ "$MASK_ROOT" -eq 1 ]]; then
+      run_cmd systemctl mask --force "$unit"
+    fi
+  done
+}
+
+copy_env_template_if_missing() {
+  local service="$1"
+  local env_name="${service%.service}.env"
+  local src="$REPO_ROOT/ops/systemd/env/$env_name"
+  local dst="$CONFIG_ROOT/$env_name"
+
+  if [[ -e "$dst" ]]; then
+    return
+  fi
+
+  [[ -f "$src" ]] || die "missing env template for $service: $src"
+  run_cmd install -m 0640 -o "$RUN_USER" -g "$RUN_GROUP" "$src" "$dst"
+}
+
+chown_runtime_paths() {
+  local path
+
+  log "Making devnet install/config/state paths user-owned"
+  run_cmd install -d -m 0755 -o "$RUN_USER" -g "$RUN_GROUP" "$TARGET_ROOT"
+  run_cmd install -d -m 0750 -o "$RUN_USER" -g "$RUN_GROUP" "$CONFIG_ROOT"
+  for path in "${STATE_ROOTS[@]}"; do
+    run_cmd install -d -m 0750 -o "$RUN_USER" -g "$RUN_GROUP" "$path"
+  done
+
+  run_cmd chown -R "$RUN_USER:$RUN_GROUP" "$TARGET_ROOT"
+  run_cmd chown -R "$RUN_USER:$RUN_GROUP" "$CONFIG_ROOT"
+  for path in "${STATE_ROOTS[@]}"; do
+    run_cmd chown -R "$RUN_USER:$RUN_GROUP" "$path"
+  done
+}
+
+install_user_units() {
+  local unit src dst
+
+  log "Installing hub units into the user systemd manager"
+  run_cmd install -d -m 0755 -o "$RUN_USER" -g "$RUN_GROUP" "$USER_SYSTEMD_DIR"
+  for unit in "${HUB_SERVICES[@]}"; do
+    src="$REPO_ROOT/ops/systemd/$unit"
+    dst="$USER_SYSTEMD_DIR/$unit"
+    [[ -f "$src" ]] || die "missing systemd template: $src"
+    copy_env_template_if_missing "$unit"
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+      printf '+ sed %q %q > %q\n' 's/WantedBy=multi-user.target/WantedBy=default.target/' "$src" "$dst"
+    else
+      sed 's/WantedBy=multi-user.target/WantedBy=default.target/' "$src" > "$dst"
+      chown "$RUN_USER:$RUN_GROUP" "$dst"
+      chmod 0644 "$dst"
+    fi
+  done
+  run_user_cmd systemctl --user daemon-reload
+}
+
+env_files_ready_for_start() {
+  local unit env_file status=0
+
+  if [[ "$START_USER" -ne 1 ]]; then
+    return 0
+  fi
+
+  log "Checking environment files before starting user services"
+  for unit in "${HUB_SERVICES[@]}"; do
+    env_file="$CONFIG_ROOT/${unit%.service}.env"
+    if [[ ! -f "$env_file" ]]; then
+      printf '[%s] ERROR: missing env file: %s\n' "$SCRIPT_NAME" "$env_file" >&2
+      status=1
+      continue
+    fi
+    if grep -q '<set-me>' "$env_file"; then
+      printf '[%s] ERROR: env file still contains <set-me>: %s\n' "$SCRIPT_NAME" "$env_file" >&2
+      status=1
+    fi
+  done
+
+  if [[ "$status" -ne 0 ]]; then
+    die "refusing to start services with incomplete env files; edit them or rerun with --no-start"
+  fi
+}
+
+service_selected() {
+  local target="$1"
+  local unit
+  for unit in "${HUB_SERVICES[@]}"; do
+    if [[ "$unit" == "$target" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+enable_and_start_user_units() {
+  if [[ "$ENABLE_USER" -eq 1 ]]; then
+    log "Enabling user hub services"
+    run_user_cmd systemctl --user enable "${HUB_SERVICES[@]}"
+  fi
+
+  if [[ "$START_USER" -eq 1 ]]; then
+    log "Starting user hub services"
+    if service_selected polystorechaind.service; then
+      run_user_cmd systemctl --user start polystorechaind.service
+    fi
+    if service_selected polystore-faucet.service; then
+      run_user_cmd systemctl --user start polystore-faucet.service
+    fi
+    if service_selected polystore-gateway-router.service; then
+      run_user_cmd systemctl --user start polystore-gateway-router.service
+    fi
+    run_user_cmd systemctl --user --no-pager --full status "${HUB_SERVICES[@]}"
+  fi
+}
+
+print_followup() {
+  cat <<EOF
+
+Rootless devnet handoff complete.
+
+Future deploys can use:
+
+  POLYSTORE_HUB_SERVICE_SCOPE=user scripts/update_devnet_stack.sh
+
+If root units were masked, the rollout script's auto mode will also resolve the
+hub services from the user manager:
+
+  scripts/update_devnet_stack.sh --dry-run --skip-build
+
+Useful checks:
+
+  systemctl --user status ${HUB_SERVICES[*]}
+  systemctl --user restart polystorechaind.service
+  journalctl --user -u polystorechaind.service -f
+
+EOF
+}
+
+parse_args "$@"
+require_root_for_live_run
+resolve_run_user
+
+log "Repo root: $REPO_ROOT"
+log "Run user: $RUN_USER uid=$RUN_UID gid=$RUN_GID"
+log "Target root: $TARGET_ROOT"
+log "Config root: $CONFIG_ROOT"
+log "State roots: ${STATE_ROOTS[*]}"
+log "Hub services: ${HUB_SERVICES[*]}"
+
+ensure_user_manager
+stop_root_units
+chown_runtime_paths
+install_user_units
+env_files_ready_for_start
+enable_and_start_user_units
+print_followup

--- a/scripts/devnet_rootless_handoff.sh
+++ b/scripts/devnet_rootless_handoff.sh
@@ -247,13 +247,29 @@ stop_root_units() {
     return
   fi
 
-  log "Stopping and disabling root hub units"
+  log "Stopping root hub units before starting user hub units"
   for unit in "${HUB_SERVICES[@]}"; do
     if [[ "$DRY_RUN" -eq 0 ]] && ! root_unit_exists "$unit"; then
       log "Root unit not loaded or masked, skipping: $unit"
       continue
     fi
     run_cmd systemctl stop "$unit"
+  done
+}
+
+disable_and_mask_root_units() {
+  local unit
+
+  if [[ "$DISABLE_ROOT" -ne 1 ]]; then
+    return
+  fi
+
+  log "Disabling root hub units after user hub services are installed"
+  for unit in "${HUB_SERVICES[@]}"; do
+    if [[ "$DRY_RUN" -eq 0 ]] && ! root_unit_exists "$unit"; then
+      log "Root unit not loaded or masked, skipping: $unit"
+      continue
+    fi
     run_cmd systemctl disable "$unit"
     if [[ "$MASK_ROOT" -eq 1 ]]; then
       run_cmd systemctl mask --force "$unit"
@@ -406,9 +422,10 @@ log "State roots: ${STATE_ROOTS[*]}"
 log "Hub services: ${HUB_SERVICES[*]}"
 
 ensure_user_manager
-stop_root_units
 chown_runtime_paths
 install_user_units
 env_files_ready_for_start
+stop_root_units
 enable_and_start_user_units
+disable_and_mask_root_units
 print_followup

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -28,6 +28,9 @@ Environment:
   POLYSTORE_PROVIDER_SERVICE_SCOPE
                                 Provider service manager: auto, user, or root
                                 (default: auto).
+  POLYSTORE_HUB_SERVICE_SCOPE   Hub service manager for polystorechaind,
+                                faucet, and user-gateway: auto, user, or root
+                                (default: auto).
   POLYSTORE_TUNNEL_SERVICES     Space-separated tunnel user services.
                                 Default: cloudflared-hub.service cloudflared-providers.service.
   POLYSTORE_RPC_BASE            Hub Tendermint RPC base URL (default: http://127.0.0.1:26657).
@@ -152,7 +155,8 @@ for provider_service in "${PROVIDER_SERVICES[@]}"; do
   fi
   SEEN_PROVIDER_SERVICES["$provider_service"]=1
 done
-read -r -a ROOT_SERVICES <<<"polystorechaind.service polystore-faucet.service polystore-gateway-router.service"
+read -r -a HUB_SERVICES <<<"polystorechaind.service polystore-faucet.service polystore-gateway-router.service"
+HUB_SERVICE_SCOPE="${POLYSTORE_HUB_SERVICE_SCOPE:-auto}"
 read -r -a TUNNEL_SERVICES <<<"${POLYSTORE_TUNNEL_SERVICES:-cloudflared-hub.service cloudflared-providers.service}"
 RPC_BASE="${POLYSTORE_RPC_BASE:-http://127.0.0.1:26657}"
 LCD_BASE="${POLYSTORE_LCD_BASE:-http://127.0.0.1:1317}"
@@ -177,6 +181,15 @@ case "$PROVIDER_SERVICE_SCOPE" in
     ;;
   *)
     echo "ERROR: POLYSTORE_PROVIDER_SERVICE_SCOPE must be auto, user, or root." >&2
+    exit 2
+    ;;
+esac
+
+case "$HUB_SERVICE_SCOPE" in
+  auto|user|root)
+    ;;
+  *)
+    echo "ERROR: POLYSTORE_HUB_SERVICE_SCOPE must be auto, user, or root." >&2
     exit 2
     ;;
 esac
@@ -569,6 +582,134 @@ provider_systemctl() {
   return "$status"
 }
 
+declare -a HUB_USER_SERVICES=()
+declare -a HUB_ROOT_SERVICES=()
+declare -A HUB_SERVICE_MANAGER=()
+HUB_SERVICE_SCOPES_RESOLVED=0
+
+require_hub_service_loaded() {
+  local scope="$1"
+  local service="$2"
+  local load_state
+
+  if [[ "$scope" == "user" ]]; then
+    load_state="$(user_unit_load_state "$service" || true)"
+  else
+    load_state="$(root_unit_load_state "$service" || true)"
+  fi
+
+  if ! unit_is_loaded "$load_state"; then
+    echo "ERROR: hub service $service is not loaded in the $scope systemd manager." >&2
+    echo "       LoadState=$(describe_load_state "$load_state"); fix the unit before stopping services." >&2
+    exit 1
+  fi
+}
+
+resolve_hub_service_scopes() {
+  local service user_state root_state found_any=0
+
+  if [[ "$HUB_SERVICE_SCOPES_RESOLVED" -eq 1 ]]; then
+    return
+  fi
+
+  HUB_USER_SERVICES=()
+  HUB_ROOT_SERVICES=()
+  HUB_SERVICE_MANAGER=()
+  echo "==> Resolving hub service managers"
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "    DRY-RUN: validating loaded hub services with non-mutating systemctl show"
+  fi
+
+  case "$HUB_SERVICE_SCOPE" in
+    user)
+      for service in "${HUB_SERVICES[@]}"; do
+        require_hub_service_loaded user "$service"
+        HUB_USER_SERVICES+=("$service")
+        HUB_SERVICE_MANAGER["$service"]="user"
+      done
+      ;;
+    root)
+      for service in "${HUB_SERVICES[@]}"; do
+        require_hub_service_loaded root "$service"
+        HUB_ROOT_SERVICES+=("$service")
+        HUB_SERVICE_MANAGER["$service"]="root"
+      done
+      ;;
+    auto)
+      for service in "${HUB_SERVICES[@]}"; do
+        user_state="$(user_unit_load_state "$service" || true)"
+        root_state="$(root_unit_load_state "$service" || true)"
+
+        if unit_is_loaded "$user_state" && unit_is_loaded "$root_state"; then
+          echo "ERROR: hub service $service exists in both user and root managers." >&2
+          echo "       Set POLYSTORE_HUB_SERVICE_SCOPE=user or root for this rollout." >&2
+          exit 1
+        fi
+
+        if unit_is_loaded "$user_state"; then
+          HUB_USER_SERVICES+=("$service")
+          HUB_SERVICE_MANAGER["$service"]="user"
+          found_any=1
+          continue
+        fi
+
+        if unit_is_loaded "$root_state"; then
+          HUB_ROOT_SERVICES+=("$service")
+          HUB_SERVICE_MANAGER["$service"]="root"
+          found_any=1
+          continue
+        fi
+
+        echo "ERROR: hub service is not loaded in user or root systemd managers: $service" >&2
+        echo "       user LoadState=$(describe_load_state "$user_state"), root LoadState=$(describe_load_state "$root_state")." >&2
+        exit 1
+      done
+
+      if [[ "$found_any" -ne 1 ]]; then
+        echo "ERROR: no hub services were loaded in user or root systemd managers." >&2
+        echo "       Set POLYSTORE_HUB_SERVICE_SCOPE for this host." >&2
+        exit 1
+      fi
+      ;;
+  esac
+
+  if [[ "${#HUB_USER_SERVICES[@]}" -gt 0 ]]; then
+    echo "    user manager: ${HUB_USER_SERVICES[*]}"
+  fi
+  if [[ "${#HUB_ROOT_SERVICES[@]}" -gt 0 ]]; then
+    echo "    root manager: ${HUB_ROOT_SERVICES[*]}"
+  fi
+  HUB_SERVICE_SCOPES_RESOLVED=1
+}
+
+hub_systemctl_each() {
+  local action="$1"
+  shift
+
+  local service manager status=0
+  resolve_hub_service_scopes
+  for service in "$@"; do
+    manager="${HUB_SERVICE_MANAGER[$service]:-}"
+    case "$manager" in
+      user)
+        user_systemctl "$action" "$service" || status=$?
+        ;;
+      root)
+        root_systemctl "$action" "$service" || status=$?
+        ;;
+      "")
+        echo "ERROR: hub service $service was not resolved for this rollout." >&2
+        status=1
+        ;;
+      *)
+        echo "ERROR: unknown hub service manager for $service: $manager" >&2
+        status=1
+        ;;
+    esac
+  done
+  return "$status"
+}
+
 preflight_required_tools() {
   echo "==> Preflighting local command dependencies"
   if ! command -v curl >/dev/null; then
@@ -581,6 +722,13 @@ preflight_required_tools() {
 
 preflight_root_service_control() {
   echo "==> Preflighting root service control before stopping services"
+  resolve_hub_service_scopes
+  resolve_provider_service_scopes
+  if [[ "${#HUB_ROOT_SERVICES[@]}" -eq 0 && "${#PROVIDER_ROOT_SERVICES[@]}" -eq 0 ]]; then
+    echo "    no root-managed hub or provider-daemon services resolved"
+    return
+  fi
+
   if [[ "$IS_ROOT" -eq 1 ]]; then
     echo "    running as root; root systemd control is available"
     return
@@ -591,10 +739,10 @@ preflight_root_service_control() {
     return
   fi
 
-  preflight_root_systemctl_authorized_each stop polystore-gateway-router.service polystore-faucet.service
-  preflight_root_systemctl_authorized_each stop polystorechaind.service
-  preflight_root_systemctl_authorized_each start polystorechaind.service
-  preflight_root_systemctl_authorized_each start polystore-faucet.service polystore-gateway-router.service
+  if [[ "${#HUB_ROOT_SERVICES[@]}" -gt 0 ]]; then
+    preflight_root_systemctl_authorized_each stop "${HUB_ROOT_SERVICES[@]}"
+    preflight_root_systemctl_authorized_each start "${HUB_ROOT_SERVICES[@]}"
+  fi
   if [[ "${#PROVIDER_ROOT_SERVICES[@]}" -gt 0 ]]; then
     preflight_root_systemctl_authorized_each stop "${PROVIDER_ROOT_SERVICES[@]}"
     preflight_root_systemctl_authorized_each start "${PROVIDER_ROOT_SERVICES[@]}"
@@ -634,24 +782,9 @@ preflight_root_systemctl_authorized() {
   exit 1
 }
 
-preflight_root_services_loaded() {
-  local service load_state
-
-  echo "==> Preflighting hub root service units"
-  if [[ "$DRY_RUN" == "1" ]]; then
-    echo "    DRY-RUN: validating loaded root services with non-mutating systemctl show: ${ROOT_SERVICES[*]}"
-  fi
-
-  for service in "${ROOT_SERVICES[@]}"; do
-    load_state="$(root_unit_load_state "$service" || true)"
-    if ! unit_is_loaded "$load_state"; then
-      echo "ERROR: hub root service $service is not loaded in the root systemd manager." >&2
-      echo "       LoadState=$(describe_load_state "$load_state"); fix the unit before stopping services." >&2
-      echo "       Fix POLYSTORE root service inventory before stopping provider-daemon services." >&2
-      exit 1
-    fi
-  done
-  echo "    root services loaded: ${ROOT_SERVICES[*]}"
+preflight_hub_services_loaded() {
+  echo "==> Preflighting hub service units"
+  resolve_hub_service_scopes
 }
 
 preflight_tunnel_services_loaded() {
@@ -937,7 +1070,8 @@ print_source_evidence() {
   fi
   echo "    provider-daemon services: ${PROVIDER_SERVICES[*]}"
   echo "    provider-daemon service scope: $PROVIDER_SERVICE_SCOPE"
-  echo "    root services: ${ROOT_SERVICES[*]}"
+  echo "    hub services: ${HUB_SERVICES[*]}"
+  echo "    hub service scope: $HUB_SERVICE_SCOPE"
   echo "    rpc base: $RPC_BASE"
   echo "    lcd base: $LCD_BASE"
   echo "    evm base: $EVM_BASE"
@@ -956,15 +1090,20 @@ print_source_evidence() {
 }
 
 print_service_status() {
-  echo "==> Root service activity"
-  if ! root_systemctl_each is-active "${ROOT_SERVICES[@]}"; then
-    echo "WARNING: root service activity status probe failed after healthchecks." >&2
+  echo "==> Hub service activity"
+  if ! hub_systemctl_each is-active "${HUB_SERVICES[@]}"; then
+    echo "WARNING: hub service activity status probe failed after healthchecks." >&2
   fi
   if [[ "$DRY_RUN" != "1" ]]; then
-    if [[ "$IS_ROOT" -eq 1 ]]; then
-      systemctl --no-pager --full status "${ROOT_SERVICES[@]}" | sed -n '1,160p' || true
-    else
-      systemctl --no-pager --full status "${ROOT_SERVICES[@]}" | sed -n '1,160p' || true
+    if [[ "${#HUB_USER_SERVICES[@]}" -gt 0 && "$IS_ROOT" -eq 1 ]]; then
+      runuser -u "$RUN_USER" -- env XDG_RUNTIME_DIR="/run/user/$RUN_UID" systemctl --user --no-pager --full status "${HUB_USER_SERVICES[@]}" | sed -n '1,160p' || true
+    elif [[ "${#HUB_USER_SERVICES[@]}" -gt 0 ]]; then
+      env XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$RUN_UID}" systemctl --user --no-pager --full status "${HUB_USER_SERVICES[@]}" | sed -n '1,160p' || true
+    fi
+    if [[ "${#HUB_ROOT_SERVICES[@]}" -gt 0 && "$IS_ROOT" -eq 1 ]]; then
+      systemctl --no-pager --full status "${HUB_ROOT_SERVICES[@]}" | sed -n '1,160p' || true
+    elif [[ "${#HUB_ROOT_SERVICES[@]}" -gt 0 ]]; then
+      systemctl --no-pager --full status "${HUB_ROOT_SERVICES[@]}" | sed -n '1,160p' || true
     fi
   fi
 
@@ -1022,7 +1161,7 @@ preflight_required_tools
 build_artifacts
 preflight_artifacts
 preflight_install_plan
-preflight_root_services_loaded
+preflight_hub_services_loaded
 preflight_tunnel_services_loaded
 resolve_provider_service_scopes
 preflight_root_service_control
@@ -1034,8 +1173,8 @@ fi
 
 echo "==> Stop order: provider-daemons -> user-gateway/faucet -> chain"
 provider_systemctl stop
-root_systemctl_each stop polystore-gateway-router.service polystore-faucet.service
-root_systemctl stop polystorechaind.service
+hub_systemctl_each stop polystore-gateway-router.service polystore-faucet.service
+hub_systemctl_each stop polystorechaind.service
 
 echo "==> Installing binaries and runtime inputs"
 install_with_backup "$SOURCE_ROOT/polystore_core/target/release/libpolystore_core.so" "$TARGET_ROOT/polystore_core/target/release/libpolystore_core.so" 755
@@ -1046,9 +1185,9 @@ install_with_backup "$SOURCE_ROOT/polystore_cli/target/release/polystore_cli" "$
 install_with_backup "$SOURCE_ROOT/polystorechain/trusted_setup.txt" "$TARGET_ROOT/polystorechain/trusted_setup.txt" 644
 
 echo "==> Start order: chain -> faucet/user-gateway -> provider-daemons"
-root_systemctl start polystorechaind.service
+hub_systemctl_each start polystorechaind.service
 wait_http "LCD node_info" "$LCD_BASE/cosmos/base/tendermint/v1beta1/node_info" 90
-root_systemctl_each start polystore-faucet.service polystore-gateway-router.service
+hub_systemctl_each start polystore-faucet.service polystore-gateway-router.service
 wait_http "faucet" "$FAUCET_BASE/health" 45
 wait_http "user-gateway (legacy router service)" "$ROUTER_BASE/health" 45
 provider_systemctl start


### PR DESCRIPTION
## Summary
- add a one-time `scripts/devnet_rootless_handoff.sh` script to move local hub services from root systemd units to user systemd units
- teach `scripts/update_devnet_stack.sh` to resolve hub services from user or root systemd managers via `POLYSTORE_HUB_SERVICE_SCOPE`
- document the rootless handoff and routine rollout workflow

## Validation
- `bash -n scripts/devnet_rootless_handoff.sh scripts/update_devnet_stack.sh`
- `shellcheck scripts/devnet_rootless_handoff.sh scripts/update_devnet_stack.sh`
- `scripts/devnet_rootless_handoff.sh --run-user mikers --dry-run --no-start`
- `scripts/update_devnet_stack.sh --dry-run --skip-build --source-root /opt/polystore`
- `git diff --check`
