### PR TITLE
fix(chain): make native EVM calls atomic and charge child gas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,12 @@ jobs:
           bash -n scripts/bench_retrieval_sessions.sh
           python3 scripts/test_bench_retrieval_sessions.py
 
+      - name: Check chain build entrypoint
+        if: matrix.service == 'polystorechain'
+        run: |
+          bash -n scripts/chain_go.sh
+          python3 scripts/test_chain_go.py
+
       - name: Build polystore_core
         if: matrix.service == 'polystore_gateway' || matrix.service == 'polystorechain'
         run: |
@@ -41,17 +47,15 @@ jobs:
       - name: Test ${{ matrix.service }}
         working-directory: ${{ matrix.service }}
         run: |
-          if [ "${{ matrix.service }}" == "polystorechain" ]; then
-            echo "Reconstructing vendor for polystorechain..."
-            go mod vendor
-            git checkout vendor
-          fi
-          
           # Add polystore_core release dir to LD_LIBRARY_PATH for polystore_gateway/polystorechain
           # We use GITHUB_WORKSPACE because working-directory is set to the service dir
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/polystore_core/target/release
-          
-          go test ./... -v
+
+          if [ "${{ matrix.service }}" == "polystorechain" ]; then
+            ../scripts/chain_go.sh test ./... -v
+          else
+            go test ./... -v
+          fi
 
   # ------------------------------------------------------------------
   # RUST CRATES (Core, CLI, P2P, Mock L1)

--- a/docs/POLYSTORECHAIND_REDEPLOY_RUNBOOK.md
+++ b/docs/POLYSTORECHAIND_REDEPLOY_RUNBOOK.md
@@ -84,6 +84,6 @@ sudo systemctl restart polystorechaind
 
 ## Notes
 
-- The script defaults to building with `-mod=mod` so local rebuilds do not get stuck on stale vendor state.
+- The script uses `scripts/chain_go.sh` to reconstruct dependencies while retaining the required tracked SDK/EVM corrections and enforcing vendor mode; see `polystorechain/VENDOR_PATCHES.md`.
 - If `libpolystore_core` is missing, the script attempts to build `polystore_core` in the selected source checkout.
 - Default runtime paths are tuned to this environment (`/opt/polystore`, `/etc/polystore/polystorechaind.env`) and can be overridden with flags.

--- a/e2e_burn.sh
+++ b/e2e_burn.sh
@@ -16,7 +16,7 @@ echo "[E2E-BURN] Building..."
 pushd "$CHAIN_DIR" >/dev/null
 cp "$ROOT_DIR/demos/kzg/trusted_setup.txt" ./trusted_setup.txt
 export CGO_LDFLAGS="-L$CORE_DIR/target/release -lpolystore_core"
-go build -o "$ROOT_DIR/polystorechaind" ./cmd/polystorechaind
+../scripts/chain_go.sh build -o "$ROOT_DIR/polystorechaind" ./cmd/polystorechaind
 popd >/dev/null
 
 BINARY="$ROOT_DIR/polystorechaind"

--- a/e2e_elasticity.sh
+++ b/e2e_elasticity.sh
@@ -127,7 +127,7 @@ require_cmd python3
 
 # Ensure binaries are built
 echo ">>> Building binaries..."
-cd polystorechain && go build -o ../polystorechaind ./cmd/polystorechaind && cd ..
+cd polystorechain && ../scripts/chain_go.sh build -o ../polystorechaind ./cmd/polystorechaind && cd ..
 
 # Clean start
 echo ">>> Resetting chain..."

--- a/e2e_flow.sh
+++ b/e2e_flow.sh
@@ -12,7 +12,7 @@ TRUSTED_SETUP="$(pwd)/polystorechain/trusted_setup.txt"
 
 # Ensure binaries are built
 echo ">>> Building binaries..."
-cd polystorechain && go build -o ../polystorechaind ./cmd/polystorechaind && cd ..
+cd polystorechain && ../scripts/chain_go.sh build -o ../polystorechaind ./cmd/polystorechaind && cd ..
 
 # Clean start
 echo ">>> Resetting chain..."

--- a/e2e_open_retrieval_session_cli.sh
+++ b/e2e_open_retrieval_session_cli.sh
@@ -112,7 +112,7 @@ export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH:-}:$CORE_DIR/target/release"
 banner "Building polystorechaind"
 pushd "$CHAIN_DIR" >/dev/null
 export CGO_LDFLAGS="-L$CORE_DIR/target/release -lpolystore_core"
-go build -o "$BINARY" ./cmd/polystorechaind
+../scripts/chain_go.sh build -o "$BINARY" ./cmd/polystorechaind
 popd >/dev/null
 
 banner "Resetting chain"

--- a/e2e_open_retrieval_session_mode2_cli.sh
+++ b/e2e_open_retrieval_session_mode2_cli.sh
@@ -117,7 +117,7 @@ export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH:-}:$CORE_DIR/target/release"
 banner "Building polystorechaind"
 pushd "$CHAIN_DIR" >/dev/null
 export CGO_LDFLAGS="-L$CORE_DIR/target/release -lpolystore_core"
-go build -o "$BINARY" ./cmd/polystorechaind
+../scripts/chain_go.sh build -o "$BINARY" ./cmd/polystorechaind
 popd >/dev/null
 
 banner "Resetting chain"

--- a/e2e_retrieval.sh
+++ b/e2e_retrieval.sh
@@ -41,7 +41,7 @@ echo ">>> Building binaries..."
 touch polystore_core/src/lib.rs
 cd polystore_core && cargo build --release --features debug-print && cd ..
 cp polystore_core/target/release/libpolystore_core.dylib . 2>/dev/null || cp polystore_core/target/release/libpolystore_core.so . 2>/dev/null || true
-cd polystorechain && go clean -cache && go build -o ../polystorechaind ./cmd/polystorechaind && cd ..
+cd polystorechain && go clean -cache && ../scripts/chain_go.sh build -o ../polystorechaind ./cmd/polystorechaind && cd ..
 cd polystore_cli && cargo build --release && cd ..
 
 export DYLD_LIBRARY_PATH=$(pwd):$DYLD_LIBRARY_PATH

--- a/e2e_retrieval_fees.sh
+++ b/e2e_retrieval_fees.sh
@@ -116,7 +116,7 @@ export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH:-}:$CORE_DIR/target/release"
 banner "Building polystorechaind"
 pushd "$CHAIN_DIR" >/dev/null
 export CGO_LDFLAGS="-L$CORE_DIR/target/release -lpolystore_core"
-go build -o "$BINARY" ./cmd/polystorechaind
+../scripts/chain_go.sh build -o "$BINARY" ./cmd/polystorechaind
 popd >/dev/null
 
 banner "Resetting chain"

--- a/e2e_slashing.sh
+++ b/e2e_slashing.sh
@@ -13,7 +13,7 @@ TRUSTED_SETUP="$(pwd)/polystorechain/trusted_setup.txt"
 
 # Ensure binaries are built
 echo ">>> Building binaries..."
-cd polystorechain && go build -o ../polystorechaind ./cmd/polystorechaind && cd ..
+cd polystorechain && ../scripts/chain_go.sh build -o ../polystorechaind ./cmd/polystorechaind && cd ..
 
 # Clean start
 echo ">>> Resetting chain..."

--- a/e2e_test.sh
+++ b/e2e_test.sh
@@ -26,7 +26,7 @@ echo "[E2E] Building polystorechaind..."
 pushd "$CHAIN_DIR" >/dev/null
 cp "$ROOT_DIR/demos/kzg/trusted_setup.txt" ./trusted_setup.txt
 export CGO_LDFLAGS="-L$CORE_DIR/target/release -lpolystore_core"
-go build -o "$ROOT_DIR/polystorechaind" ./cmd/polystorechaind
+../scripts/chain_go.sh build -o "$ROOT_DIR/polystorechaind" ./cmd/polystorechaind
 popd >/dev/null
 
 BINARY="$ROOT_DIR/polystorechaind"

--- a/install.sh
+++ b/install.sh
@@ -34,11 +34,11 @@ if command -v ignite &> /dev/null; then
     # ignite chain build might be tricky with custom CGO flags if not configured in config.yml
     # So we fall back to go build for reliability in this script
     cd polystorechain
-    go build -o ../bin/polystorechaind ./cmd/polystorechaind
+    ../scripts/chain_go.sh build -o ../bin/polystorechaind ./cmd/polystorechaind
     cd ..
 else
     cd polystorechain
-    go build -o ../bin/polystorechaind ./cmd/polystorechaind
+    ../scripts/chain_go.sh build -o ../bin/polystorechaind ./cmd/polystorechaind
     cd ..
 fi
 

--- a/performance/load_gen.sh
+++ b/performance/load_gen.sh
@@ -44,7 +44,7 @@ echo ">>> Building binaries..."
     cd ../polystorechain # Change to the polystorechain module directory
     echo "Cleaning Go build cache..."
     go clean -cache -modcache
-    CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build -o "../polystorechaind" ./cmd/polystorechaind # Build to project root
+    CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 ../scripts/chain_go.sh build -o "../polystorechaind" ./cmd/polystorechaind # Build to project root
 )
 echo "Binary info for $BINARY:"
 file "$BINARY"

--- a/polystorechain/Makefile
+++ b/polystorechain/Makefile
@@ -25,30 +25,30 @@ BUILD_FLAGS := -ldflags '$(ldflags)'
 
 test-unit:
 	@echo Running unit tests...
-	@test_output=$$(go test -mod=readonly -v -timeout 30m -short ./... 2>&1) ; \
+	@test_output=$$(../scripts/chain_go.sh test -v -timeout 30m -short ./... 2>&1) ; status=$$? ; \
 	echo "$$test_output" ; \
-	if echo "$$test_output" | grep -q "ERROR:" ; then \
-		echo "Detected 'ERROR:' in test output. Marking test-unit as failed." ; \
+	if [ "$$status" -ne 0 ] || echo "$$test_output" | grep -q "ERROR:" ; then \
+		echo "Unit tests failed. Marking test-unit as failed." ; \
 		exit 1 ; \
 	fi
 
 test-simulation:
 	@echo Running simulation tests...
-	@go test -mod=readonly -v -timeout 30m ./app -Enabled=true -NumBlocks=100 -BlockSize=200 -Commit=true -Period=5
+	@../scripts/chain_go.sh test -v -timeout 30m ./app -Enabled=true -NumBlocks=100 -BlockSize=200 -Commit=true -Period=5
 
 test-race:
 	@echo Running unit tests with race condition reporting...
-	@go test -mod=readonly -v -race -timeout 30m ./...
+	@../scripts/chain_go.sh test -v -race -timeout 30m ./...
 
 test-cover:
 	@echo Running unit tests and creating coverage report...
-	@go test -mod=readonly -v -timeout 30m -coverprofile=$(COVER_FILE) -covermode=atomic ./...
+	@../scripts/chain_go.sh test -v -timeout 30m -coverprofile=$(COVER_FILE) -covermode=atomic ./...
 	@go tool cover -html=$(COVER_FILE) -o $(COVER_HTML_FILE)
 	@rm $(COVER_FILE)
 
 bench:
 	@echo Running unit tests with benchmarking...
-	@go test -mod=readonly -v -timeout 30m -bench=. ./...
+	@../scripts/chain_go.sh test -v -timeout 30m -bench=. ./...
 
 test: govet govulncheck test-unit test-simulation
 
@@ -64,7 +64,7 @@ install:
 	@echo "--> ensure dependencies have not been modified"
 	@go mod verify
 	@echo "--> installing $(APPNAME)d"
-	@go install $(BUILD_FLAGS) -mod=readonly ./cmd/$(APPNAME)d
+	@../scripts/chain_go.sh install $(BUILD_FLAGS) ./cmd/$(APPNAME)d
 
 .PHONY: all install
 
@@ -104,7 +104,7 @@ lint-fix:
 
 govet:
 	@echo Running go vet...
-	@go vet ./...
+	@../scripts/chain_go.sh vet ./...
 
 govulncheck:
 	@echo Running govulncheck...

--- a/polystorechain/VENDOR_PATCHES.md
+++ b/polystorechain/VENDOR_PATCHES.md
@@ -3,7 +3,8 @@
 Build/test the chain with `../scripts/chain_go.sh build|test|vet|install ...`
 from this directory. The wrapper selects vendor mode even when the environment
 sets `GOFLAGS=-mod=mod`, reconstructs dependencies when go.mod/go.sum change,
-and preserves tracked vendor files including uncommitted edits. Run
+and preserves tracked source patches including uncommitted edits. Generated
+`vendor/modules.txt` is retained from the new dependency graph. Run
 `../scripts/chain_go.sh vendor` to force reconstruction. Stage newly added vendor
 patch files before reconstruction. Use one build/preparation process per checkout.
 Other Go modules keep their own dependency mode.

--- a/polystorechain/VENDOR_PATCHES.md
+++ b/polystorechain/VENDOR_PATCHES.md
@@ -8,7 +8,7 @@ and preserves tracked vendor files including uncommitted edits. Run
 patch files before reconstruction. Use one build/preparation process per checkout.
 Other Go modules keep their own dependency mode.
 
-Do not run bare `go mod vendor` over the patches. The two EVM patch version
+Do not run bare `go mod vendor` over the patches. The three EVM patch version
 constants referenced by our precompile intentionally make an unpatched
 `-mod=mod` build fail to compile. This is a consensus-affecting correction:
 validators must use the same reviewed binary at a coordinated upgrade height;
@@ -22,6 +22,10 @@ The EVM corrections are based on pinned `github.com/cosmos/evm v0.5.1`:
 - `precompiles/common/precompile.go`: retain the native journal engine; give
   each native call its own remaining child gas budget, charge native work once
   including failed actions/balance processing, and preserve actual EVM OOG.
+- `precompiles/common/balance_handler.go`: synchronize native events for module
+  accounts too, so later EVM balance changes cannot overwrite native fees.
+  Existing blocked-recipient authorization remains enforced; a disallowed EVM
+  transfer fails and the enclosing SDK transaction cache is discarded.
 - `x/vm/statedb/statedb.go`: restore cached events on rollback and publish only
   surviving new events to the caller on successful commit. A successful sibling
   after a caught revert must retain its events; prior caller events stay once.

