### PR TITLE
[codex] Define chain-funded PolyStore DA Deals

### DIFF
--- a/docs/chain-funded-da-deal-policy-fixtures.md
+++ b/docs/chain-funded-da-deal-policy-fixtures.md
@@ -1,0 +1,269 @@
+# Chain-Funded DA Deal Policy Fixtures
+
+**Status:** Planning fixtures for protocol, product, and simulation work
+**Related:**
+`rfcs/rfc-chain-funded-da-deals.md`,
+`rfcs/rfc-polyfs-da-lanes.md`,
+`docs/polyfs-chain-funded-da-deals.md`
+
+These fixtures are not final mainnet parameters. They are concrete profiles to
+keep implementation, simulations, and founder conversations grounded in real
+chain shapes.
+
+-----
+
+## Fixture A: Major L2 Retained DA
+
+**Target public chains:** Base, Arbitrum, World Chain, OP Mainnet, Unichain
+
+**Initial PolyStore role:** retained DA, historical blob retrieval, indexer
+backfill, challenger recovery, and public history. Source DA remains the
+primary settlement security layer at first.
+
+```yaml
+fixture_id: retained-major-l2-v0
+default_certificate_tier: DA_CERT_RETAINED
+primary_security_source: ethereum_blob_da
+logical_da_per_day: 0.5-2 GB
+erasure_profile: RS(8,12)
+min_providers: 12
+max_providers: 24
+min_attesting_slots: 10
+target_cert_latency: 10s-60s
+retention_window: 365d
+retrieval_payment_policy: sponsored_for_protocol_reads_requester_pays_public
+repair_policy: repair_below_10_healthy_slots
+scale_up_policy: add_providers_on_hot_retrieval_or_repair_backlog
+```
+
+Why it matters:
+
+* This is the easiest wedge because it does not ask a conservative L2 to switch
+  primary DA first.
+* It monetizes durable retrieval, backfills, explorer/indexer data, and node
+  recovery.
+* It creates proof that PolyStore can retain and serve public rollup history
+  before asking bridges to trust PolyStore certificates as primary DA.
+
+Required evidence:
+
+* one-year storage projection by chain;
+* retrieval throughput for 1, 10, and 50 concurrent backfill readers;
+* failed-provider repair time; and
+* proof bundle for a retained historical batch.
+
+-----
+
+## Fixture B: OP Stack Alt-DA Primary Pilot
+
+**Target public chains:** Mode, Zora, Soneium, World Chain test environment,
+new OP Stack appchains
+
+**Initial PolyStore role:** primary attestation-first DA through an OP Stack
+Alt-DA adapter once `DA_CERT_FAST` and `DA_CERT_RETRIEVABLE` verifier fixtures
+exist.
+
+```yaml
+fixture_id: op-stack-alt-da-primary-v0
+default_certificate_tier: DA_CERT_RETRIEVABLE
+settlement_context: op_stack_alt_da
+logical_da_per_day: 10-500 MB
+max_batch_bytes: 8-64 MiB
+erasure_profile: RS(8,12)
+min_providers: 12
+max_providers: 24
+min_attesting_slots: 10
+target_fast_cert_latency: 2s-10s
+target_retrievable_cert_latency: 10s-60s
+sample_policy: delayed_randomness_policy_v0
+retention_window: 30d-365d
+retrieval_payment_policy: chain_sponsored_derivation_requester_pays_public
+repair_policy: repair_below_10_healthy_slots
+```
+
+Why it matters:
+
+* OP Stack already has the conceptual interface for an Alt-DA server and
+  challenge semantics.
+* This is the cleanest path from "PolyStore stores and serves DA history" to
+  "PolyStore certificates can be accepted before settlement."
+* Small and mid-size OP Stack chains are more plausible pilots than the largest
+  L2s.
+
+Required evidence:
+
+* adapter can submit and retrieve batches through the PolyStore user-gateway;
+* mock verifier rejects wrong-tier, stale, and insufficient-quorum
+  certificates;
+* derivation path can recover batch bytes from retained PolyStore data; and
+* certificate latency stays inside the chosen policy window.
+
+-----
+
+## Fixture C: Orbit / AnyTrust-Style DA Deal
+
+**Target public chains:** Arbitrum Nova, Xai, ApeChain, RARI/Treasure-style
+Orbit chains
+
+**Initial PolyStore role:** replace or augment a static committee-shaped DA
+assumption with a provider-daemon market, Availability Certificates, retained
+retrieval, and repair.
+
+```yaml
+fixture_id: orbit-anytrust-da-deal-v0
+default_certificate_tier: DA_CERT_RETRIEVABLE
+settlement_context: orbit_anytrust_style
+logical_da_per_day: 50-500 MB
+max_batch_bytes: 8-64 MiB
+erasure_profile: RS(8,12)
+min_providers: 12
+max_providers: 36
+min_attesting_slots: 10
+target_fast_cert_latency: 2s-10s
+target_retrievable_cert_latency: 10s-60s
+retention_window: 90d-365d
+retrieval_payment_policy: chain_sponsored_for_derivation_and_challenge_reads
+repair_policy: repair_below_10_healthy_slots_with_hot_retrieval_scale_up
+```
+
+Why it matters:
+
+* AnyTrust-style systems already understand availability certificates and data
+  committees.
+* Xai and ApeChain-like game/consumer systems produce public history that can
+  be valuable for replay, analytics, indexers, and explorers.
+* PolyStore can differentiate by attaching retained retrieval and repair to the
+  certificate rather than stopping at committee signatures.
+
+Required evidence:
+
+* provider assignment can scale beyond a static committee;
+* public retrieval remains available during a simulated game/indexer burst;
+* retained status degrades and repairs without rewriting historical certificate
+  issuance; and
+* usage accounting separates publication, retrieval, retention, and repair.
+
+-----
+
+## Fixture D: Small Appchain Launch Deal
+
+**Target public chains:** new OP Stack, Orbit, game, NFT, social, and appchain
+launches
+
+**Initial PolyStore role:** "DA included at launch" package with one treasury
+account, one DA Deal, one lane, default retention, and predictable budget
+runway.
+
+```yaml
+fixture_id: small-appchain-launch-v0
+default_certificate_tier: DA_CERT_RETRIEVABLE
+settlement_context: generic_rollup_or_appchain
+logical_da_per_day: 10-100 MB
+max_batch_bytes: 1-16 MiB
+erasure_profile: RS(8,12)
+min_providers: 12
+max_providers: 18
+min_attesting_slots: 10
+target_fast_cert_latency: 2s-10s
+target_retrievable_cert_latency: 10s-60s
+retention_window: 90d
+retrieval_payment_policy: chain_sponsored_limited_public_reads
+repair_policy: repair_below_10_healthy_slots
+scale_up_policy: manual_or_policy_triggered_after_sustained_heat
+```
+
+Why it matters:
+
+* This is the simplest customer story: the chain funds one Deal and receives
+  availability certificates plus retained retrieval.
+* The scale is small enough for devnet and early testnet proof without masking
+  protocol issues behind huge infrastructure.
+* It gives a clean path for founder-led design partners.
+
+Required evidence:
+
+* end-to-end local devnet launch fixture;
+* policy-created lane and backing storage deal;
+* `DA_CERT_FAST` and `DA_CERT_RETRIEVABLE` issuance;
+* public retrieval with rate limits; and
+* low-funding pause behavior.
+
+-----
+
+## Fixture E: Modular DA Retained Retrieval
+
+**Target public chains/ecosystems:** Manta Pacific, Eclipse, Initia-style and
+Movement-style modular chains
+
+**Initial PolyStore role:** retained retrieval and recovery layer while the
+source DA system remains primary for publication security.
+
+```yaml
+fixture_id: modular-retained-retrieval-v0
+default_certificate_tier: DA_CERT_RETAINED
+primary_security_source: external_modular_da
+logical_da_per_day: 100 MB-10 GB
+erasure_profile: RS(8,12) or wider profile for high-throughput chains
+min_providers: 12
+max_providers: 48
+min_attesting_slots: 10
+target_cert_latency: 30s-300s
+retention_window: 180d-730d
+retrieval_payment_policy: requester_pays_with_chain_sponsored_recovery_budget
+repair_policy: repair_below_policy_health_threshold
+scale_up_policy: add_providers_on_retrieval_heat_or_retention_growth
+```
+
+Why it matters:
+
+* This does not require displacing Celestia or another source DA layer.
+* It gives modular chains durable recovery, public history, and paid retrieval.
+* It keeps PolyStore in the DA stack while the sampling-first research track
+  remains separate.
+
+Required evidence:
+
+* external source-DA commitment can be mapped to a PolyStore retained
+  generation;
+* historical range retrieval works by source namespace and height;
+* recovery reads are economically accounted for; and
+* retention renewal/migration is visible before service degradation.
+
+-----
+
+## Cross-Fixture Defaults
+
+Recommended provider profile:
+
+```yaml
+erasure_profile: RS(8,12)
+min_attesting_slots: 10
+hard_reconstructability_floor: 8
+repair_trigger: fewer_than_10_healthy_slots
+initial_provider_count: 12
+scale_up_provider_count: 18-48
+```
+
+Recommended budget classes:
+
+```yaml
+publication_budget: required
+retrieval_budget: required
+retention_budget: required
+repair_budget: required
+```
+
+Recommended public reporting:
+
+```yaml
+usage_window:
+  batches_published: true
+  logical_bytes_published: true
+  encoded_bytes_stored: true
+  certificate_count_by_tier: true
+  retrieval_bytes_served: true
+  repair_bytes_moved: true
+  projected_runway_by_budget: true
+```
+
+These defaults should become test fixtures once the chain objects exist.

