### PR TITLE
e2e: preserve existing homes and isolate retrieval benchmark binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,12 @@ jobs:
         if: matrix.service == 'polystore_gateway' || matrix.service == 'polystorechain'
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Check retrieval benchmark home isolation
+        if: matrix.service == 'polystorechain'
+        run: |
+          bash -n scripts/bench_retrieval_sessions.sh
+          python3 scripts/test_bench_retrieval_sessions.py
+
       - name: Build polystore_core
         if: matrix.service == 'polystore_gateway' || matrix.service == 'polystorechain'
         run: |

--- a/performance/README.md
+++ b/performance/README.md
@@ -58,3 +58,26 @@ The harness writes:
 - A compact run summary JSON
 
 See [`gateway_mode2_benchmark.md`](./gateway_mode2_benchmark.md) for usage details and field guidance.
+
+## Retrieval-session driver safety (#260 preparation)
+
+`scripts/bench_retrieval_sessions.sh` creates a unique chain home under
+`_artifacts/bench-retrieval-*` and builds its chain binary inside that home.
+`POLYSTORE_BENCH_HOME`, when supplied, must name a **new, nonexistent** directory
+with an existing parent. Existing files, directories and symlinks are rejected
+before any build. The driver removes only its own home on exit; `--keep-home`
+retains that home (including the binary and node log) for inspection. It does not
+permit reuse of an existing home. A replaced home is left untouched.
+
+Run the entrypoint safety checks without compiling or starting a node:
+
+```bash
+python3 scripts/test_bench_retrieval_sessions.py
+bash -n scripts/bench_retrieval_sessions.sh
+```
+
+The existing driver still submits and waits serially. Its output is a preliminary
+latency characterization, not saturation or secure-v2 capacity evidence. #260
+still requires the concurrent load driver, nonconstant fixtures, provenance and
+finite-gas qualification after the #255–#257 security prerequisites. This safety
+change alone does not qualify or activate that protocol.

--- a/performance/README.md
+++ b/performance/README.md
@@ -69,6 +69,10 @@ before any build. The driver removes only its own home on exit; `--keep-home`
 retains that home (including the binary and node log) for inspection. It does not
 permit reuse of an existing home. Recursive cleanup stays bound to the verified directory even if its pathname is
 replaced; the final pathname operation can only remove an empty directory.
+Run under an operator-controlled parent and keep the home and its ancestors
+exclusively owned and unchanged until exit. Replacement protection applies to
+recursive cleanup; builds, chain commands and configuration writes use pathnames
+and require that exclusive ownership.
 
 Run the entrypoint safety checks without compiling or starting a node:
 

--- a/performance/README.md
+++ b/performance/README.md
@@ -67,7 +67,8 @@ See [`gateway_mode2_benchmark.md`](./gateway_mode2_benchmark.md) for usage detai
 with an existing parent. Existing files, directories and symlinks are rejected
 before any build. The driver removes only its own home on exit; `--keep-home`
 retains that home (including the binary and node log) for inspection. It does not
-permit reuse of an existing home. A replaced home is left untouched.
+permit reuse of an existing home. Recursive cleanup stays bound to the verified directory even if its pathname is
+replaced; the final pathname operation can only remove an empty directory.
 
 Run the entrypoint safety checks without compiling or starting a node:
 

