### PR TITLE
chain: define inactive retrieval v2 challenge and sampling primitives

### DIFF
--- a/polystorechain/pkg/retrievalchallenge/challenge.go
+++ b/polystorechain/pkg/retrievalchallenge/challenge.go
@@ -1,0 +1,336 @@
+// Package retrievalchallenge defines inactive v2 challenge transcripts and bounded
+// derivation. It does not authenticate actors, anchors, setup files or chain state,
+// verify KZG proofs, or activate a protocol version. See the challenge RFC.
+package retrievalchallenge
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"math"
+	"math/big"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	Version = uint32(2)
+	Session = uint8(1)
+	Audit   = uint8(2)
+	Replica = uint8(1)
+	Stripe  = uint8(2)
+	// MaxSamples is an inactive v2 hard ceiling, not a quota or deployment profile.
+	MaxSamples  = uint64(4096)
+	maxAttempts = uint32(256)
+	maxMDUs     = uint64(65537) // Root table addresses nonzero MDU indices 1..65536.
+)
+
+// Window is inclusive. Snapshot state must be committed before Anchor is known.
+// In epoch 1, Snapshot=0 means the committed genesis state.
+type Window struct{ Snapshot, Anchor, First, Deadline uint64 }
+
+func (w Window) Contains(height uint64) bool {
+	return w.Snapshot <= math.MaxInt64-2 && w.Anchor == w.Snapshot+1 && w.First == w.Anchor+1 &&
+		w.First <= w.Deadline && w.Deadline <= math.MaxInt64 && height >= w.First && height <= w.Deadline
+}
+
+// SessionWindow preserves expiry at the deal end itself. New opens must precede
+// the deal end and leave at least the H+2 response height before expiry.
+func SessionWindow(open, expiry, dealEnd uint64) (Window, error) {
+	if open == 0 || open > math.MaxInt64-2 || dealEnd == 0 || dealEnd > math.MaxInt64 || open >= dealEnd || expiry > dealEnd || expiry < open+2 {
+		return Window{}, errors.New("invalid session response window")
+	}
+	return Window{open, open + 1, open + 2, expiry}, nil
+}
+
+// AuditWindow freezes at S-1, anchors at S and permits responses at S+1..E,
+// truncated at dealEnd-1. An empty interval issues no obligation (issued=false),
+// hence cannot justify an audit reward or a provider failure.
+func AuditWindow(epoch, length, dealEnd uint64) (w Window, issued bool, err error) {
+	if epoch == 0 || length < 2 || length > math.MaxInt64 || dealEnd == 0 || dealEnd > math.MaxInt64 || epoch > math.MaxInt64/length {
+		return Window{}, false, errors.New("invalid epoch response window")
+	}
+	end := epoch * length
+	start := end - length + 1
+	deadline := min(end, dealEnd-1)
+	if deadline < start+1 {
+		return Window{}, false, nil
+	}
+	return Window{start - 1, start, start + 1, deadline}, true, nil
+}
+
+// Context contains canonical values frozen by an authenticated open or epoch
+// snapshot. Addresses are decoded raw account bytes, never display strings.
+// SetupDigest identifies the externally authenticated exact setup artifact.
+// Audit ID and session-only fields are zero; session epoch fields are zero.
+type Context struct {
+	Version                           uint32
+	ChainID                           string
+	SetupDigest                       [32]byte
+	Kind                              uint8
+	ID                                [32]byte
+	DealID, Generation                uint64
+	Root                              [32]byte
+	Assigned, Payee                   [20]byte
+	Layout                            uint8
+	K, M, Slot                        uint32
+	MetadataMDUs, UserMDUs            uint64
+	StartMDU                          uint64
+	StartLeaf                         uint32
+	BlobCount                         uint64
+	EpochID, EpochLength, SampleCount uint64
+	Window                            Window
+	DealEnd                           uint64
+}
+
+func (c Context) dimensions() (rows, population uint64, err error) {
+	if c.Version != Version || len(c.ChainID) == 0 || len(c.ChainID) > 50 || !utf8.ValidString(c.ChainID) || strings.ContainsRune(c.ChainID, 0) {
+		return 0, 0, errors.New("invalid version or chain ID")
+	}
+	switch c.Layout {
+	case Replica:
+		if c.K != 1 || c.M != 0 || c.Slot != 0 {
+			return 0, 0, errors.New("noncanonical replica layout")
+		}
+		rows = 64
+	case Stripe:
+		if c.K == 0 || c.K > 64 || 64%c.K != 0 || c.M == 0 || uint64(c.K)+uint64(c.M) > 256 || uint64(c.Slot) >= uint64(c.K)+uint64(c.M) {
+			return 0, 0, errors.New("invalid stripe layout")
+		}
+		rows = 64 / uint64(c.K)
+	default:
+		return 0, 0, errors.New("unknown layout")
+	}
+	if c.MetadataMDUs == 0 || c.MetadataMDUs > maxMDUs || c.UserMDUs > maxMDUs-c.MetadataMDUs {
+		return 0, 0, errors.New("MDU range exceeds PolyFS root table")
+	}
+	// The root-table bound above also proves that this product cannot overflow.
+	population = c.UserMDUs * rows
+	switch c.Kind {
+	case Session:
+		if c.EpochID != 0 || c.EpochLength != 0 || c.SampleCount != 0 {
+			return 0, 0, errors.New("session contains audit fields")
+		}
+		expected, e := SessionWindow(c.Window.Snapshot, c.Window.Deadline, c.DealEnd)
+		if e != nil || c.Window != expected {
+			return 0, 0, errors.New("noncanonical session window")
+		}
+		if c.StartMDU < c.MetadataMDUs || c.StartMDU-c.MetadataMDUs >= c.UserMDUs || c.BlobCount == 0 || c.BlobCount > MaxSamples {
+			return 0, 0, errors.New("invalid session MDU or proof count")
+		}
+		firstLeaf := uint64(c.Slot) * rows
+		if uint64(c.StartLeaf) < firstLeaf || uint64(c.StartLeaf)-firstLeaf >= rows {
+			return 0, 0, errors.New("session leaf outside assignment")
+		}
+		row := uint64(c.StartLeaf) - firstLeaf
+		start := (c.StartMDU-c.MetadataMDUs)*rows + row
+		if c.BlobCount > population-start || c.BlobCount > rows-row {
+			return 0, 0, errors.New("session range exceeds allocation or slot")
+		}
+	case Audit:
+		if c.ID != [32]byte{} || c.Payee != c.Assigned || c.StartMDU != 0 || c.StartLeaf != 0 || c.BlobCount != 0 {
+			return 0, 0, errors.New("noncanonical audit authority or session fields")
+		}
+		expected, issued, e := AuditWindow(c.EpochID, c.EpochLength, c.DealEnd)
+		if e != nil || !issued || c.Window != expected {
+			return 0, 0, errors.New("unissued or noncanonical audit window")
+		}
+		if c.SampleCount == 0 || c.SampleCount > population || c.SampleCount > MaxSamples {
+			return 0, 0, errors.New("invalid audit sample count")
+		}
+	default:
+		return 0, 0, errors.New("unknown challenge kind")
+	}
+	return rows, population, nil
+}
+
+func appendLP(b []byte, s string) []byte {
+	b = binary.BigEndian.AppendUint32(b, uint32(len(s)))
+	return append(b, s...)
+}
+
+// Bytes returns the single canonical transcript. Only bounded, already decoded
+// fields enter it; it is not a protobuf/ABI decoder or an authorization check.
+func (c Context) Bytes() ([]byte, error) {
+	if _, _, err := c.dimensions(); err != nil {
+		return nil, err
+	}
+	b := make([]byte, 0, 512)
+	b = appendLP(b, "polystore/challenge-context/v2")
+	b = binary.BigEndian.AppendUint32(b, c.Version)
+	b = appendLP(b, c.ChainID)
+	b = append(b, c.SetupDigest[:]...)
+	b = append(b, c.Kind)
+	b = append(b, c.ID[:]...)
+	b = binary.BigEndian.AppendUint64(b, c.DealID)
+	b = binary.BigEndian.AppendUint64(b, c.Generation)
+	b = append(b, c.Root[:]...)
+	b = append(b, c.Assigned[:]...)
+	b = append(b, c.Payee[:]...)
+	b = append(b, c.Layout)
+	for _, v := range []uint32{c.K, c.M, c.Slot} {
+		b = binary.BigEndian.AppendUint32(b, v)
+	}
+	for _, v := range []uint64{c.MetadataMDUs, c.UserMDUs, c.StartMDU} {
+		b = binary.BigEndian.AppendUint64(b, v)
+	}
+	b = binary.BigEndian.AppendUint32(b, c.StartLeaf)
+	for _, v := range []uint64{c.BlobCount, c.EpochID, c.EpochLength, c.SampleCount, c.Window.Snapshot, c.Window.Anchor, c.Window.First, c.Window.Deadline, c.DealEnd} {
+		b = binary.BigEndian.AppendUint64(b, v)
+	}
+	return b, nil
+}
+
+func (c Context) Hash() ([32]byte, error) {
+	b, err := c.Bytes()
+	if err != nil {
+		return [32]byte{}, err
+	}
+	return sha256.Sum256(b), nil
+}
+
+// Challenge is an expected statement, not proof acceptance or coverage credit.
+// PopulationIndex is selected p_i; Ordinal is i, including in the z transcript.
+type Challenge struct {
+	Ordinal, PopulationIndex, MDUIndex uint64
+	LeafIndex                          uint32
+	Z                                  [32]byte
+}
+
+// Challenges derives the complete ordered list once. Callers compare exact
+// expected tuples/z before FFI and account accepted obligations once in state.
+func (c Context) Challenges(seed []byte) ([]Challenge, error) {
+	if len(seed) != 32 {
+		return nil, errors.New("seed must be exactly 32 bytes")
+	}
+	rows, population, err := c.dimensions()
+	if err != nil {
+		return nil, err
+	}
+	hash, err := c.Hash()
+	if err != nil {
+		return nil, err
+	}
+	var positions []uint64
+	if c.Kind == Audit {
+		positions, err = Sample(hash, seed, population, c.SampleCount)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		positions = make([]uint64, c.BlobCount)
+		start := (c.StartMDU-c.MetadataMDUs)*rows + uint64(c.StartLeaf) - uint64(c.Slot)*rows
+		for i := range positions {
+			positions[i] = start + uint64(i)
+		}
+	}
+	out := make([]Challenge, len(positions))
+	transcript := appendLP(make([]byte, 0, 128), "polystore/blob-challenge/v2")
+	transcript = append(transcript, hash[:]...)
+	transcript = append(transcript, seed...)
+	prefix := len(transcript)
+	for i, p := range positions {
+		v := Challenge{Ordinal: uint64(i), PopulationIndex: p, MDUIndex: c.MetadataMDUs + p/rows, LeafIndex: uint32(uint64(c.Slot)*rows + p%rows)}
+		transcript = transcript[:prefix]
+		transcript = binary.BigEndian.AppendUint64(transcript, v.Ordinal)
+		transcript = binary.BigEndian.AppendUint64(transcript, v.MDUIndex)
+		transcript = binary.BigEndian.AppendUint32(transcript, v.LeafIndex)
+		transcript = binary.BigEndian.AppendUint32(transcript, 0)
+		v.Z, err = hashToPoint(transcript, sha256.Sum256)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = v
+	}
+	return out, nil
+}
+
+var (
+	fieldModulus      = mustFieldModulus()
+	fieldModulusBytes = [32]byte(fieldModulus.FillBytes(make([]byte, 32)))
+	domainOrder       = big.NewInt(4096)
+	one               = big.NewInt(1)
+)
+
+func mustFieldModulus() *big.Int {
+	v, ok := new(big.Int).SetString("73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001", 16)
+	if !ok {
+		panic("invalid compiled field modulus")
+	}
+	return v
+}
+func validPoint(v [32]byte) bool {
+	z := new(big.Int).SetBytes(v[:])
+	return z.Sign() > 0 && z.Cmp(fieldModulus) < 0 && new(big.Int).Exp(z, domainOrder, fieldModulus).Cmp(one) != 0
+}
+func hashToPoint(transcript []byte, hash func([]byte) [32]byte) ([32]byte, error) {
+	for counter := uint32(0); counter < maxAttempts; counter++ {
+		binary.BigEndian.PutUint32(transcript[len(transcript)-4:], counter)
+		z := hash(transcript)
+		if validPoint(z) {
+			return z, nil
+		}
+	}
+	return [32]byte{}, errors.New("field challenge rejection exhausted: protocol failure")
+}
+
+// Sample draws distinct assignment-relative positions using the exact sparse
+// tail-swap Fisher-Yates variant in the RFC. It allocates O(count), never O(U).
+// The caller must authenticate hash/seed and freeze U/count before seed reveal.
+func Sample(hash [32]byte, seed []byte, population, count uint64) ([]uint64, error) {
+	if len(seed) != 32 || count > population || count > MaxSamples {
+		return nil, errors.New("invalid seed, population or bounded sample count")
+	}
+	positions := make([]uint64, count)
+	swaps := make(map[uint64]uint64, count)
+	transcript := appendLP(make([]byte, 0, 128), "polystore/audit-position/v2")
+	transcript = append(transcript, hash[:]...)
+	transcript = append(transcript, seed...)
+	transcript = append(transcript, make([]byte, 12)...)
+	for i := uint64(0); i < count; i++ {
+		binary.BigEndian.PutUint64(transcript[len(transcript)-12:], i)
+		n := population - i
+		r, err := draw(n, func(counter uint32) [32]byte {
+			binary.BigEndian.PutUint32(transcript[len(transcript)-4:], counter)
+			return sha256.Sum256(transcript)
+		})
+		if err != nil {
+			return nil, err
+		}
+		p, ok := swaps[r]
+		if !ok {
+			p = r
+		}
+		tail, ok := swaps[n-1]
+		if !ok {
+			tail = n - 1
+		}
+		positions[i] = p
+		swaps[r] = tail
+		delete(swaps, n-1)
+	}
+	return positions, nil
+}
+
+func draw(n uint64, hash func(uint32) [32]byte) (uint64, error) {
+	if n == 0 {
+		return 0, errors.New("empty draw range")
+	}
+	if n == 1 {
+		return 0, nil
+	}
+	// Reject the incomplete upper residue class; modulus reduction alone is biased.
+	modulus := new(big.Int).SetUint64(n)
+	limit := new(big.Int).Lsh(big.NewInt(1), 256)
+	remainder := new(big.Int).Mod(limit, modulus)
+	limit.Sub(limit, remainder)
+	x := new(big.Int)
+	for counter := uint32(0); counter < maxAttempts; counter++ {
+		digest := hash(counter)
+		x.SetBytes(digest[:])
+		if x.Cmp(limit) < 0 {
+			return x.Mod(x, modulus).Uint64(), nil
+		}
+	}
+	return 0, errors.New("sample rejection exhausted: protocol failure")
+}