--- a/docs/polyfs-chain-funded-da-deals.md
+++ b/docs/polyfs-chain-funded-da-deals.md
@@ -1,0 +1,421 @@
+# PolyFS Chain-Funded DA Deals
+
+**Status:** Founder strategy and technical sizing memo
+**Date:** 2026-06-29
+**Related RFCs:**
+`rfcs/rfc-polyfs-da-lanes.md`,
+`rfcs/rfc-chain-funded-da-deals.md`
+
+-----
+
+## Thesis
+
+PolyStore's best DA product is a standing availability contract for chains.
+
+The product line is:
+
+> Launch a chain with a DA Deal: publish batches, get availability
+> certificates, and keep the data retrievable for as long as the chain funds it.
+
+A chain-funded DA Deal is a standing service contract between a chain and the
+PolyStore availability-provider market. The chain funds publication,
+certification, retained retrieval, repair, and provider elasticity through a
+policy-governed Deal.
+
+In this model:
+
+* the chain's sequencer or batcher publishes ordered batches;
+* a PolyStore user-gateway or disperser encodes and disperses the batch;
+* protocol-selected provider-daemons store assigned artifacts and sign
+  attestations;
+* the PolyStore chain issues tiered Availability Certificates; and
+* derivation nodes, challengers, indexers, explorers, and archival clients can
+  retrieve the data while the Deal remains funded.
+
+The key product primitive is the **DA Deal**, not a one-off blob upload. DA
+Lanes are how batches are appended. Availability Certificates are how external
+systems accept them. Deals are how the chain continuously funds storage,
+retrieval, repair, and provider elasticity.
+
+-----
+
+## System Shape
+
+```text
+Chain
+  -> Chain-funded DA Deal
+    -> DA Lane
+      -> Batch publication
+        -> Provider assignment
+        -> Artifact dispersal
+        -> Provider availability attestations
+        -> DA_CERT_FAST
+        -> Publication-time retrieval samples
+        -> DA_CERT_RETRIEVABLE
+        -> Retained-generation audits, repair, and paid retrieval
+```
+
+| Term | Meaning |
+|---|---|
+| **Sequencer** | Orders transactions and produces chain blocks. |
+| **Batcher / publisher** | Compresses chain data into ordered DA batches and submits them to the DA lane. |
+| **Disperser / user-gateway** | Encodes the batch, derives commitments, disperses assigned artifacts, aggregates attestations, and polls certificates. |
+| **Availability provider / provider-daemon** | Receives assigned artifacts, verifies them, persists them under the referenced Deal/generation/slot, signs availability attestations, and serves samples/retrievals. |
+| **Availability Certificate** | Compact certificate that a batch satisfied a named policy and tier. |
+| **DA verifier / bridge** | External verifier, bridge, or contract that checks the certificate before accepting the batch root. |
+| **Derivation node** | Chain node that reconstructs the input stream from DA data. |
+| **Challenger / prover** | Independent actor that retrieves data to verify or challenge chain execution. |
+| **Indexer / explorer / archival client** | Long-lived reader that needs retained history and backfills. |
+
+The publication path and retrieval path should be modeled separately. A
+sequencer and batcher need the full batch. Provider-daemons generally need only
+their assigned encoded artifacts. External verifiers need a compact certificate,
+not the whole batch. Derivation nodes and indexers need data later, and may
+generate more aggregate bandwidth than initial publication.
+
+-----
+
+## Public Chain Targets
+
+These are public examples and should remain in the repo. The purpose is to make
+the product thesis concrete against actual chains and data footprints.
+
+### OP Stack and Superchain-style chains
+
+OP Stack is the most direct first integration surface because its Alt-DA mode
+already describes a DA server, L1 commitments, and challenge-window semantics.
+PolyStore can implement this as:
+
+```text
+op-batcher -> PolyStore DA server/user-gateway -> DA Lane
+  -> Availability Certificate -> L1 commitment / challenge interface
+```
+
+Concrete public examples:
+
+| Chain | Best initial PolyStore role | Why it matters |
+|---|---|---|
+| **Base** | Retained DA and historical blob retrieval first; primary Alt-DA later only if trust/security posture permits. | Largest measured Ethereum blob rollup in the sample. Strong need for indexer, explorer, and node-bootstrap history. |
+| **OP Mainnet** | Retained DA and public historical retrieval. | Canonical OP Stack chain; useful reference target even if not first primary Alt-DA customer. |
+| **World Chain** | Chain-funded DA Deal with retained retrieval; later primary Alt-DA candidate. | Consumer-scale chain where user activity can create bursty publication and retrieval demand. |
+| **Unichain** | Retained DA and high-availability retrieval for economic data. | Financial activity creates high-value backfill and indexer demand. |
+| **Soneium** | Chain-funded retained DA; possible appchain-style primary DA later. | Consumer/application orientation makes retained data service legible. |
+| **Ink** | Retained DA and dual-DA. | Financial/application data benefits from durable history and retrieval SLAs. |
+| **Mode** | Small-to-mid retained DA and primary Alt-DA pilot candidate. | Current blob footprint is small enough for a controlled pilot. |
+| **Zora** | Strong narrative fit for retained DA and public retrieval. | Media/NFT/social history is naturally long-lived and public. |
+| **Blast / Katana** | Retained DA and app-specific retrieval guarantees. | Medium DA users where retrieval and history can become differentiated services. |
+
+### Arbitrum Orbit / AnyTrust-style chains
+
+AnyTrust-style systems already make Data Availability Committees and
+availability certificates part of the mental model. PolyStore's opportunity is
+to replace or augment a static committee with a paid, accountable provider
+market and retained retrieval.
+
+| Chain | Best initial PolyStore role | Why it matters |
+|---|---|---|
+| **Arbitrum One** | Retained DA / blob-history service rather than first primary replacement. | Large conservative target; useful for archive and indexer value. |
+| **Arbitrum Nova** | AnyTrust-style retained retrieval and DA Deal proof point. | Existing AnyTrust framing makes PolyStore Availability Certificates easy to explain. |
+| **Xai** | Game-chain DA Deal and elastic retained retrieval. | High transaction count and game-state replay needs fit paid public retrieval and event-driven scale-up. |
+| **ApeChain** | Game/consumer DA Deal and retained retrieval. | High observed transaction count; strong need for replayable public history. |
+| **RARI / Treasure-style Orbit chains** | Retained public history for NFTs, games, and marketplaces. | Data is culturally and economically valuable long after publication. |
+
+### Ethereum blob rollups
+
+For existing Ethereum blob rollups, the first PolyStore product should often be
+dual DA:
+
+```text
+Ethereum blob DA for primary settlement
++ PolyStore DA Deal for retained retrieval, backfills, and recovery
+```
+
+| Chain | Best initial PolyStore role | Why it matters |
+|---|---|---|
+| **Base** | Largest immediate retained-DA opportunity in the measured set. | About 1.2 GB/day raw blob data in the snapshot. |
+| **Arbitrum** | Retained blob archive and indexer recovery. | About 0.45 GB/day raw blob data in the snapshot. |
+| **World Chain** | Consumer-scale retained DA. | About 0.32 GB/day raw blob data in the snapshot. |
+| **OP Mainnet** | Canonical retained DA reference. | About 0.18 GB/day raw blob data in the snapshot. |
+| **Starknet, Linea, Scroll, Zircuit, Mantle** | Retained DA and public retrieval. | Smaller current footprints, useful for pilots and proof bundles. |
+
+### Celestia and modular DA users
+
+For Celestia or other modular DA users, PolyStore should start as the retained
+retrieval layer while the source DA system remains the primary publication
+security layer.
+
+| Chain / ecosystem | Best initial PolyStore role | Why it matters |
+|---|---|---|
+| **Manta Pacific** | Retained retrieval and recovery for source-DA data. | Publicly associated with modular DA and a natural archive target. |
+| **Eclipse** | Retained recovery and high-throughput historical reads. | SVM-style throughput can create valuable retained data demand. |
+| **Initia / Movement-style modular chains** | Dual DA and retained retrieval. | A chain can keep its source DA security while buying PolyStore history and retrieval. |
+
+-----
+
+## Public Data Snapshot
+
+Source snapshot:
+
+* Blobscan `stats/timeseries`, `timeFrame=7d`, `rollups=all`, metrics
+  `totalBlobs,totalBlobSize,totalBlobUsageSize,totalTransactions`.
+* Latest complete Blobscan UTC day in this snapshot:
+  `2026-06-29T00:00:00.000Z`.
+* Appchain explorer stats were read from public Blockscout-style APIs on
+  2026-06-29 Hawaii time / 2026-06-30 UTC.
+* Blob raw capacity uses Blobscan `totalBlobSize`.
+* `RS(8,12)` aggregate storage uses `1.5x` raw bytes before metadata,
+  indexing, certificates, hot replicas, and operational headroom.
+
+| Chain / rollup | Latest blobs/day | Blob tx/day | Latest raw GB/day | Latest used GB/day | 7d avg raw GB/day | 7d avg used GB/day | RS(8,12) GB/day | RS one-year GB |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| Base | 9,092 | 1,516 | 1.192 | 1.166 | 1.229 | 1.198 | 1.788 | 652.5 |
+| Arbitrum | 3,465 | 1,155 | 0.454 | 0.452 | 0.398 | 0.396 | 0.681 | 248.7 |
+| World Chain | 2,470 | 494 | 0.324 | 0.321 | 0.346 | 0.343 | 0.486 | 177.3 |
+| OP Mainnet | 1,375 | 275 | 0.180 | 0.179 | 0.208 | 0.207 | 0.270 | 98.7 |
+| Unichain | 783 | 261 | 0.103 | 0.102 | 0.109 | 0.108 | 0.154 | 56.2 |
+| Soneium | 700 | 140 | 0.092 | 0.092 | 0.176 | 0.175 | 0.138 | 50.2 |
+| Katana | 632 | 205 | 0.083 | 0.069 | 0.071 | 0.058 | 0.124 | 45.4 |
+| Ink | 612 | 102 | 0.080 | 0.080 | 0.075 | 0.075 | 0.120 | 43.9 |
+| Starknet | 228 | 38 | 0.030 | 0.030 | 0.028 | 0.028 | 0.045 | 16.4 |
+| Blast | 204 | 68 | 0.027 | 0.027 | 0.027 | 0.027 | 0.040 | 14.6 |
+| Mantle | 194 | 193 | 0.025 | 0.006 | 0.025 | 0.006 | 0.038 | 13.9 |
+| Mode | 83 | 50 | 0.011 | 0.007 | 0.009 | 0.005 | 0.016 | 6.0 |
+| Zircuit | 73 | 73 | 0.010 | 0.003 | 0.009 | 0.002 | 0.014 | 5.2 |
+| Linea | 30 | 10 | 0.004 | 0.004 | 0.004 | 0.004 | 0.006 | 2.2 |
+| Zora | 24 | 24 | 0.003 | 0.001 | 0.003 | 0.001 | 0.005 | 1.7 |
+| Scroll | 21 | 17 | 0.003 | 0.003 | 0.002 | 0.002 | 0.004 | 1.5 |
+
+Blobscan-labeled rollups in aggregate:
+
+| Category | Latest blobs/day | Blob tx/day | Latest raw GB/day | Latest used GB/day | 7d avg raw GB/day | RS(8,12) latest GB/day | RS one-year GB |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| All labeled rollups | 21,249 | 5,868 | 2.785 | 2.566 | 2.881 | 4.178 | 1,524.8 |
+
+Observed public explorer transaction counts:
+
+| Chain | Public API transactions today | Public API gas used today | Sizing interpretation |
+|---|---:|---:|---|
+| Xai | 166,948 | 8,970,958,827 | Roughly 50-250 MB/day logical DA before chain-specific compression measurement. |
+| ApeChain | 201,976 | 34,828,235,521 | Roughly 60-300 MB/day logical DA before chain-specific compression measurement. |
+| Arbitrum Nova | 8,357 | 1,917,608,431 | Roughly 2-15 MB/day logical DA before chain-specific compression measurement. |
+
+At current public blob-rollup scale, storage volume is not the gating problem.
+Even all Blobscan-labeled rollups together represent only about 1.5 TB/year of
+RS(8,12)-encoded retained data before headroom. The hard requirements are
+low-latency certification, provider accountability, retrieval under bursty
+reads, historical-generation addressability, and economic automation.
+
+-----
+
+## Bandwidth Model
+
+Let:
+
+```text
+B = logical DA batch bytes
+K = reconstruction threshold
+N = encoded provider slots
+r = N / K expansion factor
+T = publication certification target in seconds
+```
+
+For the default candidate profile:
+
+```text
+K = 8
+N = 12
+r = 1.5
+aggregate provider ingress = B * 1.5
+per-slot provider ingress = B / 8
+disperser egress during certification = B * 1.5 / T
+```
+
+| Batch size | Target cert latency | Disperser egress | Per-slot provider ingress |
+|---:|---:|---:|---:|
+| 8 MiB | 2s | 6.0 MiB/s | 0.5 MiB/s |
+| 64 MiB | 10s | 9.6 MiB/s | 0.8 MiB/s |
+| 256 MiB | 20s | 19.2 MiB/s | 1.6 MiB/s |
+| 1 GiB | 60s | 25.6 MiB/s | 2.1 MiB/s |
+
+Publication bandwidth is manageable. Retrieval bandwidth is the larger
+operational swing factor:
+
+```text
+retrieval egress ~= logical_DA_bytes * active_derivation_or_backfill_readers
+```
+
+A Base-like chain at about 1.2 GB/day is not difficult to publish. If 50
+derivation nodes, indexers, or backfill jobs retrieve the same day, the retained
+retrieval surface may see about 60 GB/day. If a chain has an incident and many
+nodes resync, retrieval demand can dominate publication demand.
+
+-----
+
+## Recommended Sizing Tiers
+
+| Tier | Logical DA/day | RS(8,12) storage/day | One-year RS storage | Intended customers |
+|---|---:|---:|---:|---|
+| Small appchain | 10-100 MB | 15-150 MB | 5-55 GB | New OP Stack, Orbit, game, NFT, or appchain pilots. |
+| Active appchain | 100-500 MB | 150-750 MB | 55-274 GB | Xai/ApeChain-like or active consumer appchains. |
+| Major L2 | 0.5-2 GB | 0.75-3 GB | 274 GB-1.1 TB | Base/Arbitrum/World-style retained DA. |
+| Multi-chain retained DA market | 3-10 GB | 4.5-15 GB | 1.6-5.5 TB | Portfolio of public rollups and appchains. |
+| Future high-throughput chain | 10-100 GB | 15-150 GB | 5.5-55 TB | A chain that outgrows current blob-rollup observed volumes. |
+
+The first production target should support **10-100 GB/day per chain** even
+though most public chains in the snapshot are below that. That gives enough
+headroom to credibly sell to appchains and mid-size L2s without overbuilding for
+hypothetical exabyte demand.
+
+-----
+
+## Provider and Quorum Model
+
+Recommended v0 policy:
+
+```text
+K = 8
+N = 12
+min_attesting_slots = 10
+repair_trigger = fewer than 10 healthy slots
+hard_reconstructability_floor = 8 slots
+```
+
+The reason to require more than `K` attestations is product quality. A
+publication certificate should not mean "barely reconstructable at the moment of
+signing." It should mean the assigned provider set had meaningful live margin.
+
+Larger profiles should scale `K` and `N` together:
+
+```text
+RS(16,24): 1.5x overhead, lower per-provider shard size
+RS(32,48): 1.5x overhead, wider provider distribution
+```
+
+-----
+
+## DA Deal Policy Surface
+
+A chain-funded DA Deal should expose these knobs:
+
+```text
+DADealPolicy {
+  chain_id
+  lane_id
+  settlement_context
+  treasury_account
+  allowed_publishers
+  max_batch_bytes
+  target_cert_latency
+  erasure_profile
+  min_providers
+  max_providers
+  min_attesting_slots
+  sample_policy
+  retention_window
+  retrieval_payment_policy
+  repair_policy
+  scale_up_policy
+  provider_diversity_policy
+}
+```
+
+The policy should separate four budgets:
+
+| Budget | Pays for |
+|---|---|
+| Publication budget | Encode/disperse/certify new batches. |
+| Retention budget | Keep historical generations addressable. |
+| Retrieval budget | Serve derivation nodes, indexers, challengers, explorers, and public users. |
+| Repair budget | Replace degraded providers and restore retained service. |
+
+Autonomous renewal matters. If the chain keeps funding the Deal, data remains
+retained. If the chain stops funding it, retained status can degrade according
+to policy without rewriting historical certificate facts.
+
+-----
+
+## Integration Priority
+
+1. **Retained DA for existing Ethereum blob rollups.**
+   Easiest wedge. Keep the current primary DA system and add retained,
+   verifiable, paid retrieval through PolyStore.
+
+2. **OP Stack Alt-DA adapter.**
+   Best first primary-DA integration surface because OP Stack already has an
+   Alt-DA server/challenge concept.
+
+3. **Orbit / AnyTrust-style DA Deal.**
+   Strong conceptual fit because DACerts and committees are already legible.
+   PolyStore can provide a provider market, retrieval accountability, and
+   retained service around that shape.
+
+4. **Generic verifier SDK and proof bundle export.**
+   Needed before serious rollup integrations. External systems should verify
+   compact certificates, not replay PolyStore internals.
+
+5. **Dual DA for Celestia/modular chains.**
+   Keep the existing DA security model and add retained retrieval, recovery,
+   and paid public history.
+
+-----
+
+## Product Positioning
+
+Canonical line:
+
+> Launch a chain with a DA Deal: publish batches, receive availability
+> certificates, and keep data retrievable for as long as the chain funds the
+> deal.
+
+Technical line:
+
+> PolyStore DA Deals combine attestation-first availability certificates with
+> native retained retrieval, repair, and provider elasticity.
+
+Target customer line:
+
+> Your chain funds one DA Deal. PolyStore handles provider assignment,
+> publication certificates, retained history, retrieval payments, and repair.
+
+-----
+
+## Required Next Artifacts
+
+This memo should be treated as the market and sizing companion to the formal
+RFCs. The implementation program should proceed through:
+
+1. `DADealPolicy` protobuf/types and chain state.
+2. A devnet `RS(8,12)` chain-funded DA Deal profile.
+3. `DA_CERT_FAST` certificate issuance for a fixed provider set.
+4. `DA_CERT_RETRIEVABLE` publication-time sample sessions.
+5. OP Stack Alt-DA adapter prototype.
+6. Retained DA service and historical-generation retrieval.
+7. Policy simulations for provider churn, retrieval demand shocks, and repair
+   budget exhaustion.
+
+-----
+
+## Sources
+
+* Blobscan API docs: `https://docs.blobscan.com/docs/api`
+* Blobscan time-series API:
+  `https://api.blobscan.com/stats/timeseries?timeFrame=7d&rollups=all&metrics=totalBlobs,totalBlobSize,totalBlobUsageSize,totalTransactions`
+* Blobscan category time-series API:
+  `https://api.blobscan.com/stats/timeseries?timeFrame=7d&categories=all&metrics=totalBlobs,totalBlobSize,totalBlobUsageSize,totalTransactions`
+* EIP-4844: `https://eips.ethereum.org/EIPS/eip-4844`
+* EigenDA overview:
+  `https://docs.eigencloud.xyz/eigenda/core-concepts/overview`
+* EigenDA integration overview:
+  `https://docs.eigencloud.xyz/eigenda/integrations-guides/rollup-guides/integrations-overview`
+* OP Stack Alt-DA docs:
+  `https://docs.optimism.io/op-stack/features/experimental/alt-da-mode`
+* OP Stack Alt-DA spec:
+  `https://specs.optimism.io/experimental/alt-da.html`
+* Arbitrum AnyTrust protocol:
+  `https://docs.arbitrum.io/how-arbitrum-works/deep-dives/anytrust-protocol`
+* Xai explorer stats:
+  `https://explorer.xai-chain.net/api/v2/stats`
+* ApeChain explorer stats:
+  `https://apechain.calderaexplorer.xyz/api/v2/stats`
+* Arbitrum Nova explorer stats:
+  `https://arbitrum-nova.blockscout.com/api/v2/stats`