--- a/polystorechain/VENDOR_PATCHES.md
+++ b/polystorechain/VENDOR_PATCHES.md
@@ -1,0 +1,33 @@
+# Required dependency corrections
+
+Build/test the chain with `../scripts/chain_go.sh build|test|vet|install ...`
+from this directory. The wrapper selects vendor mode even when the environment
+sets `GOFLAGS=-mod=mod`, reconstructs dependencies when go.mod/go.sum change,
+and preserves tracked vendor files including uncommitted edits. Run
+`../scripts/chain_go.sh vendor` to force reconstruction. Stage newly added vendor
+patch files before reconstruction. Use one build/preparation process per checkout.
+Other Go modules keep their own dependency mode.
+
+Do not run bare `go mod vendor` over the patches. The two EVM patch version
+constants referenced by our precompile intentionally make an unpatched
+`-mod=mod` build fail to compile. This is a consensus-affecting correction:
+validators must use the same reviewed binary at a coordinated upgrade height;
+these source changes alone do not activate retrieval v2.
+
+Tracked baseline SDK corrections remain in cosmos-sdk `x/genutil/collect.go`,
+`x/genutil/types/genesis_state.go` and `x/staking/types/msg.go`.
+
+The EVM corrections are based on pinned `github.com/cosmos/evm v0.5.1`:
+
+- `precompiles/common/precompile.go`: retain the native journal engine; give
+  each native call its own remaining child gas budget, charge native work once
+  including failed actions/balance processing, and preserve actual EVM OOG.
+- `x/vm/statedb/statedb.go`: restore cached events on rollback and publish only
+  surviving new events to the caller on successful commit. A successful sibling
+  after a caught revert must retain its events; prior caller events stay once.
+
+The real app/store-backed regressions live in `app/precompile_native_test.go`.
+When upgrading Cosmos EVM, compare these files against the new upstream version,
+port or remove each correction only after those regressions pass, update the
+tracked `vendor/modules.txt`, and retain the compile guards until equivalent
+behavior is provided by the pinned dependency. No runtime fork selection exists.

--- a/polystorechain/app/app.go
+++ b/polystorechain/app/app.go
@@ -60,6 +60,7 @@ import (
 	// EVM Imports
 	codecaddress "github.com/cosmos/cosmos-sdk/codec/address"
 	evmante "github.com/cosmos/evm/ante"
+	precompilecommon "github.com/cosmos/evm/precompiles/common"
 	evmsrvflags "github.com/cosmos/evm/server/flags"
 	feemarket "github.com/cosmos/evm/x/feemarket"
 	feemarketkeeper "github.com/cosmos/evm/x/feemarket/keeper"
@@ -306,11 +307,20 @@ func New(
 	// Keep 31337 fallback for legacy localhost behavior when all sources are unset.
 	evmChainID := resolveEVMChainID(appOpts)
 
+	// Native precompiles journal every mounted persistent store they can touch,
+	// including auth, bank and PolyStore. The snapshot adapter needs the actual
+	// concrete keys registered by runtime, not replacement keys with equal names.
+	nativeStoreKeys := make(map[string]*storetypes.KVStoreKey)
+	for _, key := range app.GetStoreKeys() {
+		if kvKey, ok := key.(*storetypes.KVStoreKey); ok {
+			nativeStoreKeys[kvKey.Name()] = kvKey
+		}
+	}
 	evmKeeper := evmkeeper.NewKeeper(
 		app.appCodec,
 		evmKey,
 		transientKey,
-		map[string]*storetypes.KVStoreKey{evmtypes.StoreKey: evmKey},
+		nativeStoreKeys,
 		authtypes.NewModuleAddress(govtypes.ModuleName), // Authority
 		app.AuthKeeper,
 		app.BankKeeper,
@@ -329,7 +339,9 @@ func New(
 			Decimals:      uint32(evmtypes.DefaultEVMDecimals),
 		},
 	)
-	app.EVMKeeper.RegisterStaticPrecompile(polystoreprecompile.Address, polystoreprecompile.MustNew(&app.PolyStoreChainKeeper))
+	polystorePrecompile := polystoreprecompile.MustNew(&app.PolyStoreChainKeeper)
+	polystorePrecompile.BalanceHandlerFactory = precompilecommon.NewBalanceHandlerFactory(app.BankKeeper)
+	app.EVMKeeper.RegisterStaticPrecompile(polystoreprecompile.Address, polystorePrecompile)
 
 	addressCodec := codecaddress.NewBech32Codec(AccountAddressPrefix)
 	realEvmModule := evm.NewAppModule(app.EVMKeeper, app.AuthKeeper, app.BankKeeper, addressCodec)

--- a/polystorechain/app/precompile_native_test.go
+++ b/polystorechain/app/precompile_native_test.go
@@ -1,0 +1,335 @@
+package app
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+	"testing"
+
+	"cosmossdk.io/log"
+	sdkmath "cosmossdk.io/math"
+	storetypes "cosmossdk.io/store/types"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	dbm "github.com/cosmos/cosmos-db"
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	cmn "github.com/cosmos/evm/precompiles/common"
+	"github.com/cosmos/evm/x/vm/statedb"
+	evmtypes "github.com/cosmos/evm/x/vm/types"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	polystoreprecompile "polystorechain/precompiles/polystore"
+	types "polystorechain/x/polystorechain/types"
+)
+
+// callAndReturn forwards its calldata and returns the CALL success bit. Keeping
+// the outer contract successful is essential: top-level failure hides the bug.
+func callAndReturn(target common.Address, gas uint32, revert bool) []byte {
+	code := []byte{0x36, 0x60, 0, 0x60, 0, 0x37, 0x60, 0, 0x60, 0, 0x36, 0x60, 0, 0x60, 0, 0x73}
+	code = append(code, target.Bytes()...)
+	code = append(code, 0x62, byte(gas>>16), byte(gas>>8), byte(gas), 0xf1)
+	if revert {
+		return append(code, 0x50, 0x60, 0, 0x60, 0, 0xfd)
+	}
+	return append(code, 0x60, 0, 0x52, 0x60, 32, 0x60, 0, 0xf3)
+}
+
+func TestNativePrecompileNestedRollback(t *testing.T) {
+	a, baseCtx := nativePrecompileApp(t)
+	for _, tc := range []struct {
+		name    string
+		revert  bool
+		gas     uint32
+		present bool
+		sibling bool
+	}{{"nested_success", false, 5000000, true, false}, {"caught_child_revert", true, 5000000, false, false}, {"caught_out_of_gas", false, 210000, false, false}, {"caught_revert_then_success", true, 5000000, false, true}} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, _ := baseCtx.CacheContext()
+			require.NoError(t, a.PolyStoreChainKeeper.Params.Set(ctx, types.DefaultParams()))
+			anteEvent := sdk.NewEvent("ante_marker", sdk.NewAttribute("id", "before-evm"))
+			ctx.EventManager().EmitEvent(anteEvent)
+			evm, state := nativeEVM(t, a, ctx)
+			caller := common.HexToAddress("0xaa01")
+			outer := common.HexToAddress("0xaa02")
+			child := common.HexToAddress("0xaa03")
+			state.SetCode(outer, callAndReturn(child, 8000000, false))
+			state.SetCode(child, callAndReturn(polystoreprecompile.Address, tc.gas, tc.revert))
+			sibling := common.HexToAddress("0xaa04")
+			if tc.sibling {
+				first := callAndReturn(child, 8000000, false)
+				// Discard the first CALL result, then execute and return the sibling's result.
+				first = append(first[:len(first)-8], 0x50)
+				state.SetCode(outer, append(first, callAndReturn(sibling, 8000000, false)...))
+				state.SetCode(sibling, callAndReturn(polystoreprecompile.Address, 5000000, false))
+			}
+			api, err := abi.JSON(strings.NewReader(`[{"name":"requestProviderLink","type":"function","inputs":[{"name":"operator","type":"string"}],"outputs":[{"name":"ok","type":"bool"}]}]`))
+			require.NoError(t, err)
+			input, err := api.Pack("requestProviderLink", sdk.AccAddress(caller.Bytes()).String())
+			require.NoError(t, err)
+			result, left, err := evm.Call(caller, outer, input, 12000000, uint256.NewInt(0))
+			require.NoError(t, err)
+			require.Len(t, result, 32)
+			require.Less(t, left, uint64(12000000))
+			require.Equal(t, sdk.Events{anteEvent}, ctx.EventManager().Events(), "native events remain private until Commit")
+			require.NoError(t, state.Commit())
+			require.Equal(t, anteEvent, ctx.EventManager().Events()[0], "preexisting caller event remains once")
+			require.Equal(t, state.GetContext().EventManager().Events(), ctx.EventManager().Events()[1:])
+			present, err := a.PolyStoreChainKeeper.PendingProviderLinks.Has(ctx, sdk.AccAddress(child.Bytes()).String())
+			require.NoError(t, err)
+			require.Equal(t, tc.present, present, "native child state must follow EVM rollback")
+			if tc.revert && !tc.sibling {
+				require.Zero(t, result[31])
+			} else {
+				require.Equal(t, byte(1), result[31])
+			}
+			if tc.sibling {
+				present, err = a.PolyStoreChainKeeper.PendingProviderLinks.Has(ctx, sdk.AccAddress(sibling.Bytes()).String())
+				require.NoError(t, err)
+				require.True(t, present)
+				events := []sdk.Event{}
+				for _, e := range ctx.EventManager().Events() {
+					if e.Type == types.TypeMsgRequestProviderLink {
+						events = append(events, e)
+					}
+				}
+				require.Len(t, events, 1, "only the successful sibling SDK event must survive")
+				require.Contains(t, fmt.Sprint(events[0]), sdk.AccAddress(sibling.Bytes()).String())
+				require.NotContains(t, fmt.Sprint(events[0]), sdk.AccAddress(child.Bytes()).String())
+			}
+		})
+	}
+}
+
+func nativePrecompileApp(t *testing.T) (*App, sdk.Context) {
+	t.Helper()
+	a := New(log.NewNopLogger(), dbm.NewMemDB(), nil, true, simtestutil.AppOptionsMap{"home": t.TempDir(), "evm.evm-chain-id": evmtypes.DefaultEVMChainID}, baseapp.SetChainID(SimAppChainID))
+	ctx := a.NewContextLegacy(true, cmtproto.Header{Height: 10, ChainID: SimAppChainID}).WithGasMeter(storetypes.NewInfiniteGasMeter()).WithKVGasConfig(storetypes.GasConfig{}).WithTransientKVGasConfig(storetypes.GasConfig{})
+	evmParams := evmtypes.DefaultParams()
+	evmParams.ActiveStaticPrecompiles = append(evmParams.ActiveStaticPrecompiles, polystoreprecompile.AddressHex)
+	require.NoError(t, a.EVMKeeper.SetParams(ctx, evmParams))
+
+	return a, ctx
+}
+
+func nativeEVM(t *testing.T, a *App, ctx sdk.Context) (*vm.EVM, *statedb.StateDB) {
+	t.Helper()
+	state := statedb.New(ctx, a.EVMKeeper, statedb.NewEmptyTxConfig())
+	config := *params.AllEthashProtocolChanges
+	config.ChainID = big.NewInt(31337)
+	evm := vm.NewEVM(vm.BlockContext{CanTransfer: core.CanTransfer, Transfer: core.Transfer, BlockNumber: big.NewInt(10), GasLimit: 28000000}, state, &config, vm.Config{})
+	contracts, found, err := a.EVMKeeper.GetPrecompileInstance(ctx, polystoreprecompile.Address)
+	require.NoError(t, err)
+	require.True(t, found)
+	evm.SetPrecompiles(contracts.Map)
+	return evm, state
+}
+
+func TestNativePrecompileBankRollback(t *testing.T) {
+	a, baseCtx := nativePrecompileApp(t)
+	api, err := abi.JSON(strings.NewReader(`[{"name":"createDeal","type":"function","inputs":[{"type":"uint64"},{"type":"string"},{"type":"uint256"},{"type":"uint256"}],"outputs":[{"type":"uint64"}]}]`))
+	require.NoError(t, err)
+	for _, tc := range []struct {
+		name                     string
+		revert, invalid, sibling bool
+		gas                      uint32
+	}{
+		{"success", false, false, false, 5000000}, {"caught_revert", true, false, false, 5000000},
+		{"error_after_fee_and_counter", false, true, false, 5000000}, {"out_of_gas", false, false, false, 280000}, {"revert_then_sibling_success", true, false, true, 5000000},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, _ := baseCtx.CacheContext()
+			caller := common.HexToAddress("0xbb01")
+			outer := common.HexToAddress("0xbb02")
+			child := common.HexToAddress("0xbb03")
+			owner := sdk.AccAddress(child.Bytes())
+			sibling := common.HexToAddress("0xbb04")
+			siblingOwner := sdk.AccAddress(sibling.Bytes())
+			moduleAddr := a.AuthKeeper.GetModuleAddress(authtypes.FeeCollectorName)
+			denom := evmtypes.GetEVMCoinDenom()
+			pp := types.DefaultParams()
+			pp.DealCreationFee = sdk.NewInt64Coin(denom, 7)
+			require.NoError(t, a.PolyStoreChainKeeper.Params.Set(ctx, pp))
+			for i := 1; i <= 3; i++ {
+				address := sdk.AccAddress(common.HexToAddress(fmt.Sprintf("0xcc%02x", i)).Bytes()).String()
+				require.NoError(t, a.PolyStoreChainKeeper.Providers.Set(ctx, address, types.Provider{Address: address, Capabilities: "General", Status: "Active", TotalStorage: 1 << 40}))
+			}
+			funds := sdk.NewCoins(sdk.NewInt64Coin(denom, 1000), sdk.NewInt64Coin(sdk.DefaultBondDenom, 1000))
+			require.NoError(t, a.BankKeeper.MintCoins(ctx, types.ModuleName, funds))
+			require.NoError(t, a.BankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, owner, funds))
+			if tc.sibling {
+				require.NoError(t, a.BankKeeper.MintCoins(ctx, types.ModuleName, funds))
+				require.NoError(t, a.BankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, siblingOwner, funds))
+			}
+			ctx = ctx.WithEventManager(sdk.NewEventManager()).WithGasMeter(storetypes.NewInfiniteGasMeter())
+			anteEvent := sdk.NewEvent("ante_marker", sdk.NewAttribute("id", "before-evm"))
+			ctx.EventManager().EmitEvent(anteEvent)
+			evm, state := nativeEVM(t, a, ctx)
+			state.SetCode(outer, callAndReturn(child, 8000000, false))
+			state.SetCode(child, callAndReturn(polystoreprecompile.Address, tc.gas, tc.revert))
+			if tc.sibling {
+				first := callAndReturn(child, 8000000, false)
+				first = append(first[:len(first)-8], 0x50)
+				state.SetCode(outer, append(first, callAndReturn(sibling, 8000000, false)...))
+				state.SetCode(sibling, callAndReturn(polystoreprecompile.Address, 5000000, false))
+				require.Equal(t, uint64(1000), state.GetBalance(sibling).Uint64())
+			}
+			// Load the balance before native mutation, as BALANCE/CALL does in contracts.
+			require.Equal(t, uint64(1000), state.GetBalance(child).Uint64())
+			hint := "General:rs=2+1"
+			if tc.invalid {
+				hint = "bad service hint"
+			}
+			input, err := api.Pack("createDeal", pp.MinDurationBlocks+100, hint, big.NewInt(11), big.NewInt(0))
+			require.NoError(t, err)
+			result, left, err := evm.Call(caller, outer, input, 12000000, uint256.NewInt(0))
+			require.NoError(t, err)
+			require.Len(t, result, 32)
+			require.Less(t, left, uint64(12000000))
+			success := !tc.revert && !tc.invalid && tc.gas == 5000000
+			expected := int64(1000)
+			escrow := int64(1000)
+			fee := int64(0)
+			if success {
+				expected -= 7
+				escrow -= 11
+				fee = 7
+			}
+			require.Equal(t, uint64(expected), state.GetBalance(child).Uint64(), "EVM cached balance must reflect only the configured denomination")
+			if tc.sibling {
+				require.Equal(t, uint64(993), state.GetBalance(sibling).Uint64())
+				fee = 7
+			}
+			committed := success || tc.sibling
+			logs := state.Logs()
+			if committed {
+				require.Len(t, logs, 1)
+			} else {
+				require.Empty(t, logs)
+			}
+			require.Equal(t, sdk.Events{anteEvent}, ctx.EventManager().Events(), "native events remain private until Commit")
+			require.NoError(t, state.Commit())
+			require.Equal(t, anteEvent, ctx.EventManager().Events()[0], "preexisting caller event remains once")
+			require.Equal(t, state.GetContext().EventManager().Events(), ctx.EventManager().Events()[1:])
+			require.Equal(t, sdkmath.NewInt(expected), a.BankKeeper.GetBalance(ctx, owner, denom).Amount)
+			require.Equal(t, sdkmath.NewInt(escrow), a.BankKeeper.GetBalance(ctx, owner, sdk.DefaultBondDenom).Amount)
+			require.Equal(t, sdkmath.NewInt(fee), a.BankKeeper.GetBalance(ctx, moduleAddr, denom).Amount)
+			count, err := a.PolyStoreChainKeeper.DealCount.Peek(ctx)
+			require.NoError(t, err)
+			if committed {
+				require.Equal(t, uint64(1), count)
+			} else {
+				require.Zero(t, count)
+			}
+			events := 0
+			for _, e := range ctx.EventManager().Events() {
+				if e.Type == types.TypeMsgCreateDeal {
+					events++
+				}
+			}
+			if committed {
+				require.Equal(t, 1, events)
+			} else {
+				require.Zero(t, events)
+			}
+			if tc.sibling {
+				require.Equal(t, sdkmath.NewInt(993), a.BankKeeper.GetBalance(ctx, siblingOwner, denom).Amount)
+				require.Equal(t, sdkmath.NewInt(989), a.BankKeeper.GetBalance(ctx, siblingOwner, sdk.DefaultBondDenom).Amount)
+				require.Equal(t, common.BytesToHash(sibling.Bytes()), logs[0].Topics[2])
+				require.Contains(t, fmt.Sprint(ctx.EventManager().Events()), siblingOwner.String())
+				require.NotContains(t, fmt.Sprint(ctx.EventManager().Events()), owner.String())
+			}
+			spent := uint64(12000000) - left
+			if tc.gas == 280000 {
+				require.GreaterOrEqual(t, spent, uint64(tc.gas), "SDK OOG must exhaust the child gas allocation")
+			}
+			if tc.invalid {
+				require.Greater(t, spent, uint64(219000), "failed native bank work must be charged")
+			}
+			t.Logf("native creation consumed %d EVM gas", spent)
+		})
+	}
+}
+
+// gasActionPrecompile exercises the shared dependency with a known amount of
+// native work, independent of PolyStore's ABI and variable keeper gas schedule.
+type gasActionPrecompile struct {
+	cmn.Precompile
+	action cmn.NativeAction
+}
+
+func (p gasActionPrecompile) RequiredGas([]byte) uint64 { return 0 }
+func (p gasActionPrecompile) Run(e *vm.EVM, c *vm.Contract, _ bool) ([]byte, error) {
+	return p.RunNativeAction(e, c, p.action)
+}
+
+func TestNativeGasAccounting(t *testing.T) {
+	a, baseCtx := nativePrecompileApp(t)
+	for _, parentGas := range []uint64{0, 1000} {
+		for _, tc := range []struct {
+			name         string
+			work         uint64
+			failure      error
+			left         uint64
+			expected     error
+			badBankEvent bool
+		}{
+			{"success", 50, nil, 50, nil, false}, {"error", 50, errors.New("after mutation"), 50, vm.ErrExecutionReverted, false},
+			{"sdk_oog", 101, nil, 0, vm.ErrOutOfGas, false}, {"returned_oog", 10, vm.ErrOutOfGas, 0, vm.ErrOutOfGas, false}, {"balance_handler_error", 50, nil, 50, vm.ErrExecutionReverted, true},
+		} {
+			t.Run(fmt.Sprintf("%s/parent_%d", tc.name, parentGas), func(t *testing.T) {
+				ctx, _ := baseCtx.CacheContext()
+				ctx = ctx.WithGasMeter(storetypes.NewInfiniteGasMeter())
+				ctx.GasMeter().ConsumeGas(parentGas, "prior SDK work")
+				evm, state := nativeEVM(t, a, ctx)
+				address := common.HexToAddress("0x9999")
+				p := gasActionPrecompile{Precompile: cmn.Precompile{ContractAddress: address, BalanceHandlerFactory: cmn.NewBalanceHandlerFactory(a.BankKeeper)}, action: func(native sdk.Context) ([]byte, error) {
+					native.KVStore(a.GetKey(types.StoreKey)).Set([]byte("gas-regression"), []byte("written"))
+					native.EventManager().EmitEvent(sdk.NewEvent("gas-regression"))
+					native.GasMeter().ConsumeGas(tc.work, "controlled native work")
+					if tc.badBankEvent {
+						native.EventManager().EmitEvent(sdk.NewEvent("coin_spent"))
+					}
+					return nil, tc.failure
+				}}
+				evm.SetPrecompiles(vm.PrecompiledContracts{address: p})
+				_, left, err := evm.Call(common.HexToAddress("0x9911"), address, nil, 100, uint256.NewInt(0))
+				require.ErrorIs(t, err, tc.expected)
+				require.Equal(t, tc.left, left, "native SDK work must be deducted exactly once")
+				require.Equal(t, parentGas, ctx.GasMeter().GasConsumed(), "child meter must not mutate parent accounting")
+				require.NoError(t, state.Commit())
+				present := ctx.KVStore(a.GetKey(types.StoreKey)).Has([]byte("gas-regression"))
+				require.Equal(t, tc.expected == nil, present)
+				if tc.expected == nil {
+					require.Len(t, ctx.EventManager().Events(), 1)
+				} else {
+					require.Empty(t, ctx.EventManager().Events())
+				}
+			})
+		}
+	}
+}
+
+func TestNativeBalanceDenominationConversion(t *testing.T) {
+	nativePrecompileApp(t)
+	original := evmtypes.EvmCoinInfo{Denom: evmtypes.GetEVMCoinDenom(), ExtendedDenom: evmtypes.GetEVMCoinExtendedDenom(), DisplayDenom: evmtypes.GetEVMCoinDisplayDenom(), Decimals: evmtypes.GetEVMCoinDecimals().Uint32()}
+	t.Cleanup(func() { evmtypes.SetDefaultEvmCoinInfo(original) })
+	evmtypes.SetDefaultEvmCoinInfo(evmtypes.EvmCoinInfo{Denom: "utest", ExtendedDenom: "atest", DisplayDenom: "test", Decimals: 6})
+	for _, tc := range []struct {
+		amount   string
+		expected uint64
+	}{{"2utest,17zother", 2000000000000}, {"17zother", 0}} {
+		event := sdk.NewEvent("coin_received", sdk.NewAttribute(sdk.AttributeKeyAmount, tc.amount))
+		amount, err := cmn.ParseAmount(event)
+		require.NoError(t, err)
+		require.Equal(t, tc.expected, amount.Uint64())
+	}
+}

