### PR TITLE
bench: deterministic retrieval-session load driver

### DIFF
--- a/polystorechain/x/polystorechain/keeper/retrieval_session_bench_test.go
+++ b/polystorechain/x/polystorechain/keeper/retrieval_session_bench_test.go
@@ -461,6 +461,60 @@ func BenchmarkConfirmRetrievalSession(b *testing.B) {
 	b.ReportMetric(gasPerOp, "gas/op")
 }
 
+// BenchmarkCompleteRetrievalSession measures the proof-backed completion
+// ordering used by the load driver: open, submit proof, then confirm.
+// Proof construction is prepared once outside the timed loop; the keeper
+// submit and completion settlement remain measured.
+func BenchmarkCompleteRetrievalSession(b *testing.B) {
+	env := setupBenchRetrievalEnv(b)
+	b.StopTimer()
+	proof := env.benchBuildChainedProof(b, 0, 100)
+	b.StartTimer()
+
+	nonce := uint64(1)
+	var totalGas uint64
+	for b.Loop() {
+		gasBefore := benchGasConsumed(env.f.ctx)
+		openRes, err := env.msgServer.OpenRetrievalSession(env.f.ctx, &types.MsgOpenRetrievalSession{
+			Creator:        env.owner,
+			DealId:         env.dealID,
+			Provider:       env.provider,
+			ManifestRoot:   env.deal.ManifestRoot,
+			StartMduIndex:  benchTargetMduIndex,
+			StartBlobIndex: 0,
+			BlobCount:      1,
+			Nonce:          nonce,
+			ExpiresAt:      0,
+		})
+		if err != nil {
+			b.Fatalf("OpenRetrievalSession failed: %v", err)
+		}
+		_, err = env.msgServer.SubmitRetrievalSessionProof(env.f.ctx, &types.MsgSubmitRetrievalSessionProof{
+			Creator:   env.provider,
+			SessionId: openRes.SessionId,
+			Proofs:    []types.ChainedProof{proof},
+		})
+		if err != nil {
+			b.Fatalf("SubmitRetrievalSessionProof failed: %v", err)
+		}
+		_, err = env.msgServer.ConfirmRetrievalSession(env.f.ctx, &types.MsgConfirmRetrievalSession{
+			Creator:   env.owner,
+			SessionId: openRes.SessionId,
+		})
+		if err != nil {
+			b.Fatalf("ConfirmRetrievalSession failed: %v", err)
+		}
+		totalGas += benchGasConsumed(env.f.ctx) - gasBefore
+		nonce++
+	}
+
+	gasPerOp := float64(totalGas) / float64(nonce-1)
+	if gasPerOp <= 0 {
+		b.Fatalf("sanity: zero average gas (%v) over %d completions", gasPerOp, nonce-1)
+	}
+	b.ReportMetric(gasPerOp, "gas/op")
+}
+
 // TestRetrievalSessionBenchCharacterization bounds benchmark correctness:
 // every message type consumes positive gas, and submit-proof gas is
 // monotonically non-decreasing in proof count (gas is deterministic, so this
@@ -486,10 +540,11 @@ func TestRetrievalSessionBenchCharacterization(t *testing.T) {
 	require.Greater(t, openGas, uint64(0), "OpenRetrievalSession must consume gas")
 
 	// Confirm: positive gas (fresh OPEN session).
+	confirmSession := env.openBenchSession(t, 2, 1)
 	gasBefore = benchGasConsumed(env.f.ctx)
 	_, err = env.msgServer.ConfirmRetrievalSession(env.f.ctx, &types.MsgConfirmRetrievalSession{
 		Creator:   env.owner,
-		SessionId: env.openBenchSession(t, 2, 1).SessionId,
+		SessionId: confirmSession.SessionId,
 	})
 	require.NoError(t, err)
 	confirmGas := benchGasConsumed(env.f.ctx) - gasBefore

--- a/polystorechain/x/polystorechain/keeper/retrieval_session_bench_test.go
+++ b/polystorechain/x/polystorechain/keeper/retrieval_session_bench_test.go
@@ -21,18 +21,21 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strconv"
 	"testing"
 
 	"cosmossdk.io/math"
-	sdk "github.com/cosmos/cosmos-sdk/types"
+	storetypes "cosmossdk.io/store/types"
 	addresscodec "github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/cosmos/cosmos-sdk/runtime"
 	"github.com/cosmos/cosmos-sdk/testutil"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	storetypes "cosmossdk.io/store/types"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/blake2s"
 
@@ -102,10 +105,15 @@ func setupBenchRetrievalEnv(tb testing.TB) *benchRetrievalEnv {
 	copy(privOwnerBz, []byte("bench_owner_______"))
 	owner, _ := f.addressCodec.BytesToString(privOwnerBz)
 
+	serviceHint := os.Getenv("POLYSTORE_BENCH_FIXTURE_SERVICE_HINT")
+	if serviceHint == "" {
+		serviceHint = "General"
+	}
+
 	resDeal, err := msgServer.CreateDeal(f.ctx, &types.MsgCreateDeal{
 		Creator:             owner,
 		DurationBlocks:      100,
-		ServiceHint:         "General",
+		ServiceHint:         serviceHint,
 		InitialEscrowAmount: math.NewInt(100000000),
 		MaxMonthlySpend:     math.NewInt(10000000),
 	})
@@ -321,7 +329,6 @@ func buildBenchSubmitPlan(
 	}
 	return plan
 }
-
 
 func BenchmarkSubmitRetrievalSessionProof(b *testing.B) {
 	for _, count := range []int{1, 8, 64} {
@@ -742,4 +749,52 @@ func benchBlobBytesForLeaf(tb testing.TB, mduBytes []byte, shards [][]byte, k ui
 	blob := make([]byte, types.BLOB_SIZE)
 	copy(blob, shard[off:end])
 	return blob
+}
+
+// TestWriteRetrievalSessionProofFixture emits a chain-compatible proof payload
+// for the shell load driver when POLYSTORE_BENCH_FIXTURE_DIR is set. The
+// generated manifest root and proofs come from the same deterministic fixture
+// used by the in-process benchmarks.
+func TestWriteRetrievalSessionProofFixture(t *testing.T) {
+	fixtureDir := os.Getenv("POLYSTORE_BENCH_FIXTURE_DIR")
+	if fixtureDir == "" {
+		t.Skip("POLYSTORE_BENCH_FIXTURE_DIR is not set")
+	}
+
+	sessions := 1
+	if raw := os.Getenv("POLYSTORE_BENCH_FIXTURE_SESSIONS"); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		require.NoError(t, err)
+		sessions = parsed
+	}
+	proofCount := 1
+	if raw := os.Getenv("POLYSTORE_BENCH_FIXTURE_COUNT"); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		require.NoError(t, err)
+		proofCount = parsed
+	}
+	require.Greater(t, sessions, 0)
+	require.Greater(t, proofCount, 0)
+	require.LessOrEqual(t, proofCount, 32)
+	require.NoError(t, os.MkdirAll(fixtureDir, 0o755))
+
+	env := setupBenchRetrievalEnv(t)
+	payload := struct {
+		SessionID []byte               `json:"session_id"`
+		Proofs    []types.ChainedProof `json:"proofs"`
+	}{
+		SessionID: make([]byte, 32),
+		Proofs:    make([]types.ChainedProof, 0, proofCount),
+	}
+	for i := range proofCount {
+		payload.Proofs = append(payload.Proofs, env.benchBuildChainedProof(t, uint64(i), uint64(i)))
+	}
+	encoded, err := json.MarshalIndent(payload, "", "  ")
+	require.NoError(t, err)
+	for i := range sessions {
+		path := filepath.Join(fixtureDir, fmt.Sprintf("%d.json", i+1))
+		require.NoError(t, os.WriteFile(path, encoded, 0o600))
+	}
+	manifestRoot := "0x" + hex.EncodeToString(env.deal.ManifestRoot) + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(fixtureDir, "manifest_root.txt"), []byte(manifestRoot), 0o600))
 }

--- a/polystorechain/x/polystorechain/keeper/retrieval_session_bench_test.go
+++ b/polystorechain/x/polystorechain/keeper/retrieval_session_bench_test.go
@@ -322,14 +322,6 @@ func buildBenchSubmitPlan(
 	return plan
 }
 