--- a/docs/polyfs-chain-funded-da-deals.md
+++ b/docs/polyfs-chain-funded-da-deals.md
@@ -225,12 +225,13 @@ For the default candidate profile:
 K = 8
 N = 12
 r = 1.5
-aggregate provider ingress = B * 1.5
-per-slot provider ingress = B / 8
-disperser egress during certification = B * 1.5 / T
+aggregate encoded bytes = B * r
+per-slot encoded bytes = B / K
+disperser egress rate during certification = (B * r) / T
+per-slot provider ingress rate = (B / K) / T
 ```
 
-| Batch size | Target cert latency | Disperser egress | Per-slot provider ingress |
+| Batch size | Target cert latency | Disperser egress rate | Per-slot provider ingress rate |
 |---:|---:|---:|---:|
 | 8 MiB | 2s | 6.0 MiB/s | 0.5 MiB/s |
 | 64 MiB | 10s | 9.6 MiB/s | 0.8 MiB/s |

--- a/rfcs/rfc-chain-funded-da-deals.md
+++ b/rfcs/rfc-chain-funded-da-deals.md
@@ -1,0 +1,653 @@
+# RFC: Chain-Funded PolyStore DA Deals
+
+**Status:** Proposed
+**Scope:** Protocol, chain state, DA lanes, storage deals, funding policy,
+provider-daemon assignment, user-gateway/disperser behavior, retrieval
+economics
+**Depends on:**
+`whitepaper.md`,
+`rfcs/rfc-polyfs-da-lanes.md`,
+`rfcs/rfc-pricing-and-escrow-accounting.md`,
+`rfcs/rfc-retrieval-access-control-public-deals-and-vouchers.md`,
+`rfcs/rfc-mandatory-retrieval-sessions-and-batching.md`,
+`rfcs/rfc-polyfs-generation-cas-and-staged-writes.md`
+
+-----
+
+## 1. Summary
+
+This RFC defines **Chain-Funded DA Deals** as the canonical deployment object
+for PolyStore DA.
+
+The product line is:
+
+> Launch a chain with a DA Deal: publish batches, get availability
+> certificates, and keep data retrievable for as long as the chain funds it.
+
+A Chain-Funded DA Deal is a standing service contract between a chain and the
+PolyStore provider-daemon market. It links one external chain or application
+namespace to one or more DA lanes, backing storage deals, funding accounts,
+provider policies, retrieval policies, repair budgets, and scale-up rules.
+
+DA lanes remain the append-only publication streams. Availability Certificates
+remain the external verification objects. Storage deals remain the durable
+storage and economic substrate. A Chain-Funded DA Deal is the product and policy
+layer that makes those pieces usable by a chain treasury, sequencer, batcher,
+bridge, challenger, indexer, and public retrieval market.
+
+-----
+
+## 2. Motivation
+
+PolyStore has a natural DA wedge that is stronger than "decentralized storage
+as archive" and more realistic than claiming a fully sampling-first DA protocol
+before the research exists.
+
+The strong near-term shape is:
+
+* attestation-first DA certificates for publication-time acceptance;
+* publication-time retrieval samples for the `DA_CERT_RETRIEVABLE` tier;
+* retained PolyFS generations for historical access;
+* paid public retrieval for derivation nodes, challengers, indexers, explorers,
+  and users;
+* chain-funded renewal, repair, and provider elasticity; and
+* explicit policy objects that let a chain buy a DA service rather than
+  manually compose storage uploads.
+
+This is especially important because the measured public-chain data volumes are
+not the hard part. Current public blob-rollup volumes are manageable for a
+storage market. The hard part is making the service continuously funded,
+certifiable, retrievable under load, externally verifiable, and operationally
+accountable.
+
+-----
+
+## 3. Goals
+
+1. Define the product/deployment primitive for chains using PolyStore DA.
+2. Make chain treasury funding, renewal, and budget boundaries explicit.
+3. Link DA lanes, backing storage deals, certificate policies, retrieval
+   policies, repair policies, and provider scale-up rules.
+4. Support both retained-DA/dual-DA use cases and primary attestation-first DA
+   use cases.
+5. Provide a policy surface that can be mapped to OP Stack Alt-DA,
+   Arbitrum Orbit/AnyTrust-style systems, Ethereum blob-rollup retained DA,
+   and modular-chain retained retrieval.
+6. Make public chain targeting and sizing concrete enough for founder,
+   protocol, and business-development work.
+7. Preserve the security boundary from `rfcs/rfc-polyfs-da-lanes.md`: DA claims
+   depend on certificates, provider-daemon attestations, sample results, and
+   verifier policy, not on storage deals alone.
+
+-----
+
+## 4. Non-Goals
+
+This RFC does not:
+
+* claim current storage deals are already a complete primary DA layer;
+* define a Celestia-equivalent or PeerDAS-equivalent light-client sampling
+  protocol;
+* replace the DA certificate semantics in `rfcs/rfc-polyfs-da-lanes.md`;
+* finalize slashing or all fee-market parameters;
+* require every chain to use PolyStore as primary DA;
+* require every provider-daemon to store every byte; or
+* implement the messages proposed here.
+
+-----
+
+## 5. Terminology
+
+| Term | Meaning |
+|---|---|
+| **Chain-Funded DA Deal** | Standing PolyStore policy and funding object for one chain or application namespace. |
+| **DA Deal Policy** | Chain-visible parameters for allowed publishers, batch size, certificate tier, erasure profile, provider count, retrieval payment, repair, retention, and scale-up. |
+| **DA Lane** | Append-only publication stream defined in `rfcs/rfc-polyfs-da-lanes.md`. |
+| **Backing storage deal** | Existing PolyStore storage/economic object that stores retained generations and pays provider-daemons. |
+| **Treasury account** | Chain, bridge, foundation, sequencer, or governance-controlled account that funds publication, retrieval, repair, and retention. |
+| **Publisher** | Authorized sequencer, batcher, bridge, user-gateway, or disperser that appends batches. |
+| **provider-daemon** | Storage-provider runtime that receives assigned artifacts, verifies them, persists them, signs attestations, serves samples, and participates in repair. |
+| **user-gateway / disperser** | Client-side or service-side component that encodes batches, disperses artifacts, aggregates attestations, opens sample sessions, and exports proof bundles. |
+| **Availability Certificate** | Compact DA certificate emitted under a named policy and verified by an external chain, bridge, or application. |
+
+-----
+
+## 6. Product Shape
+
+The canonical service flow is:
+
+```text
+Chain treasury
+  -> funds Chain-Funded DA Deal
+    -> authorizes sequencer/batcher publishers
+      -> publishers append ordered batches to a DA Lane
+        -> user-gateway/disperser encodes and disperses artifacts
+          -> protocol-selected provider-daemons attest
+            -> PolyStore issues Availability Certificates
+              -> derivation nodes, challengers, indexers, explorers, and users
+                 retrieve retained data while the Deal remains funded
+```
+
+This object lets a new chain start with one explicit DA service contract:
+
+* one funding account;
+* one or more DA lanes;
+* one default certificate tier;
+* one retention target;
+* one retrieval payment policy;
+* one provider assignment policy; and
+* one scale-up policy.
+
+The chain should not need to manually manage individual storage uploads for
+every batch. It should fund a policy. The policy should create or link the
+necessary lane and backing-deal state.
+
+-----
+
+## 7. Proposed Chain Objects
+
+### 7.1 `DADealPolicy`
+
+```protobuf
+message DADealPolicy {
+  uint64 da_deal_id = 1;
+  string external_chain_id = 2;
+  string settlement_context = 3;
+  string treasury_account = 4;
+  repeated string allowed_publishers = 5;
+  repeated uint64 lane_ids = 6;
+  repeated uint64 backing_deal_ids = 7;
+  uint64 max_batch_bytes = 8;
+  uint64 target_cert_latency_ms = 9;
+  CertificateTier default_certificate_tier = 10;
+  string erasure_profile = 11;
+  uint32 min_providers = 12;
+  uint32 max_providers = 13;
+  uint32 min_attesting_slots = 14;
+  uint64 sample_policy_id = 15;
+  uint64 retention_window_blocks = 16;
+  uint64 retrieval_payment_policy_id = 17;
+  uint64 repair_policy_id = 18;
+  uint64 scale_up_policy_id = 19;
+  uint64 provider_diversity_policy_id = 20;
+  DADealStatus status = 21;
+}
+```
+
+`external_chain_id` is not necessarily a Cosmos chain id. It is the stable
+identifier for the chain, rollup, appchain, bridge, or namespace whose batches
+are being served.
+
+`settlement_context` describes where certificates are consumed, for example an
+Ethereum L1 contract, OP Stack Alt-DA commitment path, Orbit/AnyTrust verifier,
+or a generic SDK verifier.
+
+### 7.2 `DADealFundingAccount`
+
+```protobuf
+message DADealFundingAccount {
+  uint64 da_deal_id = 1;
+  string treasury_account = 2;
+  string publication_balance = 3;
+  string retrieval_balance = 4;
+  string retention_balance = 5;
+  string repair_balance = 6;
+  string low_watermark = 7;
+  string pause_watermark = 8;
+  uint64 last_funded_height = 9;
+  uint64 projected_runway_blocks = 10;
+}
+```
+
+The four balances SHOULD remain distinguishable:
+
+| Budget | Pays for |
+|---|---|
+| Publication | Encoding, dispersal, attestations, and certificate finalization. |
+| Retrieval | Sample sessions, derivation reads, indexer reads, explorer reads, and public retrieval subsidies. |
+| Retention | Ongoing storage of retained generations. |
+| Repair | Provider replacement, migration, and repair traffic after degradation. |
+
+Policies MAY allow one shared account internally, but accounting MUST preserve
+which service consumed funds.
+
+### 7.3 `DADealUsageWindow`
+
+```protobuf
+message DADealUsageWindow {
+  uint64 da_deal_id = 1;
+  uint64 window_start_height = 2;
+  uint64 window_end_height = 3;
+  uint64 batches_published = 4;
+  uint64 logical_bytes_published = 5;
+  uint64 encoded_bytes_stored = 6;
+  uint64 certificate_count = 7;
+  uint64 sample_count = 8;
+  uint64 retrieval_bytes_served = 9;
+  uint64 repair_bytes_moved = 10;
+  string publication_spend = 11;
+  string retrieval_spend = 12;
+  string retention_spend = 13;
+  string repair_spend = 14;
+}
+```
+
+Usage windows are needed for pricing, runway, policy tuning, and public
+reporting. They also make it possible to compare public chain footprints
+without pretending every chain has the same DA shape.
+
+### 7.4 `DADealScaleUpPolicy`
+
+```protobuf
+message DADealScaleUpPolicy {
+  uint64 scale_up_policy_id = 1;
+  uint64 da_deal_id = 2;
+  uint64 hot_retrieval_bytes_per_window = 3;
+  uint64 max_certificate_latency_ms = 4;
+  uint64 provider_error_rate_ppm = 5;
+  uint32 min_extra_providers = 6;
+  uint32 max_extra_providers = 7;
+  uint64 cooldown_blocks = 8;
+}
+```
+
+Scale-up is part of the product thesis. A chain should be able to fund a Deal
+and let PolyStore add provider-daemon capacity as publication bandwidth,
+retrieval demand, or repair pressure rises.
+
+-----
+
+## 8. Proposed Messages
+
+### 8.1 `MsgCreateDADealPolicy`
+
+Creates a chain-funded DA service policy.
+
+Required checks:
+
+* caller controls or is authorized by `treasury_account`;
+* `default_certificate_tier` is supported;
+* erasure profile is recognized;
+* provider, sample, retrieval, repair, and scale-up policies exist;
+* initial funding meets policy minimums; and
+* any linked backing deals or lanes are compatible with the policy.
+
+### 8.2 `MsgFundDADeal`
+
+Adds funds to one or more DA Deal budgets.
+
+Required checks:
+
+* sender owns funds;
+* budget class is supported;
+* balance accounting updates projected runway; and
+* low-watermark alerts clear only when all required budgets are restored.
+
+### 8.3 `MsgLinkDALane`
+
+Links an existing DA lane to a Chain-Funded DA Deal or creates a new lane under
+the policy.
+
+Required checks:
+
+* lane owner and DA Deal policy authorize the link;
+* lane `writer_policy` is compatible with `allowed_publishers`;
+* lane certificate policy is no weaker than the DA Deal target; and
+* lane backing deals satisfy retention and retrieval policy.
+
+### 8.4 `MsgUpdateDADealPolicy`
+
+Updates mutable policy fields, such as publisher set, batch cap, target tier,
+scale-up triggers, or retrieval sponsorship.
+
+Required checks:
+
+* update is authorized;
+* existing certified batches keep their historical policy identity;
+* weakening a policy cannot retroactively change certificate meaning; and
+* changes take effect at a future height or future batch id.
+
+### 8.5 `MsgRequestDADealScaleUp`
+
+Requests or records provider-daemon capacity expansion for a hot DA Deal.
+
+Required checks:
+
+* trigger satisfies `DADealScaleUpPolicy`, or caller pays an explicit premium;
+* candidate providers are eligible and diverse under policy;
+* scale-up does not reduce reconstructability for existing retained data; and
+* scale-up costs are funded.
+
+-----
+
+## 9. Public Chain Targeting
+
+Public chain names belong in this analysis. They make the service concrete and
+force sizing discipline.
+
+### 9.1 OP Stack and Superchain-style chains
+
+OP Stack is the best first primary-DA integration surface because Alt-DA already
+has a DA server, commitment path, and challenge-window mental model.
+
+| Chain | Best initial PolyStore role |
+|---|---|
+| Base | Retained DA and historical blob retrieval first; primary Alt-DA only after verifier/security posture matures. |
+| OP Mainnet | Retained DA reference target and canonical OP Stack adapter test case. |
+| World Chain | Chain-funded retained DA, then primary Alt-DA candidate for consumer-scale data. |
+| Unichain | Retained DA and high-availability retrieval for financial/indexer data. |
+| Soneium | Consumer/appchain retained DA and possible primary-DA pilot. |
+| Ink | Retained DA and dual-DA for financial/application history. |
+| Mode | Small-to-mid primary Alt-DA pilot candidate. |
+| Zora | Public retained DA and retrieval for media/NFT/social history. |
+| Blast / Katana | Medium DA users where retained retrieval and app-specific SLAs matter. |
+
+### 9.2 Arbitrum Orbit and AnyTrust-style chains
+
+AnyTrust-style systems already make committees and availability certificates
+legible. PolyStore's role is to turn that committee-shaped idea into a paid,
+accountable provider-daemon market with retained retrieval.
+
+| Chain | Best initial PolyStore role |
+|---|---|
+| Arbitrum One | Retained blob/archive service before primary replacement. |
+| Arbitrum Nova | AnyTrust-style DA Deal proof point. |
+| Xai | Game-chain DA Deal with elastic retained retrieval. |
+| ApeChain | Game/consumer DA Deal and retained public history. |
+| RARI / Treasure-style Orbit chains | Retained public history for NFT, game, and marketplace data. |
+
+### 9.3 Ethereum blob rollups
+
+For existing blob rollups, the first product is often dual DA:
+
+```text
+Ethereum blob DA for primary settlement
++ PolyStore DA Deal for retained retrieval, backfills, recovery, and public reads
+```
+
+| Chain | Best initial PolyStore role |
+|---|---|
+| Base | Largest immediate retained-DA opportunity in the measured set. |
+| Arbitrum | Retained blob archive and indexer recovery. |
+| World Chain | Consumer-scale retained DA. |
+| OP Mainnet | Canonical retained DA reference. |
+| Starknet, Linea, Scroll, Zircuit, Mantle | Smaller pilots and proof bundles. |
+
+### 9.4 Modular DA users
+
+For Celestia or other modular DA users, PolyStore should initially be retained
+retrieval and recovery, not a claim that the source DA security layer has been
+replaced.
+
+| Chain / ecosystem | Best initial PolyStore role |
+|---|---|
+| Manta Pacific | Retained retrieval and recovery for source-DA data. |
+| Eclipse | High-throughput historical retrieval and recovery. |
+| Initia / Movement-style modular chains | Dual DA and retained retrieval. |
+
+-----
+
+## 10. Sizing Profiles
+
+Recommended v0 profile:
+
+```text
+K = 8
+N = 12
+expansion = 1.5x
+min_attesting_slots = 10
+hard_reconstructability_floor = 8
+repair_trigger = fewer than 10 healthy slots
+```
+
+Representative tiers:
+
+| Tier | Logical DA/day | RS(8,12) storage/day | One-year RS storage | Intended customer |
+|---|---:|---:|---:|---|
+| Small appchain | 10-100 MB | 15-150 MB | 5-55 GB | New OP Stack, Orbit, game, NFT, or appchain pilots. |
+| Active appchain | 100-500 MB | 150-750 MB | 55-274 GB | Xai/ApeChain-like or active consumer appchains. |
+| Major L2 | 0.5-2 GB | 0.75-3 GB | 274 GB-1.1 TB | Base/Arbitrum/World-style retained DA. |
+| Multi-chain retained DA market | 3-10 GB | 4.5-15 GB | 1.6-5.5 TB | Portfolio of public rollups and appchains. |
+| Future high-throughput chain | 10-100 GB | 15-150 GB | 5.5-55 TB | Chain that outgrows current observed blob-rollup volumes. |
+
+The first production system should be designed for **10-100 GB/day per chain**
+even though current public-chain snapshots are mostly below that range. That
+headroom is large enough for credible DA positioning without overfitting the
+protocol around speculative exabyte demand.
+
+-----
+
+## 11. Lifecycle
+
+1. **Create policy.** Chain or foundation creates a `DADealPolicy`.
+2. **Fund budgets.** Treasury funds publication, retrieval, retention, and
+   repair balances.
+3. **Create or link lane.** Policy creates or links one or more DA lanes.
+4. **Create or link backing deals.** Policy creates or links backing storage
+   deals sized for the retention target.
+5. **Publish batches.** Authorized sequencer or batcher appends ordered
+   batches.
+6. **Certify.** Provider-daemons attest and the chain issues the configured
+   certificate tier.
+7. **Serve reads.** Derivation nodes, challengers, indexers, explorers, and
+   users retrieve data under public, sponsored, or requester-funded policy.
+8. **Repair and scale.** Provider degradation, retrieval heat, or publication
+   latency triggers repair or capacity expansion.
+9. **Renew or degrade.** If funding continues, retained service continues. If
+   funding stops, retained status degrades under policy without rewriting
+   historical certificate facts.
+
+-----
+
+## 12. Security and Failure Semantics
+
+The DA Deal does not make a batch available by itself. Availability still comes
+from the DA-lane certificate path.
+
+Rules:
+
+* A DA Deal MUST NOT advertise a certificate tier the linked DA lane cannot
+  issue.
+* A DA Deal MUST NOT retroactively upgrade historical certificates when policy
+  improves.
+* A DA Deal MAY downgrade future publishing when funding falls below policy
+  watermarks.
+* Retained-service degradation MUST NOT rewrite historical certificate facts.
+* Publisher authorization MUST be explicit; public append-only writes require a
+  separate anti-spam and payment policy.
+* Scale-up MUST preserve provider diversity and avoid publisher-selected
+  friendly placement.
+* Retrieval sponsorship MUST be rate-limited so public verification cannot
+  drain treasury funds accidentally.
+
+-----
+
+## 13. Implementation Roadmap
+
+### Phase 0: Docs, fixtures, and tracker alignment
+
+Deliverables:
+
+* this RFC;
+* public-chain sizing and positioning memo:
+  `docs/polyfs-chain-funded-da-deals.md`;
+* policy fixtures:
+  `docs/chain-funded-da-deal-policy-fixtures.md`;
+* DA-lanes RFC cross-reference; and
+* tracker issue update.
+
+### Phase 1: Policy object and funding account
+
+Deliverables:
+
+* `DADealPolicy`;
+* `DADealFundingAccount`;
+* create/fund/update/query messages;
+* budget accounting; and
+* policy fixtures in tests.
+
+Exit criteria:
+
+* a DA Deal can be created, funded, queried, paused on insufficient funding,
+  and linked to a lane without changing existing storage-deal behavior.
+
+### Phase 2: Lane linkage and publication path
+
+Deliverables:
+
+* link/create DA lane from a DA Deal;
+* publisher authorization;
+* append path that charges publication budget;
+* certificate policy selection from the DA Deal; and
+* usage-window accounting.
+
+Exit criteria:
+
+* a local devnet can publish a batch through a DA Deal and issue
+  `DA_CERT_FAST`.
+
+### Phase 3: Retrieval, retention, and repair budgets
+
+Deliverables:
+
+* sponsored and requester-funded retrieval policy;
+* retained-generation runway;
+* repair budget usage;
+* degradation/renewal state; and
+* scale-up trigger plumbing.
+
+Exit criteria:
+
+* a local devnet can issue `DA_CERT_RETRIEVABLE`, serve retained reads, charge
+  the correct budget class, and degrade retained service when funding expires.
+
+### Phase 4: Integration adapters
+
+Deliverables:
+
+* OP Stack Alt-DA adapter prototype;
+* Orbit/AnyTrust-style adapter sketch;
+* generic verifier SDK; and
+* proof-bundle export for external systems.
+
+Exit criteria:
+
+* one public-chain-shaped fixture can publish, certify, verify, retrieve, and
+  reconstruct through the DA Deal path.
+
+-----
+
+## 14. Tests and Evidence
+
+Required test categories:
+
+* create/fund/update/query `DADealPolicy`;
+* low-watermark and pause-watermark budget transitions;
+* lane linkage authorization;
+* publisher authorization;
+* policy weakening cannot alter historical certificate facts;
+* batch append charges publication budget;
+* sample retrieval charges retrieval budget;
+* retained service consumes retention budget;
+* repair consumes repair budget;
+* scale-up triggers only under policy; and
+* public retrieval sponsorship is rate-limited.
+
+Required evidence before production claims:
+
+* target certificate latency by tier;
+* disperser egress for representative batch sizes;
+* per-slot provider-daemon ingress;
+* retrieval throughput at 1, 10, and 50 concurrent readers;
+* repair time after provider loss;
+* provider count and diversity;
+* projected runway by budget class; and
+* bridge/verifier cost for the chosen external integration.
+
+-----
+
+## 15. Product Positioning
+
+Canonical line:
+
+> Launch a chain with a DA Deal: publish batches, receive availability
+> certificates, and keep data retrievable for as long as the chain funds the
+> Deal.
+
+Technical line:
+
+> Chain-Funded PolyStore DA Deals combine attestation-first Availability
+> Certificates with native retained retrieval, repair, and provider elasticity.
+
+Customer line:
+
+> Your chain funds one DA Deal. PolyStore handles provider assignment,
+> publication certificates, retained history, retrieval payments, and repair.
+
+This is the right public posture: direct enough to be marketable, specific
+enough to be defensible, and concrete enough to map to public chains.
+
+-----
+
+## 16. Open Questions
+
+1. Should `DADealPolicy` embed full lane policy or reference separately
+   versioned lane, quorum, sample, retrieval, repair, and scale-up policies?
+2. Should each external chain get one lane or separate lanes for batches,
+   proofs, state diffs, and metadata?
+3. What low-watermark should pause new publication versus only disabling
+   sponsored public retrieval?
+4. Which external integration should be first: OP Stack Alt-DA, Orbit/AnyTrust,
+   or generic verifier SDK?
+5. How should public append-only writes be authorized and priced if a chain
+   wants third parties to publish under the same DA Deal?
+6. What is the minimum policy information an external verifier needs to bind a
+   certificate to a specific chain-funded service contract?
+
+-----
+
+## 17. Recommendation
+
+Adopt Chain-Funded DA Deals as the primary product and implementation framing
+for PolyStore DA.
+
+The golden path is:
+
+1. sell retained DA and historical retrieval for existing public rollups;
+2. implement DA Deal policy and funding;
+3. issue `DA_CERT_FAST` through a DA Deal;
+4. issue `DA_CERT_RETRIEVABLE` through publication-time samples;
+5. prototype OP Stack Alt-DA and Orbit/AnyTrust-style integrations; and
+6. keep sampling-first DAS as a separate research track until the formal model
+   is strong enough.
+
+This keeps PolyStore differentiated around the thing it can plausibly own:
+availability certificates that are connected to durable retrieval, retained
+history, repair, and an economically funded provider-daemon market.
+
+-----
+
+## 18. References
+
+Local:
+
+* `docs/polyfs-chain-funded-da-deals.md`
+* `docs/chain-funded-da-deal-policy-fixtures.md`
+* `rfcs/rfc-polyfs-da-lanes.md`
+* `rfcs/rfc-pricing-and-escrow-accounting.md`
+* `rfcs/rfc-retrieval-access-control-public-deals-and-vouchers.md`
+* `rfcs/rfc-mandatory-retrieval-sessions-and-batching.md`
+* `rfcs/rfc-polyfs-generation-cas-and-staged-writes.md`
+
+External:
+
+* OP Stack Alt-DA docs:
+  `https://docs.optimism.io/op-stack/features/experimental/alt-da-mode`
+* OP Stack Alt-DA spec:
+  `https://specs.optimism.io/experimental/alt-da.html`
+* Arbitrum AnyTrust protocol:
+  `https://docs.arbitrum.io/how-arbitrum-works/deep-dives/anytrust-protocol`
+* EigenDA overview:
+  `https://docs.eigencloud.xyz/eigenda/core-concepts/overview`
+* Blobscan API docs:
+  `https://docs.blobscan.com/docs/api`