--- a/scripts/bench_retrieval_sessions.sh
+++ b/scripts/bench_retrieval_sessions.sh
@@ -90,16 +90,34 @@ cleanup() {
   fi
   if [ "$KEEP_HOME" != "1" ]; then
     python3 - "$CHAIN_HOME" "$HOME_ID" <<'PYHOME'
-import os, shutil, stat, sys
+import os, shutil, sys
+path, expected = sys.argv[1:]
 try:
-    s = os.lstat(sys.argv[1])
-except FileNotFoundError:
-    pass
+    fd = os.open(path, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+except OSError:
+    print("[bench-sessions] home changed; refusing cleanup: " + path, file=sys.stderr)
 else:
-    if stat.S_ISDIR(s.st_mode) and f"{s.st_dev}:{s.st_ino}" == sys.argv[2]:
-        shutil.rmtree(sys.argv[1])
-    else:
-        print("[bench-sessions] home changed; refusing cleanup: " + sys.argv[1], file=sys.stderr)
+    try:
+        s = os.fstat(fd)
+        if f"{s.st_dev}:{s.st_ino}" != expected:
+            print("[bench-sessions] home changed; refusing cleanup: " + path, file=sys.stderr)
+        else:
+            # This short-lived Python process alone changes cwd. Relative
+            # deletion stays bound to the verified inode even if path is renamed.
+            os.fchdir(fd)
+            for entry in os.scandir("."):
+                if entry.is_dir(follow_symlinks=False):
+                    shutil.rmtree(entry.name)
+                else:
+                    os.unlink(entry.name)
+            try:
+                current = os.lstat(path)
+                if (current.st_dev, current.st_ino) == (s.st_dev, s.st_ino):
+                    os.rmdir(path)  # Never recurse through this pathname again.
+            except FileNotFoundError:
+                pass
+    finally:
+        os.close(fd)
 PYHOME
   fi
 }

--- a/scripts/bench_retrieval_sessions.sh
+++ b/scripts/bench_retrieval_sessions.sh
@@ -10,7 +10,6 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CHAIN_DIR="$ROOT_DIR/polystorechain"
 CORE_DIR="$ROOT_DIR/polystore_core"
-BIN="$CHAIN_DIR/polystorechaind"
 MODULE_CLI="${POLYSTORE_CHAIN_MODULE_CLI_NAME:-nilchain}"
 
 SESSIONS="${POLYSTORE_BENCH_SESSIONS:-5}"
@@ -21,7 +20,7 @@ PROOFS_DIR_WAS_SET=0
 [ -n "$PROOFS_DIR" ] && PROOFS_DIR_WAS_SET=1
 PROOF_MANIFEST_ROOT="${POLYSTORE_BENCH_MANIFEST_ROOT:-}"
 OUTPUT="${POLYSTORE_BENCH_OUTPUT:-$ROOT_DIR/bench_results_retrieval_sessions.json}"
-CHAIN_HOME="${POLYSTORE_BENCH_HOME:-$ROOT_DIR/_artifacts/bench_retrieval_sessions_data}"
+CHAIN_HOME="${POLYSTORE_BENCH_HOME:-}"
 CHAIN_ID="${CHAIN_ID:-31337}"
 RPC_ADDR="${RPC_ADDR:-tcp://127.0.0.1:26658}"
 P2P_ADDR="${P2P_ADDR:-tcp://127.0.0.1:26659}"
@@ -54,15 +53,30 @@ else
 fi
 GAS_LIMIT="${POLYSTORE_BENCH_GAS:-$DEFAULT_GAS}"
 
-CORE_LIB="$CORE_LIB_DIR/libpolystore_core.so"
-log "building polystore_core"
-(cd "$CORE_DIR" && cargo build --release) || fail "cargo build --release failed"
-export LD_LIBRARY_PATH="$CORE_LIB_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-export CGO_LDFLAGS="-L$CORE_LIB_DIR -lpolystore_core${CGO_LDFLAGS:+ $CGO_LDFLAGS}"
-
-log "building polystorechaind"
-(cd "$CHAIN_DIR" && GOFLAGS="${GOFLAGS:-} -mod=mod" go build -o "$BIN" ./cmd/polystorechaind) || fail "chain build failed"
-
+# Claim a new directory before building. An existing home is never disposable,
+# even with --keep-home. Resolve the parent, not the final component (symlinks).
+CHAIN_HOME="$(python3 - "$CHAIN_HOME" "$ROOT_DIR/_artifacts" <<'PYHOME'
+import os, pathlib, sys, tempfile
+if sys.argv[1]:
+    requested = pathlib.Path(os.path.abspath(sys.argv[1]))
+    path = requested.parent.resolve(strict=True) / requested.name
+    if os.path.lexists(path):
+        raise SystemExit("POLYSTORE_BENCH_HOME must not already exist: " + str(path))
+    path.mkdir(mode=0o700)
+else:
+    parent = pathlib.Path(sys.argv[2]).resolve()
+    parent.mkdir(parents=True, exist_ok=True)
+    path = pathlib.Path(tempfile.mkdtemp(prefix="bench-retrieval-", dir=parent))
+print(path)
+PYHOME
+)" || fail "cannot create isolated chain home"
+HOME_ID="$(python3 - "$CHAIN_HOME" <<'PYHOME'
+import os, sys
+s = os.lstat(sys.argv[1])
+print(f"{s.st_dev}:{s.st_ino}")
+PYHOME
+)"
+BIN="$CHAIN_HOME/polystorechaind"
 NODE_PID=""
 cleanup() {
   if [ -n "$NODE_PID" ] && kill -0 "$NODE_PID" 2>/dev/null; then
@@ -74,11 +88,34 @@ cleanup() {
     done
     kill -9 "$NODE_PID" 2>/dev/null || true
   fi
-  if [ "$KEEP_HOME" != "1" ] && [ -d "$CHAIN_HOME" ]; then rm -rf "$CHAIN_HOME"; fi
+  if [ "$KEEP_HOME" != "1" ]; then
+    python3 - "$CHAIN_HOME" "$HOME_ID" <<'PYHOME'
+import os, shutil, stat, sys
+try:
+    s = os.lstat(sys.argv[1])
+except FileNotFoundError:
+    pass
+else:
+    if stat.S_ISDIR(s.st_mode) and f"{s.st_dev}:{s.st_ino}" == sys.argv[2]:
+        shutil.rmtree(sys.argv[1])
+    else:
+        print("[bench-sessions] home changed; refusing cleanup: " + sys.argv[1], file=sys.stderr)
+PYHOME
+  fi
 }
 trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+log "isolated chain home $CHAIN_HOME (keep=$KEEP_HOME)"
 
-rm -rf "$CHAIN_HOME"
+CORE_LIB="$CORE_LIB_DIR/libpolystore_core.so"
+log "building polystore_core"
+(cd "$CORE_DIR" && cargo build --release) || fail "cargo build --release failed"
+export LD_LIBRARY_PATH="$CORE_LIB_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export CGO_LDFLAGS="-L$CORE_LIB_DIR -lpolystore_core${CGO_LDFLAGS:+ $CGO_LDFLAGS}"
+
+log "building polystorechaind"
+(cd "$CHAIN_DIR" && GOFLAGS="${GOFLAGS:-} -mod=mod" go build -o "$BIN" ./cmd/polystorechaind) || fail "chain build failed"
 
 prepare_proof_fixtures() {
   [ "$PROOFS_PER_SESSION" -gt 0 ] || return 0

--- a/scripts/test_bench_retrieval_sessions.py
+++ b/scripts/test_bench_retrieval_sessions.py
@@ -2,6 +2,7 @@
 import os
 from pathlib import Path
 import subprocess
+import sys
 import tempfile
 import unittest
 
@@ -101,6 +102,39 @@ class BenchmarkHomeTest(unittest.TestCase):
             self.assertIn("home changed; refusing cleanup", result.stderr)
             self.assertTrue(home.is_symlink())
             self.assertEqual((target / "sentinel").read_text(), "preserve")
+
+    def test_cleanup_race_cannot_delete_replacement_contents(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fakebin = root / "bin"
+            fakebin.mkdir()
+            home = root / "home"
+            cargo = fakebin / "cargo"
+            cargo.write_text('#!/bin/sh\nmkdir "$POLYSTORE_BENCH_HOME/owned-child"\nexit 89\n')
+            cargo.chmod(0o755)
+            python = fakebin / "python3"
+            # Replace the home immediately before the recursive deletion starts.
+            python.write_text(f"#!{sys.executable}\n" + '''
+import os, pathlib, re, shutil, sys
+code = sys.stdin.read()
+if len(sys.argv) == 4 and re.fullmatch(r"[0-9]+:[0-9]+", sys.argv[3]):
+    original = shutil.rmtree
+    def replace_then_remove(*args, **kwargs):
+        path = pathlib.Path(os.environ["POLYSTORE_BENCH_HOME"])
+        path.rename(str(path) + ".original")
+        path.mkdir()
+        (path / "operator-data").write_text("preserve")
+        return original(*args, **kwargs)
+    shutil.rmtree = replace_then_remove
+sys.argv = sys.argv[1:]
+exec(compile(code, "<benchmark home>", "exec"))
+''')
+            python.chmod(0o755)
+            env = dict(os.environ, PATH=f"{fakebin}:{os.environ['PATH']}", POLYSTORE_BENCH_HOME=str(home))
+            result = subprocess.run(["bash", str(SCRIPT)], env=env, capture_output=True, text=True, timeout=10)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual((home / "operator-data").read_text(), "preserve")
+            self.assertTrue(Path(str(home) + ".original").is_dir())
 
 
 if __name__ == "__main__":

--- a/scripts/test_bench_retrieval_sessions.py
+++ b/scripts/test_bench_retrieval_sessions.py
@@ -1,0 +1,107 @@
+"""Safety checks for the actual benchmark entrypoint; no build or node is run."""
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("bench_retrieval_sessions.sh")
+
+
+class BenchmarkHomeTest(unittest.TestCase):
+    def test_existing_paths_are_preserved_before_build(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            build_marker = root / "build-called"
+            fakebin = root / "bin"
+            fakebin.mkdir()
+            cargo = fakebin / "cargo"
+            cargo.write_text('#!/bin/sh\nprintf called > "$BUILD_MARKER"\nexit 89\n')
+            cargo.chmod(0o755)
+            env = dict(os.environ, PATH=f"{fakebin}:{os.environ['PATH']}", BUILD_MARKER=str(build_marker))
+            existing = root / "existing"
+            existing.mkdir()
+            sentinel = existing / "operator-data"
+            sentinel.write_text("preserve")
+            link = root / "link"
+            link.symlink_to(existing, target_is_directory=True)
+            dangling = root / "dangling"
+            dangling.symlink_to(root / "absent", target_is_directory=True)
+            for home in (existing, link, dangling, sentinel):
+                with self.subTest(home=home.name):
+                    result = subprocess.run(["bash", str(SCRIPT)], env=dict(env, POLYSTORE_BENCH_HOME=str(home)), capture_output=True, text=True, timeout=10)
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn("must not already exist", result.stderr)
+                    self.assertFalse(build_marker.exists(), result.stderr)
+                    self.assertEqual(sentinel.read_text(), "preserve")
+                    self.assertTrue(link.is_symlink())
+                    self.assertTrue(dangling.is_symlink())
+
+    def test_only_new_owned_home_is_cleaned_on_build_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fakebin = root / "bin"
+            fakebin.mkdir()
+            cargo = fakebin / "cargo"
+            cargo.write_text("#!/bin/sh\nexit 89\n")
+            cargo.chmod(0o755)
+            home = root / "new-home"
+            env = dict(os.environ, PATH=f"{fakebin}:{os.environ['PATH']}", POLYSTORE_BENCH_HOME=str(home))
+            for keep in (False, True):
+                with self.subTest(keep=keep):
+                    result = subprocess.run(["bash", str(SCRIPT)] + (["--keep-home"] if keep else []), env=env, capture_output=True, text=True, timeout=10)
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn("cargo build --release failed", result.stderr)
+                    self.assertEqual(home.is_dir(), keep)
+
+    def test_binary_is_built_inside_each_unique_default_home(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fakebin = root / "bin"
+            fakebin.mkdir()
+            for name, body in (
+                ("cargo", "exit 0"),
+                ("go", 'printf "%s\\n" "$@" > "$BUILD_ARGS"; exit 89'),
+            ):
+                command = fakebin / name
+                command.write_text("#!/bin/sh\n" + body + "\n")
+                command.chmod(0o755)
+            args_file = root / "args"
+            env = dict(os.environ, PATH=f"{fakebin}:{os.environ['PATH']}", BUILD_ARGS=str(args_file))
+            env.pop("POLYSTORE_BENCH_HOME", None)
+            homes = []
+            for _ in range(2):
+                result = subprocess.run(["bash", str(SCRIPT)], env=env, capture_output=True, text=True, timeout=10)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("chain build failed", result.stderr)
+                args = args_file.read_text().splitlines()
+                binary = Path(args[args.index("-o") + 1])
+                self.assertEqual(binary.name, "polystorechaind")
+                self.assertTrue(binary.parent.name.startswith("bench-retrieval-"))
+                self.assertFalse(binary.parent.exists())
+                homes.append(binary.parent)
+            self.assertNotEqual(*homes)
+
+    def test_replaced_home_is_not_removed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fakebin = root / "bin"
+            fakebin.mkdir()
+            home = root / "home"
+            target = root / "operator-data"
+            target.mkdir()
+            (target / "sentinel").write_text("preserve")
+            cargo = fakebin / "cargo"
+            cargo.write_text('#!/bin/sh\nmv "$POLYSTORE_BENCH_HOME" "$POLYSTORE_BENCH_HOME.original"\nln -s "$OPERATOR_DATA" "$POLYSTORE_BENCH_HOME"\nexit 89\n')
+            cargo.chmod(0o755)
+            env = dict(os.environ, PATH=f"{fakebin}:{os.environ['PATH']}", POLYSTORE_BENCH_HOME=str(home), OPERATOR_DATA=str(target))
+            result = subprocess.run(["bash", str(SCRIPT)], env=env, capture_output=True, text=True, timeout=10)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("home changed; refusing cleanup", result.stderr)
+            self.assertTrue(home.is_symlink())
+            self.assertEqual((target / "sentinel").read_text(), "preserve")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The retrieval benchmark previously deleted its configured chain home and overwrote the checkout's chain binary. It now claims a unique home before building, rejects every existing custom path (including dangling symlinks), and builds the binary inside the owned home. Recursive exit cleanup uses an open directory handle after verifying its identity; `--keep-home` retains the new home for inspection.

The home and its ancestors must stay exclusively owned and unchanged during the run, under an operator-controlled parent. Recursive cleanup tolerates pathname replacement; ongoing builds/node/configuration writes use pathnames and do not provide that protection. Independent review reproduced that limitation and accepted this explicit ownership requirement for the startup-only scope.

Preparation for #260 under #254. This PR covers startup isolation only and does not close either issue. The existing serial driver is not secure-v2 saturation evidence; concurrent load, nonconstant fixtures, provenance and finite-gas qualification remain tracked in #260.

Validation:
- `python3 scripts/test_bench_retrieval_sessions.py`: 5 entrypoint tests pass; fake build commands exercise existing-path rejection, build-failure cleanup/retention, distinct default homes and binary placement, refusal to clean a replaced home, and replacement during recursive cleanup. The existing-path and retained-home assertions failed before the initial fix; the cleanup race regression failed before the review fix.
- `bash -n scripts/bench_retrieval_sessions.sh` and `git diff --check`: pass.
- CI runs these checks before the chain build. No node or expensive capacity benchmark was run for this startup-only change.

Hosted Codex review is clean at `c3d50424`; both prior review threads are resolved. All 28 current-head checks pass; GitHub reports no merge conflicts. Human merge approval is required by the tracker delivery policy. No protocol activation or performance improvement is claimed.