--- a/polystorechain/app/precompile_native_test.go
+++ b/polystorechain/app/precompile_native_test.go
@@ -259,6 +259,155 @@ func TestNativePrecompileBankRollback(t *testing.T) {
 	}
 }
 
+// Native module fees must survive later EVM balance reconciliation. Blocked
+// recipients retain their existing authorization policy and abort the SDK tx.
+func TestNativeModuleBalanceReconciliation(t *testing.T) {
+	a, baseCtx := nativePrecompileApp(t)
+	api, err := abi.JSON(strings.NewReader(`[{"name":"createDeal","type":"function","inputs":[{"type":"uint64"},{"type":"string"},{"type":"uint256"},{"type":"uint256"}],"outputs":[{"type":"uint64"}]}]`))
+	require.NoError(t, err)
+	for _, preload := range []bool{false, true} {
+		for _, tc := range []struct {
+			name                                            string
+			revertNative, revertTransfer, blocked, noNative bool
+		}{
+			{"native_then_legal_transfer", false, false, false, false},
+			{"native_then_blocked_transfer", false, false, true, false},
+			{"reverted_native_then_blocked_transfer", true, false, true, false},
+			{"native_then_reverted_blocked_transfer", false, true, true, false},
+			{"blocked_transfer_without_native", false, false, true, true},
+		} {
+			t.Run(fmt.Sprintf("%s/preloaded_%t", tc.name, preload), func(t *testing.T) {
+				ctx, _ := baseCtx.CacheContext()
+				caller := common.HexToAddress("0xdd01")
+				outer := common.HexToAddress("0xdd02")
+				child := common.HexToAddress("0xdd03")
+				receiver := common.HexToAddress("0xdd04")
+				owner := sdk.AccAddress(child.Bytes())
+				moduleAddr := a.AuthKeeper.GetModuleAddress(authtypes.FeeCollectorName)
+				moduleEVM := common.BytesToAddress(moduleAddr)
+				denom := evmtypes.GetEVMCoinDenom()
+				pp := types.DefaultParams()
+				pp.DealCreationFee = sdk.NewInt64Coin(denom, 7)
+				require.NoError(t, a.PolyStoreChainKeeper.Params.Set(ctx, pp))
+				for i := 1; i <= 3; i++ {
+					address := sdk.AccAddress(common.HexToAddress(fmt.Sprintf("0xee%02x", i)).Bytes()).String()
+					require.NoError(t, a.PolyStoreChainKeeper.Providers.Set(ctx, address, types.Provider{Address: address, Capabilities: "General", Status: "Active", TotalStorage: 1 << 40}))
+				}
+				funds := sdk.NewCoins(sdk.NewInt64Coin(denom, 1000))
+				require.NoError(t, a.BankKeeper.MintCoins(ctx, types.ModuleName, funds))
+				require.NoError(t, a.BankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, owner, funds))
+				moduleFunds := sdk.NewCoins(sdk.NewInt64Coin(denom, 13))
+				require.NoError(t, a.BankKeeper.MintCoins(ctx, types.ModuleName, moduleFunds))
+				require.NoError(t, a.BankKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleName, authtypes.FeeCollectorName, moduleFunds))
+				supply := a.BankKeeper.GetSupply(ctx, denom)
+				ctx = ctx.WithEventManager(sdk.NewEventManager())
+				parentCtx := ctx
+				// ApplyTransaction similarly encloses StateDB.Commit in an SDK cache.
+				ctx, commitTx := parentCtx.CacheContext()
+				evm, state := nativeEVM(t, a, ctx)
+				state.SetCode(outer, callAndReturn(child, 8000000, false))
+				state.SetCode(child, callAndReturn(polystoreprecompile.Address, 5000000, tc.revertNative))
+				if preload {
+					require.Equal(t, uint64(13), state.GetBalance(moduleEVM).Uint64())
+				}
+				input, err := api.Pack("createDeal", pp.MinDurationBlocks+100, "General:rs=2+1", big.NewInt(0), big.NewInt(0))
+				require.NoError(t, err)
+				if !tc.noNative {
+					_, _, err = evm.Call(caller, outer, input, 12000000, uint256.NewInt(0))
+					require.NoError(t, err)
+				}
+				moduleExpected := uint64(20)
+				if tc.revertNative || tc.noNative {
+					moduleExpected = 13
+				}
+				require.Equal(t, moduleExpected, state.GetBalance(moduleEVM).Uint64(), "native fee must synchronize the module EVM balance")
+				snapshot := state.Snapshot()
+				if tc.blocked {
+					receiver = moduleEVM
+				}
+				core.Transfer(state, child, receiver, uint256.NewInt(1))
+				if tc.revertTransfer {
+					state.RevertToSnapshot(snapshot)
+				}
+				ownerExpected := uint64(1013 - moduleExpected)
+				if tc.blocked && !tc.revertTransfer {
+					require.ErrorContains(t, state.Commit(), "not allowed to receive funds")
+					moduleExpected, ownerExpected = 13, 1000
+					require.Empty(t, parentCtx.EventManager().Events(), "failed transaction must publish no events")
+					count, err := a.PolyStoreChainKeeper.DealCount.Peek(parentCtx)
+					require.NoError(t, err)
+					require.Zero(t, count, "failed transaction must publish no native stores")
+				} else {
+					require.NoError(t, state.Commit())
+					commitTx()
+					if !tc.revertTransfer {
+						ownerExpected--
+						require.Equal(t, sdkmath.OneInt(), a.BankKeeper.GetBalance(parentCtx, sdk.AccAddress(receiver.Bytes()), denom).Amount)
+					}
+				}
+				require.Equal(t, sdkmath.NewIntFromUint64(moduleExpected), a.BankKeeper.GetBalance(parentCtx, moduleAddr, denom).Amount)
+				require.Equal(t, sdkmath.NewIntFromUint64(ownerExpected), a.BankKeeper.GetBalance(parentCtx, owner, denom).Amount)
+				require.Equal(t, supply, a.BankKeeper.GetSupply(parentCtx, denom), "native plus EVM transfers must conserve supply")
+				require.True(t, a.BankKeeper.GetBalance(parentCtx, a.AuthKeeper.GetModuleAddress(evmtypes.ModuleName), denom).IsZero(), "temporary EVM mint account must settle to zero")
+				module, ok := a.AuthKeeper.GetAccount(parentCtx, moduleAddr).(sdk.ModuleAccountI)
+				require.True(t, ok)
+				require.Equal(t, authtypes.FeeCollectorName, module.GetName())
+			})
+		}
+	}
+}
+
+func TestNativeModuleBalanceRoundTrip(t *testing.T) {
+	a, baseCtx := nativePrecompileApp(t)
+	for _, revertSecond := range []bool{false, true} {
+		t.Run(fmt.Sprintf("revert_second_%t", revertSecond), func(t *testing.T) {
+			ctx, _ := baseCtx.CacheContext()
+			owner := common.HexToAddress("0xfa01")
+			child := common.HexToAddress("0xfa02")
+			address := common.HexToAddress("0xfa03")
+			moduleAddr := a.AuthKeeper.GetModuleAddress(authtypes.FeeCollectorName)
+			moduleEVM := common.BytesToAddress(moduleAddr)
+			denom := evmtypes.GetEVMCoinDenom()
+			funds := sdk.NewCoins(sdk.NewInt64Coin(denom, 13))
+			require.NoError(t, a.BankKeeper.MintCoins(ctx, types.ModuleName, funds))
+			require.NoError(t, a.BankKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleName, authtypes.FeeCollectorName, funds))
+			supply := a.BankKeeper.GetSupply(ctx, denom)
+			ctx = ctx.WithEventManager(sdk.NewEventManager())
+			evm, state := nativeEVM(t, a, ctx)
+			p := gasActionPrecompile{Precompile: cmn.Precompile{ContractAddress: address, BalanceHandlerFactory: cmn.NewBalanceHandlerFactory(a.BankKeeper)}, action: func(native sdk.Context) ([]byte, error) {
+				// Module spends and receives in one native call. Neither event can
+				// be skipped or replayed by the second call's balance handler.
+				if err := a.BankKeeper.SendCoinsFromModuleToAccount(native, authtypes.FeeCollectorName, sdk.AccAddress(owner.Bytes()), sdk.NewCoins(sdk.NewInt64Coin(denom, 3))); err != nil {
+					return nil, err
+				}
+				return nil, a.BankKeeper.SendCoinsFromAccountToModule(native, sdk.AccAddress(owner.Bytes()), authtypes.FeeCollectorName, sdk.NewCoins(sdk.NewInt64Coin(denom, 1)))
+			}}
+			evm.SetPrecompiles(vm.PrecompiledContracts{address: p})
+			_, _, err := evm.Call(owner, address, nil, 5000000, uint256.NewInt(0))
+			require.NoError(t, err)
+			require.Equal(t, uint64(11), state.GetBalance(moduleEVM).Uint64())
+			require.Equal(t, uint64(2), state.GetBalance(owner).Uint64())
+			state.SetCode(child, callAndReturn(address, 5000000, revertSecond))
+			_, _, err = evm.Call(owner, child, nil, 8000000, uint256.NewInt(0))
+			if revertSecond {
+				require.ErrorIs(t, err, vm.ErrExecutionReverted)
+			} else {
+				require.NoError(t, err)
+			}
+			moduleExpected, ownerExpected := int64(9), int64(4)
+			if revertSecond {
+				moduleExpected, ownerExpected = 11, 2
+			}
+			require.Equal(t, uint64(moduleExpected), state.GetBalance(moduleEVM).Uint64())
+			require.Equal(t, uint64(ownerExpected), state.GetBalance(owner).Uint64())
+			require.NoError(t, state.Commit())
+			require.Equal(t, sdkmath.NewInt(moduleExpected), a.BankKeeper.GetBalance(ctx, moduleAddr, denom).Amount)
+			require.Equal(t, sdkmath.NewInt(ownerExpected), a.BankKeeper.GetBalance(ctx, sdk.AccAddress(owner.Bytes()), denom).Amount)
+			require.Equal(t, supply, a.BankKeeper.GetSupply(ctx, denom))
+		})
+	}
+}
+
 // gasActionPrecompile exercises the shared dependency with a known amount of
 // native work, independent of PolyStore's ABI and variable keeper gas schedule.
 type gasActionPrecompile struct {

--- a/polystorechain/precompiles/polystore/polystore.go
+++ b/polystorechain/precompiles/polystore/polystore.go
@@ -10,7 +10,10 @@ import (
 
 	"cosmossdk.io/collections"
 	"cosmossdk.io/math"
+	storetypes "cosmossdk.io/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	cmn "github.com/cosmos/evm/precompiles/common"
+	"github.com/cosmos/evm/x/vm/statedb"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
@@ -19,6 +22,11 @@ import (
 	nilkeeper "polystorechain/x/polystorechain/keeper"
 	"polystorechain/x/polystorechain/types"
 )
+
+// Build with scripts/chain_go.sh: upstream v0.5.1 lacks these required fixes.
+// Referencing both versions makes accidental -mod=mod builds fail closed.
+const nativeGasFixVersion = cmn.PolyStoreNativeGasFixVersion
+const nativeJournalFixVersion = statedb.PolyStoreNativeJournalFixVersion
 
 const AddressHex = "0x0000000000000000000000000000000000000900"
 
@@ -280,11 +288,8 @@ const polystoreABIJSON = `[
   {"type":"event","name":"RetrievalSessionConfirmed","inputs":[{"name":"sessionId","type":"bytes32","indexed":true},{"name":"owner","type":"address","indexed":true}]}
 ]`
 
-type sdkContextGetter interface {
-	GetContext() sdk.Context
-}
-
 type Precompile struct {
+	cmn.Precompile
 	keeper *nilkeeper.Keeper
 	abi    abi.ABI
 }
@@ -294,7 +299,14 @@ func New(keeper *nilkeeper.Keeper) (*Precompile, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Precompile{keeper: keeper, abi: parsed}, nil
+	return &Precompile{
+		Precompile: cmn.Precompile{
+			KvGasConfig:          storetypes.KVGasConfig(),
+			TransientKVGasConfig: storetypes.TransientGasConfig(),
+			ContractAddress:      Address,
+		},
+		keeper: keeper, abi: parsed,
+	}, nil
 }
 
 func MustNew(keeper *nilkeeper.Keeper) *Precompile {
@@ -308,7 +320,9 @@ func MustNew(keeper *nilkeeper.Keeper) *Precompile {
 func (p *Precompile) Address() common.Address { return Address }
 
 func (p *Precompile) RequiredGas(input []byte) uint64 {
-	// Conservative linear model: calldata + fixed overhead; avoids underpricing heavy FFI verification.
+	// Preserve the existing calldata admission charge. RunNativeAction additionally
+	// meters SDK work against the remaining child gas; proof-specific FFI pricing
+	// is a separate requirement and is not provided by this formula.
 	const base = uint64(200_000)
 	const perByte = uint64(64)
 	return base + perByte*uint64(len(input))
@@ -325,12 +339,14 @@ func (p *Precompile) Run(evm *vm.EVM, contract *vm.Contract, readonly bool) ([]b
 		return nil, errors.New("polystore precompile: missing keeper")
 	}
 
-	stateGetter, ok := evm.StateDB.(sdkContextGetter)
-	if !ok {
-		return nil, errors.New("polystore precompile: statedb does not expose sdk context")
-	}
-	ctx := stateGetter.GetContext()
+	return p.RunNativeAction(evm, contract, func(ctx sdk.Context) ([]byte, error) {
+		return p.runNative(ctx, evm, contract)
+	})
+}
 
+// All selectors share the Cosmos EVM journal, SDK gas meter and balance bridge.
+// A nested EVM revert must undo native writes even when its caller catches it.
+func (p *Precompile) runNative(ctx sdk.Context, evm *vm.EVM, contract *vm.Contract) ([]byte, error) {
 	input := contract.Input
 	if len(input) < 4 {
 		return nil, errors.New("polystore precompile: missing selector")

--- a/polystorechain/precompiles/polystore/polystore.go
+++ b/polystorechain/precompiles/polystore/polystore.go
@@ -24,8 +24,9 @@ import (
 )
 
 // Build with scripts/chain_go.sh: upstream v0.5.1 lacks these required fixes.
-// Referencing both versions makes accidental -mod=mod builds fail closed.
+// Referencing the required versions makes accidental -mod=mod builds fail closed.
 const nativeGasFixVersion = cmn.PolyStoreNativeGasFixVersion
+const nativeBalanceFixVersion = cmn.PolyStoreNativeBalanceFixVersion
 const nativeJournalFixVersion = statedb.PolyStoreNativeJournalFixVersion
 
 const AddressHex = "0x0000000000000000000000000000000000000900"

--- a/polystorechain/vendor/github.com/cosmos/evm/precompiles/common/balance_handler.go
+++ b/polystorechain/vendor/github.com/cosmos/evm/precompiles/common/balance_handler.go
@@ -1,0 +1,120 @@
+package common
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/tracing"
+
+	"github.com/cosmos/evm/utils"
+	precisebanktypes "github.com/cosmos/evm/x/precisebank/types"
+	"github.com/cosmos/evm/x/vm/statedb"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+)
+
+// PolyStoreNativeBalanceFixVersion identifies complete native balance synchronization.
+const PolyStoreNativeBalanceFixVersion = 1
+
+// BalanceHandlerFactory is a factory struct to create BalanceHandler instances.
+type BalanceHandlerFactory struct {
+	bankKeeper BankKeeper
+}
+
+// NewBalanceHandler creates a new BalanceHandler instance.
+func NewBalanceHandlerFactory(bankKeeper BankKeeper) *BalanceHandlerFactory {
+	return &BalanceHandlerFactory{
+		bankKeeper: bankKeeper,
+	}
+}
+
+func (bhf BalanceHandlerFactory) NewBalanceHandler() *BalanceHandler {
+	return &BalanceHandler{
+		bankKeeper:    bhf.bankKeeper,
+		prevEventsLen: 0,
+	}
+}
+
+// BalanceHandler is a struct that handles balance changes in the Cosmos SDK context.
+type BalanceHandler struct {
+	bankKeeper    BankKeeper
+	prevEventsLen int
+}
+
+// BeforeBalanceChange is called before any balance changes by precompile methods.
+// It records the current number of events in the context to later process balance changes
+// using the recorded events.
+func (bh *BalanceHandler) BeforeBalanceChange(ctx sdk.Context) {
+	bh.prevEventsLen = len(ctx.EventManager().Events())
+}
+
+// AfterBalanceChange processes the recorded events and updates the stateDB accordingly.
+// It handles the bank events for coin spent and coin received, updating the balances
+// of the spender and receiver addresses respectively.
+//
+// Include module and blocked accounts: authorized native keeper transfers may
+// change them, and leaving their EVM balances stale can overwrite those changes
+// during a later commit. Synchronization does not authorize new transfers; the
+// bank keeper still enforces its recipient policy when reconciling EVM deltas.
+func (bh *BalanceHandler) AfterBalanceChange(ctx sdk.Context, stateDB *statedb.StateDB) error {
+	events := ctx.EventManager().Events()
+
+	for _, event := range events[bh.prevEventsLen:] {
+		switch event.Type {
+		case banktypes.EventTypeCoinSpent:
+			spenderAddr, err := ParseAddress(event, banktypes.AttributeKeySpender)
+			if err != nil {
+				return fmt.Errorf("failed to parse spender address from event %q: %w", banktypes.EventTypeCoinSpent, err)
+			}
+
+			amount, err := ParseAmount(event)
+			if err != nil {
+				return fmt.Errorf("failed to parse amount from event %q: %w", banktypes.EventTypeCoinSpent, err)
+			}
+
+			stateDB.SubBalance(common.BytesToAddress(spenderAddr.Bytes()), amount, tracing.BalanceChangeUnspecified)
+
+		case banktypes.EventTypeCoinReceived:
+			receiverAddr, err := ParseAddress(event, banktypes.AttributeKeyReceiver)
+			if err != nil {
+				return fmt.Errorf("failed to parse receiver address from event %q: %w", banktypes.EventTypeCoinReceived, err)
+			}
+
+			amount, err := ParseAmount(event)
+			if err != nil {
+				return fmt.Errorf("failed to parse amount from event %q: %w", banktypes.EventTypeCoinReceived, err)
+			}
+
+			stateDB.AddBalance(common.BytesToAddress(receiverAddr.Bytes()), amount, tracing.BalanceChangeUnspecified)
+
+		case precisebanktypes.EventTypeFractionalBalanceChange:
+			addr, err := ParseAddress(event, precisebanktypes.AttributeKeyAddress)
+			if err != nil {
+				return fmt.Errorf("failed to parse address from event %q: %w", precisebanktypes.EventTypeFractionalBalanceChange, err)
+			}
+
+			delta, err := ParseFractionalAmount(event)
+			if err != nil {
+				return fmt.Errorf("failed to parse amount from event %q: %w", precisebanktypes.EventTypeFractionalBalanceChange, err)
+			}
+
+			deltaAbs, err := utils.Uint256FromBigInt(new(big.Int).Abs(delta))
+			if err != nil {
+				return fmt.Errorf("failed to convert delta to Uint256: %w", err)
+			}
+
+			if delta.Sign() == 1 {
+				stateDB.AddBalance(common.BytesToAddress(addr.Bytes()), deltaAbs, tracing.BalanceChangeUnspecified)
+			} else if delta.Sign() == -1 {
+				stateDB.SubBalance(common.BytesToAddress(addr.Bytes()), deltaAbs, tracing.BalanceChangeUnspecified)
+			}
+
+		default:
+			continue
+		}
+	}
+
+	return nil
+}

--- a/polystorechain/vendor/github.com/cosmos/evm/precompiles/common/precompile.go
+++ b/polystorechain/vendor/github.com/cosmos/evm/precompiles/common/precompile.go
@@ -1,0 +1,254 @@
+package common
+
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/vm"
+
+	"github.com/cosmos/evm/x/vm/statedb"
+
+	storetypes "cosmossdk.io/store/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// PolyStoreNativeGasFixVersion identifies the pinned child gas accounting correction.
+const PolyStoreNativeGasFixVersion = 1
+
+// NativeAction abstract the native execution logic of the stateful precompile, it's passed to the base `Precompile`
+// struct, base `Precompile` struct will handle things the native context setup, gas management, panic recovery etc,
+// before and after the execution.
+//
+// It's usually implemented by the precompile itself.
+type NativeAction func(ctx sdk.Context) ([]byte, error)
+
+// Precompile is the base struct for precompiles that requires to access cosmos native storage.
+type Precompile struct {
+	KvGasConfig          storetypes.GasConfig
+	TransientKVGasConfig storetypes.GasConfig
+	ContractAddress      common.Address
+
+	// BalanceHandlerFactory is optional
+	BalanceHandlerFactory *BalanceHandlerFactory
+}
+
+// RequiredGas calculates the base minimum required gas for a transaction or a query.
+// It uses the method ID to determine if the input is a transaction or a query and
+// uses the Cosmos SDK gas config flat cost and the flat per byte cost * len(argBz) to calculate the gas.
+func (p Precompile) RequiredGas(input []byte, isTransaction bool) uint64 {
+	if isTransaction {
+		return p.KvGasConfig.WriteCostFlat + (p.KvGasConfig.WriteCostPerByte * uint64(len(input)))
+	}
+
+	return p.KvGasConfig.ReadCostFlat + (p.KvGasConfig.ReadCostPerByte * uint64(len(input)))
+}
+
+// Run prepare the native context to execute native action for stateful precompile,
+// it manages the snapshot and revert of the multi-store.
+func (p Precompile) RunNativeAction(evm *vm.EVM, contract *vm.Contract, action NativeAction) ([]byte, error) {
+	bz, err := p.runNativeAction(evm, contract, action)
+	// Exhausted native gas is an EVM exceptional halt, not a refundable REVERT.
+	if errors.Is(err, vm.ErrOutOfGas) {
+		return nil, vm.ErrOutOfGas
+	}
+	if err != nil {
+		return ReturnRevertError(evm, err)
+	}
+
+	return bz, nil
+}
+
+func (p Precompile) runNativeAction(evm *vm.EVM, contract *vm.Contract, action NativeAction) (bz []byte, err error) {
+	stateDB, ok := evm.StateDB.(*statedb.StateDB)
+	if !ok {
+		return nil, errors.New(ErrNotRunInEvm)
+	}
+
+	// get the stateDB cache ctx
+	ctx, err := stateDB.GetCacheContext()
+	if err != nil {
+		return nil, err
+	}
+
+	// take a snapshot of the current state before any changes
+	// to be able to revert the changes
+	snapshot := stateDB.MultiStoreSnapshot()
+	events := ctx.EventManager().Events()
+
+	// add precompileCall entry on the stateDB journal
+	// this allows to revert the changes within an evm tx
+	if err := stateDB.AddPrecompileFn(snapshot, events); err != nil {
+		return nil, err
+	}
+
+	// commit the current changes in the cache ctx
+	// to get the updated state for the precompile call
+	if err := stateDB.CommitWithCacheCtx(); err != nil {
+		return nil, err
+	}
+
+	// set the default SDK gas configuration to track gas usage
+	// we are changing the gas meter type, so it panics gracefully when out of gas
+	ctx = ctx.WithGasMeter(storetypes.NewGasMeter(contract.Gas)).
+		WithKVGasConfig(p.KvGasConfig).
+		WithTransientKVGasConfig(p.TransientKVGasConfig)
+
+	// Only this child invocation belongs to this meter. Parent SDK consumption
+	// must neither shrink its allowance nor be charged to it again.
+	initialGas := ctx.GasMeter().GasConsumed()
+	defer HandleGasError(ctx, contract, initialGas, &err)()
+
+	var balanceHandler *BalanceHandler
+	if p.BalanceHandlerFactory != nil {
+		balanceHandler = p.BalanceHandlerFactory.NewBalanceHandler()
+	}
+
+	if balanceHandler != nil {
+		balanceHandler.BeforeBalanceChange(ctx)
+	}
+
+	bz, err = action(ctx)
+	if err != nil {
+		return bz, err
+	}
+
+	if balanceHandler != nil {
+		if err := balanceHandler.AfterBalanceChange(ctx, stateDB); err != nil {
+			return nil, err
+		}
+	}
+
+	return bz, nil
+}
+
+// SetupABI runs the initial setup required to run a transaction or a query.
+// It returns the ABI method, initial gas and calling arguments.
+func SetupABI(
+	api abi.ABI,
+	contract *vm.Contract,
+	readOnly bool,
+	isTransaction func(name *abi.Method) bool,
+) (method *abi.Method, args []interface{}, err error) {
+	// NOTE: This is a special case where the calling transaction does not specify a function name.
+	// In this case we default to a `fallback` or `receive` function on the contract.
+
+	// Simplify the calldata checks
+	isEmptyCallData := len(contract.Input) == 0
+	isShortCallData := len(contract.Input) > 0 && len(contract.Input) < 4
+	isStandardCallData := len(contract.Input) >= 4
+
+	switch {
+	// Case 1: Calldata is empty
+	case isEmptyCallData:
+		method, err = emptyCallData(api, contract)
+
+	// Case 2: calldata is non-empty but less than 4 bytes needed for a method
+	case isShortCallData:
+		method, err = methodIDCallData(api)
+
+	// Case 3: calldata is non-empty and contains the minimum 4 bytes needed for a method
+	case isStandardCallData:
+		method, err = standardCallData(api, contract)
+	}
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// return error if trying to write to state during a read-only call
+	if readOnly && isTransaction(method) {
+		return nil, nil, vm.ErrWriteProtection
+	}
+
+	// if the method type is `function` continue looking for arguments
+	if method.Type == abi.Function {
+		argsBz := contract.Input[4:]
+		args, err = method.Inputs.Unpack(argsBz)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	return method, args, nil
+}
+
+// HandleGasError charges native SDK work exactly once, including failed actions
+// and balance synchronization. SDK out-of-gas panics exhaust the child allowance.
+func HandleGasError(ctx sdk.Context, contract *vm.Contract, initialGas storetypes.Gas, err *error) func() {
+	return func() {
+		if r := recover(); r != nil {
+			switch r.(type) {
+			case storetypes.ErrorOutOfGas:
+				*err = vm.ErrOutOfGas
+			default:
+				panic(r)
+			}
+		}
+		if errors.Is(*err, vm.ErrOutOfGas) || ctx.GasMeter().IsPastLimit() {
+			_ = contract.UseGas(contract.Gas, nil, tracing.GasChangeCallFailedExecution)
+			*err = vm.ErrOutOfGas
+			return
+		}
+		usedGas := ctx.GasMeter().GasConsumed() - initialGas
+		if !contract.UseGas(usedGas, nil, tracing.GasChangeCallPrecompiledContract) {
+			_ = contract.UseGas(contract.Gas, nil, tracing.GasChangeCallFailedExecution)
+			*err = vm.ErrOutOfGas
+		}
+	}
+}
+
+func (p Precompile) Address() common.Address {
+	return p.ContractAddress
+}
+
+func (p *Precompile) SetAddress(addr common.Address) {
+	p.ContractAddress = addr
+}
+
+// emptyCallData is a helper function that returns the method to be called when the calldata is empty.
+func emptyCallData(api abi.ABI, contract *vm.Contract) (method *abi.Method, err error) {
+	switch {
+	// Case 1.1: Send call or transfer tx - 'receive' is called if present and value is transferred
+	case contract.Value().Sign() > 0 && api.HasReceive():
+		return &api.Receive, nil
+	// Case 1.2: Either 'receive' is not present, or no value is transferred - call 'fallback' if present
+	case api.HasFallback():
+		return &api.Fallback, nil
+	// Case 1.3: Neither 'receive' nor 'fallback' are present - return error
+	default:
+		return nil, vm.ErrExecutionReverted
+	}
+}
+
+// methodIDCallData is a helper function that returns the method to be called when the calldata is less than 4 bytes.
+func methodIDCallData(api abi.ABI) (method *abi.Method, err error) {
+	// Case 2.2: calldata contains less than 4 bytes needed for a method and 'fallback' is not present - return error
+	if !api.HasFallback() {
+		return nil, vm.ErrExecutionReverted
+	}
+	// Case 2.1: calldata contains less than 4 bytes needed for a method - 'fallback' is called if present
+	return &api.Fallback, nil
+}
+
+// standardCallData is a helper function that returns the method to be called when the calldata is 4 bytes or more.
+func standardCallData(api abi.ABI, contract *vm.Contract) (method *abi.Method, err error) {
+	methodID := contract.Input[:4]
+	// NOTE: this function iterates over the method map and returns
+	// the method with the given ID
+	method, err = api.MethodById(methodID)
+
+	// Case 3.1 calldata contains a non-existing method ID, and `fallback` is not present - return error
+	if err != nil && !api.HasFallback() {
+		return nil, err
+	}
+
+	// Case 3.2: calldata contains a non-existing method ID - 'fallback' is called if present
+	if err != nil && api.HasFallback() {
+		return &api.Fallback, nil
+	}
+
+	return method, nil
+}

--- a/polystorechain/vendor/github.com/cosmos/evm/x/vm/statedb/statedb.go
+++ b/polystorechain/vendor/github.com/cosmos/evm/x/vm/statedb/statedb.go
@@ -1,0 +1,759 @@
+package statedb
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"sort"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/stateless"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/trie"
+	"github.com/ethereum/go-ethereum/trie/utils"
+	"github.com/holiman/uint256"
+
+	"github.com/cosmos/evm/x/vm/store/snapshotmulti"
+	vmstoretypes "github.com/cosmos/evm/x/vm/store/types"
+	"github.com/cosmos/evm/x/vm/types"
+
+	errorsmod "cosmossdk.io/errors"
+	storetypes "cosmossdk.io/store/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// revision is the identifier of a version of state.
+// it consists of an auto-increment id and a journal index.
+// it's safer to use than using journal index alone.
+type revision struct {
+	id           int
+	journalIndex int
+	events       sdk.Events
+}
+
+var _ vm.StateDB = &StateDB{}
+
+// PolyStoreNativeJournalFixVersion identifies the pinned native event journal correction.
+const PolyStoreNativeJournalFixVersion = 1
+
+// StateDB structs within the ethereum protocol are used to store anything
+// within the merkle trie. StateDBs take care of caching and storing
+// nested states. It's the general query interface to retrieve:
+// * Contracts
+// * Accounts
+type StateDB struct {
+	keeper Keeper
+	ctx    sdk.Context
+	// Publish only surviving EVM execution events to the caller on Commit.
+	callerEvents sdk.EventManagerI
+	// cacheCtx is used on precompile calls. It allows to commit the current journal
+	// entries to get the updated state in for the precompile call.
+	cacheCtx sdk.Context
+	// writeCache function contains all the changes related to precompile calls.
+	writeCache func()
+	// snapshotter is used for snapshot creation and revert
+	// this snapshot is used for precompile call
+	snapshotter vmstoretypes.Snapshotter
+
+	// Transient storage
+	transientStorage transientStorage
+
+	// Journal of state modifications. This is the backbone of
+	// Snapshot and RevertToSnapshot.
+	journal        *journal
+	validRevisions []revision
+	nextRevisionID int
+
+	stateObjects map[common.Address]*stateObject
+
+	txConfig TxConfig
+
+	// The refund counter, also used by state transitioning.
+	refund uint64
+
+	// Per-transaction logs
+	logs []*ethtypes.Log
+
+	// Per-transaction access list
+	accessList *accessList
+
+	// The count of calls to precompiles
+	precompileCallsCounter uint8
+}
+
+func (s *StateDB) CreateContract(address common.Address) {
+	obj := s.getStateObject(address)
+	if !obj.newContract {
+		obj.newContract = true
+		s.journal.append(createContractChange{
+			&address,
+		})
+	}
+}
+
+// GetStorageRoot calculates the hash of the trie root by iterating through all storage objects for a given account
+func (s *StateDB) GetStorageRoot(addr common.Address) common.Hash {
+	sr := trie.NewStackTrie(nil)
+	s.keeper.ForEachStorage(s.ctx, addr, func(key, value common.Hash) bool {
+		if err := sr.Update(key.Bytes(), value.Bytes()); err != nil {
+			s.ctx.Logger().Error("failed adding state during storage root hash", "err", err.Error())
+			return false
+		}
+		return true
+	})
+	return sr.Hash()
+}
+
+func (s *StateDB) IsStorageEmpty(addr common.Address) bool {
+	empty := true
+	s.keeper.ForEachStorage(s.ctx, addr, func(key, value common.Hash) bool {
+		empty = false
+		return false
+	})
+	return empty
+}
+
+/*
+	PointCache, Witness, and AccessEvents are all utilized for verkle trees.
+	For now, we just return nil and verkle trees are not supported.
+*/
+
+func (s *StateDB) PointCache() *utils.PointCache {
+	return nil
+}
+
+func (s *StateDB) Witness() *stateless.Witness {
+	// TODO support verkle tries?
+	return nil
+}
+
+func (s *StateDB) AccessEvents() *state.AccessEvents {
+	return nil
+}
+
+func (s *StateDB) Finalise(deleteEmptyObjects bool) {
+	for addr := range s.journal.dirties {
+		obj, exist := s.stateObjects[addr]
+		if !exist {
+			continue
+		}
+		if obj.selfDestructed || (deleteEmptyObjects && obj.empty()) {
+			delete(s.stateObjects, obj.address)
+		}
+	}
+}
+
+// New creates a new state from a given trie.
+func New(ctx sdk.Context, keeper Keeper, txConfig TxConfig) *StateDB {
+	callerEvents := ctx.EventManager()
+	ctx = ctx.WithEventManager(sdk.NewEventManager())
+	return &StateDB{
+		keeper:           keeper,
+		ctx:              ctx,
+		callerEvents:     callerEvents,
+		stateObjects:     make(map[common.Address]*stateObject),
+		journal:          newJournal(),
+		accessList:       newAccessList(),
+		transientStorage: newTransientStorage(),
+		txConfig:         txConfig,
+	}
+}
+
+// Keeper returns the underlying `Keeper`
+func (s *StateDB) Keeper() Keeper {
+	return s.keeper
+}
+
+// GetContext returns the transaction Context.
+func (s *StateDB) GetContext() sdk.Context {
+	return s.ctx
+}
+
+// GetCacheContext returns the stateDB CacheContext.
+func (s *StateDB) GetCacheContext() (sdk.Context, error) {
+	if s.writeCache == nil {
+		err := s.cache()
+		if err != nil {
+			return s.ctx, err
+		}
+	}
+	return s.cacheCtx, nil
+}
+
+// MultiStoreSnapshot snapshots stateDB CacheMultiStore
+// and returns snapshot index
+func (s *StateDB) MultiStoreSnapshot() int {
+	return s.snapshotter.Snapshot()
+}
+
+func (s *StateDB) RevertMultiStore(snapshot int, events sdk.Events) {
+	s.snapshotter.RevertToSnapshot(snapshot)
+	// Restore the live cache event stream too: later native siblings must append
+	// to the snapshot, and writeCache must publish their surviving events.
+	eventManager := sdk.NewEventManager()
+	eventManager.EmitEvents(events)
+	s.cacheCtx = s.cacheCtx.WithEventManager(eventManager)
+	s.writeCache = func() {
+		s.ctx.EventManager().EmitEvents(s.cacheCtx.EventManager().Events())
+		s.cacheCtx.MultiStore().(storetypes.CacheMultiStore).Write()
+	}
+}
+
+// cache creates the stateDB cache context
+func (s *StateDB) cache() error {
+	if s.ctx.MultiStore() == nil {
+		return errors.New("ctx has no multi store")
+	}
+	s.cacheCtx, _ = s.ctx.CacheContext()
+
+	// Get KVStores for modules wired to app
+	cms := s.cacheCtx.MultiStore().(storetypes.CacheMultiStore)
+	storeKeys := s.keeper.KVStoreKeys()
+
+	// Create and set snapshot store to stateDB
+	snapshotStore := snapshotmulti.NewStore(cms, storeKeys)
+	s.snapshotter = snapshotStore
+	s.cacheCtx = s.cacheCtx.WithMultiStore(snapshotStore)
+	s.writeCache = func() {
+		s.ctx.EventManager().EmitEvents(s.cacheCtx.EventManager().Events())
+		s.cacheCtx.MultiStore().(storetypes.CacheMultiStore).Write()
+	}
+
+	return nil
+}
+
+// AddLog adds a log, called by evm.
+func (s *StateDB) AddLog(log *ethtypes.Log) {
+	s.journal.append(addLogChange{})
+
+	log.TxIndex = s.txConfig.TxIndex
+	log.Index = s.txConfig.LogIndex + uint(len(s.logs))
+	s.logs = append(s.logs, log)
+}
+
+// Logs returns the logs of current transaction.
+func (s *StateDB) Logs() []*ethtypes.Log {
+	return s.logs
+}
+
+// AddRefund adds gas to the refund counter
+func (s *StateDB) AddRefund(gas uint64) {
+	s.journal.append(refundChange{prev: s.refund})
+	s.refund += gas
+}
+
+// SubRefund removes gas from the refund counter.
+// This method will panic if the refund counter goes below zero
+func (s *StateDB) SubRefund(gas uint64) {
+	s.journal.append(refundChange{prev: s.refund})
+	if gas > s.refund {
+		panic(fmt.Sprintf("Refund counter below zero (gas: %d > refund: %d)", gas, s.refund))
+	}
+	s.refund -= gas
+}
+
+// Exist reports whether the given account address exists in the state.
+// Notably this also returns true for self-destructed accounts.
+func (s *StateDB) Exist(addr common.Address) bool {
+	return s.getStateObject(addr) != nil
+}
+
+// Empty returns whether the state object is either non-existent
+// or empty according to the EIP161 specification (balance = nonce = code = 0)
+func (s *StateDB) Empty(addr common.Address) bool {
+	so := s.getStateObject(addr)
+	return so == nil || so.empty()
+}
+
+// GetBalance retrieves the balance from the given address or 0 if object not found
+func (s *StateDB) GetBalance(addr common.Address) *uint256.Int {
+	stateObject := s.getStateObject(addr)
+	if stateObject != nil {
+		return stateObject.Balance()
+	}
+	return common.U2560
+}
+
+// GetNonce returns the nonce of account, 0 if not exists.
+func (s *StateDB) GetNonce(addr common.Address) uint64 {
+	stateObject := s.getStateObject(addr)
+	if stateObject != nil {
+		return stateObject.Nonce()
+	}
+
+	return 0
+}
+
+// GetCode returns the code of account, nil if not exists.
+func (s *StateDB) GetCode(addr common.Address) []byte {
+	stateObject := s.getStateObject(addr)
+	if stateObject != nil {
+		return stateObject.Code()
+	}
+	return nil
+}
+
+// GetCodeSize returns the code size of account.
+func (s *StateDB) GetCodeSize(addr common.Address) int {
+	stateObject := s.getStateObject(addr)
+	if stateObject != nil {
+		return stateObject.CodeSize()
+	}
+	return 0
+}
+
+// GetCodeHash returns the code hash of account.
+func (s *StateDB) GetCodeHash(addr common.Address) common.Hash {
+	stateObject := s.getStateObject(addr)
+	if stateObject == nil {
+		return common.Hash{}
+	}
+	return common.BytesToHash(stateObject.CodeHash())
+}
+
+// GetState retrieves a value from the given account's storage trie.
+func (s *StateDB) GetState(addr common.Address, hash common.Hash) common.Hash {
+	stateObject := s.getStateObject(addr)
+	if stateObject != nil {
+		return stateObject.GetState(hash)
+	}
+	return common.Hash{}
+}
+
+// GetCommittedState retrieves a value from the given account's committed storage trie.
+func (s *StateDB) GetCommittedState(addr common.Address, hash common.Hash) common.Hash {
+	stateObject := s.getStateObject(addr)
+	if stateObject != nil {
+		return stateObject.GetCommittedState(hash)
+	}
+	return common.Hash{}
+}
+
+// GetStateAndCommittedState returns the current value and the original value.
+func (s *StateDB) GetStateAndCommittedState(addr common.Address, hash common.Hash) (common.Hash, common.Hash) {
+	stateObject := s.getStateObject(addr)
+	if stateObject != nil {
+		return stateObject.GetState(hash), stateObject.GetCommittedState(hash)
+	}
+	return common.Hash{}, common.Hash{}
+}
+
+// GetRefund returns the current value of the refund counter.
+func (s *StateDB) GetRefund() uint64 {
+	return s.refund
+}
+
+// AddPreimage records a SHA3 preimage seen by the VM.
+// AddPreimage performs a no-op since the EnablePreimageRecording flag is disabled
+// on the vm.Config during state transitions. No store trie preimages are written
+// to the database.
+func (s *StateDB) AddPreimage(_ common.Hash, _ []byte) {}
+
+// getStateObject retrieves a state object given by the address, returning nil if
+// the object is not found.
+func (s *StateDB) getStateObject(addr common.Address) *stateObject {
+	// Prefer live objects if any is available
+	if obj := s.stateObjects[addr]; obj != nil {
+		return obj
+	}
+	// If no live objects are available, load it from keeper
+	account := s.keeper.GetAccount(s.ctx, addr)
+	if account == nil {
+		return nil
+	}
+	// Insert into the live set
+	obj := newObject(s, addr, *account)
+	s.setStateObject(obj)
+	return obj
+}
+
+// getOrNewStateObject retrieves a state object or create a new state object if nil.
+func (s *StateDB) getOrNewStateObject(addr common.Address) *stateObject {
+	stateObject := s.getStateObject(addr)
+	if stateObject == nil {
+		stateObject, _ = s.createObject(addr)
+	}
+	return stateObject
+}
+
+// createObject creates a new state object. If there is an existing account with
+// the given address, it is overwritten and returned as the second return value.
+func (s *StateDB) createObject(addr common.Address) (newobj, prev *stateObject) {
+	prev = s.getStateObject(addr)
+
+	newobj = newObject(s, addr, Account{})
+	if prev == nil {
+		s.journal.append(createObjectChange{account: &addr})
+	} else {
+		s.journal.append(resetObjectChange{prev: prev})
+	}
+	s.setStateObject(newobj)
+	if prev != nil {
+		return newobj, prev
+	}
+	return newobj, nil
+}
+
+// CreateAccount explicitly creates a state object. If a state object with the address
+// already exists the balance is carried over to the new account.
+//
+// CreateAccount is called during the EVM CREATE operation. The situation might arise that
+// a contract does the following:
+//
+// 1. sends funds to sha(account ++ (nonce + 1))
+// 2. tx_create(sha(account ++ nonce)) (note that this gets the address of 1)
+//
+// Carrying over the balance ensures that Ether doesn't disappear.
+func (s *StateDB) CreateAccount(addr common.Address) {
+	newObj, prev := s.createObject(addr)
+	if prev != nil {
+		newObj.setBalance(prev.account.Balance)
+	}
+}
+
+// ForEachStorage iterate the contract storage, the iteration order is not defined.
+func (s *StateDB) ForEachStorage(addr common.Address, cb func(key, value common.Hash) bool) error {
+	so := s.getStateObject(addr)
+	if so == nil {
+		return nil
+	}
+	s.keeper.ForEachStorage(s.ctx, addr, func(key, value common.Hash) bool {
+		if value, dirty := so.dirtyStorage[key]; dirty {
+			return cb(key, value)
+		}
+		if len(value) > 0 {
+			return cb(key, value)
+		}
+		return true
+	})
+	return nil
+}
+
+func (s *StateDB) setStateObject(object *stateObject) {
+	s.stateObjects[object.Address()] = object
+}
+
+/*
+ * SETTERS
+ */
+
+// AddPrecompileFn adds a precompileCall journal entry
+// with a snapshot of the multi-store and events previous
+// to the precompile call.
+func (s *StateDB) AddPrecompileFn(snapshot int, events sdk.Events) error {
+	s.journal.append(precompileCallChange{
+		snapshot: snapshot,
+		events:   events,
+	})
+	s.precompileCallsCounter++
+	if s.precompileCallsCounter > types.MaxPrecompileCalls {
+		return fmt.Errorf("max calls to precompiles (%d) reached", types.MaxPrecompileCalls)
+	}
+	return nil
+}
+
+// AddBalance adds amount to the account associated with addr.
+func (s *StateDB) AddBalance(addr common.Address, amount *uint256.Int, reason tracing.BalanceChangeReason) uint256.Int {
+	stateObject := s.getOrNewStateObject(addr)
+	if stateObject == nil {
+		return uint256.Int{}
+	}
+	return stateObject.AddBalance(amount)
+}
+
+// SubBalance subtracts amount from the account associated with addr.
+func (s *StateDB) SubBalance(addr common.Address, amount *uint256.Int, reason tracing.BalanceChangeReason) uint256.Int {
+	stateObject := s.getOrNewStateObject(addr)
+	if stateObject == nil {
+		return uint256.Int{}
+	}
+	if amount.IsZero() {
+		return *(stateObject.Balance())
+	}
+	return stateObject.SubBalance(amount)
+}
+
+// SetNonce sets the nonce of account.
+func (s *StateDB) SetNonce(addr common.Address, nonce uint64, reason tracing.NonceChangeReason) {
+	stateObject := s.getOrNewStateObject(addr)
+	if stateObject != nil {
+		stateObject.SetNonce(nonce)
+	}
+}
+
+// SetCode sets the code of account.
+func (s *StateDB) SetCode(addr common.Address, code []byte) []byte {
+	stateObject := s.getOrNewStateObject(addr)
+	var prev []byte
+	if stateObject != nil {
+		prev = slices.Clone(stateObject.code)
+		stateObject.SetCode(crypto.Keccak256Hash(code), code)
+	}
+	return prev
+}
+
+// SetState sets the contract state.
+func (s *StateDB) SetState(addr common.Address, key, value common.Hash) common.Hash {
+	if stateObject := s.getOrNewStateObject(addr); stateObject != nil {
+		return stateObject.SetState(key, value)
+	}
+	return common.Hash{}
+}
+
+// SetBalance sets the balance of account associated with addr to amount.
+func (s *StateDB) SetBalance(addr common.Address, amount *uint256.Int, reason tracing.BalanceChangeReason) {
+	stateObject := s.getOrNewStateObject(addr)
+	if stateObject != nil {
+		stateObject.SetBalance(amount)
+	}
+}
+
+// SetStorage replaces the entire storage for the specified account with given
+// storage. This function should only be used for debugging and the mutations
+// must be discarded afterwards.
+func (s *StateDB) SetStorage(addr common.Address, storage Storage) {
+	stateObject := s.getOrNewStateObject(addr)
+	stateObject.SetStorage(storage)
+}
+
+// SelfDestruct marks the given account as self-destructed.
+// This clears the account balance.
+//
+// The account's state object is still available until the state is committed,
+// getStateObject will return a non-nil account after SelfDestruct.
+func (s *StateDB) SelfDestruct(addr common.Address) uint256.Int {
+	stateObject := s.getStateObject(addr)
+	var prevBalance uint256.Int
+	if stateObject == nil {
+		return prevBalance
+	}
+	prevBalance = *(stateObject.Balance())
+	s.journal.append(selfDestructChange{
+		account:     &addr,
+		prev:        stateObject.selfDestructed,
+		prevbalance: new(uint256.Int).Set(stateObject.Balance()),
+	})
+	stateObject.markSelfDestructed()
+	stateObject.account.Balance = new(uint256.Int)
+	return prevBalance
+}
+
+func (s *StateDB) SelfDestruct6780(addr common.Address) (uint256.Int, bool) {
+	stateObject := s.getStateObject(addr)
+	if stateObject == nil {
+		return uint256.Int{}, false
+	}
+
+	if stateObject.newContract {
+		return s.SelfDestruct(addr), true
+	}
+	return *(stateObject.Balance()), false
+}
+
+// HasSelfDestructed returns if the contract is self-destructed in current transaction.
+func (s *StateDB) HasSelfDestructed(addr common.Address) bool {
+	stateObject := s.getStateObject(addr)
+	if stateObject != nil {
+		return stateObject.selfDestructed
+	}
+	return false
+}
+
+// SetTransientState sets transient storage for a given account. It
+// adds the change to the journal so that it can be rolled back
+// to its previous value if there is a revert.
+func (s *StateDB) SetTransientState(addr common.Address, key, value common.Hash) {
+	prev := s.GetTransientState(addr, key)
+	if prev == value {
+		return
+	}
+	s.journal.append(transientStorageChange{
+		account:  &addr,
+		key:      key,
+		prevalue: prev,
+	})
+	s.setTransientState(addr, key, value)
+}
+
+// setTransientState is a lower level setter for transient storage. It
+// is called during a revert to prevent modifications to the journal.
+func (s *StateDB) setTransientState(addr common.Address, key, value common.Hash) {
+	s.transientStorage.Set(addr, key, value)
+}
+
+// GetTransientState gets transient storage for a given account.
+func (s *StateDB) GetTransientState(addr common.Address, key common.Hash) common.Hash {
+	return s.transientStorage.Get(addr, key)
+}
+
+// Prepare handles the preparatory steps for executing a state transition with.
+// This method must be invoked before state transition.
+//
+// Berlin fork:
+// - Add sender to access list (2929)
+// - Add destination to access list (2929)
+// - Add precompiles to access list (2929)
+// - Add the contents of the optional tx access list (2930)
+//
+// Potential EIPs:
+// - Reset access list (Berlin)
+// - Add coinbase to access list (EIP-3651)
+// - Reset transient storage (EIP-1153)
+func (s *StateDB) Prepare(rules params.Rules, sender, coinbase common.Address, dst *common.Address,
+	precompiles []common.Address, list ethtypes.AccessList,
+) {
+	if rules.IsEIP2929 && rules.IsEIP4762 {
+		panic("eip2929 and eip4762 are both activated")
+	}
+	if rules.IsEIP2929 {
+		// Clear out any leftover from previous executions
+		al := newAccessList()
+		s.accessList = al
+
+		al.AddAddress(sender)
+		if dst != nil {
+			al.AddAddress(*dst)
+			// If it's a create-tx, the destination will be added inside evm.create
+		}
+		for _, addr := range precompiles {
+			al.AddAddress(addr)
+		}
+		for _, el := range list {
+			al.AddAddress(el.Address)
+			for _, key := range el.StorageKeys {
+				al.AddSlot(el.Address, key)
+			}
+		}
+		if rules.IsShanghai { // EIP-3651: warm coinbase
+			al.AddAddress(coinbase)
+		}
+	}
+	// Reset transient storage at the beginning of transaction execution
+	s.transientStorage = newTransientStorage()
+}
+
+// AddAddressToAccessList adds the given address to the access list
+func (s *StateDB) AddAddressToAccessList(addr common.Address) {
+	if s.accessList.AddAddress(addr) {
+		s.journal.append(accessListAddAccountChange{&addr})
+	}
+}
+
+// AddSlotToAccessList adds the given (address, slot)-tuple to the access list
+func (s *StateDB) AddSlotToAccessList(addr common.Address, slot common.Hash) {
+	addrMod, slotMod := s.accessList.AddSlot(addr, slot)
+	if addrMod {
+		// In practice, this should not happen, since there is no way to enter the
+		// scope of 'address' without having the 'address' become already added
+		// to the access list (via call-variant, create, etc).
+		// Better safe than sorry, though
+		s.journal.append(accessListAddAccountChange{&addr})
+	}
+	if slotMod {
+		s.journal.append(accessListAddSlotChange{
+			address: &addr,
+			slot:    &slot,
+		})
+	}
+}
+
+// AddressInAccessList returns true if the given address is in the access list.
+func (s *StateDB) AddressInAccessList(addr common.Address) bool {
+	return s.accessList.ContainsAddress(addr)
+}
+
+// SlotInAccessList returns true if the given (address, slot)-tuple is in the access list.
+func (s *StateDB) SlotInAccessList(addr common.Address, slot common.Hash) (addressPresent bool, slotPresent bool) {
+	return s.accessList.Contains(addr, slot)
+}
+
+// Snapshot returns an identifier for the current revision of the state.
+func (s *StateDB) Snapshot() int {
+	id := s.nextRevisionID
+	s.nextRevisionID++
+	s.validRevisions = append(s.validRevisions, revision{id, s.journal.length(), s.ctx.EventManager().Events()})
+	return id
+}
+
+// RevertToSnapshot reverts all state changes made since the given revision.
+func (s *StateDB) RevertToSnapshot(revid int) {
+	// Find the snapshot in the stack of valid snapshots.
+	idx := sort.Search(len(s.validRevisions), func(i int) bool {
+		return s.validRevisions[i].id >= revid
+	})
+	if idx == len(s.validRevisions) || s.validRevisions[idx].id != revid {
+		panic(fmt.Errorf("revision id %v cannot be reverted", revid))
+	}
+	snapshot := s.validRevisions[idx].journalIndex
+
+	// revert back to snapshotted events
+	eventManager := sdk.NewEventManager()
+	eventManager.EmitEvents(s.validRevisions[idx].events)
+	s.ctx = s.ctx.WithEventManager(eventManager)
+
+	// Replay the journal to undo changes and remove invalidated snapshots
+	s.journal.Revert(s, snapshot)
+	s.validRevisions = s.validRevisions[:idx]
+}
+
+// Commit writes the dirty states to keeper
+// the StateDB object should be discarded after committed.
+func (s *StateDB) Commit() error {
+	// writeCache func will exist only when there's a call to a precompile.
+	// It applies all the store updates preformed by precompile calls.
+	if s.writeCache != nil {
+		s.writeCache()
+	}
+	if err := s.commitWithCtx(s.ctx); err != nil {
+		return err
+	}
+	s.callerEvents.EmitEvents(s.ctx.EventManager().Events())
+	return nil
+}
+
+// CommitWithCacheCtx writes the dirty states to keeper using the cacheCtx.
+// This function is used before any precompile call to make sure the cacheCtx
+// is updated with the latest changes within the tx (StateDB's journal entries).
+func (s *StateDB) CommitWithCacheCtx() error {
+	return s.commitWithCtx(s.cacheCtx)
+}
+
+// commitWithCtx writes the dirty states to keeper
+// using the provided context
+func (s *StateDB) commitWithCtx(ctx sdk.Context) error {
+	for _, addr := range s.journal.sortedDirties() {
+		obj := s.stateObjects[addr]
+		if obj.selfDestructed {
+			if err := s.keeper.DeleteAccount(ctx, obj.Address()); err != nil {
+				return errorsmod.Wrapf(err, "failed to delete account %s", obj.Address())
+			}
+		} else {
+			if obj.code != nil && obj.dirtyCode {
+				if len(obj.code) == 0 {
+					s.keeper.DeleteCode(ctx, obj.CodeHash())
+				} else {
+					s.keeper.SetCode(ctx, obj.CodeHash(), obj.code)
+				}
+			}
+			if err := s.keeper.SetAccount(ctx, obj.Address(), obj.account); err != nil {
+				return errorsmod.Wrap(err, "failed to set account")
+			}
+
+			for _, key := range obj.dirtyStorage.SortedKeys() {
+				valueBytes := obj.dirtyStorage[key].Bytes()
+				if len(valueBytes) == 0 {
+					s.keeper.DeleteState(ctx, obj.Address(), key)
+				} else {
+					s.keeper.SetState(ctx, obj.Address(), key, valueBytes)
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/polystorechain/vendor/modules.txt
+++ b/polystorechain/vendor/modules.txt
@@ -1349,6 +1349,7 @@ github.com/cosmos/evm/mempool/miner
 github.com/cosmos/evm/mempool/txpool
 github.com/cosmos/evm/mempool/txpool/legacypool
 github.com/cosmos/evm/metrics
+github.com/cosmos/evm/precompiles/common
 github.com/cosmos/evm/rpc
 github.com/cosmos/evm/rpc/backend
 github.com/cosmos/evm/rpc/namespaces/ethereum/debug

--- a/release.sh
+++ b/release.sh
@@ -33,7 +33,7 @@ echo ">>> Building polystorechaind..."
     make proto-gen
     # Link against release lib
     export CGO_LDFLAGS="-L$(pwd)/../polystore_core/target/release -lpolystore_core"
-    go build -ldflags "-X main.Version=$VERSION" -o ../dist/bin/polystorechaind ./cmd/polystorechaind
+    ../scripts/chain_go.sh build -ldflags "-X main.Version=$VERSION" -o ../dist/bin/polystorechaind ./cmd/polystorechaind
 )
 
 # 4. Build polystore_cli (Rust)

--- a/scripts/bench_retrieval_sessions.sh
+++ b/scripts/bench_retrieval_sessions.sh
@@ -133,7 +133,7 @@ export LD_LIBRARY_PATH="$CORE_LIB_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 export CGO_LDFLAGS="-L$CORE_LIB_DIR -lpolystore_core${CGO_LDFLAGS:+ $CGO_LDFLAGS}"
 
 log "building polystorechaind"
-(cd "$CHAIN_DIR" && GOFLAGS="${GOFLAGS:-} -mod=mod" go build -o "$BIN" ./cmd/polystorechaind) || fail "chain build failed"
+(cd "$CHAIN_DIR" && ../scripts/chain_go.sh build -o "$BIN" ./cmd/polystorechaind) || fail "chain build failed"
 
 prepare_proof_fixtures() {
   [ "$PROOFS_PER_SESSION" -gt 0 ] || return 0
@@ -147,7 +147,7 @@ prepare_proof_fixtures() {
       POLYSTORE_BENCH_FIXTURE_SESSIONS="$SESSIONS" \
       POLYSTORE_BENCH_FIXTURE_COUNT="$PROOFS_PER_SESSION" \
       POLYSTORE_BENCH_FIXTURE_SERVICE_HINT="General:rs=2+1" \
-        GOFLAGS="${GOFLAGS:-} -mod=mod" go test ./x/polystorechain/keeper -run '^TestWriteRetrievalSessionProofFixture$' -count=1
+        ../scripts/chain_go.sh test ./x/polystorechain/keeper -run '^TestWriteRetrievalSessionProofFixture$' -count=1
     ) || fail "proof fixture generation failed"
   else
     [ -d "$PROOFS_DIR" ] || fail "proof fixture directory does not exist: $PROOFS_DIR"

--- a/scripts/chain_go.sh
+++ b/scripts/chain_go.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Chain builds require the tracked Cosmos SDK/EVM corrections in vendor.
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR/polystorechain"
+GO_BIN="${GO_BIN:-go}"
+
+case "${1:-}" in
+  build|install|test|vet|list|vendor) ;;
+  *) echo "usage: $0 {build|install|test|vet|list|vendor} [go arguments]" >&2; exit 2 ;;
+esac
+for arg in "$@"; do
+  case "$arg" in
+    -mod|-mod=*) echo "chain_go.sh selects required vendor mode" >&2; exit 2 ;;
+  esac
+done
+
+# A changed dependency set (or a fresh checkout) needs reconstruction. Preserve
+# working-tree patches, including local edits; never git-checkout over them.
+source_id="$(git hash-object go.mod go.sum)"
+if [[ "$1" == vendor || ! -f vendor/.polystore-source || "$(cat vendor/.polystore-source)" != "$source_id" ]]; then
+  (
+    backup="$(mktemp -d "${TMPDIR:-/tmp}/polystore-vendor.XXXXXX")"
+    git ls-files -z vendor > "$backup/paths"
+    tar -cf "$backup/patches.tar" --null -T "$backup/paths"
+    restore_patches() {
+      status=$?
+      tar -xf "$backup/patches.tar" || status=1
+      rm -r "$backup"
+      exit "$status"
+    }
+    trap restore_patches EXIT
+    GOFLAGS= "$GO_BIN" mod vendor
+  )
+  printf '%s\n' "$source_id" > vendor/.polystore-source
+fi
+if [[ "$1" == vendor ]]; then exit 0; fi
+
+# Last GOFLAGS value wins, including inherited CI/deployment -mod=mod values.
+export GOFLAGS="${GOFLAGS:-} -mod=vendor"
+exec "$GO_BIN" "$@"

--- a/scripts/chain_go.sh
+++ b/scripts/chain_go.sh
@@ -21,7 +21,8 @@ source_id="$(git hash-object go.mod go.sum)"
 if [[ "$1" == vendor || ! -f vendor/.polystore-source || "$(cat vendor/.polystore-source)" != "$source_id" ]]; then
   (
     backup="$(mktemp -d "${TMPDIR:-/tmp}/polystore-vendor.XXXXXX")"
-    git ls-files -z vendor > "$backup/paths"
+    # modules.txt describes the freshly generated dependency graph, not a patch.
+    git ls-files -z -- vendor ':(exclude)vendor/modules.txt' > "$backup/paths"
     tar -cf "$backup/patches.tar" --null -T "$backup/paths"
     restore_patches() {
       status=$?

--- a/scripts/redeploy_polystorechaind.sh
+++ b/scripts/redeploy_polystorechaind.sh
@@ -48,7 +48,7 @@ Options:
   -h, --help                Show this help
 
 Environment knobs:
-  POLYSTORECHAIN_BUILD_GOFLAGS    GOFLAGS override for build (default appends -mod=mod)
+  POLYSTORECHAIN_BUILD_GOFLAGS    additional build GOFLAGS (vendor mode is mandatory)
   POLYSTORE_CORE_LIB_DIR          Override path containing libpolystore_core.so / libpolystore_core.dylib
 USAGE
 }
@@ -258,22 +258,18 @@ ensure_polystore_core_runtime() {
 build_polystorechaind() {
   local build_goflags
   build_goflags="${POLYSTORECHAIN_BUILD_GOFLAGS:-${GOFLAGS:-}}"
-  case " $build_goflags " in
-    *" -mod="*) ;;
-    *) build_goflags="${build_goflags} -mod=mod" ;;
-  esac
   build_goflags="$(printf '%s' "$build_goflags" | xargs)"
 
   log "building polystorechaind from $SOURCE_ROOT/polystorechain"
   if [ "$DRY_RUN" -eq 1 ]; then
-    printf '+ (cd %q && GOFLAGS=%q go build -o %q ./cmd/polystorechaind)\n' \
+    printf '+ (cd %q && GOFLAGS=%q ../scripts/chain_go.sh build -o %q ./cmd/polystorechaind)\n' \
       "$SOURCE_ROOT/polystorechain" "$build_goflags" "$SOURCE_ROOT/polystorechain/polystorechaind"
     return 0
   fi
 
   (
     cd "$SOURCE_ROOT/polystorechain"
-    GOFLAGS="$build_goflags" go build -o "$SOURCE_ROOT/polystorechain/polystorechaind" ./cmd/polystorechaind
+    GOFLAGS="$build_goflags" ../scripts/chain_go.sh build -o "$SOURCE_ROOT/polystorechain/polystorechaind" ./cmd/polystorechaind
   )
 }
 

--- a/scripts/run_devnet_alpha_multi_sp.sh
+++ b/scripts/run_devnet_alpha_multi_sp.sh
@@ -365,8 +365,8 @@ PY
 
 ensure_polystorechaind() {
   banner "Building polystorechaind (via $GO_BIN)"
-  (cd "$ROOT_DIR/polystorechain" && GOFLAGS="${GOFLAGS:-} -mod=mod" "$GO_BIN" build -o "$POLYSTORECHAIND_BIN" ./cmd/polystorechaind)
-  (cd "$ROOT_DIR/polystorechain" && GOFLAGS="${GOFLAGS:-} -mod=mod" "$GO_BIN" install ./cmd/polystorechaind)
+  (cd "$ROOT_DIR/polystorechain" && GO_BIN="$GO_BIN" ../scripts/chain_go.sh build -o "$POLYSTORECHAIND_BIN" ./cmd/polystorechaind)
+  (cd "$ROOT_DIR/polystorechain" && GO_BIN="$GO_BIN" ../scripts/chain_go.sh install ./cmd/polystorechaind)
 }
 
 ensure_polystore_cli() {

--- a/scripts/run_devnet_provider.sh
+++ b/scripts/run_devnet_provider.sh
@@ -393,10 +393,8 @@ ensure_polystorechaind() {
     return 0
   fi
   ensure_polystore_core_runtime
-  local build_goflags="${GOFLAGS:-}"
-  build_goflags="${build_goflags} -mod=mod"
   echo "==> Building polystorechaind..."
-  (cd "$ROOT_DIR/polystorechain" && GOFLAGS="$build_goflags" "$GO_BIN" build -o "$POLYSTORECHAIND_BIN" ./cmd/polystorechaind)
+  (cd "$ROOT_DIR/polystorechain" && GO_BIN="$GO_BIN" ../scripts/chain_go.sh build -o "$POLYSTORECHAIND_BIN" ./cmd/polystorechaind)
 }
 
 ensure_polystore_cli() {

--- a/scripts/run_local_stack.sh
+++ b/scripts/run_local_stack.sh
@@ -435,20 +435,9 @@ ensure_polystorechaind() {
   ensure_polystore_core_shared
   banner "Building and installing polystorechaind (via $GO_BIN)"
   
-  # Reconstruct vendor directory to handle partial vendoring strategy
-  (
-    cd "$ROOT_DIR/polystorechain"
-    echo "Reconstructing vendor for polystorechain..."
-    "$GO_BIN" mod vendor
-    # Restore tracked vendor files (if any) to preserve patches/partial vendoring
-    if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-      git checkout vendor 2>/dev/null || true
-    fi
-  )
-
-  (cd "$ROOT_DIR/polystorechain" && "$GO_BIN" build -o "$ROOT_DIR/polystorechain/polystorechaind" ./cmd/polystorechaind)
+  (cd "$ROOT_DIR/polystorechain" && GO_BIN="$GO_BIN" ../scripts/chain_go.sh build -o "$ROOT_DIR/polystorechain/polystorechaind" ./cmd/polystorechaind)
   # Also install to GOPATH/bin to ensure it's in PATH for arbitrary shell calls
-  (cd "$ROOT_DIR/polystorechain" && "$GO_BIN" install ./cmd/polystorechaind)
+  (cd "$ROOT_DIR/polystorechain" && GO_BIN="$GO_BIN" ../scripts/chain_go.sh install ./cmd/polystorechaind)
 }
 
 ensure_polystore_cli() {

--- a/scripts/test_bench_retrieval_sessions.py
+++ b/scripts/test_bench_retrieval_sessions.py
@@ -1,5 +1,6 @@
 """Safety checks for the actual benchmark entrypoint; no build or node is run."""
 import os
+import shutil
 from pathlib import Path
 import subprocess
 import sys
@@ -11,6 +12,21 @@ SCRIPT = Path(__file__).with_name("bench_retrieval_sessions.sh")
 
 
 class BenchmarkHomeTest(unittest.TestCase):
+    def setUp(self):
+        # Mock builds must not prepare or stamp the developer's real vendor tree.
+        checkout = tempfile.TemporaryDirectory()
+        self.addCleanup(checkout.cleanup)
+        root = Path(checkout.name)
+        for directory in ("scripts", "polystore_core", "polystorechain/vendor"):
+            (root / directory).mkdir(parents=True)
+        for name in (SCRIPT.name, "chain_go.sh"):
+            shutil.copy2(SCRIPT.with_name(name), root / "scripts" / name)
+        for name in ("go.mod", "go.sum", "vendor/correction.go"):
+            (root / "polystorechain" / name).write_text("mock dependency\n")
+        subprocess.run(["git", "init", "-q", str(root)], check=True)
+        subprocess.run(["git", "-C", str(root), "add", "."], check=True)
+        self.script = root / "scripts" / SCRIPT.name
+
     def test_existing_paths_are_preserved_before_build(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -31,7 +47,7 @@ class BenchmarkHomeTest(unittest.TestCase):
             dangling.symlink_to(root / "absent", target_is_directory=True)
             for home in (existing, link, dangling, sentinel):
                 with self.subTest(home=home.name):
-                    result = subprocess.run(["bash", str(SCRIPT)], env=dict(env, POLYSTORE_BENCH_HOME=str(home)), capture_output=True, text=True, timeout=10)
+                    result = subprocess.run(["bash", str(self.script)], env=dict(env, POLYSTORE_BENCH_HOME=str(home)), capture_output=True, text=True, timeout=10)
                     self.assertNotEqual(result.returncode, 0)
                     self.assertIn("must not already exist", result.stderr)
                     self.assertFalse(build_marker.exists(), result.stderr)
@@ -51,7 +67,7 @@ class BenchmarkHomeTest(unittest.TestCase):
             env = dict(os.environ, PATH=f"{fakebin}:{os.environ['PATH']}", POLYSTORE_BENCH_HOME=str(home))
             for keep in (False, True):
                 with self.subTest(keep=keep):
-                    result = subprocess.run(["bash", str(SCRIPT)] + (["--keep-home"] if keep else []), env=env, capture_output=True, text=True, timeout=10)
+                    result = subprocess.run(["bash", str(self.script)] + (["--keep-home"] if keep else []), env=env, capture_output=True, text=True, timeout=10)
                     self.assertNotEqual(result.returncode, 0)
                     self.assertIn("cargo build --release failed", result.stderr)
                     self.assertEqual(home.is_dir(), keep)
@@ -63,7 +79,7 @@ class BenchmarkHomeTest(unittest.TestCase):
             fakebin.mkdir()
             for name, body in (
                 ("cargo", "exit 0"),
-                ("go", 'printf "%s\\n" "$@" > "$BUILD_ARGS"; exit 89'),
+                ("go", 'if [ "$1" = mod ] && [ "$2" = vendor ]; then exit 0; fi; printf "%s\\n" "$@" > "$BUILD_ARGS"; exit 89'),
             ):
                 command = fakebin / name
                 command.write_text("#!/bin/sh\n" + body + "\n")
@@ -73,7 +89,7 @@ class BenchmarkHomeTest(unittest.TestCase):
             env.pop("POLYSTORE_BENCH_HOME", None)
             homes = []
             for _ in range(2):
-                result = subprocess.run(["bash", str(SCRIPT)], env=env, capture_output=True, text=True, timeout=10)
+                result = subprocess.run(["bash", str(self.script)], env=env, capture_output=True, text=True, timeout=10)
                 self.assertNotEqual(result.returncode, 0)
                 self.assertIn("chain build failed", result.stderr)
                 args = args_file.read_text().splitlines()
@@ -97,7 +113,7 @@ class BenchmarkHomeTest(unittest.TestCase):
             cargo.write_text('#!/bin/sh\nmv "$POLYSTORE_BENCH_HOME" "$POLYSTORE_BENCH_HOME.original"\nln -s "$OPERATOR_DATA" "$POLYSTORE_BENCH_HOME"\nexit 89\n')
             cargo.chmod(0o755)
             env = dict(os.environ, PATH=f"{fakebin}:{os.environ['PATH']}", POLYSTORE_BENCH_HOME=str(home), OPERATOR_DATA=str(target))
-            result = subprocess.run(["bash", str(SCRIPT)], env=env, capture_output=True, text=True, timeout=10)
+            result = subprocess.run(["bash", str(self.script)], env=env, capture_output=True, text=True, timeout=10)
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("home changed; refusing cleanup", result.stderr)
             self.assertTrue(home.is_symlink())
@@ -131,7 +147,7 @@ exec(compile(code, "<benchmark home>", "exec"))
 ''')
             python.chmod(0o755)
             env = dict(os.environ, PATH=f"{fakebin}:{os.environ['PATH']}", POLYSTORE_BENCH_HOME=str(home))
-            result = subprocess.run(["bash", str(SCRIPT)], env=env, capture_output=True, text=True, timeout=10)
+            result = subprocess.run(["bash", str(self.script)], env=env, capture_output=True, text=True, timeout=10)
             self.assertNotEqual(result.returncode, 0)
             self.assertEqual((home / "operator-data").read_text(), "preserve")
             self.assertTrue(Path(str(home) + ".original").is_dir())

--- a/scripts/test_chain_go.py
+++ b/scripts/test_chain_go.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Exercise the real chain build entrypoint without compiling dependencies."""
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+class ChainGoTest(unittest.TestCase):
+    def test_patch_preservation_and_required_build_mode(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "scripts").mkdir()
+            chain = root / "polystorechain"
+            (chain / "vendor").mkdir(parents=True)
+            script = root / "scripts/chain_go.sh"
+            shutil.copyfile(Path(__file__).with_name("chain_go.sh"), script)
+            for name in ("go.mod", "go.sum"):
+                (chain / name).write_text("dependency v1\n")
+            patch = chain / "vendor/correction.go"
+            patch.write_text("tracked correction\n")
+            subprocess.run(["git", "init", "-q", str(root)], check=True)
+            subprocess.run(["git", "-C", str(root), "add", "."], check=True)
+            patch.write_text("uncommitted correction\n")
+            fake = root / "go"
+            fake.write_text('''#!/usr/bin/env python3
+import json, os, pathlib, sys
+with open(os.environ["CALLS"], "a") as out:
+    out.write(json.dumps([sys.argv[1:], os.environ.get("GOFLAGS")]) + "\\n")
+if sys.argv[1:] == ["mod", "vendor"]:
+    pathlib.Path("vendor/correction.go").write_text("upstream without correction\\n")
+    sys.exit(int(os.environ.get("VENDOR_EXIT", "0")))
+sys.exit(int(os.environ.get("BUILD_EXIT", "0")))
+''')
+            fake.chmod(0o755)
+            calls = root / "calls.jsonl"
+            env = dict(os.environ, GO_BIN=str(fake), CALLS=str(calls), GOFLAGS="-trimpath -mod=mod")
+
+            def run(*args, **overrides):
+                return subprocess.run(["bash", str(script), *args], env=dict(env, **overrides), capture_output=True, text=True)
+
+            self.assertEqual(run("build", "./cmd/polystorechaind").returncode, 0)
+            self.assertEqual(patch.read_text(), "uncommitted correction\n")
+            recorded = [json.loads(x) for x in calls.read_text().splitlines()]
+            self.assertEqual(recorded, [[["mod", "vendor"], ""], [["build", "./cmd/polystorechaind"], "-trimpath -mod=mod -mod=vendor"]])
+            self.assertEqual(run("test", "./...", BUILD_EXIT="7").returncode, 7)
+            self.assertEqual(len(calls.read_text().splitlines()), 3, "reuse unchanged dependency tree")
+            self.assertEqual(run("build", "-mod=mod", "./...").returncode, 2)
+            self.assertEqual(len(calls.read_text().splitlines()), 3, "reject bypass before running Go")
+
+            (chain / "go.mod").write_text("dependency v2\n")
+            self.assertEqual(run("test", "./...", VENDOR_EXIT="9").returncode, 9)
+            self.assertEqual(patch.read_text(), "uncommitted correction\n", "failed vendoring must preserve edits")
+            self.assertEqual(run("test", "./...").returncode, 0)
+            self.assertEqual(patch.read_text(), "uncommitted correction\n")
+            self.assertEqual(run("vendor").returncode, 0)
+            self.assertEqual(patch.read_text(), "uncommitted correction\n")
+            shutil.copyfile(Path(__file__).resolve().parents[1] / "polystorechain/Makefile", chain / "Makefile")
+            failed = subprocess.run(["make", "-s", "test-unit"], cwd=chain, env=dict(env, BUILD_EXIT="7"), capture_output=True)
+            self.assertNotEqual(failed.returncode, 0, "Makefile must propagate Go test failure")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_chain_go.py
+++ b/scripts/test_chain_go.py
@@ -22,6 +22,8 @@ class ChainGoTest(unittest.TestCase):
                 (chain / name).write_text("dependency v1\n")
             patch = chain / "vendor/correction.go"
             patch.write_text("tracked correction\n")
+            manifest = chain / "vendor/modules.txt"
+            manifest.write_text("dependency v1\n")
             subprocess.run(["git", "init", "-q", str(root)], check=True)
             subprocess.run(["git", "-C", str(root), "add", "."], check=True)
             patch.write_text("uncommitted correction\n")
@@ -32,6 +34,7 @@ with open(os.environ["CALLS"], "a") as out:
     out.write(json.dumps([sys.argv[1:], os.environ.get("GOFLAGS")]) + "\\n")
 if sys.argv[1:] == ["mod", "vendor"]:
     pathlib.Path("vendor/correction.go").write_text("upstream without correction\\n")
+    pathlib.Path("vendor/modules.txt").write_text(pathlib.Path("go.mod").read_text())
     sys.exit(int(os.environ.get("VENDOR_EXIT", "0")))
 sys.exit(int(os.environ.get("BUILD_EXIT", "0")))
 ''')
@@ -56,6 +59,7 @@ sys.exit(int(os.environ.get("BUILD_EXIT", "0")))
             self.assertEqual(patch.read_text(), "uncommitted correction\n", "failed vendoring must preserve edits")
             self.assertEqual(run("test", "./...").returncode, 0)
             self.assertEqual(patch.read_text(), "uncommitted correction\n")
+            self.assertEqual(manifest.read_text(), "dependency v2\n", "keep regenerated metadata for the new dependency graph")
             self.assertEqual(run("vendor").returncode, 0)
             self.assertEqual(patch.read_text(), "uncommitted correction\n")
             shutil.copyfile(Path(__file__).resolve().parents[1] / "polystorechain/Makefile", chain / "Makefile")

--- a/scripts/update_devnet_stack.sh
+++ b/scripts/update_devnet_stack.sh
@@ -1027,7 +1027,7 @@ build_artifacts() {
 
   echo "==> Building coupled devnet artifacts"
   run_build_in_dir "$SOURCE_ROOT/polystore_core" cargo build --release
-  run_build_in_dir "$SOURCE_ROOT/polystorechain" env GOFLAGS="$(goflags_with_mod)" go build -o "$SOURCE_ROOT/polystorechain/polystorechaind" ./cmd/polystorechaind
+  run_build_in_dir "$SOURCE_ROOT/polystorechain" ../scripts/chain_go.sh build -o "$SOURCE_ROOT/polystorechain/polystorechaind" ./cmd/polystorechaind
   run_build_in_dir "$SOURCE_ROOT/polystore_gateway" env GOFLAGS="$(goflags_with_mod)" go build -o "$SOURCE_ROOT/polystore_gateway/polystore_gateway" .
   run_build_in_dir "$SOURCE_ROOT/polystore_faucet" env GOFLAGS="$(goflags_with_mod)" go build -o "$SOURCE_ROOT/polystore_faucet/polystore_faucet" .
   run_build_in_dir "$SOURCE_ROOT/polystore_cli" cargo build --release

--- a/scripts/validate_polyfs_root_migration.sh
+++ b/scripts/validate_polyfs_root_migration.sh
@@ -133,8 +133,8 @@ export DYLD_LIBRARY_PATH="$CORE_DIR/target/release${DYLD_LIBRARY_PATH:+:$DYLD_LI
 
 run cargo test --manifest-path "$CORE_DIR/Cargo.toml" --test mdu0_root_table_test -- --nocapture
 
-run_in "$CHAIN_DIR" go test ./x/crypto_ffi -run 'TestVerifyMdu0RootTableProofRejectsWrongTargetRoot'
-run_in "$CHAIN_DIR" go test ./x/polystorechain/keeper -run 'TestProveLiveness_HappyPath|TestRetrievalSession_Lifecycle_ConfirmThenProof'
+run_in "$CHAIN_DIR" ../scripts/chain_go.sh test ./x/crypto_ffi -run 'TestVerifyMdu0RootTableProofRejectsWrongTargetRoot'
+run_in "$CHAIN_DIR" ../scripts/chain_go.sh test ./x/polystorechain/keeper -run 'TestProveLiveness_HappyPath|TestRetrievalSession_Lifecycle_ConfirmThenProof'
 
 run_in "$GATEWAY_DIR" go test . -run 'TestProofHeaderJSONHighIndexNoManifestBinVerifies|TestProofHeaderJSONRejectsStaleMdu0RootTable'
 


### PR DESCRIPTION
Native calls through the PolyStore EVM precompile previously bypassed the EVM journal and its child gas allowance. A successful child call followed by a caught REVERT could retain native writes; failed native work charged only the fixed calldata fee. The shared dispatcher now uses Cosmos EVM's native-action wrapper with the app's actual persistent store keys and its existing denomination-aware balance handler.

Real regressions exposed three additional bugs in pinned Cosmos EVM v0.5.1. Small corrections retain its journal engine while charging successful/failed/OOG native work exactly once and preserving only surviving SDK events, including a successful sibling after a caught revert. Module accounts also participate in native balance synchronization; skipping them let a later EVM transfer overwrite native fee payments. Existing blocked-recipient permissions remain enforced, with failed transactions preserving balances and supply. StateDB event publication also preserves preexisting caller events exactly once. The tracked dependency files are full upstream files with these narrow changes; compare them against v0.5.1 for the minimal patch.

Chain build, test, install and deployment paths use `scripts/chain_go.sh` to preserve tracked working-tree vendor corrections and enforce vendor mode. Compile-time patch markers reject accidental unpatched builds. Other Go modules retain their dependency mode. `polystorechain/VENDOR_PATCHES.md` records provenance and the upgrade/removal procedure. The Makefile unit-test target now propagates a failing Go exit status.

Partial S2 for #255 under #254; closes neither issue. This does not add challenge/session v2, prepaid proof crypto, ABI allocation limits, receipt range validation or a finite production profile. These remain tracked prerequisites. This changes consensus behavior and requires a coordinated validator upgrade; no deployment or v2 activation is performed.

Validation:
- Real app/store-backed EVM tests: nested success, caught child REVERT, errors after native bank writes, OOG, and reverted child followed by successful funded sibling. Assert native records, configured-denomination and unrelated stake balances, EVM cached balances, SDK events and EVM logs.
- Twelve module-account regressions: balance preload timing, native fees plus legal transfers, blocked-recipient rejection with and without native calls, enclosing transaction rollback, module debit/credit round trips and total supply conservation.
- Controlled native gas tests: charge 50 units once with 100 available, on success and ordinary failure; OOG exhausts the child allowance; parent consumption does not alter the child budget. Balance conversion/filter tests include six decimal places.
- Full app, precompile and keeper package tests pass through the wrapper. A wrapper node build with inherited `GOFLAGS=-mod=mod` and executable version smoke pass; direct unpatched module-mode compilation fails on the required patch markers.
- `python3 scripts/test_chain_go.py` and syntax checks for every touched shell pass. The real wrapper test preserves uncommitted patches through successful/failed reconstruction, enforces vendor mode, reuses unchanged dependencies and propagates test failures through Makefile.

With journal wiring in place, the bounded creation regression isolates the pinned gas correction: success stays at 299,443; native failure increases from 217,914 to 266,331 because it now pays for performed work; a 280,000-gas OOG child consumes its allowance (285,370 including outer work). These are accounting regressions, not throughput/capacity qualification. #260 retains final performance qualification.

PRs #261/#262 are merged. The combined benchmark entrypoint checks pass from isolated temporary checkouts, including dependency preparation. The user granted standing merge approval conditional on current-head clean Codex review and passing CI.

Final local validation on `b5a5518682edf08784a3bd507785330b75de3b1d`: app/precompile/keeper/challenge package suites and all six Python entrypoint checks pass. Independent Astra review accepts this exact head after reproducing and verifying the module-balance fix. Hosted Codex review and current-head CI remain required before merge.