--- a/rfcs/rfc-polyfs-da-lanes.md
+++ b/rfcs/rfc-polyfs-da-lanes.md
@@ -12,7 +12,8 @@ attestations, retrieval economics
 `rfcs/rfc-mode2-onchain-state.md`,
 `rfcs/rfc-retrieval-access-control-public-deals-and-vouchers.md`,
 `rfcs/rfc-pricing-and-escrow-accounting.md`,
-`rfcs/rfc-polyfs-root-contract.md`
+`rfcs/rfc-polyfs-root-contract.md`,
+`rfcs/rfc-chain-funded-da-deals.md`
 
 -----
 
@@ -34,6 +35,15 @@ closer to an EigenDA-shaped operator/quorum model than to a Celestia-shaped DAS
 chain. PolyStore's differentiation is that a certificate can bind publication
 availability to durable retrieval, repair, payment, and retained PolyFS
 generations.
+
+The canonical deployment model is a **Chain-Funded DA Deal**:
+
+> A chain funds one DA Deal, publishes batches through one or more DA lanes,
+> receives availability certificates, and keeps the data retrievable for as long
+> as the Deal remains funded.
+
+This keeps the public product concrete. Chains buy a standing DA service; DA
+lanes append and certify batches; backing deals retain and serve the data.
 
 This RFC defines three certificate tiers:
 