--- a/polystorechain/pkg/retrievalchallenge/challenge_test.go
+++ b/polystorechain/pkg/retrievalchallenge/challenge_test.go
@@ -1,0 +1,353 @@
+package retrievalchallenge
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"math"
+	"os"
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+func fixtureContext() Context {
+	c := Context{Version: 2, ChainID: "polystore-test-1", Kind: Session, DealID: 9007199254740993, Generation: 7,
+		Layout: Stripe, K: 8, M: 4, Slot: 3, MetadataMDUs: 2, UserMDUs: 133, StartMDU: 134, StartLeaf: 25, BlobCount: 3,
+		Window: Window{Snapshot: 100, Anchor: 101, First: 102, Deadline: 150}, DealEnd: 200}
+	for i := range c.SetupDigest {
+		c.SetupDigest[i] = byte(i)
+		c.ID[i] = byte(i + 32)
+		c.Root[i] = byte(i + 64)
+	}
+	for i := range c.Assigned {
+		c.Assigned[i] = byte(i + 96)
+		c.Payee[i] = byte(i + 116)
+	}
+	return c
+}
+func fixtureSeed() []byte {
+	b := make([]byte, 32)
+	for i := range b {
+		b[i] = byte(i + 136)
+	}
+	return b
+}
+
+func TestWindows(t *testing.T) {
+	for _, tt := range []struct {
+		open, expiry, end uint64
+		ok                bool
+	}{{1, 3, 4, true}, {1, 2, 4, false}, {0, 3, 4, false}, {1, 4, 4, true}, {math.MaxInt64 - 2, math.MaxInt64 - 1, math.MaxInt64, false}, {math.MaxUint64, 1, 2, false}, {math.MaxInt64 - 3, math.MaxInt64 - 1, math.MaxInt64, true}} {
+		w, err := SessionWindow(tt.open, tt.expiry, tt.end)
+		if (err == nil) != tt.ok {
+			t.Fatalf("session %+v: %+v %v", tt, w, err)
+		}
+	}
+	for _, tt := range []struct {
+		epoch, length, end uint64
+		issued, ok         bool
+	}{{1, 1, 10, false, false}, {1, 2, 10, true, true}, {2, 2, 4, false, true}, {2, 2, 5, true, true}, {0, 2, 10, false, false}, {math.MaxUint64, 2, 10, false, false}, {1, math.MaxUint64, 10, false, false}} {
+		w, issued, err := AuditWindow(tt.epoch, tt.length, tt.end)
+		if (err == nil) != tt.ok || issued != tt.issued {
+			t.Fatalf("audit %+v: %+v issued=%v err=%v", tt, w, issued, err)
+		}
+	}
+	w, _ := SessionWindow(1, 3, 4)
+	for _, h := range []uint64{0, 1, 2, 4, math.MaxUint64} {
+		if w.Contains(h) {
+			t.Fatal("accepted out of window", h)
+		}
+	}
+	if !w.Contains(3) {
+		t.Fatal("inclusive deadline rejected")
+	}
+}
+
+func TestContextRejectsAmbiguityAndBounds(t *testing.T) {
+	mutations := []func(*Context){
+		func(c *Context) { c.Version = 1 }, func(c *Context) { c.Kind = 0 }, func(c *Context) { c.ChainID = "" }, func(c *Context) { c.ChainID = string(make([]byte, 51)) }, func(c *Context) { c.ChainID = "a\x00b" }, func(c *Context) { c.ChainID = "\xff" },
+		func(c *Context) { c.Layout = 0 }, func(c *Context) { c.K = 3 }, func(c *Context) { c.M = math.MaxUint32 }, func(c *Context) { c.Slot = 12 }, func(c *Context) { c.MetadataMDUs = 0 }, func(c *Context) { c.MetadataMDUs = math.MaxUint64 }, func(c *Context) { c.UserMDUs = math.MaxUint64 },
+		func(c *Context) { c.StartMDU = 1 }, func(c *Context) { c.StartMDU = 135 }, func(c *Context) { c.StartLeaf = 23 }, func(c *Context) { c.StartLeaf = 31; c.BlobCount = 2 }, func(c *Context) { c.BlobCount = 0 }, func(c *Context) { c.BlobCount = math.MaxUint64 },
+		func(c *Context) { c.EpochID = 1 }, func(c *Context) { c.SampleCount = 1 }, func(c *Context) { c.Window.Anchor++ }, func(c *Context) { c.Window.First++ }, func(c *Context) { c.Window.Deadline = c.DealEnd + 1 },
+	}
+	for i, mutate := range mutations {
+		c := fixtureContext()
+		mutate(&c)
+		if _, err := c.Bytes(); err == nil {
+			t.Errorf("mutation %d accepted", i)
+		}
+	}
+	c := fixtureContext()
+	base, _ := c.Hash()
+	mutations = []func(*Context){func(c *Context) { c.DealID++ }, func(c *Context) { c.Generation++ }, func(c *Context) { c.Root[0]++ }, func(c *Context) { c.ID[0]++ }, func(c *Context) { c.Payee[0]++ }, func(c *Context) { c.Assigned[0]++ }, func(c *Context) { c.SetupDigest[0]++ }, func(c *Context) { c.ChainID += "x" }, func(c *Context) { c.StartLeaf++ }, func(c *Context) { c.BlobCount-- }, func(c *Context) { c.Window.Deadline-- }}
+	for i, mutate := range mutations {
+		c := fixtureContext()
+		mutate(&c)
+		h, err := c.Hash()
+		if err != nil || h == base {
+			t.Errorf("unbound field %d: %v", i, err)
+		}
+	}
+}
+
+func TestAuditAndReplicaCanonicalBounds(t *testing.T) {
+	c := fixtureContext()
+	c.Kind = Audit
+	c.ID = [32]byte{}
+	c.Payee = c.Assigned
+	c.StartMDU = 0
+	c.StartLeaf = 0
+	c.BlobCount = 0
+	c.EpochID = 2
+	c.EpochLength = 100
+	c.SampleCount = 8
+	c.Window.Deadline = 199
+	mutations := []func(*Context){func(c *Context) { c.ID[0] = 1 }, func(c *Context) { c.Payee[0]++ }, func(c *Context) { c.StartLeaf = 1 }, func(c *Context) { c.StartMDU = 1 }, func(c *Context) { c.BlobCount = 1 }, func(c *Context) { c.EpochLength = 1 }, func(c *Context) { c.EpochID = 0 }, func(c *Context) { c.SampleCount = 0 }, func(c *Context) { c.SampleCount = 1065 }, func(c *Context) { c.UserMDUs = 1000; c.SampleCount = MaxSamples + 1 }, func(c *Context) { c.Window.Deadline++ }, func(c *Context) { c.UserMDUs = 0 }}
+	for i, mutate := range mutations {
+		bad := c
+		mutate(&bad)
+		if _, err := bad.Bytes(); err == nil {
+			t.Fatalf("audit mutation %d accepted", i)
+		}
+	}
+	c = fixtureContext()
+	c.Layout = Replica
+	c.K = 1
+	c.M = 0
+	c.Slot = 0
+	c.StartLeaf = 0
+	c.BlobCount = 64
+	if _, err := c.Challenges(fixtureSeed()); err != nil {
+		t.Fatal(err)
+	}
+	c.StartLeaf = 1
+	if _, err := c.Bytes(); err == nil {
+		t.Fatal("replica session crossed MDU")
+	}
+	c.StartLeaf = 0
+	c.Slot = 1
+	if _, err := c.Bytes(); err == nil {
+		t.Fatal("replica nonzero slot accepted")
+	}
+	c.Slot = 0
+	c.UserMDUs = 65535
+	c.StartMDU = 65536
+	if _, err := c.Bytes(); err != nil {
+		t.Fatal("last addressable MDU rejected", err)
+	}
+	c.UserMDUs++
+	if _, err := c.Bytes(); err == nil {
+		t.Fatal("root-table overflow accepted")
+	}
+	for _, w := range []Window{{0, 1, 2, math.MaxUint64}, {1, 2, 2, 3}, {1, 3, 4, 5}, {math.MaxUint64, 0, 1, 2}} {
+		if w.Contains(w.First) {
+			t.Fatal("malformed window accepted")
+		}
+	}
+}
+
+func TestSamplingAndPointBounds(t *testing.T) {
+	seed := fixtureSeed()
+	hash := sha256.Sum256([]byte("context"))
+	for _, u := range []uint64{0, 1, 2, 8, 132, 1375, 4096, math.MaxUint64} {
+		q := min(u, MaxSamples)
+		p, err := Sample(hash, seed, u, q)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if uint64(len(p)) != q {
+			t.Fatal("count")
+		}
+		seen := map[uint64]bool{}
+		for _, v := range p {
+			if v >= u || seen[v] {
+				t.Fatalf("invalid sample %d of %d", v, u)
+			}
+			seen[v] = true
+		}
+		again, _ := Sample(hash, seed, u, q)
+		if !reflect.DeepEqual(p, again) {
+			t.Fatal("nondeterministic")
+		}
+	}
+	for _, tt := range []struct{ u, q uint64 }{{0, 1}, {1, 2}, {math.MaxUint64, MaxSamples + 1}} {
+		if _, err := Sample(hash, seed, tt.u, tt.q); err == nil {
+			t.Fatal("unbounded sample accepted")
+		}
+	}
+	for _, n := range []int{0, 31, 33, 48, 64} {
+		if _, err := Sample(hash, make([]byte, n), 8, 1); err == nil {
+			t.Fatal("bad seed accepted", n)
+		}
+	}
+	c := fixtureContext()
+	got, err := c.Challenges(seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, v := range got {
+		if v.Ordinal != uint64(i) || v.MDUIndex != 134 || v.LeafIndex != uint32(25+i) {
+			t.Fatalf("bad session tuple %+v", v)
+		}
+		if !validPoint(v.Z) {
+			t.Fatal("invalid field point")
+		}
+	}
+	mutated := append([]byte(nil), seed...)
+	mutated[0]++
+	different, _ := c.Challenges(mutated)
+	if reflect.DeepEqual(got, different) {
+		t.Fatal("seed unbound")
+	}
+}
+
+func TestRejectionExhaustionAndDomain(t *testing.T) {
+	var zero, one, maximum [32]byte
+	one[31] = 1
+	for i := range maximum {
+		maximum[i] = 255
+	}
+	for _, v := range [][32]byte{zero, one, maximum, fieldModulusBytes} {
+		if validPoint(v) {
+			t.Fatal("invalid point accepted")
+		}
+	}
+	minusOne := fieldModulusBytes
+	minusOne[31]--
+	if validPoint(minusOne) {
+		t.Fatal("nontrivial 4096th root of unity accepted")
+	}
+	valid := [32]byte{}
+	valid[31] = 2
+	callsToAccept := 0
+	z, err := hashToPoint(make([]byte, 4), func(b []byte) [32]byte {
+		callsToAccept++
+		if callsToAccept == 256 {
+			return valid
+		}
+		return maximum
+	})
+	if err != nil || z != valid || callsToAccept != 256 {
+		t.Fatal("last permitted point attempt failed")
+	}
+
+	calls := 0
+	_, err = hashToPoint(make([]byte, 4), func([]byte) [32]byte { calls++; return maximum })
+	if err == nil || calls != 256 {
+		t.Fatalf("exhaustion calls=%d err=%v", calls, err)
+	}
+	calls = 0
+	_, err = draw(3, func(uint32) [32]byte { calls++; return maximum })
+	if err == nil || calls != 256 {
+		t.Fatalf("draw exhaustion calls=%d err=%v", calls, err)
+	}
+	if v, err := draw(1, func(uint32) [32]byte { t.Fatal("n=1 hashed"); return zero }); err != nil || v != 0 {
+		t.Fatal(v, err)
+	}
+	maximum[31]--
+	if v, err := draw(3, func(uint32) [32]byte { return maximum }); err != nil || v != 2 {
+		t.Fatal(v, err)
+	}
+}
+
+func TestIndependentGolden(t *testing.T) {
+	var golden struct {
+		Vectors map[string]struct {
+			Bytes     string `json:"context_hex"`
+			Hash      string `json:"context_hash"`
+			Positions []struct {
+				Ordinal         uint64 `json:"ordinal"`
+				PopulationIndex uint64 `json:"population_index"`
+				MDU             uint64 `json:"mdu_index"`
+				Leaf            uint32 `json:"leaf_index"`
+				Z               string `json:"z"`
+			} `json:"samples"`
+		} `json:"vectors"`
+	}
+	data, err := os.ReadFile("testdata/challenge-golden.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = json.Unmarshal(data, &golden); err != nil {
+		t.Fatal(err)
+	}
+	if len(golden.Vectors) != 2 {
+		t.Fatal("expected session and audit fixtures")
+	}
+	for name, f := range golden.Vectors {
+		c := fixtureContext()
+		if name == "audit" {
+			c.Kind = Audit
+			c.ID = [32]byte{}
+			c.Payee = c.Assigned
+			c.StartMDU = 0
+			c.StartLeaf = 0
+			c.BlobCount = 0
+			c.EpochID = 2
+			c.EpochLength = 100
+			c.SampleCount = 8
+			c.Window.Deadline = 199
+		} else if name != "session" {
+			t.Fatal("unknown vector")
+		}
+		b, err := c.Bytes()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if hex.EncodeToString(b) != f.Bytes {
+			t.Fatal(name, "canonical bytes drift")
+		}
+		h, _ := c.Hash()
+		if hex.EncodeToString(h[:]) != f.Hash {
+			t.Fatal(name, "hash drift")
+		}
+		got, err := c.Challenges(fixtureSeed())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != len(f.Positions) {
+			t.Fatal("count drift")
+		}
+		for i, w := range f.Positions {
+			v := got[i]
+			if v.Ordinal != w.Ordinal || v.PopulationIndex != w.PopulationIndex || v.MDUIndex != w.MDU || v.LeafIndex != w.Leaf || hex.EncodeToString(v.Z[:]) != w.Z {
+				t.Fatalf("%s challenge %d drift: %+v expected %+v", name, i, v, w)
+			}
+		}
+	}
+}
+
+func BenchmarkContext(b *testing.B) {
+	c := fixtureContext()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := c.Hash(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+func BenchmarkSessionChallenges(b *testing.B) {
+	c := fixtureContext()
+	seed := fixtureSeed()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := c.Challenges(seed); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+func BenchmarkAuditSamples(b *testing.B) {
+	seed := fixtureSeed()
+	hash := sha256.Sum256(seed)
+	for _, q := range []uint64{132, 1375} {
+		b.Run(strconv.FormatUint(q, 10), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, err := Sample(hash, seed, 1000000, q); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/polystorechain/pkg/retrievalchallenge/testdata/challenge-golden.json
+++ b/polystorechain/pkg/retrievalchallenge/testdata/challenge-golden.json
@@ -1,0 +1,279 @@
+{
+  "schema": {
+    "encoding": "LP = U32BE byte length followed by bytes; all unsigned integers big endian; no delimiters or padding",
+    "fields": [
+      [
+        "domain",
+        "LP",
+        "polystore/challenge-context/v2"
+      ],
+      [
+        "version",
+        "u32",
+        2
+      ],
+      [
+        "chain_id",
+        "LP",
+        "polystore-test-1"
+      ],
+      [
+        "setup_digest",
+        "hex32",
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+      ],
+      [
+        "kind",
+        "u8",
+        1
+      ],
+      [
+        "context_id",
+        "hex32",
+        "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
+      ],
+      [
+        "deal_id",
+        "u64",
+        9007199254740993
+      ],
+      [
+        "generation",
+        "u64",
+        7
+      ],
+      [
+        "root",
+        "hex32",
+        "404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f"
+      ],
+      [
+        "assigned",
+        "hex20",
+        "606162636465666768696a6b6c6d6e6f70717273"
+      ],
+      [
+        "payee",
+        "hex20",
+        "7475767778797a7b7c7d7e7f8081828384858687"
+      ],
+      [
+        "layout",
+        "u8",
+        2
+      ],
+      [
+        "k",
+        "u32",
+        8
+      ],
+      [
+        "m",
+        "u32",
+        4
+      ],
+      [
+        "slot",
+        "u32",
+        3
+      ],
+      [
+        "metadata_mdus",
+        "u64",
+        2
+      ],
+      [
+        "user_mdus",
+        "u64",
+        133
+      ],
+      [
+        "start_mdu",
+        "u64",
+        134
+      ],
+      [
+        "start_leaf",
+        "u32",
+        25
+      ],
+      [
+        "blob_count",
+        "u64",
+        3
+      ],
+      [
+        "epoch_id",
+        "u64",
+        0
+      ],
+      [
+        "epoch_length",
+        "u64",
+        0
+      ],
+      [
+        "sample_count",
+        "u64",
+        0
+      ],
+      [
+        "snapshot_height",
+        "u64",
+        100
+      ],
+      [
+        "anchor_height",
+        "u64",
+        101
+      ],
+      [
+        "first_response_height",
+        "u64",
+        102
+      ],
+      [
+        "deadline_height",
+        "u64",
+        150
+      ],
+      [
+        "deal_end",
+        "u64",
+        200
+      ]
+    ],
+    "seed_hex": "88898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7",
+    "point_transcript": "LP(polystore/blob-challenge/v2) || context_hash32 || seed32 || U64BE(ordinal) || U64BE(mdu_index) || U32BE(leaf_index) || U32BE(counter)",
+    "point_accept": "0 < BE(SHA256(transcript)) < Fr and z**4096 % Fr != 1; counters 0..255; Fr=0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001",
+    "audit_override": {
+      "kind": 2,
+      "context_id": "0000000000000000000000000000000000000000000000000000000000000000",
+      "payee": "606162636465666768696a6b6c6d6e6f70717273",
+      "start_mdu": 0,
+      "start_leaf": 0,
+      "blob_count": 0,
+      "epoch_id": 2,
+      "epoch_length": 100,
+      "sample_count": 8,
+      "snapshot_height": 100,
+      "anchor_height": 101,
+      "first_response_height": 102,
+      "deadline_height": 199
+    },
+    "audit_transcript": "LP(polystore/audit-position/v2) || context_hash32 || seed32 || U64BE(ordinal) || U32BE(counter)",
+    "audit_draw": "n=U-i; n=1 means r=0 without hashing; otherwise reject x >= (2**256 // n)*n, take r=x%n; sparse swap map: p=map.get(r,r); map[r]=map.get(n-1,n-1); delete map[n-1]; U=user_mdus*(64/k); mdu=metadata_mdus+p//rows; leaf=slot*rows+p%rows; point ordinal remains i"
+  },
+  "vectors": {
+    "session": {
+      "context_hex": "0000001e706f6c7973746f72652f6368616c6c656e67652d636f6e746578742f76320000000200000010706f6c7973746f72652d746573742d31000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f01202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f00200000000000010000000000000007404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868702000000080000000400000003000000000000000200000000000000850000000000000086000000190000000000000003000000000000000000000000000000000000000000000000000000000000006400000000000000650000000000000066000000000000009600000000000000c8",
+      "context_hash": "149a5172e6f8575ab191bda9df5ed2516a90b819ee024da764906ed20309fa59",
+      "population": 1064,
+      "samples": [
+        {
+          "ordinal": 0,
+          "mdu_index": 134,
+          "leaf_index": 25,
+          "z": "2e066a220067a30871359e2ef6347f8273622796325fe48864f93752bd63ae6f",
+          "scalar_counter": 0,
+          "population_index": 1057
+        },
+        {
+          "ordinal": 1,
+          "mdu_index": 134,
+          "leaf_index": 26,
+          "z": "5d5b3b94706e69a4fe744c0f8e315c0248c223a490bf02ee4232bad1db88755c",
+          "scalar_counter": 2,
+          "population_index": 1058
+        },
+        {
+          "ordinal": 2,
+          "mdu_index": 134,
+          "leaf_index": 27,
+          "z": "24f212b29fdcaa98863292b2091334341d8260c860d9a8bc412d062e8a6c3f12",
+          "scalar_counter": 0,
+          "population_index": 1059
+        }
+      ]
+    },
+    "audit": {
+      "context_hex": "0000001e706f6c7973746f72652f6368616c6c656e67652d636f6e746578742f76320000000200000010706f6c7973746f72652d746573742d31000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f02000000000000000000000000000000000000000000000000000000000000000000200000000000010000000000000007404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f70717273606162636465666768696a6b6c6d6e6f707172730200000008000000040000000300000000000000020000000000000085000000000000000000000000000000000000000000000000000000020000000000000064000000000000000800000000000000640000000000000065000000000000006600000000000000c700000000000000c8",
+      "context_hash": "38d5a33424b7a547919ab74162dd0399c818afddae2f487c5d4d64aacbf69c43",
+      "population": 1064,
+      "samples": [
+        {
+          "ordinal": 0,
+          "mdu_index": 19,
+          "leaf_index": 24,
+          "z": "16ebc6f8981491210bf4242e16cdbd2a16d573885385013efedd3eb45585ac18",
+          "scalar_counter": 0,
+          "population_index": 136,
+          "position_counter": 0
+        },
+        {
+          "ordinal": 1,
+          "mdu_index": 43,
+          "leaf_index": 30,
+          "z": "12358e173aff905d48b41873a525e1b4eecf5b366d84eed091faeedc71665b49",
+          "scalar_counter": 1,
+          "population_index": 334,
+          "position_counter": 0
+        },
+        {
+          "ordinal": 2,
+          "mdu_index": 38,
+          "leaf_index": 27,
+          "z": "218cd5fd2937dfd06b1a34a73985c37e41e1e92f72a2cadf66645c8f04f2ff59",
+          "scalar_counter": 0,
+          "population_index": 291,
+          "position_counter": 0
+        },
+        {
+          "ordinal": 3,
+          "mdu_index": 130,
+          "leaf_index": 30,
+          "z": "63cbe48beed86f028636dc15b75a40f23630891ff164e7001c049f6185ce97e4",
+          "scalar_counter": 2,
+          "population_index": 1030,
+          "position_counter": 0
+        },
+        {
+          "ordinal": 4,
+          "mdu_index": 113,
+          "leaf_index": 25,
+          "z": "242672f08e5a4e5b94f982a06ca1cd7bee13a5ce9aefacdf0f7700da0b59848f",
+          "scalar_counter": 0,
+          "population_index": 889,
+          "position_counter": 0
+        },
+        {
+          "ordinal": 5,
+          "mdu_index": 125,
+          "leaf_index": 28,
+          "z": "5d16e699968dfacf447420eecefe9fc71cd95d07546d1a5b23d444799de3a518",
+          "scalar_counter": 1,
+          "population_index": 988,
+          "position_counter": 0
+        },
+        {
+          "ordinal": 6,
+          "mdu_index": 70,
+          "leaf_index": 28,
+          "z": "2dda5af67b55928c9c1234719564bae46259e09b0c59b0bf78d023a05eeb03cb",
+          "scalar_counter": 1,
+          "population_index": 548,
+          "position_counter": 0
+        },
+        {
+          "ordinal": 7,
+          "mdu_index": 29,
+          "leaf_index": 28,
+          "z": "6f6a7fd5d86341c232d58891f568255b21d73e6dc8967bb0d5cf26b01474e1be",
+          "scalar_counter": 4,
+          "population_index": 220,
+          "position_counter": 0
+        }
+      ]
+    }
+  }
+}

--- a/polystorechain/pkg/retrievalchallenge/testdata/challenge-golden.json
+++ b/polystorechain/pkg/retrievalchallenge/testdata/challenge-golden.json
@@ -35,12 +35,12 @@
       [
         "deal_id",
         "u64",
-        9007199254740993
+        "9007199254740993"
       ],
       [
         "generation",
         "u64",
-        7
+        "7"
       ],
       [
         "root",
@@ -80,17 +80,17 @@
       [
         "metadata_mdus",
         "u64",
-        2
+        "2"
       ],
       [
         "user_mdus",
         "u64",
-        133
+        "133"
       ],
       [
         "start_mdu",
         "u64",
-        134
+        "134"
       ],
       [
         "start_leaf",
@@ -100,47 +100,47 @@
       [
         "blob_count",
         "u64",
-        3
+        "3"
       ],
       [
         "epoch_id",
         "u64",
-        0
+        "0"
       ],
       [
         "epoch_length",
         "u64",
-        0
+        "0"
       ],
       [
         "sample_count",
         "u64",
-        0
+        "0"
       ],
       [
         "snapshot_height",
         "u64",
-        100
+        "100"
       ],
       [
         "anchor_height",
         "u64",
-        101
+        "101"
       ],
       [
         "first_response_height",
         "u64",
-        102
+        "102"
       ],
       [
         "deadline_height",
         "u64",
-        150
+        "150"
       ],
       [
         "deal_end",
         "u64",
-        200
+        "200"
       ]
     ],
     "seed_hex": "88898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7",
@@ -150,16 +150,16 @@
       "kind": 2,
       "context_id": "0000000000000000000000000000000000000000000000000000000000000000",
       "payee": "606162636465666768696a6b6c6d6e6f70717273",
-      "start_mdu": 0,
+      "start_mdu": "0",
       "start_leaf": 0,
-      "blob_count": 0,
-      "epoch_id": 2,
-      "epoch_length": 100,
-      "sample_count": 8,
-      "snapshot_height": 100,
-      "anchor_height": 101,
-      "first_response_height": 102,
-      "deadline_height": 199
+      "blob_count": "0",
+      "epoch_id": "2",
+      "epoch_length": "100",
+      "sample_count": "8",
+      "snapshot_height": "100",
+      "anchor_height": "101",
+      "first_response_height": "102",
+      "deadline_height": "199"
     },
     "audit_transcript": "LP(polystore/audit-position/v2) || context_hash32 || seed32 || U64BE(ordinal) || U32BE(counter)",
     "audit_draw": "n=U-i; n=1 means r=0 without hashing; otherwise reject x >= (2**256 // n)*n, take r=x%n; sparse swap map: p=map.get(r,r); map[r]=map.get(n-1,n-1); delete map[n-1]; U=user_mdus*(64/k); mdu=metadata_mdus+p//rows; leaf=slot*rows+p%rows; point ordinal remains i"

--- a/polystorechain/pkg/retrievalchallenge/testdata/check_vectors.py
+++ b/polystorechain/pkg/retrievalchallenge/testdata/check_vectors.py
@@ -1,0 +1,82 @@
+"""Independent oracle: Python stdlib, transcribed from the frozen wire schema."""
+import hashlib
+import json
+from pathlib import Path
+
+BASE = Path(__file__).parent
+GOLDEN = json.loads((BASE / 'challenge-golden.json').read_text())
+SCHEMA = GOLDEN['schema']
+FR = int('73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001', 16)
+SEED = bytes.fromhex(SCHEMA['seed_hex'])
+
+def u(value, width):
+    return value.to_bytes(width, 'big')
+
+def lp(value):
+    value = value.encode()
+    return u(len(value), 4) + value
+
+def encode(values):
+    result = b''
+    for name, kind, default in SCHEMA['fields']:
+        value = values.get(name, default)
+        if kind == 'LP':
+            result += lp(value)
+        elif kind.startswith('hex'):
+            result += bytes.fromhex(value)
+        else:
+            result += u(value, int(kind[1:]) // 8)
+    return result
+
+def challenge(ctx, ordinal, mdu, leaf):
+    prefix = lp('polystore/blob-challenge/v2') + ctx + SEED + u(ordinal, 8) + u(mdu, 8) + u(leaf, 4)
+    for counter in range(256):
+        digest = hashlib.sha256(prefix + u(counter, 4)).digest()
+        z = int.from_bytes(digest, 'big')
+        if 0 < z < FR and pow(z, 4096, FR) != 1:
+            return {'ordinal': ordinal, 'mdu_index': mdu, 'leaf_index': leaf, 'z': digest.hex(), 'scalar_counter': counter}
+    raise ValueError('exhausted')
+
+vectors = {'schema': SCHEMA, 'vectors': {}}
+for name, override in [('session', {}), ('audit', SCHEMA['audit_override'])]:
+    values = {field: default for field, kind, default in SCHEMA['fields']}
+    values.update(override)
+    wire = encode(values)
+    ctx = hashlib.sha256(wire).digest()
+    rows = 64 // values['k']
+    population = values['user_mdus'] * rows
+    samples = []
+    if name == 'session':
+        for i in range(values['blob_count']):
+            leaf = values['start_leaf'] + i
+            sample = challenge(ctx, i, values['start_mdu'], leaf)
+            sample['population_index'] = (values['start_mdu'] - values['metadata_mdus']) * rows + leaf - values['slot'] * rows
+            samples.append(sample)
+    else:
+        # This independent implementation uses a full list rather than the Go
+        # sparse map; both implement sampling without replacement by swap-delete.
+        available = list(range(population))
+        for i in range(values['sample_count']):
+            n = len(available)
+            if n == 1:
+                r, counter = 0, 0
+            else:
+                limit = (2**256 // n) * n
+                prefix = lp('polystore/audit-position/v2') + ctx + SEED + u(i, 8)
+                for counter in range(256):
+                    x = int.from_bytes(hashlib.sha256(prefix + u(counter, 4)).digest(), 'big')
+                    if x < limit:
+                        r = x % n
+                        break
+                else:
+                    raise ValueError('exhausted')
+            p = available[r]
+            available[r] = available[-1]
+            available.pop()
+            sample = challenge(ctx, i, values['metadata_mdus'] + p // rows, values['slot'] * rows + p % rows)
+            sample.update(population_index=p, position_counter=counter)
+            samples.append(sample)
+    vectors['vectors'][name] = {'context_hex': wire.hex(), 'context_hash': ctx.hex(), 'population': population, 'samples': samples}
+
+assert vectors == GOLDEN, 'independent v2 transcript/sample/point vectors drifted'
+print('independent v2 session and audit vectors match')

--- a/polystorechain/pkg/retrievalchallenge/testdata/check_vectors.py
+++ b/polystorechain/pkg/retrievalchallenge/testdata/check_vectors.py
@@ -41,6 +41,11 @@ vectors = {'schema': SCHEMA, 'vectors': {}}
 for name, override in [('session', {}), ('audit', SCHEMA['audit_override'])]:
     values = {field: default for field, kind, default in SCHEMA['fields']}
     values.update(override)
+    for field, kind, _ in SCHEMA['fields']:
+        if kind == 'u64':
+            value = values[field]
+            assert isinstance(value, str) and value.isascii() and value.isdecimal(), 'u64 fixture inputs must be decimal strings'
+            values[field] = int(value)
     wire = encode(values)
     ctx = hashlib.sha256(wire).digest()
     rows = 64 // values['k']

--- a/rfcs/rfc-challenge-derivation-and-quotas.md
+++ b/rfcs/rfc-challenge-derivation-and-quotas.md
@@ -1,11 +1,235 @@
-# RFC: Challenge Derivation & Proof Quota Policy (Unified Liveness v1)
+# RFC: Challenge Derivation & Proof Quota Policy
 
-**Status:** Partially implemented in devnet
+**Status:** Legacy v1 runtime; v2 primitives implemented, activation unavailable
 **Scope:** Chain protocol policy (`polystorechain/`)
 **Motivation:** `spec.md` §7.6; Appendix B #3 (challenge derivation), #4 (quota + penalty curve)
 **Depends on:** `spec.md`, `rfcs/rfc-mode2-onchain-state.md`, `rfcs/rfc-blob-alignment-and-striping.md`
 
 ---
+
+## Version 2: canonical challenge primitives (inactive)
+
+The pure Go package `polystorechain/pkg/retrievalchallenge` implements this section's
+serialization, response windows, distinct sampling and off-domain evaluation points.
+It has **no runtime caller or activation switch**. It does not authenticate an
+actor, setup artifact, block hash or snapshot, perform KZG verification, enforce
+payment/coverage accounting, or establish that bytes were delivered. Legacy v1
+runtime behavior remains unchanged. Issues #254–#257 and #260 own integration and
+qualification; this first #255 S0 slice does not complete #255.
+
+This section supersedes the historical v1 assumptions below **for future v2
+activation**. In particular, ordinary retrieval cannot reduce independent storage
+audits, a public proof cannot select its payee, and a proposer-influenced block
+hash is not an unbiased beacon. No absolute anti-grinding or delivery claim is
+supported by the legacy description.
+
+### Canonical bytes and ownership
+
+`LP(x)` means a four-byte unsigned big-endian byte length followed by the bytes of
+`x`. Integers below are unsigned big endian; fixed byte strings have no prefix or
+padding. The exact transcript is the following concatenation, in table order.
+`context_hash = SHA256(transcript)`. JSON, protobuf, EVM ABI encodings and displayed
+bech32/hex strings are **not** hash inputs. Clients must preserve uint64 values
+without conversion through JavaScript `Number`.
+
+| Field | Encoding | Canonical value/source required at integration |
+| --- | --- | --- |
+| domain | LP ASCII | `polystore/challenge-context/v2` |
+| version | U32 | 2 |
+| chain_id | LP UTF-8 | Authenticated chain ID; 1–50 bytes, valid UTF-8, no NUL |
+| setup_digest | 32 bytes | SHA-256 of the exact accepted trusted-setup artifact; expected digest authenticated by the protocol profile |
+| kind | U8 | 1 = paid session; 2 = assigned storage audit |
+| context_id | 32 bytes | Existing session ID for kind 1; all zero for kind 2, whose identity is the bound epoch/assignment tuple |
+| deal_id, generation | U64 each | Frozen deal and content generation |
+| root | 32 bytes | Frozen PolyFS root |
+| assigned, payee | 20 bytes each | Canonical raw account addresses; distinct fields even when equal |
+| layout | U8 | 1 = replica; 2 = StripeReplica |
+| K, M, slot | U32 each | Replica: exactly 1,0,0. Stripe: K divides 64, 1<=K<=64, M>0, K+M<=256, slot<K+M |
+| metadata_mdus, user_mdus | U64 each | Metadata includes MDU 0 and all witness MDUs; metadata>=1 and total<=65537 |
+| start_mdu | U64 | Session start; zero for audit |
+| start_leaf | U32 | Session start in slot-major ordering; zero for audit |
+| blob_count | U64 | Session count; zero for audit |
+| epoch_id, epoch_length, sample_count | U64 each | Audit snapshot values; all zero for session |
+| snapshot_height, anchor_height, first_response_height, deadline_height | U64 each | Validated immutable inclusive response window below |
+| deal_end | U64 | Frozen deal end height |
+
+The root table admits nonzero MDU indices 1..65536; hence the total count includes
+MDU 0 and may reach 65537. This format uses the existing 64 blobs per user MDU.
+`rows=64/K` for Stripe and 64 for replica; `U=user_mdus*rows` is the audit population
+**for this assignment**, excluding metadata and including allocated padding/parity
+where applicable. Bounds must precede arithmetic/allocation. These small fixed
+layout bounds also prevent multiplication/leaf-index overflow.
+
+A v2 session covers an exact positive contiguous range within **one user MDU and
+one assignment**: `metadata_mdus<=start_mdu<metadata_mdus+user_mdus` and
+`slot*rows<=start_leaf<start_leaf+blob_count<=(slot+1)*rows`. This intentionally
+narrows legacy replica sessions that could span MDUs. Use separate sessions for
+separate MDUs; do not reinterpret old sessions. Each opened blob requires a fresh
+opening, including a partially requested blob. `blob_count*131072` is billed
+encoded coverage, not observed transport bytes or logical payload length.
+
+For audits, payee equals assigned and context_id/session fields are zero. Audit
+`sample_count` must be positive, no greater than U and no greater than **4096**.
+4096 is the inactive v2 hard allocation/work ceiling, not the quota policy or a
+claim that an active chain can process that many proofs. A profile may set a lower
+cap (the #260 reference experiment uses min(U,132)); an infeasible desired
+assurance target remains unqualified. No audit context is created for U=0 or a
+zero/disabled quota. The standalone sampler permits U=Q=0 and returns an empty set.
+
+The primitive accepts fixed-size root/setup/address/ID bytes as data. Integration
+must authenticate their values; structurally valid bytes, a context digest and a
+zero default are not evidence of registration, ownership, trust or authorization.
+Do not let a submitted context replace authoritative frozen state.
+
+### Issuance and response windows
+
+All heights must fit positive signed int64 chain heights, except audit snapshot 0
+which denotes committed genesis state. All deadlines below are inclusive.
+
+- Session opened at H: snapshot H, anchor H+1, first response H+2. Require
+  H>=1, H<deal_end and H+2<=expires_at<=deal_end. Preserve existing session
+  expiry semantics (`height>expires_at`); do not silently extend an expiry.
+- Epoch e with frozen length L>=2: start S=1+(e-1)L and end E=eL. Snapshot
+  committed state S-1, anchor S, and accept S+1..min(E,deal_end-1). Overflow,
+  epoch 0 and L<2 are errors. An empty response interval issues no obligation
+  and warrants neither an audit reward nor provider failure.
+
+The session deadline may equal deal_end; the audit deadline is strictly before
+it. These are deliberately different existing lifetime contracts. Later parameter
+or root/assignment changes cannot move an already issued window or reroll its
+challenge. Validation does not fetch a block or declare a seed available.
+
+### Fixed anchor and bounded derivation
+
+The chain must persist/query the exact canonical 32-byte committed hash of
+the predetermined anchor height. A caller cannot choose the seed, substitute a
+later height, or fall back to nil/current-block data. A missing/corrupt/pruned
+anchor is protocol failure, not provider failure. This initial trusted-devnet
+source assumes non-grinding proposers; permissionless sampling/reward security is
+blocked until an authenticated, predetermined future beacon round is integrated
+and qualified. Hashing extra fields or several proposer-controlled blocks does
+not remove bias. Source authentication and unavailable-round behavior remain
+outside these pure primitives and cannot be skipped at activation.
+
+For expected ordinal i and tuple (mdu,leaf), hash:
+
+```text
+LP("polystore/blob-challenge/v2") || context_hash || seed32 ||
+U64BE(i) || U64BE(mdu) || U32BE(leaf) || U32BE(counter)
+```
+
+Interpret SHA-256 as an unsigned big-endian integer. Try counters 0..255, accepting
+only `0<z<Fr` and `z^4096 mod Fr != 1`, with
+`Fr=0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001`.
+Return z as exactly 32 big-endian bytes. Exhaustion is explicit protocol failure;
+there is no biased modular fallback. Do not hash proof bytes, y, transaction hash
+or a prover-selected nonce into the challenge being answered.
+
+The new z is an off-domain polynomial evaluation, not a literal byte challenge.
+Commitments, Merkle paths and root-table openings are immutable structure and may
+be reused. Constant and zero polynomials can yield identical valid opening bytes
+at different z; they remain valid. No global proof-byte uniqueness rule is added.
+KZG verification and once-only state accounting are separate integration steps;
+this helper proves neither delivery, incompressibility, storage exclusivity nor a
+formal proof-of-retrievability extractor.
+
+### Distinct audit positions
+
+Freeze U and Q from the eligible ACTIVE assignment before anchor revelation.
+Ordinary/session/legacy retrieval activity must not subtract from Q. At ordinal i,
+set n=U-i and hash:
+
+```text
+LP("polystore/audit-position/v2") || context_hash || seed32 ||
+U64BE(i) || U32BE(counter)
+```
+
+Interpret the digest as x. Reject `x>=floor(2^256/n)*n`; otherwise take r=x%n.
+For n=1 take r=0 without hashing. Try at most 256 counters per draw. Sparse
+Fisher-Yates uses a request-local map and exactly this tail-swap variant:
+
+```text
+p_i = map.get(r, r)
+map[r] = map.get(n-1, n-1)
+delete map[n-1]
+mdu = metadata_mdus + p_i / rows
+leaf = slot*rows + p_i % rows
+```
+
+The selected position is **p_i**, not ordinal i. Keep i separately in the point
+transcript and eventual coverage key. For replica, slot=0 and rows=64. The map and
+output use O(Q) storage; no U-sized array or retry-until-unique loop is allowed in
+production. Derive Q once per context/request and compare the entire expected
+ordered tuple list before FFI; do not regenerate Q for each proof. No lower-level
+sampling helper authenticates the supplied context hash or seed.
+
+### Integration and migration gates (not implemented by this slice)
+
+The authenticated native/sponsored/EVM open must normalize and persist the effective
+`authorized_proof_provider`, defaulting to assigned, in durable session state
+including COMPLETED. A deputy requires the requester's authority and registration.
+Sponsored opens must preserve the voucher issuer's provider restriction; protocol
+opens must preserve task/repair serving authority. An optional field cannot grant
+arbitrary budget payees or bypass `VoucherAuth.provider`. An unassigned deputy
+needs an issuer-authorized voucher version; no consumed-voucher reuse. A later
+fallback uses a new authorized funded session and the old expiry/refund path.
+
+The remaining #255 integration belongs in the existing seams:
+
+- [session opens, proof admission and settlement](../polystorechain/x/polystorechain/keeper/msg_server.go),
+  [protobuf state](../polystorechain/proto/polystorechain/polystorechain/v1/types.proto)
+  and [messages](../polystorechain/proto/polystorechain/polystorechain/v1/tx.proto):
+  durable normalized authority, generated ABI/bindings, authoritative context query,
+  shared native/EVM validation and once-only settlement. Nothing here installs them.
+- [unified liveness](../polystorechain/x/polystorechain/keeper/unified_liveness.go),
+  [rewards](../polystorechain/x/polystorechain/keeper/base_rewards.go) and
+  [epoch finalization](../polystorechain/x/polystorechain/keeper/slashing.go):
+  frozen eligible assignments, finite admission/retention caps, once-only coverage
+  and no organic credit subtraction or unsubstantiated provider failure attribution.
+  Open-time gas alone cannot bound future epoch work.
+- Coordinated migration: keep historical COMPLETED terminal; unsupported legacy
+  OPEN/USER_CONFIRMED/PROOF_SUBMITTED become expiry-refund-only with original locks
+  and refund sources. Never infer missing payees or relabel old proofs as fresh.
+  Secure continuation uses a new funded session without consumed-voucher reuse.
+- Retain immutable generations for both session and audit references; historical
+  reads cannot change `.active_generation`. Reject mutations if required reference
+  capacity cannot be preserved. No migration or retention mechanism is installed here.
+
+[#255](https://github.com/Polynomialstore/polystore/issues/255) remains open for
+these integrations, bounded gas and actual EVM rollback. Network activation remains
+unavailable until compatible provider-daemon, user-gateway, browser and EVM paths
+verify bytes before normal confirmation and
+[#260](https://github.com/Polynomialstore/polystore/issues/260) qualifies the named
+finite-gas deployment profile. Passing vector tests is not runtime signer binding,
+seed capture, delivery, reward or rollback qualification. Pricing is unchanged.
+
+### Reproducible checks
+
+```sh
+cd polystorechain
+go test -mod=vendor ./pkg/retrievalchallenge -count=1
+go test -mod=vendor ./pkg/retrievalchallenge -race -count=1
+go test -mod=vendor ./pkg/retrievalchallenge -run '^$' -bench . -benchmem
+python3 pkg/retrievalchallenge/testdata/check_vectors.py
+```
+
+The checked-in fixture contains exact transcript bytes, hashes, selected positions,
+MDU/leaf indices and z values, including deal ID above JavaScript's safe integer
+limit. The independent Python oracle uses a full-list shuffle for the small fixture;
+the Go implementation uses the bounded sparse map. The oracle checks the committed
+fixture without regenerating it. Boundary tests cover empty populations, layout and
+window validity, overflow, metadata exclusion, repeated samples, invalid seed
+lengths, nontrivial roots of unity and forced rejection exhaustion. Benchmarks
+characterize only these new Go helpers; there is no FFI/native scratch allocation,
+KZG throughput result, capacity qualification or speedup claim.
+
+---
+
+## Historical v1 reference
+
+The sections below describe legacy policy and implementation history. Their organic
+credit subtraction and anti-grinding claims are not the v2 contract, and must not
+be used to claim secure v2 behavior before the integration gates above pass.
 
 ## 0. Executive Summary
 

--- a/rfcs/rfc-challenge-derivation-and-quotas.md
+++ b/rfcs/rfc-challenge-derivation-and-quotas.md
@@ -30,7 +30,9 @@ supported by the legacy description.
 padding. The exact transcript is the following concatenation, in table order.
 `context_hash = SHA256(transcript)`. JSON, protobuf, EVM ABI encodings and displayed
 bech32/hex strings are **not** hash inputs. Clients must preserve uint64 values
-without conversion through JavaScript `Number`.
+without conversion through JavaScript `Number`. The golden fixture encodes every
+U64 input as a decimal JSON string; parse those strings with `BigInt` in JavaScript.
+This fixture representation does not change the binary transcript.
 
 | Field | Encoding | Canonical value/source required at integration |
 | --- | --- | --- |


### PR DESCRIPTION
Retrieval v2 needs every component to derive the same immutable challenge and the same distinct audit samples. This adds a pure stdlib Go implementation and a normative RFC transcript for context hashing, session/audit response windows, sparse sampling without replacement, and off-domain KZG evaluation points. Golden vectors come from an independently written Python implementation with dense sampling.

Partial S0 implementation for #255 under #254. There are no runtime callers or activation switch. Actor authorization, protobuf/ABI/query integration, seed capture, keeper enforcement, migration, settlement, EVM atomicity and deployment qualification remain in #255–#257/#260; this PR closes none of them.

Validation from `polystorechain/`:
- `go test -mod=vendor ./pkg/retrievalchallenge -count=1`
- `go test -mod=vendor -race ./pkg/retrievalchallenge -count=1`
- `go vet -mod=vendor ./pkg/retrievalchallenge`
- `python3 pkg/retrievalchallenge/testdata/check_vectors.py`
- `git diff --check`

All passed. Tests cover independent transcript/point vectors, nontrivial roots of unity, bounded rejection/exhaustion, signed-height overflow, canonical layout/authority fields, one-MDU windows, seed lengths, root-table bounds, selected-position mapping and distinct sampling up to the hard cap. A fresh independent Astra review accepted 7b2b50a7 (including its decimal-string U64 fixture correction), including 1,032 dense-versus-sparse full-population cases and 42 layout boundary combinations. Review scope was this inactive primitive only. A Node JSON.parse/BigInt check also preserved the fixture deal ID above 2^53; all expected wire bytes/hashes stayed unchanged.

Preliminary local Apple M3 characterization (`go test -mod=vendor ./pkg/retrievalchallenge -run '^$' -bench . -benchmem -benchtime=100ms`):

| Operation | ns/op | ops/sec | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: |
| Context hash | 363 | 2,754,821 | 512 | 1 |
| Three session challenges | 8,986 | 111,284 | 2,592 | 23 |
| 132 audit positions | 54,440 | 18,369 | 46,184 | 796 |
| 1,375 audit positions | 1,056,000 | 947 | 467,233 | 8,256 |

These are short runs on a shared host, not capacity or speedup evidence. Position benchmarks exclude field-point derivation, KZG proving/verification, native scratch, networking and chain execution. Production sampling uses O(Q) memory and never allocates the full population. The 4,096 hard ceiling is inactive and does not qualify any deployment profile.

Hosted [Codex review is clean at 7b2b50a7](https://github.com/Polynomialstore/polystore/pull/262#issuecomment-5576512931), with no review threads. All 28 current-head checks pass and GitHub reports no merge conflicts. Human merge approval is pending under the tracker delivery rule. Merging this PR cannot activate v2 or complete S0/#255.
