### PR TITLE
fix(bench): correct wall-bound period arithmetic

### DIFF
--- a/bench/retrieval_session_capacity/ac0fa173.json
+++ b/bench/retrieval_session_capacity/ac0fa173.json
@@ -117,8 +117,8 @@
       "sessions_per_day": 13276.8
     },
     "period_at_wall_bound_estimate": {
-      "sessions_per_hour": 4117.0,
-      "sessions_per_day": 98808.0
+      "sessions_per_hour": 147745.9,
+      "sessions_per_day": 3545901.4
     }
   },
   "limiter_classification": {


### PR DESCRIPTION
## Summary

Corrects the derived wall-bound period arithmetic in the merged capacity evidence artifact from #248.

- The sessions/block estimate (`43.72`) and observed block interval (`1.0653 s`) were already correct.
- Correct derived wall-bound period is `147,745.9 sessions/hour` and `3,545,901.4 sessions/day`, not the previously recorded lower values.
- Serial observed measurements are unchanged: `553.2 sessions/hour` mean and `525.6 sessions/hour` in the five-minute run.

## Validation

- `python3 -m json.tool bench/retrieval_session_capacity/ac0fa173.json`
- `git diff --check`

This is an evidence-only correction; no protocol or harness code changes.