@@ -100,8 +110,7 @@ already has:
 ### 2.3 PolyStore's DA shape
 
 PolyStore DA should be **attestation-first with retrieval-native hardening**.
-The first competitive claim should not be "cheapest or fastest generic DA." It
-should be:
+The first competitive claim should be:
 
 > PolyStore DA certificates bind publication-time availability to an accountable
 > retrieval and retention substrate.
@@ -110,6 +119,27 @@ That claim is narrower, easier to defend, and more differentiated. It says the
 batch was not merely signed by a quorum. It also says the batch is mapped into a
 PolyFS generation, backed by storage deals, subject to retrieval sessions, and
 eligible for repair or retained access after certification.
+
+### 2.4 Chain-Funded DA Deals
+
+The DA-lanes protocol should be packaged as a chain-funded service.
+
+A Chain-Funded DA Deal gives a chain:
+
+* a treasury-funded policy object;
+* allowed sequencer, batcher, user-gateway, or disperser publishers;
+* one or more DA lanes;
+* one or more backing storage deals;
+* an erasure profile and provider assignment policy;
+* a target certificate tier;
+* retention and retrieval payment policy;
+* repair and provider scale-up policy; and
+* public usage and runway accounting.
+
+This is the route from protocol primitive to marketable product. "Launch a
+chain with a DA Deal" is not just marketing language. It is the policy layer
+that lets a chain autonomously fund publication, certification, retained
+retrieval, repair, and provider elasticity.
 
 -----
 