-func preopenSessions(b *testing.B, env *benchRetrievalEnv, count int) [][]byte {
-	b.Helper()
-	sessions := make([][]byte, b.N)
-	for i := range b.N {
-		sessions[i] = env.openBenchSession(b, uint64(i)+1, uint64(count)).SessionId
-	}
-	return sessions
-}
 
 func BenchmarkSubmitRetrievalSessionProof(b *testing.B) {
 	for _, count := range []int{1, 8, 64} {
@@ -337,16 +329,19 @@ func BenchmarkSubmitRetrievalSessionProof(b *testing.B) {
 			env := setupBenchRetrievalEnv(b)
 			require.GreaterOrEqual(b, env.leafCount, uint64(count))
 
-			// Untimed: one fresh session plan per measured iteration.
-			plans := make([][]benchSessionPlan, b.N)
-			for i := range b.N {
-				plans[i] = buildBenchSubmitPlan(b, env, uint64(i)*1000+1, count)
-			}
+			// Lazily prepare one fresh session plan per measured iteration. b.Loop
+			// may expand beyond the initial b.N target.
+			plans := make([][]benchSessionPlan, 0, b.N)
 
 			b.ReportMetric(float64(count), "proofs/op")
 			iter := 0
 			var totalGas uint64
 			for b.Loop() {
+				if iter == len(plans) {
+					b.StopTimer()
+					plans = append(plans, buildBenchSubmitPlan(b, env, uint64(iter)*1000+1, count))
+					b.StartTimer()
+				}
 				plan := plans[iter]
 				iter++
 
@@ -427,12 +422,17 @@ func BenchmarkSubmitRetrievalSessionProof(b *testing.B) {
 func BenchmarkConfirmRetrievalSession(b *testing.B) {
 	env := setupBenchRetrievalEnv(b)
 
-	// Untimed: one fresh OPEN session per measured iteration.
-	sessions := preopenSessions(b, env, 1)
-
+	// Lazily preopen one fresh OPEN session per measured iteration. b.Loop may
+	// expand beyond the initial b.N target.
+	sessions := make([][]byte, 0, b.N)
 	idx := 0
 	var totalGas uint64
 	for b.Loop() {
+		if idx == len(sessions) {
+			b.StopTimer()
+			sessions = append(sessions, env.openBenchSession(b, uint64(idx)+1, 1).SessionId)
+			b.StartTimer()
+		}
 		session := sessions[idx]
 		idx++
 

--- a/polystorechain/x/polystorechain/keeper/retrieval_session_bench_test.go
+++ b/polystorechain/x/polystorechain/keeper/retrieval_session_bench_test.go
@@ -515,6 +515,51 @@ func BenchmarkCompleteRetrievalSession(b *testing.B) {
 	b.ReportMetric(gasPerOp, "gas/op")
 }
 
+func BenchmarkCancelRetrievalSession(b *testing.B) {
+	env := setupBenchRetrievalEnv(b)
+	cancelCtx := sdk.UnwrapSDKContext(env.f.ctx).WithBlockHeight(10)
+	sessions := make([][]byte, 0, b.N)
+	idx := 0
+	var totalGas uint64
+	for b.Loop() {
+		if idx == len(sessions) {
+			b.StopTimer()
+			openRes, err := env.msgServer.OpenRetrievalSession(env.f.ctx, &types.MsgOpenRetrievalSession{
+				Creator:        env.owner,
+				DealId:         env.dealID,
+				Provider:       env.provider,
+				ManifestRoot:   env.deal.ManifestRoot,
+				StartMduIndex:  benchTargetMduIndex,
+				StartBlobIndex: 0,
+				BlobCount:      1,
+				Nonce:          uint64(idx) + 1,
+				ExpiresAt:      1,
+			})
+			require.NoError(b, err)
+			sessions = append(sessions, openRes.SessionId)
+			b.StartTimer()
+		}
+		session := sessions[idx]
+		idx++
+
+		gasBefore := benchGasConsumed(cancelCtx)
+		_, err := env.msgServer.CancelRetrievalSession(cancelCtx, &types.MsgCancelRetrievalSession{
+			Creator:   env.owner,
+			SessionId: session,
+		})
+		totalGas += benchGasConsumed(cancelCtx) - gasBefore
+		if err != nil {
+			b.Fatalf("CancelRetrievalSession failed: %v", err)
+		}
+	}
+
+	gasPerOp := float64(totalGas) / float64(idx)
+	if gasPerOp <= 0 {
+		b.Fatalf("sanity: zero average gas (%v) over %d cancellations", gasPerOp, idx)
+	}
+	b.ReportMetric(gasPerOp, "gas/op")
+}
+
 // TestRetrievalSessionBenchCharacterization bounds benchmark correctness:
 // every message type consumes positive gas, and submit-proof gas is
 // monotonically non-decreasing in proof count (gas is deterministic, so this

--- a/polystorechain/x/polystorechain/keeper/retrieval_session_bench_test.go
+++ b/polystorechain/x/polystorechain/keeper/retrieval_session_bench_test.go
@@ -374,17 +374,21 @@ func BenchmarkSubmitRetrievalSessionProof(b *testing.B) {
 			b.ReportMetric(gasPerProof*float64(count), "gas/op")
 		})
 
-		// FFI-isolation probe: measures ONLY the cumulative crypto_ffi verify
-		// cost of `count` chained proofs, using the same two exported FFI
-		// entry points keeper.verifyPolyFSChainedProof calls. No state access,
-		// no gas metering — this bounds the FFI share of the full submit op.
+		// FFI-wrapper isolation probe: measures ONLY the cumulative crypto_ffi
+		// verification cost of `count` chained proofs. The timed loop calls the
+		// same two exported FFI entry points keeper.verifyPolyFSChainedProof
+		// uses, with all Merkle paths flattened before timing; it excludes
+		// keeper/state access and gas metering.
 		b.Run(fmt.Sprintf("ffi-verify-only-%d", count), func(b *testing.B) {
 			env := setupBenchRetrievalEnv(b)
 			proofs := make([]types.ChainedProof, count)
+			rootTableMerklePaths := make([][]byte, count)
+			merklePaths := make([][]byte, count)
 			for i := range count {
 				proofs[i] = env.benchBuildChainedProof(b, uint64(i), uint64(i)+100)
+				rootTableMerklePaths[i] = benchFlattenPath(proofs[i].RootTableDuMerklePath)
+				merklePaths[i] = benchFlattenPath(proofs[i].MerklePath)
 			}
-			rootTableMerkle := benchFlattenPath(proofs[0].RootTableDuMerklePath)
 
 			b.ReportMetric(float64(count), "proofs/op")
 			for b.Loop() {
@@ -395,7 +399,7 @@ func BenchmarkSubmitRetrievalSessionProof(b *testing.B) {
 						p.MduIndex,
 						p.MduRootFr,
 						p.RootTableDuCommitment,
-						rootTableMerkle,
+						rootTableMerklePaths[j],
 						p.ManifestOpening,
 					)
 					if err != nil || !ok {
@@ -404,7 +408,7 @@ func BenchmarkSubmitRetrievalSessionProof(b *testing.B) {
 					ok, err = crypto_ffi.VerifyMduProof(
 						p.MduRootFr,
 						p.BlobCommitment,
-						benchFlattenPath(p.MerklePath),
+						merklePaths[j],
 						p.BlobIndex,
 						env.leafCount,
 						p.ZValue,

--- a/polystorechain/x/polystorechain/keeper/retrieval_session_bench_test.go
+++ b/polystorechain/x/polystorechain/keeper/retrieval_session_bench_test.go
@@ -1,0 +1,741 @@
+package keeper_test
+
+// Deterministic retrieval-session throughput benchmarks (issue #245).
+//
+// These benchmarks reuse the exact fixture/construction pattern of
+// msg_server_retrieval_sessions_test.go and retrieval_proof_helpers_test.go:
+// initFixture-style in-memory keeper, registered providers, one funded deal,
+// and a single family of valid Mode 2 chained proofs built through crypto_ffi.
+//
+// Local *testing.TB-compatible copies of the *testing.T-typed helpers live at
+// the bottom of this file (Go does not let us pass a *testing.B where a
+// *testing.T is declared); their bodies are verbatim adaptations.
+//
+// Gas accounting is deliberately separated from wall-clock timing: gas is read
+// off the context meter around each measured op and accumulated separately,
+// then reported as a custom "gas/op" metric. Sessions needed by the submit /
+// confirm benchmarks are opened BEFORE the timed loop so the timer only sees
+// the operation under measurement.
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"testing"
+
+	"cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	addresscodec "github.com/cosmos/cosmos-sdk/codec/address"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	storetypes "cosmossdk.io/store/types"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/blake2s"
+
+	"polystorechain/x/crypto_ffi"
+	"polystorechain/x/polystorechain/keeper"
+	module "polystorechain/x/polystorechain/module"
+	"polystorechain/x/polystorechain/types"
+)
+
+const benchTargetMduIndex = uint64(2) // MDU #0 metadata + one witness MDU, then first user MDU.
+const benchWitnessMdus = uint64(1)
+
+type benchRetrievalEnv struct {
+	f         *fixture
+	msgServer types.MsgServer
+	owner     string
+	provider  string
+	dealID    uint64
+	deal      types.Deal
+
+	k         uint64
+	m         uint64
+	rows      uint64
+	leafCount uint64
+
+	mduData     []byte
+	witnessFlat []byte
+	shards      [][]byte
+	mduRoot     []byte
+
+	rootTableDuCommitment []byte
+	rootTableDuMerklePath [][]byte
+	rootTableOpening      []byte
+}
+
+func benchGasConsumed(ctx context.Context) uint64 {
+	return sdk.UnwrapSDKContext(ctx).GasMeter().GasConsumed()
+}
+
+func setupBenchRetrievalEnv(tb testing.TB) *benchRetrievalEnv {
+	tb.Helper()
+
+	os.Setenv("KZG_TRUSTED_SETUP", "../../../trusted_setup.txt")
+	if _, err := os.Stat("../../../trusted_setup.txt"); os.IsNotExist(err) {
+		tb.Skip("trusted_setup.txt not found at ../../../trusted_setup.txt, skipping retrieval session benchmark")
+	}
+
+	f := newBenchFixture(tb)
+	msgServer := keeper.NewMsgServerImpl(f.keeper)
+
+	// Register enough providers for placement (same pattern as lifecycle tests).
+	for i := range 10 {
+		addrBz := make([]byte, 20)
+		copy(addrBz, []byte("bench_provider___"))
+		addrBz[16] = byte('A' + i)
+		addr, _ := f.addressCodec.BytesToString(addrBz)
+		_, err := msgServer.RegisterProvider(f.ctx, &types.MsgRegisterProvider{
+			Creator:      addr,
+			Capabilities: "General",
+			TotalStorage: 100000000000,
+			Endpoints:    testProviderEndpoints,
+		})
+		require.NoError(tb, err)
+	}
+
+	privOwnerBz := make([]byte, 20)
+	copy(privOwnerBz, []byte("bench_owner_______"))
+	owner, _ := f.addressCodec.BytesToString(privOwnerBz)
+
+	resDeal, err := msgServer.CreateDeal(f.ctx, &types.MsgCreateDeal{
+		Creator:             owner,
+		DurationBlocks:      100,
+		ServiceHint:         "General",
+		InitialEscrowAmount: math.NewInt(100000000),
+		MaxMonthlySpend:     math.NewInt(10000000),
+	})
+	require.NoError(tb, err)
+	require.NotEmpty(tb, resDeal.AssignedProviders)
+
+	require.NoError(tb, crypto_ffi.Init("../../../trusted_setup.txt"))
+
+	mduData := make([]byte, 8*1024*1024)
+	dealAfterCreate, err := f.keeper.Deals.Get(sdk.UnwrapSDKContext(f.ctx), resDeal.DealId)
+	require.NoError(tb, err)
+	require.NotNil(tb, dealAfterCreate.Mode2Profile)
+	k := uint64(dealAfterCreate.Mode2Profile.K)
+	m := uint64(dealAfterCreate.Mode2Profile.M)
+	rows := uint64(64) / k
+
+	witnessFlat, shards, err := crypto_ffi.ExpandMduRs(mduData, k, m)
+	require.NoError(tb, err)
+	root, err := crypto_ffi.ComputeMduRootFromWitnessFlat(witnessFlat)
+	require.NoError(tb, err)
+
+	polyfsCid, mdu0 := benchBuildPolyFSMdu0(tb, map[uint64][]byte{benchTargetMduIndex: root})
+	rootTableDuCommitment, rootTableDuMerklePath, rootTableOpening := benchMdu0RootTableProof(tb, mdu0, benchTargetMduIndex, root)
+
+	_, err = msgServer.UpdateDealContent(f.ctx, &types.MsgUpdateDealContent{
+		Creator:     owner,
+		DealId:      resDeal.DealId,
+		Cid:         polyfsCid,
+		Size_:       8 * 1024 * 1024,
+		TotalMdus:   4,
+		WitnessMdus: benchWitnessMdus,
+	})
+	require.NoError(tb, err)
+
+	deal, err := f.keeper.Deals.Get(sdk.UnwrapSDKContext(f.ctx), resDeal.DealId)
+	require.NoError(tb, err)
+	require.Len(tb, deal.ManifestRoot, types.POLYFS_ROOT_SIZE)
+
+	return &benchRetrievalEnv{
+		f:                     f,
+		msgServer:             msgServer,
+		owner:                 owner,
+		provider:              resDeal.AssignedProviders[0],
+		dealID:                resDeal.DealId,
+		deal:                  deal,
+		k:                     k,
+		m:                     m,
+		rows:                  rows,
+		leafCount:             (k + m) * rows,
+		mduData:               mduData,
+		witnessFlat:           witnessFlat,
+		shards:                shards,
+		mduRoot:               root,
+		rootTableDuCommitment: rootTableDuCommitment,
+		rootTableDuMerklePath: rootTableDuMerklePath,
+		rootTableOpening:      rootTableOpening,
+	}
+}
+
+// benchBuildChainedProof constructs a valid ChainedProof for leafIndex within
+// the committed MDU, mirroring commitValidMode2ContentAndProof's construction.
+func (e *benchRetrievalEnv) benchBuildChainedProof(tb testing.TB, leafIndex uint64, zHint uint64) types.ChainedProof {
+	tb.Helper()
+	require.True(tb, leafIndex < e.leafCount, "leafIndex out of range")
+
+	path := benchMerklePathFromWitnessFlat(tb, e.witnessFlat, leafIndex)
+	commitmentOff := int(leafIndex) * 48
+	blobCommitment := make([]byte, 48)
+	copy(blobCommitment, e.witnessFlat[commitmentOff:commitmentOff+48])
+
+	slot := leafIndex / e.rows
+	row := leafIndex % e.rows
+	blobBytes := benchBlobBytesForLeaf(tb, e.mduData, e.shards, e.k, slot, row)
+
+	z := make([]byte, 32)
+	z[0] = 42
+	z[1] = byte(slot & 0xFF)
+	var zb [8]byte
+	binary.BigEndian.PutUint64(zb[:], zHint)
+	copy(z[2:10], zb[:])
+
+	kzgProof, y, err := crypto_ffi.ComputeBlobProof(blobBytes, z)
+	require.NoError(tb, err)
+
+	return types.ChainedProof{
+		MduIndex:              benchTargetMduIndex,
+		MduRootFr:             e.mduRoot,
+		ManifestOpening:       e.rootTableOpening,
+		RootTableDuCommitment: e.rootTableDuCommitment,
+		RootTableDuMerklePath: e.rootTableDuMerklePath,
+		BlobCommitment:        blobCommitment,
+		MerklePath:            path,
+		BlobIndex:             uint32(leafIndex),
+		ZValue:                z,
+		YValue:                y,
+		KzgOpeningProof:       kzgProof,
+	}
+}
+
+func (e *benchRetrievalEnv) openBenchSession(tb testing.TB, nonce uint64, blobCount uint64) *types.MsgOpenRetrievalSessionResponse {
+	tb.Helper()
+	openRes, err := e.msgServer.OpenRetrievalSession(e.f.ctx, &types.MsgOpenRetrievalSession{
+		Creator:        e.owner,
+		DealId:         e.dealID,
+		Provider:       e.provider,
+		ManifestRoot:   e.deal.ManifestRoot,
+		StartMduIndex:  benchTargetMduIndex,
+		StartBlobIndex: 0,
+		BlobCount:      blobCount,
+		Nonce:          nonce,
+		ExpiresAt:      0,
+	})
+	require.NoError(tb, err)
+	require.Len(tb, openRes.SessionId, 32)
+	return openRes
+}
+
+func BenchmarkOpenRetrievalSession(b *testing.B) {
+	env := setupBenchRetrievalEnv(b)
+
+	var totalGas uint64
+	// b.Loop gives no index; track our own counter for unique nonces.
+	nonce := uint64(0)
+	var gasBefore uint64
+	for b.Loop() {
+		gasBefore = benchGasConsumed(env.f.ctx)
+		openRes, err := env.msgServer.OpenRetrievalSession(env.f.ctx, &types.MsgOpenRetrievalSession{
+			Creator:        env.owner,
+			DealId:         env.dealID,
+			Provider:       env.provider,
+			ManifestRoot:   env.deal.ManifestRoot,
+			StartMduIndex:  benchTargetMduIndex,
+			StartBlobIndex: 0,
+			BlobCount:      1,
+			Nonce:          nonce + 1, // unique nonce per op: nonce replays are rejected
+			ExpiresAt:      0,
+		})
+		totalGas += benchGasConsumed(env.f.ctx) - gasBefore
+		nonce++
+		if err != nil {
+			b.Fatalf("OpenRetrievalSession failed: %v", err)
+		}
+		if len(openRes.SessionId) != 32 {
+			b.Fatalf("unexpected session id length %d", len(openRes.SessionId))
+		}
+	}
+
+	gasPerOp := float64(totalGas) / float64(nonce)
+	if gasPerOp <= 0 {
+		b.Fatalf("sanity: zero average gas (%v) over %d opens", gasPerOp, nonce)
+	}
+	b.ReportMetric(gasPerOp, "gas/op")
+}
+
+type benchSessionPlan struct {
+	sessionID []byte
+	creator   string
+	proofs    []types.ChainedProof
+}
+
+func (e *benchRetrievalEnv) slotProvider(tb testing.TB, slot uint64) string {
+	tb.Helper()
+	if int(slot) < len(e.deal.Mode2Slots) && e.deal.Mode2Slots[slot] != nil {
+		return e.deal.Mode2Slots[slot].Provider
+	}
+	require.Less(tb, int(slot), len(e.deal.Providers))
+	return e.deal.Providers[slot]
+}
+
+// buildBenchSubmitPlan opens the sessions needed to deliver `count` chained
+// proofs. Mode 2 caps each session's blob range at a single placement slot
+// (rows blobs), so proofs are spread across ceil(count/rows) slot-scoped
+// sessions, each opened with the provider assigned to that slot.
+func buildBenchSubmitPlan(
+	tb testing.TB,
+	env *benchRetrievalEnv,
+	nonceBase uint64,
+	count int,
+) []benchSessionPlan {
+	tb.Helper()
+	plan := make([]benchSessionPlan, 0, (count+int(env.rows)-1)/int(env.rows))
+	leaf := uint64(0)
+	nonce := nonceBase
+	for emitted := 0; emitted < count; {
+		n := count - emitted
+		if n > int(env.rows) {
+			n = int(env.rows)
+		}
+		slot := leaf / env.rows
+		provider := env.slotProvider(tb, slot)
+
+		proofs := make([]types.ChainedProof, n)
+		for i := range n {
+			proofs[i] = env.benchBuildChainedProof(tb, leaf, leaf+100)
+			leaf++
+		}
+
+		openRes, err := env.msgServer.OpenRetrievalSession(env.f.ctx, &types.MsgOpenRetrievalSession{
+			Creator:        env.owner,
+			DealId:         env.dealID,
+			Provider:       provider,
+			ManifestRoot:   env.deal.ManifestRoot,
+			StartMduIndex:  benchTargetMduIndex,
+			StartBlobIndex: uint32(proofs[0].BlobIndex),
+			BlobCount:      uint64(n),
+			Nonce:          nonce,
+			ExpiresAt:      0,
+		})
+		require.NoError(tb, err)
+		nonce++
+		emitted += n
+		plan = append(plan, benchSessionPlan{sessionID: openRes.SessionId, creator: provider, proofs: proofs})
+	}
+	return plan
+}
+
+func preopenSessions(b *testing.B, env *benchRetrievalEnv, count int) [][]byte {
+	b.Helper()
+	sessions := make([][]byte, b.N)
+	for i := range b.N {
+		sessions[i] = env.openBenchSession(b, uint64(i)+1, uint64(count)).SessionId
+	}
+	return sessions
+}
+
+func BenchmarkSubmitRetrievalSessionProof(b *testing.B) {
+	for _, count := range []int{1, 8, 64} {
+		b.Run(fmt.Sprintf("proofs-%d", count), func(b *testing.B) {
+			env := setupBenchRetrievalEnv(b)
+			require.GreaterOrEqual(b, env.leafCount, uint64(count))
+
+			// Untimed: one fresh session plan per measured iteration.
+			plans := make([][]benchSessionPlan, b.N)
+			for i := range b.N {
+				plans[i] = buildBenchSubmitPlan(b, env, uint64(i)*1000+1, count)
+			}
+
+			b.ReportMetric(float64(count), "proofs/op")
+			iter := 0
+			var totalGas uint64
+			for b.Loop() {
+				plan := plans[iter]
+				iter++
+
+				for _, step := range plan {
+					gasBefore := benchGasConsumed(env.f.ctx)
+					res, err := env.msgServer.SubmitRetrievalSessionProof(env.f.ctx, &types.MsgSubmitRetrievalSessionProof{
+						Creator:   step.creator,
+						SessionId: step.sessionID,
+						Proofs:    step.proofs,
+					})
+					totalGas += benchGasConsumed(env.f.ctx) - gasBefore
+					if err != nil {
+						b.Fatalf("SubmitRetrievalSessionProof failed: %v", err)
+					}
+					if !res.Success {
+						b.Fatal("sanity: submit did not report success")
+					}
+				}
+			}
+
+			gasPerProof := float64(totalGas) / float64(iter*count)
+			if gasPerProof <= 0 {
+				b.Fatalf("sanity: zero average gas (%v) over %d proofs", gasPerProof, iter*count)
+			}
+			b.ReportMetric(gasPerProof*float64(count), "gas/op")
+		})
+
+		// FFI-isolation probe: measures ONLY the cumulative crypto_ffi verify
+		// cost of `count` chained proofs, using the same two exported FFI
+		// entry points keeper.verifyPolyFSChainedProof calls. No state access,
+		// no gas metering — this bounds the FFI share of the full submit op.
+		b.Run(fmt.Sprintf("ffi-verify-only-%d", count), func(b *testing.B) {
+			env := setupBenchRetrievalEnv(b)
+			proofs := make([]types.ChainedProof, count)
+			for i := range count {
+				proofs[i] = env.benchBuildChainedProof(b, uint64(i), uint64(i)+100)
+			}
+			rootTableMerkle := benchFlattenPath(proofs[0].RootTableDuMerklePath)
+
+			b.ReportMetric(float64(count), "proofs/op")
+			for b.Loop() {
+				for j := range count {
+					p := &proofs[j]
+					ok, err := crypto_ffi.VerifyMdu0RootTableProof(
+						env.deal.ManifestRoot,
+						p.MduIndex,
+						p.MduRootFr,
+						p.RootTableDuCommitment,
+						rootTableMerkle,
+						p.ManifestOpening,
+					)
+					if err != nil || !ok {
+						b.Fatalf("hop1 verify failed: ok=%v err=%v", ok, err)
+					}
+					ok, err = crypto_ffi.VerifyMduProof(
+						p.MduRootFr,
+						p.BlobCommitment,
+						benchFlattenPath(p.MerklePath),
+						p.BlobIndex,
+						env.leafCount,
+						p.ZValue,
+						p.YValue,
+						p.KzgOpeningProof,
+					)
+					if err != nil || !ok {
+						b.Fatalf("hop3 verify failed: ok=%v err=%v", ok, err)
+					}
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkConfirmRetrievalSession(b *testing.B) {
+	env := setupBenchRetrievalEnv(b)
+
+	// Untimed: one fresh OPEN session per measured iteration.
+	sessions := preopenSessions(b, env, 1)
+
+	idx := 0
+	var totalGas uint64
+	for b.Loop() {
+		session := sessions[idx]
+		idx++
+
+		gasBefore := benchGasConsumed(env.f.ctx)
+		_, err := env.msgServer.ConfirmRetrievalSession(env.f.ctx, &types.MsgConfirmRetrievalSession{
+			Creator:   env.owner,
+			SessionId: session,
+		})
+		totalGas += benchGasConsumed(env.f.ctx) - gasBefore
+		if err != nil {
+			b.Fatalf("ConfirmRetrievalSession failed: %v", err)
+		}
+	}
+
+	gasPerOp := float64(totalGas) / float64(idx)
+	if gasPerOp <= 0 {
+		b.Fatalf("sanity: zero average gas (%v) over %d confirms", gasPerOp, idx)
+	}
+	b.ReportMetric(gasPerOp, "gas/op")
+}
+
+// TestRetrievalSessionBenchCharacterization bounds benchmark correctness:
+// every message type consumes positive gas, and submit-proof gas is
+// monotonically non-decreasing in proof count (gas is deterministic, so this
+// comparison is exact rather than statistical).
+func TestRetrievalSessionBenchCharacterization(t *testing.T) {
+	env := setupBenchRetrievalEnv(t)
+
+	// Open: positive gas.
+	gasBefore := benchGasConsumed(env.f.ctx)
+	_, err := env.msgServer.OpenRetrievalSession(env.f.ctx, &types.MsgOpenRetrievalSession{
+		Creator:        env.owner,
+		DealId:         env.dealID,
+		Provider:       env.provider,
+		ManifestRoot:   env.deal.ManifestRoot,
+		StartMduIndex:  benchTargetMduIndex,
+		StartBlobIndex: 0,
+		BlobCount:      1,
+		Nonce:          1,
+		ExpiresAt:      0,
+	})
+	require.NoError(t, err)
+	openGas := benchGasConsumed(env.f.ctx) - gasBefore
+	require.Greater(t, openGas, uint64(0), "OpenRetrievalSession must consume gas")
+
+	// Confirm: positive gas (fresh OPEN session).
+	gasBefore = benchGasConsumed(env.f.ctx)
+	_, err = env.msgServer.ConfirmRetrievalSession(env.f.ctx, &types.MsgConfirmRetrievalSession{
+		Creator:   env.owner,
+		SessionId: env.openBenchSession(t, 2, 1).SessionId,
+	})
+	require.NoError(t, err)
+	confirmGas := benchGasConsumed(env.f.ctx) - gasBefore
+	require.Greater(t, confirmGas, uint64(0), "ConfirmRetrievalSession must consume gas")
+
+	// Cancel: positive gas. Cancel only succeeds on an EXPIRED session, so
+	// open with ExpiresAt=1 and cancel at a later block height (same pattern
+	// as TestRetrievalSession_LocksFeesAndCancels).
+	cancelCtx := sdk.UnwrapSDKContext(env.f.ctx).WithBlockHeight(10)
+	cancelRes, err := env.msgServer.OpenRetrievalSession(env.f.ctx, &types.MsgOpenRetrievalSession{
+		Creator:        env.owner,
+		DealId:         env.dealID,
+		Provider:       env.provider,
+		ManifestRoot:   env.deal.ManifestRoot,
+		StartMduIndex:  benchTargetMduIndex,
+		StartBlobIndex: 0,
+		BlobCount:      1,
+		Nonce:          3,
+		ExpiresAt:      1,
+	})
+	require.NoError(t, err)
+
+	gasBefore = benchGasConsumed(cancelCtx)
+	_, err = env.msgServer.CancelRetrievalSession(cancelCtx, &types.MsgCancelRetrievalSession{
+		Creator:   env.owner,
+		SessionId: cancelRes.SessionId,
+	})
+	require.NoError(t, err)
+	cancelGas := benchGasConsumed(cancelCtx) - gasBefore
+	require.Greater(t, cancelGas, uint64(0), "CancelRetrievalSession must consume gas")
+
+	// Submit: positive gas and monotone non-decreasing in proof count. Mode 2
+	// sessions are slot-scoped, so each count is delivered via its session
+	// plan and gas is summed over every message in the plan.
+	submitGas := make(map[int]uint64)
+	for _, count := range []int{1, 8, 64} {
+		plan := buildBenchSubmitPlan(t, env, uint64(count)+100, count)
+		var totalGas uint64
+		for _, step := range plan {
+			gasBefore = benchGasConsumed(env.f.ctx)
+			_, err := env.msgServer.SubmitRetrievalSessionProof(env.f.ctx, &types.MsgSubmitRetrievalSessionProof{
+				Creator:   step.creator,
+				SessionId: step.sessionID,
+				Proofs:    step.proofs,
+			})
+			require.NoError(t, err)
+			totalGas += benchGasConsumed(env.f.ctx) - gasBefore
+		}
+		require.Greater(t, totalGas, uint64(0), "SubmitRetrievalSessionProof must consume gas")
+		submitGas[count] = totalGas
+		t.Logf("submit proofs=%d gas=%d", count, submitGas[count])
+	}
+	require.LessOrEqual(t, submitGas[1], submitGas[8], "submit gas must be non-decreasing in proof count")
+	require.LessOrEqual(t, submitGas[8], submitGas[64], "submit gas must be non-decreasing in proof count")
+
+	// Wall-clock sanity (ns/op > 0) is inherent to the benchmarks themselves;
+	// here we additionally assert the FFI hop-verify path succeeds standalone.
+	proof := env.benchBuildChainedProof(t, 0, 7)
+	ok, err := crypto_ffi.VerifyMdu0RootTableProof(
+		env.deal.ManifestRoot, proof.MduIndex, proof.MduRootFr,
+		proof.RootTableDuCommitment, benchFlattenPath(proof.RootTableDuMerklePath), proof.ManifestOpening)
+	require.NoError(t, err)
+	require.True(t, ok)
+	ok, err = crypto_ffi.VerifyMduProof(
+		proof.MduRootFr, proof.BlobCommitment, benchFlattenPath(proof.MerklePath),
+		proof.BlobIndex, env.leafCount, proof.ZValue, proof.YValue, proof.KzgOpeningProof)
+	require.NoError(t, err)
+	require.True(t, ok)
+}
+
+// ---------------------------------------------------------------------------
+// *testing.TB-compatible copies of the *testing.T-typed fixture helpers.
+// Bodies follow keeper_test.go initFixture, msg_server_test.go polyfs helpers,
+// and mode2_proof_test.go merkle/blob helpers verbatim.
+// ---------------------------------------------------------------------------
+
+func newBenchFixture(tb testing.TB) *fixture {
+	tb.Helper()
+
+	encCfg := moduletestutil.MakeTestEncodingConfig(module.AppModule{})
+	addressCodec := addresscodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix())
+	storeKey := storetypes.NewKVStoreKey(types.StoreKey)
+
+	storeService := runtime.NewKVStoreService(storeKey)
+	ctx := testutil.DefaultContextWithDB(tb, storeKey, storetypes.NewTransientStoreKey("transient_test")).Ctx
+
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	sdkCtx = sdkCtx.WithChainID("test-chain")
+	ctx = sdkCtx
+
+	authority := authtypes.NewModuleAddress(types.GovModuleName)
+
+	k := keeper.NewKeeper(
+		storeService,
+		encCfg.Codec,
+		addressCodec,
+		authority,
+		MockBankKeeper{},
+		MockAccountKeeper{},
+	)
+
+	if err := k.Params.Set(ctx, types.DefaultParams()); err != nil {
+		tb.Fatalf("failed to set params: %v", err)
+	}
+
+	return &fixture{ctx: ctx, keeper: k, addressCodec: addressCodec}
+}
+
+func benchBuildPolyFSMdu0(tb testing.TB, rootsByMdu map[uint64][]byte) (cid string, mdu0 []byte) {
+	tb.Helper()
+	require.NotEmpty(tb, rootsByMdu)
+
+	mdu0 = make([]byte, types.MDU_SIZE)
+	rootsByDu := make(map[uint64][][]byte)
+	for mduIndex, root := range rootsByMdu {
+		require.Len(tb, root, 32)
+		du, cell := benchRootTablePositionForMduIndex(tb, mduIndex)
+		require.Less(tb, du, uint64(16), "MDU root table supports 16 DUs")
+		roots := rootsByDu[du]
+		for uint64(len(roots)) <= cell {
+			roots = append(roots, make([]byte, 32))
+		}
+		roots[cell] = root
+		rootsByDu[du] = roots
+	}
+
+	for du, roots := range rootsByDu {
+		_, blob := benchComputeManifestCid(tb, roots)
+		start := int(du) * types.BLOB_SIZE
+		copy(mdu0[start:start+types.BLOB_SIZE], blob)
+	}
+
+	polyfsRoot, err := crypto_ffi.ComputeMduMerkleRoot(mdu0)
+	require.NoError(tb, err)
+	return "0x" + hex.EncodeToString(polyfsRoot), mdu0
+}
+
+func benchComputeManifestCid(tb testing.TB, mduRoots [][]byte) (cid string, manifestBlob []byte) {
+	tb.Helper()
+	commitment, blob, err := crypto_ffi.ComputeManifestCommitment(mduRoots)
+	require.NoError(tb, err)
+	return "0x" + hex.EncodeToString(commitment), blob
+}
+
+func benchRootTablePositionForMduIndex(tb testing.TB, mduIndex uint64) (du uint64, cell uint64) {
+	tb.Helper()
+	require.GreaterOrEqual(tb, mduIndex, uint64(1), "MDU #0 is metadata and is not represented in its root table")
+	idx := mduIndex - 1
+	return idx / 4096, idx % 4096
+}
+
+func benchMdu0RootTableProof(
+	tb testing.TB,
+	mdu0 []byte,
+	mduIndex uint64,
+	targetMduRoot []byte,
+) (rootTableDuCommitment []byte, rootTableDuMerklePath [][]byte, rootTableOpening []byte) {
+	tb.Helper()
+	duCommitment, duMerkleFlat, opening, _, err := crypto_ffi.ComputeMdu0RootTableProof(mdu0, mduIndex, targetMduRoot)
+	require.NoError(tb, err)
+	return duCommitment, benchSplitFlatPath(tb, duMerkleFlat), opening
+}
+
+func benchSplitFlatPath(tb testing.TB, flat []byte) [][]byte {
+	tb.Helper()
+	require.NotEmpty(tb, flat)
+	require.Equal(tb, 0, len(flat)%32)
+	out := make([][]byte, 0, len(flat)/32)
+	for off := 0; off < len(flat); off += 32 {
+		node := make([]byte, 32)
+		copy(node, flat[off:off+32])
+		out = append(out, node)
+	}
+	return out
+}
+
+func benchFlattenPath(path [][]byte) []byte {
+	n := 0
+	for _, p := range path {
+		n += len(p)
+	}
+	out := make([]byte, 0, n)
+	for _, p := range path {
+		out = append(out, p...)
+	}
+	return out
+}
+
+func benchMerklePathFromWitnessFlat(tb testing.TB, witnessFlat []byte, leafIndex uint64) [][]byte {
+	tb.Helper()
+	require.True(tb, len(witnessFlat) > 0 && len(witnessFlat)%48 == 0, "witnessFlat must be a non-empty multiple of 48 bytes")
+	leafCount := len(witnessFlat) / 48
+	require.True(tb, int(leafIndex) >= 0 && int(leafIndex) < leafCount, "leafIndex out of range")
+
+	level := make([][32]byte, 0, leafCount)
+	for i := 0; i < len(witnessFlat); i += 48 {
+		level = append(level, blake2s.Sum256(witnessFlat[i:i+48]))
+	}
+	idx := int(leafIndex)
+
+	path := make([][]byte, 0, 10)
+	for len(level) > 1 {
+		if idx%2 == 0 {
+			if idx+1 < len(level) {
+				h := make([]byte, 32)
+				copy(h, level[idx+1][:])
+				path = append(path, h)
+			}
+		} else {
+			h := make([]byte, 32)
+			copy(h, level[idx-1][:])
+			path = append(path, h)
+		}
+
+		next := make([][32]byte, 0, (len(level)+1)/2)
+		for i := 0; i < len(level); i += 2 {
+			left := level[i]
+			if i+1 < len(level) {
+				right := level[i+1]
+				var pair [64]byte
+				copy(pair[:32], left[:])
+				copy(pair[32:], right[:])
+				next = append(next, blake2s.Sum256(pair[:]))
+				continue
+			}
+			// rs_merkle propagates the left node when no sibling exists.
+			next = append(next, left)
+		}
+		level = next
+		idx /= 2
+	}
+	return path
+}
+
+func benchBlobBytesForLeaf(tb testing.TB, mduBytes []byte, shards [][]byte, k uint64, slot uint64, row uint64) []byte {
+	tb.Helper()
+	rows := uint64(64) / k
+	require.True(tb, row < rows, "row out of range")
+	require.True(tb, k > 0 && slot < uint64(len(shards)), "slot out of range")
+
+	// Data slots map directly back to original MDU blobs.
+	if slot < k {
+		blobIndex := row*k + slot
+		off := int(blobIndex) * types.BLOB_SIZE
+		end := off + types.BLOB_SIZE
+		require.True(tb, end <= len(mduBytes), "blob slice out of range")
+		blob := make([]byte, types.BLOB_SIZE)
+		copy(blob, mduBytes[off:end])
+		return blob
+	}
+
+	// Parity slots come from RS expansion shards.
+	shard := shards[slot]
+	require.Len(tb, shard, int(rows)*types.BLOB_SIZE, "shard length mismatch")
+	off := int(row) * types.BLOB_SIZE
+	end := off + types.BLOB_SIZE
+	blob := make([]byte, types.BLOB_SIZE)
+	copy(blob, shard[off:end])
+	return blob
+}

--- a/scripts/bench_retrieval_sessions.sh
+++ b/scripts/bench_retrieval_sessions.sh
@@ -328,50 +328,65 @@ if len(raw) >= 32:
 print("")' <<<"$LAST_TXJSON")
     [ -n "$SESSION_ID" ] || fail "open tx $LAST_TXHASH has no open_retrieval_session session_id"
     if [ "$PROOFS_PER_SESSION" -eq 0 ]; then
+      proof_ok=0
       record_skip submit-proof "$i" "POLYSTORE_BENCH_PROOFS_PER_SESSION=0 (proof stage skipped)"
     else
       PROOF_FILE="$PROOFS_DIR/$i.json"
       [ -f "$PROOF_FILE" ] || fail "missing proof payload $PROOF_FILE"
-      python3 - "$PROOF_FILE" "$SESSION_ID" "$PROOFS_PER_SESSION" <<'PY'
+      # Never mutate a caller-owned fixture; inject this run's session ID into
+      # a per-session copy because owner/provider addresses are regenerated.
+      RUNTIME_PROOF_FILE="$CHAIN_HOME/proof-$i.json"
+      cp "$PROOF_FILE" "$RUNTIME_PROOF_FILE"
+      python3 - "$RUNTIME_PROOF_FILE" "$SESSION_ID" "$PROOFS_PER_SESSION" <<'PY'
 import base64, binascii, json, sys
-
-obj = json.load(open(sys.argv[1]))
-payload_id = str(obj.get("session_id", "")).strip()
-try:
-    payload_bytes = base64.b64decode(payload_id, validate=True)
-    if base64.b64encode(payload_bytes).decode("ascii") != payload_id:
-        raise ValueError("non-canonical base64")
-except (ValueError, binascii.Error):
-    hex_id = payload_id[2:] if payload_id.lower().startswith("0x") else payload_id
+def decode_session_id(value, label):
+    text = str(value).strip()
     try:
-        payload_bytes = bytes.fromhex(hex_id)
+        decoded = base64.b64decode(text, validate=True)
+        if base64.b64encode(decoded).decode("ascii") == text and len(decoded) == 32:
+            return decoded
+    except (ValueError, binascii.Error):
+        pass
+    hex_id = text[2:] if text.lower().startswith("0x") else text
+    try:
+        decoded = bytes.fromhex(hex_id)
     except ValueError as exc:
-        raise SystemExit(f"proof payload session_id is not strict base64 or hex: {exc}")
-runtime_id = sys.argv[2].strip()
-if runtime_id.lower().startswith("0x"):
-    runtime_id = runtime_id[2:]
-try:
-    runtime_bytes = bytes.fromhex(runtime_id)
-except ValueError as exc:
-    raise SystemExit(f"open tx session_id is not hex: {exc}")
-if len(payload_bytes) != 32 or len(runtime_bytes) != 32:
-    raise SystemExit("proof and open session_id values must both be exactly 32 bytes")
-if payload_bytes != runtime_bytes:
-    raise SystemExit("proof payload session_id does not match exact open tx session_id")
+        raise SystemExit(f"{label} is not strict base64 or hex: {exc}")
+    if len(decoded) != 32:
+        raise SystemExit(f"{label} must be exactly 32 bytes")
+    return decoded
+
+proof_path = sys.argv[1]
+obj = json.load(open(proof_path))
+if "session_id" in obj:
+    decode_session_id(obj["session_id"], "proof payload session_id")
+runtime_bytes = decode_session_id(sys.argv[2], "open tx session_id")
 proofs = obj.get("proofs")
 if not isinstance(proofs, list) or len(proofs) != int(sys.argv[3]):
     raise SystemExit(f"proof payload must contain exactly {sys.argv[3]} proofs")
+obj["session_id"] = base64.b64encode(runtime_bytes).decode("ascii")
+with open(proof_path, "w") as stream:
+    json.dump(obj, stream, indent=1)
 PY
-      send_tx submit-proof "$i" "$PROVIDER_NAME" submit-retrieval-proof "$PROOF_FILE" \
-        || log "session $i proof transaction failed (recorded)"
-
+      if send_tx submit-proof "$i" "$PROVIDER_NAME" submit-retrieval-proof "$RUNTIME_PROOF_FILE"; then
+        proof_ok=1
+      else
+        proof_ok=0
+        log "session $i proof transaction failed (recorded)"
+      fi
     fi
-    send_tx confirm-session "$i" "$USER_NAME" confirm-retrieval-session --session-id "$SESSION_ID" \
-      || log "session $i confirm transaction failed (recorded)"
+
+    if [ "$PROOFS_PER_SESSION" -eq 0 ] || [ "$proof_ok" -eq 1 ]; then
+      send_tx confirm-session "$i" "$USER_NAME" confirm-retrieval-session --session-id "$SESSION_ID" \
+        || log "session $i confirm transaction failed (recorded)"
+    else
+      record_skip confirm-session "$i" "proof transaction failed; confirmation skipped"
+    fi
   else
     log "session $i open transaction failed (recorded)"
   fi
 done
+sample_block
 END_NS=$(date +%s%N)
 
 python3 - "$OUTPUT" "$START_NS" "$END_NS" <<'PY'
@@ -393,11 +408,19 @@ load_rate = round(load_sent / wall, 3) if wall > 0 else None
 session_indices = range(1, int(doc["config"]["sessions"]) + 1)
 successful = {(t.get("index"), t.get("kind"))
               for t in load_txs if t.get("code") == 0 and not t.get("error")}
-sessions_completed = sum(
+sessions_confirmed = sum(
     1 for i in session_indices
     if (i, "open-session") in successful and (i, "confirm-session") in successful
 )
-sessions_per_sec = round(sessions_completed / wall, 3) if wall > 0 else None
+proofs_enabled = int(doc["config"]["proofs_per_session"]) > 0
+sessions_completed = sum(
+    1 for i in session_indices
+    if (i, "open-session") in successful
+    and (i, "submit-proof") in successful
+    and (i, "confirm-session") in successful
+) if proofs_enabled else 0
+confirmed_rate = round(sessions_confirmed / wall, 3) if wall > 0 else None
+completed_rate = round(sessions_completed / wall, 3) if proofs_enabled and wall > 0 else None
 summary = {
   "total_records": len(txs), "total_ok": total_ok, "total_failed": total_failed,
   "total_skipped": total_skipped, "total_txs_sent": total_sent,
@@ -405,7 +428,11 @@ summary = {
   "load_skipped": load_skipped, "load_txs_sent": load_sent,
   "load_txs_per_sec": load_rate, "txs_per_sec": load_rate,
   "sessions_attempted": int(doc["config"]["sessions"]),
-  "sessions_completed": sessions_completed, "sessions_per_sec": sessions_per_sec,
+  "sessions_confirmed": sessions_confirmed,
+  "sessions_confirmed_per_sec": confirmed_rate,
+  "sessions_completed": sessions_completed,
+  "sessions_per_sec": completed_rate,
+  "completion_basis": "open+proof+confirm" if proofs_enabled else "not measured (proof stage skipped)",
   "target_sessions_per_sec": int(doc["config"]["target_sessions_per_sec"]),
   "serial_driver": True, "saturation": False,
   "wall_seconds": round(wall, 3),

--- a/scripts/bench_retrieval_sessions.sh
+++ b/scripts/bench_retrieval_sessions.sh
@@ -14,7 +14,7 @@ BIN="$CHAIN_DIR/polystorechaind"
 MODULE_CLI="${POLYSTORE_CHAIN_MODULE_CLI_NAME:-nilchain}"
 
 SESSIONS="${POLYSTORE_BENCH_SESSIONS:-5}"
-RATE="${POLYSTORE_BENCH_RATE:-5}"
+TARGET_SESSIONS_PER_SEC="${POLYSTORE_BENCH_RATE:-5}"
 PROOFS_PER_SESSION="${POLYSTORE_BENCH_PROOFS_PER_SESSION:-0}"
 PROOFS_DIR="${POLYSTORE_BENCH_PROOFS_DIR:-}"
 OUTPUT="${POLYSTORE_BENCH_OUTPUT:-$ROOT_DIR/bench_results_retrieval_sessions.json}"
@@ -39,8 +39,11 @@ require_cmd go
 require_cmd curl
 require_cmd python3
 [[ "$SESSIONS" =~ ^[0-9]+$ && "$SESSIONS" -gt 0 ]] || fail "POLYSTORE_BENCH_SESSIONS must be a positive integer"
-[[ "$RATE" =~ ^[0-9]+$ && "$RATE" -gt 0 ]] || fail "POLYSTORE_BENCH_RATE must be a positive integer"
+[[ "$TARGET_SESSIONS_PER_SEC" =~ ^[0-9]+$ && "$TARGET_SESSIONS_PER_SEC" -gt 0 ]] || fail "POLYSTORE_BENCH_RATE (target_sessions_per_sec) must be a positive integer"
 [[ "$PROOFS_PER_SESSION" =~ ^[0-9]+$ ]] || fail "POLYSTORE_BENCH_PROOFS_PER_SESSION must be a non-negative integer"
+if [ "$PROOFS_PER_SESSION" -gt 0 ] && [ "$PROOFS_PER_SESSION" -gt 32 ]; then
+  fail "POLYSTORE_BENCH_PROOFS_PER_SESSION must be 1..32 for the explicit General:rs=2+1 fixture (or 0 to skip proofs)"
+fi
 if [ "$PROOFS_PER_SESSION" -gt 0 ] && [ -z "$PROOFS_DIR" ]; then
   fail "POLYSTORE_BENCH_PROOFS_PER_SESSION=$PROOFS_PER_SESSION requires POLYSTORE_BENCH_PROOFS_DIR with <session-index>.json payloads"
 fi
@@ -248,11 +251,15 @@ send_tx() { # send_tx <kind> <index> <from> <module-cli-args...>
   [ "$rc" -eq 0 ] && [ -n "$txjson" ] && [ "$code" -eq 0 ]
 }
 
-python3 - "$OUTPUT" "$SESSIONS" "$RATE" "$PROOFS_PER_SESSION" "$CHAIN_ID" "$RPC_ADDR" "$MODULE_CLI" <<'PY'
+python3 - "$OUTPUT" "$SESSIONS" "$TARGET_SESSIONS_PER_SEC" "$PROOFS_PER_SESSION" "$CHAIN_ID" "$RPC_ADDR" "$MODULE_CLI" <<'PY'
 import json, sys, time
-json.dump({"config": {"sessions": int(sys.argv[2]), "rate_tps": int(sys.argv[3]),
-  "proofs_per_session": int(sys.argv[4]), "chain_id": sys.argv[5], "rpc": sys.argv[6],
-  "module_cli": sys.argv[7], "started_unix_ns": time.time_ns()}, "blocks": [], "txs": []},
+json.dump({"config": {
+  "sessions": int(sys.argv[2]), "target_sessions_per_sec": int(sys.argv[3]),
+  "proofs_per_session": int(sys.argv[4]), "chain_id": sys.argv[5],
+  "rpc": sys.argv[6], "module_cli": sys.argv[7], "serial_driver": True,
+  "saturation": False,
+  "driver_note": "single-client paced path; sessions/block ceiling comes from gas/time arithmetic and in-process benchmarks, not arbitrary parallel saturation",
+  "started_unix_ns": time.time_ns()}, "blocks": [], "txs": []},
   open(sys.argv[1], "w"), indent=1)
 PY
 
@@ -286,16 +293,25 @@ log "deal $DEAL_ID assigned $ASSIGNED_COUNT providers"
 MANIFEST_HEX="0x$(python3 -c 'print("ab" * 32)')"
 send_tx update-deal-content 0 "$USER_NAME" update-deal-content --deal-id "$DEAL_ID" --cid "$MANIFEST_HEX" \
   --size 131072 --total-mdus 3 --witness-mdus 1 || fail "update-deal-content setup transaction failed"
+BLOB_COUNT=1
+if [ "$PROOFS_PER_SESSION" -gt 0 ]; then
+  BLOB_COUNT="$PROOFS_PER_SESSION"
+fi
 
-INTERVAL_NS=$((1000000000 / RATE))
+INTERVAL_NS=$((1000000000 / TARGET_SESSIONS_PER_SEC))
 START_NS=$(date +%s%N)
 for i in $(seq 1 "$SESSIONS"); do
+  target=$((START_NS + (i - 1) * INTERVAL_NS))
+  now=$(date +%s%N)
+  if [ "$now" -lt "$target" ]; then
+    sleep "$(( (target - now) / 1000000000 )).$(( ((target - now) % 1000000000) / 1000000 ))"
+  fi
   sample_block
   NONCE="$i"
   if send_tx open-session "$i" "$USER_NAME" open-retrieval-session --deal-id "$DEAL_ID" --provider "$PROVIDER_ADDR" \
-      --manifest-root "$MANIFEST_HEX" --start-mdu-index 2 --start-blob-index 0 --blob-count 1 --nonce "$NONCE"; then
+      --manifest-root "$MANIFEST_HEX" --start-mdu-index 2 --start-blob-index 0 --blob-count "$BLOB_COUNT" --nonce "$NONCE"; then
     # LAST_TXJSON is the exact open transaction; never search sender history.
-    SESSION_ID=$(python3 -c 'import binascii,json,sys
+    SESSION_ID=$(python3 -c 'import json,sys
 d=json.load(sys.stdin)
 events=list(d.get("events",[]))
 for log in d.get("logs",[]):
@@ -316,11 +332,35 @@ print("")' <<<"$LAST_TXJSON")
     else
       PROOF_FILE="$PROOFS_DIR/$i.json"
       [ -f "$PROOF_FILE" ] || fail "missing proof payload $PROOF_FILE"
-      python3 - "$PROOF_FILE" "$SESSION_ID" <<'PY'
-import json, sys
+      python3 - "$PROOF_FILE" "$SESSION_ID" "$PROOFS_PER_SESSION" <<'PY'
+import base64, binascii, json, sys
+
 obj = json.load(open(sys.argv[1]))
-if obj.get("session_id") != sys.argv[2]:
+payload_id = str(obj.get("session_id", "")).strip()
+try:
+    payload_bytes = base64.b64decode(payload_id, validate=True)
+    if base64.b64encode(payload_bytes).decode("ascii") != payload_id:
+        raise ValueError("non-canonical base64")
+except (ValueError, binascii.Error):
+    hex_id = payload_id[2:] if payload_id.lower().startswith("0x") else payload_id
+    try:
+        payload_bytes = bytes.fromhex(hex_id)
+    except ValueError as exc:
+        raise SystemExit(f"proof payload session_id is not strict base64 or hex: {exc}")
+runtime_id = sys.argv[2].strip()
+if runtime_id.lower().startswith("0x"):
+    runtime_id = runtime_id[2:]
+try:
+    runtime_bytes = bytes.fromhex(runtime_id)
+except ValueError as exc:
+    raise SystemExit(f"open tx session_id is not hex: {exc}")
+if len(payload_bytes) != 32 or len(runtime_bytes) != 32:
+    raise SystemExit("proof and open session_id values must both be exactly 32 bytes")
+if payload_bytes != runtime_bytes:
     raise SystemExit("proof payload session_id does not match exact open tx session_id")
+proofs = obj.get("proofs")
+if not isinstance(proofs, list) or len(proofs) != int(sys.argv[3]):
+    raise SystemExit(f"proof payload must contain exactly {sys.argv[3]} proofs")
 PY
       send_tx submit-proof "$i" "$PROVIDER_NAME" submit-retrieval-proof "$PROOF_FILE" \
         || log "session $i proof transaction failed (recorded)"
@@ -330,11 +370,6 @@ PY
       || log "session $i confirm transaction failed (recorded)"
   else
     log "session $i open transaction failed (recorded)"
-  fi
-  now=$(date +%s%N)
-  target=$((START_NS + i * INTERVAL_NS))
-  if [ "$now" -lt "$target" ]; then
-    sleep "$(( (target - now) / 1000000000 )).$(( ((target - now) % 1000000000) / 1000000 ))"
   fi
 done
 END_NS=$(date +%s%N)
@@ -355,14 +390,25 @@ load_failed = sum(1 for t in load_txs if not t.get("skipped") and (t.get("code")
 load_skipped = sum(1 for t in load_txs if t.get("skipped"))
 load_sent = sum(1 for t in load_txs if not t.get("skipped"))
 load_rate = round(load_sent / wall, 3) if wall > 0 else None
+session_indices = range(1, int(doc["config"]["sessions"]) + 1)
+successful = {(t.get("index"), t.get("kind"))
+              for t in load_txs if t.get("code") == 0 and not t.get("error")}
+sessions_completed = sum(
+    1 for i in session_indices
+    if (i, "open-session") in successful and (i, "confirm-session") in successful
+)
+sessions_per_sec = round(sessions_completed / wall, 3) if wall > 0 else None
 summary = {
   "total_records": len(txs), "total_ok": total_ok, "total_failed": total_failed,
   "total_skipped": total_skipped, "total_txs_sent": total_sent,
   "load_records": len(load_txs), "load_ok": load_ok, "load_failed": load_failed,
   "load_skipped": load_skipped, "load_txs_sent": load_sent,
-  "load_txs_per_sec": load_rate, "wall_seconds": round(wall, 3),
-  # Keep the historical key as an alias for the load-only rate.
-  "txs_per_sec": load_rate,
+  "load_txs_per_sec": load_rate, "txs_per_sec": load_rate,
+  "sessions_attempted": int(doc["config"]["sessions"]),
+  "sessions_completed": sessions_completed, "sessions_per_sec": sessions_per_sec,
+  "target_sessions_per_sec": int(doc["config"]["target_sessions_per_sec"]),
+  "serial_driver": True, "saturation": False,
+  "wall_seconds": round(wall, 3),
 }
 if doc["blocks"]:
     heights = [b["height"] for b in doc["blocks"]]

--- a/scripts/bench_retrieval_sessions.sh
+++ b/scripts/bench_retrieval_sessions.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # bench_retrieval_sessions.sh — deterministic single-node retrieval-session
 # throughput/load driver (issue #245).
+# Measurement boundary: START_NS/END_NS covers the paced load loop, while each
+# transaction latency starts before CLI submission and ends after wait_for_tx
+# confirms the committed transaction is queryable.
+
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -223,12 +227,13 @@ send_tx() { # send_tx <kind> <index> <from> <module-cli-args...>
   before=$(curl -sf "$LCD/status" | python3 -c 'import json,sys; print(json.load(sys.stdin)["result"]["sync_info"]["latest_block_height"])' 2>/dev/null || echo 0)
   started=$(date +%s%N)
   out=$("$BIN" tx "$MODULE_CLI" "$@" --from "$from" "${TXARGS[@]}" 2>&1) && rc=0 || rc=$?
-  finished=$(date +%s%N)
   hash=$(parse_json_record <<<"$out" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("txhash", ""))' 2>/dev/null || true)
   LAST_TXHASH="$hash"
   txjson=""
   if [ -n "$hash" ]; then txjson=$(wait_for_tx "$hash" || true); fi
   LAST_TXJSON="$txjson"
+  finished=$(date +%s%N)
+
   after=$(curl -sf "$LCD/status" | python3 -c 'import json,sys; print(json.load(sys.stdin)["result"]["sync_info"]["latest_block_height"])' 2>/dev/null || echo 0)
   code=1
   error="$out"
@@ -267,6 +272,15 @@ DEAL_ID=$(python3 -c 'import json,sys; d=json.load(sys.stdin); xs=d.get("deals",
 ASSIGNED_COUNT=$(python3 -c 'import json,sys; d=json.load(sys.stdin); xs=d.get("deals",[]); print(len(xs[-1].get("providers",[])) if xs else 0)' <<<"$DEALS_JSON")
 [ "$ASSIGNED_COUNT" -ge 3 ] || fail "Mode 2 deal has $ASSIGNED_COUNT eligible providers; expected at least 3"
 PROVIDER_ADDR=$(python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["deals"][-1]["providers"][0])' <<<"$DEALS_JSON")
+PROVIDER_NAME=""
+for i in "${!PROVIDER_ADDRS[@]}"; do
+  if [ "${PROVIDER_ADDRS[$i]}" = "$PROVIDER_ADDR" ]; then
+    PROVIDER_NAME="${PROVIDER_NAMES[$i]}"
+    break
+  fi
+done
+[ -n "$PROVIDER_NAME" ] || fail "assigned provider $PROVIDER_ADDR has no matching key"
+
 log "deal $DEAL_ID assigned $ASSIGNED_COUNT providers"
 
 MANIFEST_HEX="0x$(python3 -c 'print("ab" * 32)')"
@@ -308,8 +322,9 @@ obj = json.load(open(sys.argv[1]))
 if obj.get("session_id") != sys.argv[2]:
     raise SystemExit("proof payload session_id does not match exact open tx session_id")
 PY
-      send_tx submit-proof "$i" "${PROVIDER_NAMES[0]}" submit-retrieval-proof "$PROOF_FILE" \
+      send_tx submit-proof "$i" "$PROVIDER_NAME" submit-retrieval-proof "$PROOF_FILE" \
         || log "session $i proof transaction failed (recorded)"
+
     fi
     send_tx confirm-session "$i" "$USER_NAME" confirm-retrieval-session --session-id "$SESSION_ID" \
       || log "session $i confirm transaction failed (recorded)"
@@ -329,13 +344,26 @@ import json, sys
 doc = json.load(open(sys.argv[1]))
 wall = (int(sys.argv[3]) - int(sys.argv[2])) / 1e9
 txs = doc["txs"]
-ok = sum(1 for t in txs if t.get("code") == 0 and not t.get("error"))
-failed = sum(1 for t in txs if not t.get("skipped") and (t.get("code") not in (0, None) or t.get("error")))
-skipped = sum(1 for t in txs if t.get("skipped"))
-sent = sum(1 for t in txs if not t.get("skipped"))
-summary = {"total_records": len(txs), "ok": ok, "failed": failed, "skipped": skipped,
-  "txs_sent": sent, "wall_seconds": round(wall, 3),
-  "txs_per_sec": round(sent / wall, 3) if wall > 0 else None}
+load_kinds = {"open-session", "submit-proof", "confirm-session"}
+load_txs = [t for t in txs if t.get("kind") in load_kinds]
+total_ok = sum(1 for t in txs if t.get("code") == 0 and not t.get("error"))
+total_failed = sum(1 for t in txs if not t.get("skipped") and (t.get("code") not in (0, None) or t.get("error")))
+total_skipped = sum(1 for t in txs if t.get("skipped"))
+total_sent = sum(1 for t in txs if not t.get("skipped"))
+load_ok = sum(1 for t in load_txs if t.get("code") == 0 and not t.get("error"))
+load_failed = sum(1 for t in load_txs if not t.get("skipped") and (t.get("code") not in (0, None) or t.get("error")))
+load_skipped = sum(1 for t in load_txs if t.get("skipped"))
+load_sent = sum(1 for t in load_txs if not t.get("skipped"))
+load_rate = round(load_sent / wall, 3) if wall > 0 else None
+summary = {
+  "total_records": len(txs), "total_ok": total_ok, "total_failed": total_failed,
+  "total_skipped": total_skipped, "total_txs_sent": total_sent,
+  "load_records": len(load_txs), "load_ok": load_ok, "load_failed": load_failed,
+  "load_skipped": load_skipped, "load_txs_sent": load_sent,
+  "load_txs_per_sec": load_rate, "wall_seconds": round(wall, 3),
+  # Keep the historical key as an alias for the load-only rate.
+  "txs_per_sec": load_rate,
+}
 if doc["blocks"]:
     heights = [b["height"] for b in doc["blocks"]]
     summary.update({"block_height_start": min(heights), "block_height_end": max(heights),

--- a/scripts/bench_retrieval_sessions.sh
+++ b/scripts/bench_retrieval_sessions.sh
@@ -61,7 +61,7 @@ export LD_LIBRARY_PATH="$CORE_LIB_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 export CGO_LDFLAGS="-L$CORE_LIB_DIR -lpolystore_core${CGO_LDFLAGS:+ $CGO_LDFLAGS}"
 
 log "building polystorechaind"
-(cd "$CHAIN_DIR" && go build -o "$BIN" ./cmd/polystorechaind) || fail "chain build failed"
+(cd "$CHAIN_DIR" && GOFLAGS="${GOFLAGS:-} -mod=mod" go build -o "$BIN" ./cmd/polystorechaind) || fail "chain build failed"
 
 NODE_PID=""
 cleanup() {
@@ -92,7 +92,7 @@ prepare_proof_fixtures() {
       POLYSTORE_BENCH_FIXTURE_SESSIONS="$SESSIONS" \
       POLYSTORE_BENCH_FIXTURE_COUNT="$PROOFS_PER_SESSION" \
       POLYSTORE_BENCH_FIXTURE_SERVICE_HINT="General:rs=2+1" \
-        go test ./x/polystorechain/keeper -run '^TestWriteRetrievalSessionProofFixture$' -count=1
+        GOFLAGS="${GOFLAGS:-} -mod=mod" go test ./x/polystorechain/keeper -run '^TestWriteRetrievalSessionProofFixture$' -count=1
     ) || fail "proof fixture generation failed"
   else
     [ -d "$PROOFS_DIR" ] || fail "proof fixture directory does not exist: $PROOFS_DIR"

--- a/scripts/bench_retrieval_sessions.sh
+++ b/scripts/bench_retrieval_sessions.sh
@@ -1,0 +1,347 @@
+#!/usr/bin/env bash
+# bench_retrieval_sessions.sh — deterministic single-node retrieval-session
+# throughput/load driver (issue #245).
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHAIN_DIR="$ROOT_DIR/polystorechain"
+CORE_DIR="$ROOT_DIR/polystore_core"
+BIN="$CHAIN_DIR/polystorechaind"
+MODULE_CLI="${POLYSTORE_CHAIN_MODULE_CLI_NAME:-nilchain}"
+
+SESSIONS="${POLYSTORE_BENCH_SESSIONS:-5}"
+RATE="${POLYSTORE_BENCH_RATE:-5}"
+PROOFS_PER_SESSION="${POLYSTORE_BENCH_PROOFS_PER_SESSION:-0}"
+PROOFS_DIR="${POLYSTORE_BENCH_PROOFS_DIR:-}"
+OUTPUT="${POLYSTORE_BENCH_OUTPUT:-$ROOT_DIR/bench_results_retrieval_sessions.json}"
+CHAIN_HOME="${POLYSTORE_BENCH_HOME:-$ROOT_DIR/_artifacts/bench_retrieval_sessions_data}"
+CHAIN_ID="${CHAIN_ID:-31337}"
+RPC_ADDR="${RPC_ADDR:-tcp://127.0.0.1:26658}"
+P2P_ADDR="${P2P_ADDR:-tcp://127.0.0.1:26659}"
+RPC_HOST_PORT="${RPC_ADDR#*://}"
+LCD="http://$RPC_HOST_PORT"
+DENOM="${POLYSTORE_DENOM:-stake}"
+GAS_PRICE="${POLYSTORE_GAS_PRICES:-0.001aatom}"
+CORE_LIB_DIR="${POLYSTORE_CORE_LIB_DIR:-$CORE_DIR/target/release}"
+KEEP_HOME=0
+[ "${1:-}" = "--keep-home" ] && KEEP_HOME=1
+
+log()  { printf '[bench-sessions] %s\n' "$*"; }
+fail() { printf '[bench-sessions] ERROR: %s\n' "$*" >&2; exit 1; }
+require_cmd() { command -v "$1" >/dev/null 2>&1 || fail "missing '$1'; install it and rerun"; }
+
+require_cmd cargo
+require_cmd go
+require_cmd curl
+require_cmd python3
+[[ "$SESSIONS" =~ ^[0-9]+$ && "$SESSIONS" -gt 0 ]] || fail "POLYSTORE_BENCH_SESSIONS must be a positive integer"
+[[ "$RATE" =~ ^[0-9]+$ && "$RATE" -gt 0 ]] || fail "POLYSTORE_BENCH_RATE must be a positive integer"
+[[ "$PROOFS_PER_SESSION" =~ ^[0-9]+$ ]] || fail "POLYSTORE_BENCH_PROOFS_PER_SESSION must be a non-negative integer"
+if [ "$PROOFS_PER_SESSION" -gt 0 ] && [ -z "$PROOFS_DIR" ]; then
+  fail "POLYSTORE_BENCH_PROOFS_PER_SESSION=$PROOFS_PER_SESSION requires POLYSTORE_BENCH_PROOFS_DIR with <session-index>.json payloads"
+fi
+
+CORE_LIB="$CORE_LIB_DIR/libpolystore_core.so"
+if [ ! -f "$CORE_LIB" ]; then
+  log "libpolystore_core.so missing; building polystore_core"
+  (cd "$CORE_DIR" && cargo build --release) || fail "cargo build --release failed; build $CORE_LIB manually and rerun"
+fi
+[ -f "$CORE_LIB" ] || fail "missing $CORE_LIB after cargo build --release; run (cd $CORE_DIR && cargo build --release)"
+export LD_LIBRARY_PATH="$CORE_LIB_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export CGO_LDFLAGS="-L$CORE_LIB_DIR -lpolystore_core${CGO_LDFLAGS:+ $CGO_LDFLAGS}"
+
+if [ ! -x "$BIN" ]; then
+  log "building polystorechaind"
+  (cd "$CHAIN_DIR" && go build -o "$BIN" ./cmd/polystorechaind) || fail "chain build failed; run (cd $CHAIN_DIR && go build -o $BIN ./cmd/polystorechaind)"
+fi
+
+NODE_PID=""
+cleanup() {
+  if [ -n "$NODE_PID" ] && kill -0 "$NODE_PID" 2>/dev/null; then
+    log "stopping node pid $NODE_PID"
+    kill "$NODE_PID" 2>/dev/null || true
+    for _ in $(seq 1 10); do
+      kill -0 "$NODE_PID" 2>/dev/null || break
+      sleep 0.2
+    done
+    kill -9 "$NODE_PID" 2>/dev/null || true
+  fi
+  if [ "$KEEP_HOME" != "1" ] && [ -d "$CHAIN_HOME" ]; then rm -rf "$CHAIN_HOME"; fi
+}
+trap cleanup EXIT
+
+rm -rf "$CHAIN_HOME"
+mkdir -p "$(dirname "$OUTPUT")"
+
+log "initializing chain home $CHAIN_HOME (chain-id $CHAIN_ID, module $MODULE_CLI)"
+"$BIN" init bench-sessions --chain-id "$CHAIN_ID" --home "$CHAIN_HOME" >/dev/null 2>&1
+KEYRING_ARGS=(--keyring-backend test --home "$CHAIN_HOME")
+TXARGS=(--keyring-backend test --home "$CHAIN_HOME" --chain-id "$CHAIN_ID"
+  --gas-adjustment 1.5 --gas-prices "$GAS_PRICE" --node "$RPC_ADDR" --output json -y)
+
+add_key() {
+  set +o pipefail
+  yes | "$BIN" keys add "$1" "${KEYRING_ARGS[@]}" --output json >/dev/null 2>&1
+  local rc=$?
+  set -o pipefail
+  return "$rc"
+}
+USER_NAME=bench-user
+PROVIDER_NAMES=(bench-provider1 bench-provider2 bench-provider3)
+add_key "$USER_NAME"
+USER_ADDR=$("$BIN" keys show "$USER_NAME" -a "${KEYRING_ARGS[@]}")
+PROVIDER_ADDRS=()
+for name in "${PROVIDER_NAMES[@]}"; do
+  add_key "$name"
+  addr=$("$BIN" keys show "$name" -a "${KEYRING_ARGS[@]}")
+  PROVIDER_ADDRS+=("$addr")
+done
+
+# Fund the fee token as well as stake: EVM-enabled ante handling requires aatom.
+FUNDING="100000000000$DENOM,1000000000000000000aatom"
+"$BIN" genesis add-genesis-account "$USER_ADDR" "$FUNDING" "${KEYRING_ARGS[@]}" >/dev/null
+for addr in "${PROVIDER_ADDRS[@]}"; do
+  "$BIN" genesis add-genesis-account "$addr" "$FUNDING" "${KEYRING_ARGS[@]}" >/dev/null
+done
+"$BIN" genesis gentx "$USER_NAME" "50000000000$DENOM" --chain-id "$CHAIN_ID" "${KEYRING_ARGS[@]}" >/dev/null
+"$BIN" genesis collect-gentxs --home "$CHAIN_HOME" >/dev/null
+python3 - "$CHAIN_HOME/config/genesis.json" <<'PY'
+import json, sys
+path = sys.argv[1]
+data = json.load(open(path))
+bank = data["app_state"]["bank"]
+metadata = bank.get("denom_metadata", [])
+if not any(item.get("base") == "aatom" for item in metadata):
+    metadata.append({
+        "description": "EVM fee token metadata",
+        "denom_units": [
+            {"denom": "aatom", "exponent": 0, "aliases": ["uatom"]},
+            {"denom": "atom", "exponent": 18, "aliases": []},
+        ],
+        "base": "aatom", "display": "atom", "name": "Atom", "symbol": "ATOM",
+        "uri": "", "uri_hash": "",
+    })
+bank["denom_metadata"] = metadata
+json.dump(data, open(path, "w"), indent=1)
+PY
+"$BIN" genesis validate --home "$CHAIN_HOME" >/dev/null || fail "invalid genesis after provider fixture setup"
+
+# Keep blocks short so each recorded transaction becomes queryable promptly.
+sed -i.bak 's/timeout_commit = "5s"/timeout_commit = "1s"/' "$CHAIN_HOME/config/config.toml"
+log "starting node (rpc $RPC_ADDR, p2p $P2P_ADDR)"
+"$BIN" start --home "$CHAIN_HOME" --rpc.laddr "$RPC_ADDR" --p2p.laddr "$P2P_ADDR" \
+  --minimum-gas-prices "$GAS_PRICE" >"$CHAIN_HOME/node.log" 2>&1 &
+NODE_PID=$!
+for _ in $(seq 1 60); do
+  height=$(curl -sf "$LCD/status" | python3 -c 'import json,sys; print(int(json.load(sys.stdin)["result"]["sync_info"]["latest_block_height"]))' 2>/dev/null || echo 0)
+  if [ "$height" -ge 1 ]; then break; fi
+  kill -0 "$NODE_PID" 2>/dev/null || { tail -40 "$CHAIN_HOME/node.log" >&2; fail "node exited during startup"; }
+  sleep 1
+done
+height=$(curl -sf "$LCD/status" | python3 -c 'import json,sys; print(int(json.load(sys.stdin)["result"]["sync_info"]["latest_block_height"]))' 2>/dev/null || echo 0)
+[ "$height" -ge 1 ] || { tail -40 "$CHAIN_HOME/node.log" >&2; fail "node did not produce first block at $RPC_ADDR"; }
+
+wait_for_tx() {
+  local hash="$1" out
+  for _ in $(seq 1 60); do
+    out=$("$BIN" query tx "$hash" --home "$CHAIN_HOME" --node "$RPC_ADDR" --output json 2>/dev/null || true)
+    if [ -n "$out" ] && python3 -c 'import json,sys; d=json.load(sys.stdin); raise SystemExit(0 if d.get("txhash") else 1)' <<<"$out" 2>/dev/null; then
+      printf '%s' "$out"
+      return 0
+    fi
+    sleep 0.25
+done
+return 1
+}
+
+TX_SEQ=0
+record_tx() {
+  TX_SEQ=$((TX_SEQ + 1))
+  TX_KIND="$1" TX_INDEX="$2" TX_FROM="$3" TX_HASH="$4" TX_CODE="$5" \
+    TX_LATENCY_MS="$6" TX_HEIGHT_BEFORE="$7" TX_HEIGHT_AFTER="$8" TX_ERROR="$9" \
+    python3 - "$OUTPUT" "$TX_SEQ" <<'PY'
+import json, os, sys
+doc = json.load(open(sys.argv[1]))
+def val(name, default=""):
+    return os.environ.get(name, default)
+def integer(name, default=None):
+    raw = val(name)
+    return default if raw == "" else int(raw)
+rec = {
+    "seq": int(sys.argv[2]), "kind": val("TX_KIND"), "index": int(val("TX_INDEX", "0")),
+    "from": val("TX_FROM"), "txhash": val("TX_HASH"), "code": integer("TX_CODE", None),
+    "latency_ms": integer("TX_LATENCY_MS", None), "height_before": integer("TX_HEIGHT_BEFORE", None),
+    "height_after": integer("TX_HEIGHT_AFTER", None), "error": val("TX_ERROR"),
+}
+doc["txs"].append(rec)
+json.dump(doc, open(sys.argv[1], "w"), indent=1)
+PY
+}
+
+record_skip() {
+  TX_SEQ=$((TX_SEQ + 1))
+  TX_KIND="$1" TX_INDEX="$2" TX_ERROR="$3" python3 - "$OUTPUT" "$TX_SEQ" <<'PY'
+import json, os, sys
+doc = json.load(open(sys.argv[1]))
+doc["txs"].append({"seq": int(sys.argv[2]), "kind": os.environ["TX_KIND"],
+  "index": int(os.environ["TX_INDEX"]), "txhash": "", "code": None,
+  "latency_ms": None, "height_before": None, "height_after": None,
+  "error": os.environ["TX_ERROR"], "skipped": True})
+json.dump(doc, open(sys.argv[1], "w"), indent=1)
+PY
+}
+
+sample_block() {
+  python3 - "$OUTPUT" "$LCD/status" <<'PY'
+import json, sys, time, urllib.request
+try:
+    body = json.load(urllib.request.urlopen(sys.argv[2], timeout=5))
+    height = int(body["result"]["sync_info"]["latest_block_height"])
+except Exception:
+    height = 0
+doc = json.load(open(sys.argv[1]))
+doc["blocks"].append({"height": height, "unix_ns": time.time_ns()})
+json.dump(doc, open(sys.argv[1], "w"), indent=1)
+PY
+}
+
+parse_json_record() {
+  python3 -c 'import json,sys
+for line in reversed(sys.stdin.read().splitlines()):
+  try:
+    obj=json.loads(line)
+    if isinstance(obj, dict):
+      print(json.dumps(obj)); raise SystemExit
+  except json.JSONDecodeError:
+    pass
+raise SystemExit(1)'
+}
+
+send_tx() { # send_tx <kind> <index> <from> <module-cli-args...>
+  local kind="$1" index="$2" from="$3"; shift 3
+  local before after started finished out rc hash txjson code error
+  before=$(curl -sf "$LCD/status" | python3 -c 'import json,sys; print(json.load(sys.stdin)["result"]["sync_info"]["latest_block_height"])' 2>/dev/null || echo 0)
+  started=$(date +%s%N)
+  out=$("$BIN" tx "$MODULE_CLI" "$@" --from "$from" "${TXARGS[@]}" 2>&1) && rc=0 || rc=$?
+  finished=$(date +%s%N)
+  hash=$(parse_json_record <<<"$out" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("txhash", ""))' 2>/dev/null || true)
+  LAST_TXHASH="$hash"
+  txjson=""
+  if [ -n "$hash" ]; then txjson=$(wait_for_tx "$hash" || true); fi
+  LAST_TXJSON="$txjson"
+  after=$(curl -sf "$LCD/status" | python3 -c 'import json,sys; print(json.load(sys.stdin)["result"]["sync_info"]["latest_block_height"])' 2>/dev/null || echo 0)
+  code=1
+  error="$out"
+  if [ -n "$txjson" ]; then
+    code=$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("code",0))' <<<"$txjson")
+    error=$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("raw_log", ""))' <<<"$txjson")
+  elif [ -z "$hash" ]; then
+    error="transaction did not return txhash: $out"
+  fi
+  [ "${#error}" -le 300 ] || error="${error:0:300}"
+  record_tx "$kind" "$index" "$from" "$hash" "$code" "$(( (finished - started) / 1000000 ))" "$before" "$after" "$error"
+  [ "$rc" -eq 0 ] && [ -n "$txjson" ] && [ "$code" -eq 0 ]
+}
+
+python3 - "$OUTPUT" "$SESSIONS" "$RATE" "$PROOFS_PER_SESSION" "$CHAIN_ID" "$RPC_ADDR" "$MODULE_CLI" <<'PY'
+import json, sys, time
+json.dump({"config": {"sessions": int(sys.argv[2]), "rate_tps": int(sys.argv[3]),
+  "proofs_per_session": int(sys.argv[4]), "chain_id": sys.argv[5], "rpc": sys.argv[6],
+  "module_cli": sys.argv[7], "started_unix_ns": time.time_ns()}, "blocks": [], "txs": []},
+  open(sys.argv[1], "w"), indent=1)
+PY
+
+log "registering three funded providers"
+for i in "${!PROVIDER_ADDRS[@]}"; do
+  send_tx register-provider "$((i + 1))" "${PROVIDER_NAMES[$i]}" register-provider General 100000000000 \
+    --endpoint "/ip4/127.0.0.1/tcp/$((8080 + i))/http" || fail "provider registration failed for ${PROVIDER_NAMES[$i]}"
+done
+
+log "creating Mode 2 deal"
+send_tx create-deal 0 "$USER_NAME" create-deal 100000 100000000 10000000 --service-hint "General:rs=2+1" \
+  || fail "create-deal setup transaction failed"
+DEALS_JSON=$("$BIN" query "$MODULE_CLI" list-deals --home "$CHAIN_HOME" --node "$RPC_ADDR" --output json 2>/dev/null) \
+  || fail "query $MODULE_CLI list-deals failed"
+DEAL_ID=$(python3 -c 'import json,sys; d=json.load(sys.stdin); xs=d.get("deals",[]); print(xs[-1].get("id",xs[-1].get("deal_id",0)) if xs else "")' <<<"$DEALS_JSON")
+[ -n "$DEAL_ID" ] || fail "query $MODULE_CLI list-deals returned no deal"
+ASSIGNED_COUNT=$(python3 -c 'import json,sys; d=json.load(sys.stdin); xs=d.get("deals",[]); print(len(xs[-1].get("providers",[])) if xs else 0)' <<<"$DEALS_JSON")
+[ "$ASSIGNED_COUNT" -ge 3 ] || fail "Mode 2 deal has $ASSIGNED_COUNT eligible providers; expected at least 3"
+PROVIDER_ADDR=$(python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["deals"][-1]["providers"][0])' <<<"$DEALS_JSON")
+log "deal $DEAL_ID assigned $ASSIGNED_COUNT providers"
+
+MANIFEST_HEX="0x$(python3 -c 'print("ab" * 32)')"
+send_tx update-deal-content 0 "$USER_NAME" update-deal-content --deal-id "$DEAL_ID" --cid "$MANIFEST_HEX" \
+  --size 131072 --total-mdus 3 --witness-mdus 1 || fail "update-deal-content setup transaction failed"
+
+INTERVAL_NS=$((1000000000 / RATE))
+START_NS=$(date +%s%N)
+for i in $(seq 1 "$SESSIONS"); do
+  sample_block
+  NONCE="$i"
+  if send_tx open-session "$i" "$USER_NAME" open-retrieval-session --deal-id "$DEAL_ID" --provider "$PROVIDER_ADDR" \
+      --manifest-root "$MANIFEST_HEX" --start-mdu-index 2 --start-blob-index 0 --blob-count 1 --nonce "$NONCE"; then
+    # LAST_TXJSON is the exact open transaction; never search sender history.
+    SESSION_ID=$(python3 -c 'import binascii,json,sys
+d=json.load(sys.stdin)
+events=list(d.get("events",[]))
+for log in d.get("logs",[]):
+  events.extend(log.get("events",[]))
+for event in events:
+  if event.get("type","").split(".")[-1] == "open_retrieval_session":
+    for attr in event.get("attributes",[]):
+      if attr.get("key") == "session_id":
+        print(attr.get("value","")); raise SystemExit
+# Current keeper response has no custom event; decode the response bytes from this exact tx.
+raw=bytes.fromhex(d.get("data",""))
+if len(raw) >= 32:
+  print(raw[-32:].hex()); raise SystemExit
+print("")' <<<"$LAST_TXJSON")
+    [ -n "$SESSION_ID" ] || fail "open tx $LAST_TXHASH has no open_retrieval_session session_id"
+    if [ "$PROOFS_PER_SESSION" -eq 0 ]; then
+      record_skip submit-proof "$i" "POLYSTORE_BENCH_PROOFS_PER_SESSION=0 (proof stage skipped)"
+    else
+      PROOF_FILE="$PROOFS_DIR/$i.json"
+      [ -f "$PROOF_FILE" ] || fail "missing proof payload $PROOF_FILE"
+      python3 - "$PROOF_FILE" "$SESSION_ID" <<'PY'
+import json, sys
+obj = json.load(open(sys.argv[1]))
+if obj.get("session_id") != sys.argv[2]:
+    raise SystemExit("proof payload session_id does not match exact open tx session_id")
+PY
+      send_tx submit-proof "$i" "${PROVIDER_NAMES[0]}" submit-retrieval-proof "$PROOF_FILE" \
+        || log "session $i proof transaction failed (recorded)"
+    fi
+    send_tx confirm-session "$i" "$USER_NAME" confirm-retrieval-session --session-id "$SESSION_ID" \
+      || log "session $i confirm transaction failed (recorded)"
+  else
+    log "session $i open transaction failed (recorded)"
+  fi
+  now=$(date +%s%N)
+  target=$((START_NS + i * INTERVAL_NS))
+  if [ "$now" -lt "$target" ]; then
+    sleep "$(( (target - now) / 1000000000 )).$(( ((target - now) % 1000000000) / 1000000 ))"
+  fi
+done
+END_NS=$(date +%s%N)
+
+python3 - "$OUTPUT" "$START_NS" "$END_NS" <<'PY'
+import json, sys
+doc = json.load(open(sys.argv[1]))
+wall = (int(sys.argv[3]) - int(sys.argv[2])) / 1e9
+txs = doc["txs"]
+ok = sum(1 for t in txs if t.get("code") == 0 and not t.get("error"))
+failed = sum(1 for t in txs if not t.get("skipped") and (t.get("code") not in (0, None) or t.get("error")))
+skipped = sum(1 for t in txs if t.get("skipped"))
+sent = sum(1 for t in txs if not t.get("skipped"))
+summary = {"total_records": len(txs), "ok": ok, "failed": failed, "skipped": skipped,
+  "txs_sent": sent, "wall_seconds": round(wall, 3),
+  "txs_per_sec": round(sent / wall, 3) if wall > 0 else None}
+if doc["blocks"]:
+    heights = [b["height"] for b in doc["blocks"]]
+    summary.update({"block_height_start": min(heights), "block_height_end": max(heights),
+      "blocks_produced": max(heights) - min(heights)})
+doc["summary"] = summary
+json.dump(doc, open(sys.argv[1], "w"), indent=1)
+print(json.dumps(summary, indent=1))
+PY
+log "results written to $OUTPUT"

--- a/scripts/bench_retrieval_sessions.sh
+++ b/scripts/bench_retrieval_sessions.sh
@@ -17,6 +17,9 @@ SESSIONS="${POLYSTORE_BENCH_SESSIONS:-5}"
 TARGET_SESSIONS_PER_SEC="${POLYSTORE_BENCH_RATE:-5}"
 PROOFS_PER_SESSION="${POLYSTORE_BENCH_PROOFS_PER_SESSION:-0}"
 PROOFS_DIR="${POLYSTORE_BENCH_PROOFS_DIR:-}"
+PROOFS_DIR_WAS_SET=0
+[ -n "$PROOFS_DIR" ] && PROOFS_DIR_WAS_SET=1
+PROOF_MANIFEST_ROOT="${POLYSTORE_BENCH_MANIFEST_ROOT:-}"
 OUTPUT="${POLYSTORE_BENCH_OUTPUT:-$ROOT_DIR/bench_results_retrieval_sessions.json}"
 CHAIN_HOME="${POLYSTORE_BENCH_HOME:-$ROOT_DIR/_artifacts/bench_retrieval_sessions_data}"
 CHAIN_ID="${CHAIN_ID:-31337}"
@@ -44,23 +47,21 @@ require_cmd python3
 if [ "$PROOFS_PER_SESSION" -gt 0 ] && [ "$PROOFS_PER_SESSION" -gt 32 ]; then
   fail "POLYSTORE_BENCH_PROOFS_PER_SESSION must be 1..32 for the explicit General:rs=2+1 fixture (or 0 to skip proofs)"
 fi
-if [ "$PROOFS_PER_SESSION" -gt 0 ] && [ -z "$PROOFS_DIR" ]; then
-  fail "POLYSTORE_BENCH_PROOFS_PER_SESSION=$PROOFS_PER_SESSION requires POLYSTORE_BENCH_PROOFS_DIR with <session-index>.json payloads"
+if [ "$PROOFS_PER_SESSION" -gt 0 ]; then
+  DEFAULT_GAS=$((250000 + PROOFS_PER_SESSION * 50000))
+else
+  DEFAULT_GAS=auto
 fi
+GAS_LIMIT="${POLYSTORE_BENCH_GAS:-$DEFAULT_GAS}"
 
 CORE_LIB="$CORE_LIB_DIR/libpolystore_core.so"
-if [ ! -f "$CORE_LIB" ]; then
-  log "libpolystore_core.so missing; building polystore_core"
-  (cd "$CORE_DIR" && cargo build --release) || fail "cargo build --release failed; build $CORE_LIB manually and rerun"
-fi
-[ -f "$CORE_LIB" ] || fail "missing $CORE_LIB after cargo build --release; run (cd $CORE_DIR && cargo build --release)"
+log "building polystore_core"
+(cd "$CORE_DIR" && cargo build --release) || fail "cargo build --release failed"
 export LD_LIBRARY_PATH="$CORE_LIB_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 export CGO_LDFLAGS="-L$CORE_LIB_DIR -lpolystore_core${CGO_LDFLAGS:+ $CGO_LDFLAGS}"
 
-if [ ! -x "$BIN" ]; then
-  log "building polystorechaind"
-  (cd "$CHAIN_DIR" && go build -o "$BIN" ./cmd/polystorechaind) || fail "chain build failed; run (cd $CHAIN_DIR && go build -o $BIN ./cmd/polystorechaind)"
-fi
+log "building polystorechaind"
+(cd "$CHAIN_DIR" && go build -o "$BIN" ./cmd/polystorechaind) || fail "chain build failed"
 
 NODE_PID=""
 cleanup() {
@@ -78,13 +79,55 @@ cleanup() {
 trap cleanup EXIT
 
 rm -rf "$CHAIN_HOME"
+
+prepare_proof_fixtures() {
+  [ "$PROOFS_PER_SESSION" -gt 0 ] || return 0
+  if [ "$PROOFS_DIR_WAS_SET" -eq 0 ]; then
+    PROOFS_DIR="$CHAIN_HOME/proof-fixtures"
+    mkdir -p "$PROOFS_DIR"
+    log "generating deterministic proof fixtures in $PROOFS_DIR"
+    (
+      cd "$CHAIN_DIR"
+      POLYSTORE_BENCH_FIXTURE_DIR="$PROOFS_DIR" \
+      POLYSTORE_BENCH_FIXTURE_SESSIONS="$SESSIONS" \
+      POLYSTORE_BENCH_FIXTURE_COUNT="$PROOFS_PER_SESSION" \
+      POLYSTORE_BENCH_FIXTURE_SERVICE_HINT="General:rs=2+1" \
+        go test ./x/polystorechain/keeper -run '^TestWriteRetrievalSessionProofFixture$' -count=1
+    ) || fail "proof fixture generation failed"
+  else
+    [ -d "$PROOFS_DIR" ] || fail "proof fixture directory does not exist: $PROOFS_DIR"
+  fi
+  if [ -z "$PROOF_MANIFEST_ROOT" ]; then
+    [ -f "$PROOFS_DIR/manifest_root.txt" ] || \
+      fail "proof mode requires $PROOFS_DIR/manifest_root.txt or POLYSTORE_BENCH_MANIFEST_ROOT"
+    PROOF_MANIFEST_ROOT="$(tr -d '[:space:]' < "$PROOFS_DIR/manifest_root.txt")"
+  fi
+  PROOF_MANIFEST_ROOT="$(python3 - "$PROOF_MANIFEST_ROOT" <<'PY'
+import sys
+value = sys.argv[1].strip()
+hex_value = value[2:] if value.lower().startswith("0x") else value
+if len(hex_value) != 64:
+    raise SystemExit("manifest root must contain exactly 32 bytes")
+try:
+    bytes.fromhex(hex_value)
+except ValueError as exc:
+    raise SystemExit(f"manifest root is not hexadecimal: {exc}")
+print("0x" + hex_value.lower())
+PY
+  )" || fail "invalid POLYSTORE_BENCH_MANIFEST_ROOT"
+  for i in $(seq 1 "$SESSIONS"); do
+    [ -f "$PROOFS_DIR/$i.json" ] || fail "missing proof payload $PROOFS_DIR/$i.json"
+  done
+}
+
 mkdir -p "$(dirname "$OUTPUT")"
 
 log "initializing chain home $CHAIN_HOME (chain-id $CHAIN_ID, module $MODULE_CLI)"
 "$BIN" init bench-sessions --chain-id "$CHAIN_ID" --home "$CHAIN_HOME" >/dev/null 2>&1
 KEYRING_ARGS=(--keyring-backend test --home "$CHAIN_HOME")
 TXARGS=(--keyring-backend test --home "$CHAIN_HOME" --chain-id "$CHAIN_ID"
-  --gas-adjustment 1.5 --gas-prices "$GAS_PRICE" --node "$RPC_ADDR" --output json -y)
+  --gas "$GAS_LIMIT" --gas-adjustment 1.5 --gas-prices "$GAS_PRICE" --node "$RPC_ADDR" --output json -y)
+prepare_proof_fixtures
 
 add_key() {
   set +o pipefail
@@ -199,15 +242,14 @@ PY
 }
 
 sample_block() {
-  python3 - "$OUTPUT" "$LCD/status" <<'PY'
-import json, sys, time, urllib.request
-try:
-    body = json.load(urllib.request.urlopen(sys.argv[2], timeout=5))
-    height = int(body["result"]["sync_info"]["latest_block_height"])
-except Exception:
-    height = 0
+  local height
+  height=$(curl -sf "$LCD/status" | python3 -c 'import json,sys; print(int(json.load(sys.stdin)["result"]["sync_info"]["latest_block_height"]))') \
+    || fail "block height sample failed at $LCD/status"
+  [[ "$height" =~ ^[1-9][0-9]*$ ]] || fail "invalid block height sample: $height"
+  python3 - "$OUTPUT" "$height" <<'PY'
+import json, sys, time
 doc = json.load(open(sys.argv[1]))
-doc["blocks"].append({"height": height, "unix_ns": time.time_ns()})
+doc["blocks"].append({"height": int(sys.argv[2]), "unix_ns": time.time_ns()})
 json.dump(doc, open(sys.argv[1], "w"), indent=1)
 PY
 }
@@ -251,12 +293,13 @@ send_tx() { # send_tx <kind> <index> <from> <module-cli-args...>
   [ "$rc" -eq 0 ] && [ -n "$txjson" ] && [ "$code" -eq 0 ]
 }
 
-python3 - "$OUTPUT" "$SESSIONS" "$TARGET_SESSIONS_PER_SEC" "$PROOFS_PER_SESSION" "$CHAIN_ID" "$RPC_ADDR" "$MODULE_CLI" <<'PY'
+python3 - "$OUTPUT" "$SESSIONS" "$TARGET_SESSIONS_PER_SEC" "$PROOFS_PER_SESSION" "$CHAIN_ID" "$RPC_ADDR" "$MODULE_CLI" "$GAS_LIMIT" <<'PY'
 import json, sys, time
 json.dump({"config": {
   "sessions": int(sys.argv[2]), "target_sessions_per_sec": int(sys.argv[3]),
   "proofs_per_session": int(sys.argv[4]), "chain_id": sys.argv[5],
-  "rpc": sys.argv[6], "module_cli": sys.argv[7], "serial_driver": True,
+  "rpc": sys.argv[6], "module_cli": sys.argv[7], "gas_limit": sys.argv[8],
+  "serial_driver": True,
   "saturation": False,
   "driver_note": "single-client paced path; sessions/block ceiling comes from gas/time arithmetic and in-process benchmarks, not arbitrary parallel saturation",
   "started_unix_ns": time.time_ns()}, "blocks": [], "txs": []},
@@ -290,7 +333,11 @@ done
 
 log "deal $DEAL_ID assigned $ASSIGNED_COUNT providers"
 
-MANIFEST_HEX="0x$(python3 -c 'print("ab" * 32)')"
+if [ "$PROOFS_PER_SESSION" -gt 0 ]; then
+  MANIFEST_HEX="$PROOF_MANIFEST_ROOT"
+else
+  MANIFEST_HEX="0x$(python3 -c 'print("ab" * 32)')"
+fi
 send_tx update-deal-content 0 "$USER_NAME" update-deal-content --deal-id "$DEAL_ID" --cid "$MANIFEST_HEX" \
   --size 131072 --total-mdus 3 --witness-mdus 1 || fail "update-deal-content setup transaction failed"
 BLOB_COUNT=1


### PR DESCRIPTION
## Summary

Implements #245 under parent #244 as a deterministic, rerunnable single-node retrieval-session load driver. The latest exact head is `a3a387abbee48046b4d766dea2acffcdba85a172`.

- Builds `polystore_core` and `polystorechaind` on every run, uses repo-local `LD_LIBRARY_PATH`, forces Go module mode (`-mod=mod`) for clean checkouts with incomplete vendoring, and uses `${POLYSTORE_CHAIN_MODULE_CLI_NAME:-nilchain}` consistently.
- Initializes one chain with `bench-provider1..3`, registers all three, creates `General:rs=2+1`, commits one user MDU plus one witness MDU, and requires three assigned providers.
- Records queryable transaction hashes, exact open transaction/session extraction, block samples before and after the load loop, and a structured summary JSON.
- Uses generated `confirm-retrieval-session --session-id`.
- Proof mode uses the configured `POLYSTORE_BENCH_PROOFS_PER_SESSION` as `--blob-count`, validates exactly that many proofs, copies each caller fixture into the disposable chain home, and injects the runtime session ID in protobuf-JSON base64 before submission. The caller-owned fixture is never mutated.
- Proof-enabled runs choose a bounded gas limit (`250000 + 50000 * proofs_per_session` by default); `POLYSTORE_BENCH_GAS` overrides it, while proof-skipped runs retain CLI `--gas auto`.
- Benchmark loops use `b.Loop()` safely; per-iteration fixtures are prepared outside timed regions where needed.
- Separates the `OPEN -> USER_CONFIRMED` confirmation benchmark from `BenchmarkCompleteRetrievalSession`, which measures the proof-backed `OPEN -> PROOF_SUBMITTED -> COMPLETED` ordering used by the load driver.
- Includes a cancellation benchmark for the expired-session `MsgCancelRetrievalSession` path, with the same gas and wall-time reporting.
- `POLYSTORE_BENCH_RATE` is reported as `target_sessions_per_sec`; each session is paced at its scheduled start. Results separate confirmed-session rate, proof-backed protocol-completion rate, and load transaction rate, and explicitly identify the serial, non-saturating driver.
- When proofs are skipped (`POLYSTORE_BENCH_PROOFS_PER_SESSION=0`), the result reports `sessions_confirmed` but deliberately reports `sessions_completed=0` and `sessions_per_sec=null`; the completion basis says that protocol completion was not measured.

## Finding dispositions

| Finding | Disposition |
|---|---|
| Benchmark fixtures indexed only to initial `b.N` and could panic under default `b.Loop()` | **Fixed** — submit plans and confirm sessions are lazily created at each expanded iteration under `b.StopTimer()`/`b.StartTimer()`. |
| Proof payload session ID compared hex-to-base64 and could not submit valid protobuf JSON | **Fixed** — strict base64/hex/`0x` decoding validates 32-byte IDs, then the runtime ID is written as protobuf-JSON base64 into a disposable per-session copy. |
| Configured proof count was ignored and open sessions used `--blob-count 1` | **Fixed** — proofs must be `1..32` for the explicit `General:rs=2+1` fixture, `--blob-count` matches the configured count, and payload proof count is exact. `0` remains the proof-skipped smoke mode. |
| Generic `rate_tps` overstated serial transaction/session saturation | **Fixed** — config/help naming uses `target_sessions_per_sec`, pacing occurs before each session sequence, and summary reports confirmed/completed session rates separately from `load_txs_per_sec`; `serial_driver=true`, `saturation=false`. |
| Runtime proof payloads used IDs from a different regenerated key set | **Fixed** — each payload is copied to `$POLYSTORE_BENCH_HOME/proof-<index>.json` and receives the exact ID returned by that session's open transaction. |
| Confirmation could be counted after a failed proof, and skipped proofs were labeled completed | **Fixed** — confirmation is skipped after a failed proof; `sessions_completed` requires successful open+proof+confirm and is zero when proof mode is disabled. |
| Ending block sample omitted blocks produced by the final session | **Fixed** — the block height is sampled once after the loop before deriving `block_height_end` and `blocks_produced`. |
| Proof-enabled load failed at the default 200000-gas CLI ceiling for multi-proof payloads | **Fixed** — proof mode supplies a bounded numeric gas limit derived from the configured proof count, with an explicit environment override. |
| Confirm benchmark covered only the `OPEN -> USER_CONFIRMED` branch while proof-backed load uses `PROOF_SUBMITTED -> COMPLETED` | **Fixed** — `BenchmarkCompleteRetrievalSession` measures the proof-backed ordering separately, with proof construction outside the timed loop and submit/settlement in the timed path. |
| Confirmation characterization baseline included session creation | **Fixed** — the characterization opens the fixture first, then captures gas immediately before `ConfirmRetrievalSession`. |
| Clean checkouts could select incomplete repository vendor mode for Go build/fixture commands | **Fixed** — the harness appends `-mod=mod` to `GOFLAGS` for both `polystorechaind` builds and proof-fixture generation. |
| Cancellation cost was only characterized for gas, not wall time | **Fixed** — `BenchmarkCancelRetrievalSession` measures the expired-session cancellation handler in gas and wall time. |

## Validation at exact head `a3a387ab`

| Command | Result |
|---|---|
| `bash -n scripts/bench_retrieval_sessions.sh` | pass |
| `git diff --check` | pass |
| Embedded proof-session-ID decoder check (base64, hex, `0x` hex) | pass |
| `GOFLAGS=-mod=mod LD_LIBRARY_PATH=/mnt/fast4tb/omp-retrieval-bench/wt-245/polystore_core/target/release go test ./x/polystorechain/keeper -run 'RetrievalSession(Open|Submit|Confirm)|TestRetrievalSessionBenchCharacterization|TestWriteRetrievalSessionProofFixture' -count=1` | pass |
| `GOFLAGS=-mod=mod LD_LIBRARY_PATH=/mnt/fast4tb/omp-retrieval-bench/wt-245/polystore_core/target/release go test ./x/polystorechain/keeper -run '^TestWriteRetrievalSessionProofFixture$' -count=1` | pass; clean module-mode fixture compilation |
| `GOFLAGS=-mod=mod LD_LIBRARY_PATH=/mnt/fast4tb/omp-retrieval-bench/wt-245/polystore_core/target/release go test ./x/polystorechain/keeper -run '^$' -bench 'Benchmark(Open|Submit|Confirm|Complete|Cancel)RetrievalSession' -benchtime=100ms -count=1` | pass; open `199,813 ns/op`, submit proofs-1 `12,238,555 ns/op`, proofs-8 `89,438,302 ns/op`, proofs-64 `712,284,307 ns/op`, confirm `29,188 ns/op`, complete `16,188,692 ns/op`, cancel `361,174 ns/op`; submit proof gas `32,159 / 105,822 / 1,109,526 gas/op`, complete gas `124,779 gas/op`, cancel gas `119,106 gas/op` |
| `POLYSTORE_BENCH_SESSIONS=1 POLYSTORE_BENCH_RATE=1 POLYSTORE_BENCH_PROOFS_PER_SESSION=0 POLYSTORE_BENCH_OUTPUT=/mnt/fast4tb/omp-retrieval-bench/wt-245/_artifacts/smoke_zero_proof_retry_a3a387ab.json POLYSTORE_BENCH_HOME=/mnt/fast4tb/omp-retrieval-bench/wt-245/_artifacts/smoke_zero_proof_retry_a3a387ab_home bash scripts/bench_retrieval_sessions.sh` | pass; `sessions_attempted=1`, `sessions_confirmed=1`, `sessions_completed=0`, `sessions_per_sec=null`, `target_sessions_per_sec=1`, `load_txs_per_sec=0.44`, `gas_limit=auto`, `serial_driver=true`, `saturation=false`; proof stage explicitly skipped |
| `POLYSTORE_BENCH_SESSIONS=1 POLYSTORE_BENCH_RATE=1 POLYSTORE_BENCH_PROOFS_PER_SESSION=8 POLYSTORE_BENCH_OUTPUT=/mnt/fast4tb/omp-retrieval-bench/wt-245/_artifacts/smoke_eight_proof_retry_a3a387ab.json POLYSTORE_BENCH_HOME=/mnt/fast4tb/omp-retrieval-bench/wt-245/_artifacts/smoke_eight_proof_retry_a3a387ab_home bash scripts/bench_retrieval_sessions.sh` | pass; `sessions_attempted=1`, `sessions_confirmed=1`, `sessions_completed=1`, `sessions_per_sec=0.174`, `target_sessions_per_sec=1`, `load_txs_per_sec=0.521`, `gas_limit=650000`, `serial_driver=true`, `saturation=false` |
| `POLYSTORE_BENCH_PROOFS_PER_SESSION=33 bash scripts/bench_retrieval_sessions.sh` | bounded guard fails clearly before setup: explicit `General:rs=2+1` fixture supports `1..32` (or `0` to skip) |

## Measurement boundary and limitation

`START_NS` is captured immediately before the paced session loop and `END_NS` immediately after it. `sessions_confirmed_per_sec` counts successful open+confirm pairs. `sessions_per_sec` counts only successful open+proof+confirm protocol completions and is intentionally null when proof mode is disabled. `load_txs_per_sec` counts load transaction submissions separately. Each transaction latency ends only after the commit wait/query completes.

This remains instrumentation/benchmark source only: `serial_driver=true` and `saturation=false`. It measures a single-client paced path. Child B's sessions/block ceiling comes from gas/time arithmetic and in-process benchmarks, not a claim that this script sustains arbitrary parallel rate.

Refs: #244, #245