@@ -124,12 +154,14 @@ eligible for repair or retained access after certification.
    Availability Certificates.
 4. Keep storage deals as the durable storage and economic substrate, not the DA
    publication object itself.
-5. Define a compact certificate verification surface for rollups, bridge
+5. Adopt Chain-Funded DA Deals as the deployment and funding primitive for
+   public chains using PolyStore DA.
+6. Define a compact certificate verification surface for rollups, bridge
    contracts, and external applications.
-6. Reuse existing PolyStore primitives wherever possible.
-7. Make provider accountability, retrieval payment, post-certification repair,
+7. Reuse existing PolyStore primitives wherever possible.
+8. Make provider accountability, retrieval payment, post-certification repair,
    and retained historical generations first-class properties of the design.
-8. Keep the future DAS/light-client path available without depending on that
+9. Keep the future DAS/light-client path available without depending on that
    stronger claim for the first product.
 
 -----
@@ -144,7 +176,7 @@ This RFC does not:
 * specify a final probability bound for every sampling profile;
 * define final slashing economics for all false attestation cases;
 * require a new consensus protocol for PolyStore;
-* require every storage provider to store every byte;
+* require every provider-daemon to store every byte;
 * define an L1 bridge contract in detail; or
 * implement the proposed messages or state machines.
 
@@ -155,6 +187,7 @@ This RFC does not:
 | Term | Meaning |
 |---|---|
 | **Deal** | Existing PolyStore storage/economic object. Deals remain the substrate for provider placement, escrow, retrieval policy, roots, and repair. |
+| **Chain-Funded DA Deal** | Standing service contract that links an external chain or namespace to DA lanes, backing deals, funding accounts, provider policies, retrieval policy, repair, and scale-up. |
 | **PolyFS generation** | Immutable committed content state identified by a PolyFS root and generation. |
 | **DA Lane** | Append-only publication stream backed by one or more deals. |
 | **Batch** | One ordered publication unit in a DA Lane. |
@@ -199,6 +232,18 @@ DA lanes answer:
 
 The lane is the publication abstraction. The deal is the storage and economic
 substrate. The Availability Certificate is the bridge between them.
+
+Chain-Funded DA Deals add the deployment abstraction above both. They answer:
+
+* which external chain or namespace is being served;
+* which treasury funds publication, retrieval, retention, and repair;
+* which publishers can append;
+* which certificate tier is required by default;
+* which public retrieval and sampling policy applies; and
+* when provider-daemon capacity should scale up.
+
+See `rfcs/rfc-chain-funded-da-deals.md` for the policy object and funding
+surface.
 
 -----
 
@@ -298,6 +343,10 @@ specific height.
 -----
 
 ## 9. Proposed Chain Objects
+
+Chain-Funded DA Deal objects live in `rfcs/rfc-chain-funded-da-deals.md`.
+Those objects reference the DA lane, batch, provider-assignment, sample, and
+certificate objects below.
 
 ### 9.1 `DALane`
 
@@ -556,7 +605,8 @@ issued under a specific tier, policy, provider set, and height.
 
 ### 10.1 `MsgCreateDALane`
 
-Creates an append-only lane backed by one or more existing deals.
+Creates an append-only lane backed by one or more existing deals. A lane MAY be
+created directly by its owner or through a Chain-Funded DA Deal policy.
 
 Required checks:
 
@@ -568,6 +618,9 @@ Required checks:
   costs for the requested tiers;
 * quorum policy is a recognized protocol policy; and
 * certificate policy is a recognized protocol policy.
+
+If created through a Chain-Funded DA Deal, the lane's writer, fee, retrieval,
+retention, and certificate policies MUST be compatible with that DA Deal policy.
 
 ### 10.2 `MsgAppendDABatch`
 
@@ -1064,6 +1117,8 @@ only.
 Deliverables:
 
 * formal certificate tier semantics;
+* Chain-Funded DA Deal policy and funding RFC;
+* public-chain sizing and positioning memo;
 * tracker issue with milestones and gates
   (`https://github.com/Polynomialstore/polystore/issues/231`);
 * implementation boundaries for chain, user-gateway, provider-daemon, and
@@ -1074,6 +1129,7 @@ Exit criteria:
 
 * this RFC clearly defines `DA_CERT_FAST`, `DA_CERT_RETRIEVABLE`, and
   `DA_CERT_RETAINED`;
+* Chain-Funded DA Deals are defined as the canonical deployment model;
 * tracker issue exists and is linked from the RFC PR; and
 * no public messaging depends on full DAS claims.
 
@@ -1081,6 +1137,7 @@ Exit criteria:
 
 Deliverables:
 
+* `DADealPolicy` and funding-account linkage for one Chain-Funded DA Deal;
 * `DABatchHeader`;
 * `DAQuorumPolicy`;
 * fixed provider assignment policy;
@@ -1092,6 +1149,7 @@ Deliverables:
 
 Exit criteria:
 
+* a Chain-Funded DA Deal can create or link a lane and pay for publication;
 * a batch moves from append to attested certificate;
 * invalid or missing provider attestations fail certification;
 * certificate verification surface is compact enough for a mock rollup verifier;
@@ -1174,6 +1232,9 @@ Every implementation PR should state which certificate tier it affects.
 
 Minimum test categories:
 
+* DA Deal create/fund/update/query tests;
+* DA Deal low-watermark and pause-watermark funding tests;
+* DA Deal to DA lane linkage authorization tests;
 * append CAS and lane-root tests;
 * provider assignment determinism tests;
 * attestation signature/domain-separator tests;
@@ -1190,10 +1251,13 @@ Performance evidence should be added before production claims:
 * batch size;
 * encoding profile;
 * provider count;
+* DA Deal budget runway by publication, retrieval, retention, and repair class;
+* disperser egress during certification;
+* per-slot provider-daemon ingress;
 * attestation aggregation latency;
 * certification latency by tier;
 * sample count and sample-serving latency;
-* retrieval throughput after certification;
+* retrieval throughput after certification at 1, 10, and 50 concurrent readers;
 * repair time after provider loss; and
 * bridge/verifier cost.
 
@@ -1209,6 +1273,12 @@ Suggested name family:
 * PolyDA, only after the security model is strong enough
 
 Suggested one-liner:
+
+> Launch a chain with a DA Deal: publish batches, receive availability
+> certificates, and keep data retrievable for as long as the chain funds the
+> Deal.
+
+Suggested protocol one-liner:
 
 > PolyStore DA Lanes let applications publish erasure-coded batches, receive an
 > availability certificate, and keep the same data retrievable through paid,
@@ -1248,22 +1318,28 @@ Suggested claim to avoid:
    generations use relative to provisional-generation cleanup?
 10. Which external integration should be first: OP Stack alt-DA, a generic SDK,
     or a source-DA archive bridge?
+11. Should `DADealPolicy` embed full lane policy or reference separately
+    versioned quorum, sample, retrieval, repair, and scale-up policies?
+12. Which provider scale-up triggers should be automatic protocol behavior
+    versus premium service requests from the chain treasury?
 
 -----
 
 ## 24. Recommendation
 
-Adopt PolyFS DA Lanes as an attestation-first DA direction with
-`DA_CERT_RETRIEVABLE` as the flagship target.
+Adopt PolyFS DA Lanes as an attestation-first DA direction with Chain-Funded DA
+Deals as the deployment model and `DA_CERT_RETRIEVABLE` as the flagship
+certificate target.
 
 The recommended sequencing is:
 
 1. Keep historical DA archive/retrieval as the near-term commercial wedge.
-2. Implement `DA_CERT_FAST` as the smallest primary-DA certificate.
-3. Implement `DA_CERT_RETRIEVABLE` before making differentiated DA claims.
-4. Implement `DA_CERT_RETAINED` after retrievable certification and repair hooks
+2. Implement Chain-Funded DA Deal policy, funding, and lane linkage.
+3. Implement `DA_CERT_FAST` as the smallest primary-DA certificate.
+4. Implement `DA_CERT_RETRIEVABLE` before making differentiated DA claims.
+5. Implement `DA_CERT_RETAINED` after retrievable certification and repair hooks
    work in devnet.
-5. Keep sampling-first DAS as a research track rather than the first product
+6. Keep sampling-first DAS as a research track rather than the first product
    claim.
 
 This direction avoids cloning existing DA systems. It focuses PolyStore on the
@@ -1279,7 +1355,10 @@ Local:
 
 * `whitepaper.md`
 * `docs/notes/HISTORICAL_DA_ARCHIVAL_RETRIEVAL_MARKET.md`
+* `docs/polyfs-chain-funded-da-deals.md`
+* `docs/chain-funded-da-deal-policy-fixtures.md`
 * `rfcs/rfc-blob-alignment-and-striping.md`
+* `rfcs/rfc-chain-funded-da-deals.md`
 * `rfcs/rfc-polyfs-generation-cas-and-staged-writes.md`
 * `rfcs/rfc-mandatory-retrieval-sessions-and-batching.md`
 * `rfcs/rfc-challenge-derivation-and-quotas.md`


### PR DESCRIPTION
## Summary

This PR turns the recent PolyStore DA strategy work into repo-backed artifacts:

- Adds `rfcs/rfc-chain-funded-da-deals.md` as the formal proposal for Chain-Funded DA Deals as the canonical PolyStore DA deployment object.
- Adds `docs/polyfs-chain-funded-da-deals.md` with market/product analysis, public-chain target lists, public data snapshots, sizing, bandwidth, and positioning.
- Adds `docs/chain-funded-da-deal-policy-fixtures.md` with concrete policy fixtures for major L2 retained DA, OP Stack Alt-DA pilots, Orbit/AnyTrust-style chains, appchain launch deals, and modular DA retained retrieval.
- Updates `rfcs/rfc-polyfs-da-lanes.md` so DA lanes remain the certificate/state-machine layer while Chain-Funded DA Deals become the funding/deployment layer.

## Why

The protocol direction is sharper if PolyStore DA is framed as:

> Launch a chain with a DA Deal: publish batches, receive availability certificates, and keep data retrievable for as long as the chain funds the Deal.

This keeps the strongest path explicit: attestation-first DA certificates with native retained retrieval, repair, provider elasticity, and public-chain-grade funding policy.

## Public Chain Context

The new docs intentionally include public chain examples and sizing analysis for Base, OP Mainnet, World Chain, Unichain, Soneium, Ink, Mode, Zora, Blast/Katana, Arbitrum One/Nova, Xai, ApeChain, and modular DA users such as Manta Pacific/Eclipse-style deployments.

## Validation

- `git diff --check`
- Scoped ASCII scan over the four touched docs
- Scoped terminology/overclaim search for unsupported claims and legacy runtime terms

Docs/RFC-only change; no code tests were run.

Refs #231
