### PR TITLE
Fix E2E upload polling when conditional controls disappear

### DIFF
--- a/.github/workflows/e2e_playwright.yml
+++ b/.github/workflows/e2e_playwright.yml
@@ -41,6 +41,10 @@ jobs:
         working-directory: polystore-website
         run: npx playwright install --with-deps chromium
 
+      - name: Test conditional upload polling without a devnet
+        working-directory: polystore-website
+        run: npx playwright test tests/mode2-stripe.spec.ts tests/gateway-absent-ui.spec.ts tests/mode2-setup-bump-live.spec.ts --grep 'upload completion polling'
+
       - name: Start Dev Server
         working-directory: polystore-website
         run: |

--- a/polystore-website/tests/gateway-absent-ui.spec.ts
+++ b/polystore-website/tests/gateway-absent-ui.spec.ts
@@ -22,11 +22,11 @@ async function readDealManifestRoot(page: Page, dealId: string): Promise<string>
 }
 
 async function isUploaderResetToInitialState(page: Page): Promise<boolean> {
-  const panelState = await page.getByTestId('mdu-upload-card').evaluateAll((nodes) => nodes[0]?.getAttribute('data-panel-state') ?? null).catch(() => null)
+  const panelState = await page.getByTestId('mdu-upload-card').evaluateAll((nodes) => nodes.length === 1 ? nodes[0].getAttribute('data-panel-state') : null).catch(() => null)
   if (panelState !== 'idle') return false
-  const step2State = await page.getByTestId('workflow-step-2').evaluateAll((nodes) => nodes[0]?.getAttribute('data-step-state') ?? null).catch(() => null)
-  const step3State = await page.getByTestId('workflow-step-3').evaluateAll((nodes) => nodes[0]?.getAttribute('data-step-state') ?? null).catch(() => null)
-  const step4State = await page.getByTestId('workflow-step-4').evaluateAll((nodes) => nodes[0]?.getAttribute('data-step-state') ?? null).catch(() => null)
+  const step2State = await page.getByTestId('workflow-step-2').evaluateAll((nodes) => nodes.length === 1 ? nodes[0].getAttribute('data-step-state') : null).catch(() => null)
+  const step3State = await page.getByTestId('workflow-step-3').evaluateAll((nodes) => nodes.length === 1 ? nodes[0].getAttribute('data-step-state') : null).catch(() => null)
+  const step4State = await page.getByTestId('workflow-step-4').evaluateAll((nodes) => nodes.length === 1 ? nodes[0].getAttribute('data-step-state') : null).catch(() => null)
   const fileInputCount = await page.getByTestId('mdu-file-input').count().catch(() => 0)
   return step2State === 'idle' && step3State === 'idle' && step4State === 'idle' && fileInputCount > 0
 }
@@ -57,9 +57,9 @@ async function isCommitCompleteOrReset(
   if (expectedFilePath) {
     if (await hasDealFileRow(page, expectedFilePath)) return true
   }
-  const panelState = await page.getByTestId('mdu-upload-card').evaluateAll((nodes) => nodes[0]?.getAttribute('data-panel-state') ?? null).catch(() => null)
+  const panelState = await page.getByTestId('mdu-upload-card').evaluateAll((nodes) => nodes.length === 1 ? nodes[0].getAttribute('data-panel-state') : null).catch(() => null)
   if (panelState === 'success') return true
-  const commitText = ((await commitBtn.allTextContents().then((texts) => texts[0] || '').catch(() => '')) || '').trim()
+  const commitText = ((await commitBtn.allTextContents().then((texts) => texts.length === 1 ? texts[0] : '').catch(() => '')) || '').trim()
   if (/Committed!/i.test(commitText)) return true
   if (allowReset && (await isUploaderResetToInitialState(page))) return true
   return false
@@ -95,7 +95,7 @@ async function completeUploadAndCommit(
         .poll(async () => {
           if (await isCommitCompleteOrReset(page, commitBtn, expectedFilePath, dealId, initialManifestRoot, true)) return true
           if (await commitBtn.evaluateAll((buttons) => buttons.length === 1 && buttons[0].matches(':enabled')).catch(() => false)) return true
-          const text = ((await uploadBtn.allTextContents().then((texts) => texts[0] || '').catch(() => '')) || '').trim()
+          const text = ((await uploadBtn.allTextContents().then((texts) => texts.length === 1 ? texts[0] : '').catch(() => '')) || '').trim()
           return /Upload Complete/i.test(text)
         }, { timeout: 120_000 })
         .toBe(true)
@@ -394,6 +394,19 @@ test('upload completion polling observes removed controls', async ({ page }) => 
   const commitBtn = page.getByTestId('mdu-commit')
   await commitBtn.evaluate((button) => button.remove())
   // Missing controls alone are not completion and must not block the next poll.
+  expect(await isCommitCompleteOrReset(page, commitBtn, 'uploaded.bin', '', '', true)).toBe(false)
+
+  // Duplicate locators remain invalid, matching the previous strict reads.
+  await page.setContent(`
+    <div data-testid="mdu-upload-card" data-panel-state="uploading"></div>
+    <button data-testid="mdu-commit" disabled>Committed!</button>
+    <button data-testid="mdu-commit" disabled>Committed!</button>
+  `)
+  expect(await isCommitCompleteOrReset(page, commitBtn, 'uploaded.bin', '', '', true)).toBe(false)
+  await page.setContent(`
+    <div data-testid="mdu-upload-card" data-panel-state="success"></div>
+    <div data-testid="mdu-upload-card" data-panel-state="success"></div>
+  `)
   expect(await isCommitCompleteOrReset(page, commitBtn, 'uploaded.bin', '', '', true)).toBe(false)
 
   await page.setContent(`

--- a/polystore-website/tests/gateway-absent-ui.spec.ts
+++ b/polystore-website/tests/gateway-absent-ui.spec.ts
@@ -17,16 +17,16 @@ function extractManifestRoot(text: string): string {
 async function readDealManifestRoot(page: Page, dealId: string): Promise<string> {
   const cell = page.getByTestId(`deal-manifest-${dealId}`)
   if ((await cell.count().catch(() => 0)) === 0) return ''
-  const text = (await cell.first().textContent().catch(() => '')) || ''
+  const text = (await cell.first().allTextContents().then((texts) => texts[0] || '').catch(() => '')) || ''
   return extractManifestRoot(text)
 }
 
 async function isUploaderResetToInitialState(page: Page): Promise<boolean> {
-  const panelState = await page.getByTestId('mdu-upload-card').getAttribute('data-panel-state').catch(() => null)
+  const panelState = await page.getByTestId('mdu-upload-card').evaluateAll((nodes) => nodes[0]?.getAttribute('data-panel-state') ?? null).catch(() => null)
   if (panelState !== 'idle') return false
-  const step2State = await page.getByTestId('workflow-step-2').getAttribute('data-step-state').catch(() => null)
-  const step3State = await page.getByTestId('workflow-step-3').getAttribute('data-step-state').catch(() => null)
-  const step4State = await page.getByTestId('workflow-step-4').getAttribute('data-step-state').catch(() => null)
+  const step2State = await page.getByTestId('workflow-step-2').evaluateAll((nodes) => nodes[0]?.getAttribute('data-step-state') ?? null).catch(() => null)
+  const step3State = await page.getByTestId('workflow-step-3').evaluateAll((nodes) => nodes[0]?.getAttribute('data-step-state') ?? null).catch(() => null)
+  const step4State = await page.getByTestId('workflow-step-4').evaluateAll((nodes) => nodes[0]?.getAttribute('data-step-state') ?? null).catch(() => null)
   const fileInputCount = await page.getByTestId('mdu-file-input').count().catch(() => 0)
   return step2State === 'idle' && step3State === 'idle' && step4State === 'idle' && fileInputCount > 0
 }
@@ -57,9 +57,9 @@ async function isCommitCompleteOrReset(
   if (expectedFilePath) {
     if (await hasDealFileRow(page, expectedFilePath)) return true
   }
-  const panelState = await page.getByTestId('mdu-upload-card').getAttribute('data-panel-state').catch(() => null)
+  const panelState = await page.getByTestId('mdu-upload-card').evaluateAll((nodes) => nodes[0]?.getAttribute('data-panel-state') ?? null).catch(() => null)
   if (panelState === 'success') return true
-  const commitText = ((await commitBtn.textContent().catch(() => '')) || '').trim()
+  const commitText = ((await commitBtn.allTextContents().then((texts) => texts[0] || '').catch(() => '')) || '').trim()
   if (/Committed!/i.test(commitText)) return true
   if (allowReset && (await isUploaderResetToInitialState(page))) return true
   return false
@@ -79,7 +79,7 @@ async function completeUploadAndCommit(
   while (Date.now() < deadline) {
     if (await isCommitCompleteOrReset(page, commitBtn, expectedFilePath, dealId, initialManifestRoot, true)) return
 
-    const commitReady = (await commitBtn.count().catch(() => 0)) > 0 && (await commitBtn.isEnabled().catch(() => false))
+    const commitReady = (await commitBtn.count().catch(() => 0)) > 0 && (await commitBtn.evaluateAll((buttons) => buttons.length === 1 && buttons[0].matches(':enabled')).catch(() => false))
     if (commitReady) {
       await commitBtn.click({ force: true, timeout: 10_000 })
       await expect
@@ -88,14 +88,14 @@ async function completeUploadAndCommit(
       return
     }
 
-    const uploadReady = (await uploadBtn.count().catch(() => 0)) > 0 && (await uploadBtn.isVisible().catch(() => false)) && (await uploadBtn.isEnabled().catch(() => false))
+    const uploadReady = (await uploadBtn.count().catch(() => 0)) > 0 && (await uploadBtn.isVisible().catch(() => false)) && (await uploadBtn.evaluateAll((buttons) => buttons.length === 1 && buttons[0].matches(':enabled')).catch(() => false))
     if (uploadReady) {
       await uploadBtn.click({ force: true, timeout: 10_000 })
       await expect
         .poll(async () => {
           if (await isCommitCompleteOrReset(page, commitBtn, expectedFilePath, dealId, initialManifestRoot, true)) return true
-          if (await commitBtn.isEnabled().catch(() => false)) return true
-          const text = ((await uploadBtn.textContent().catch(() => '')) || '').trim()
+          if (await commitBtn.evaluateAll((buttons) => buttons.length === 1 && buttons[0].matches(':enabled')).catch(() => false)) return true
+          const text = ((await uploadBtn.allTextContents().then((texts) => texts[0] || '').catch(() => '')) || '').trim()
           return /Upload Complete/i.test(text)
         }, { timeout: 120_000 })
         .toBe(true)
@@ -383,4 +383,29 @@ test.describe('gateway absent', () => {
       throw e
     }
   })
+})
+
+test('upload completion polling observes removed controls', async ({ page }) => {
+  test.setTimeout(5_000)
+  await page.setContent(`
+    <div data-testid="mdu-upload-card" data-panel-state="uploading"></div>
+    <button data-testid="mdu-commit" disabled>Confirming...</button>
+  `)
+  const commitBtn = page.getByTestId('mdu-commit')
+  await commitBtn.evaluate((button) => button.remove())
+  // Missing controls alone are not completion and must not block the next poll.
+  expect(await isCommitCompleteOrReset(page, commitBtn, 'uploaded.bin', '', '', true)).toBe(false)
+
+  await page.setContent(`
+    <div data-testid="mdu-upload-card" data-panel-state="idle"></div>
+    <div data-testid="workflow-step-2" data-step-state="idle"></div>
+    <div data-testid="workflow-step-3" data-step-state="idle"></div>
+    <div data-testid="workflow-step-4" data-step-state="idle"></div>
+    <input data-testid="mdu-file-input" type="file">
+  `)
+
+  await expect.poll(() => isCommitCompleteOrReset(page, commitBtn, 'uploaded.bin', '', '', true), { timeout: 1_000 }).toBe(true)
+  expect(await isCommitCompleteOrReset(page, commitBtn, 'uploaded.bin', '', '', false)).toBe(false)
+  await page.setContent('')
+  expect(await isCommitCompleteOrReset(page, commitBtn, 'uploaded.bin', '', '', true)).toBe(false)
 })

--- a/polystore-website/tests/mode2-setup-bump-live.spec.ts
+++ b/polystore-website/tests/mode2-setup-bump-live.spec.ts
@@ -128,10 +128,10 @@ async function isCommitCompleteOrReset(page: Page, commitBtn: Locator, filePath:
     }
   }
 
-  const panelState = await page.getByTestId('mdu-upload-card').evaluateAll((nodes) => nodes[0]?.getAttribute('data-panel-state') ?? null).catch(() => null)
+  const panelState = await page.getByTestId('mdu-upload-card').evaluateAll((nodes) => nodes.length === 1 ? nodes[0].getAttribute('data-panel-state') : null).catch(() => null)
   if (panelState === 'success') return true
 
-  const text = ((await commitBtn.allTextContents().then((texts) => texts[0] || '').catch(() => '')) || '').trim()
+  const text = ((await commitBtn.allTextContents().then((texts) => texts.length === 1 ? texts[0] : '').catch(() => '')) || '').trim()
   if (/Committed!/i.test(text)) return true
   return false
 }
@@ -284,7 +284,20 @@ test('upload completion polling observes removed controls', async ({ page }) => 
   // Missing controls alone are not completion and must not block the next poll.
   expect(await isCommitCompleteOrReset(page, commitBtn, 'uploaded.bin')).toBe(false)
 
-  await page.getByTestId('mdu-upload-card').evaluate((card) => card.setAttribute('data-panel-state', 'success'))
+  // Duplicate locators remain invalid, matching the previous strict reads.
+  await page.setContent(`
+    <div data-testid="mdu-upload-card" data-panel-state="uploading"></div>
+    <button data-testid="mdu-commit" disabled>Committed!</button>
+    <button data-testid="mdu-commit" disabled>Committed!</button>
+  `)
+  expect(await isCommitCompleteOrReset(page, commitBtn, 'uploaded.bin')).toBe(false)
+  await page.setContent(`
+    <div data-testid="mdu-upload-card" data-panel-state="success"></div>
+    <div data-testid="mdu-upload-card" data-panel-state="success"></div>
+  `)
+  expect(await isCommitCompleteOrReset(page, commitBtn, 'uploaded.bin')).toBe(false)
+
+  await page.setContent('<div data-testid="mdu-upload-card" data-panel-state="success"></div>')
 
   await expect.poll(() => isCommitCompleteOrReset(page, commitBtn, 'uploaded.bin'), { timeout: 1_000 }).toBe(true)
   await page.setContent('')

--- a/polystore-website/tests/mode2-setup-bump-live.spec.ts
+++ b/polystore-website/tests/mode2-setup-bump-live.spec.ts
@@ -128,10 +128,10 @@ async function isCommitCompleteOrReset(page: Page, commitBtn: Locator, filePath:
     }
   }
 
-  const panelState = await page.getByTestId('mdu-upload-card').getAttribute('data-panel-state').catch(() => null)
+  const panelState = await page.getByTestId('mdu-upload-card').evaluateAll((nodes) => nodes[0]?.getAttribute('data-panel-state') ?? null).catch(() => null)
   if (panelState === 'success') return true
 
-  const text = ((await commitBtn.textContent().catch(() => '')) || '').trim()
+  const text = ((await commitBtn.allTextContents().then((texts) => texts[0] || '').catch(() => '')) || '').trim()
   if (/Committed!/i.test(text)) return true
   return false
 }
@@ -142,14 +142,14 @@ async function completeUploadAndCommit(uploadBtn: Locator, commitBtn: Locator, f
   while (Date.now() < deadline) {
     if (await isCommitCompleteOrReset(page, commitBtn, filePath, dealId)) return
 
-    const commitEnabled = (await commitBtn.count().catch(() => 0)) > 0 && (await commitBtn.isEnabled().catch(() => false))
+    const commitEnabled = (await commitBtn.count().catch(() => 0)) > 0 && (await commitBtn.evaluateAll((buttons) => buttons.length === 1 && buttons[0].matches(':enabled')).catch(() => false))
     if (commitEnabled) {
       await commitBtn.click({ force: true })
       await expect.poll(() => isCommitCompleteOrReset(page, commitBtn, filePath, dealId), { timeout: 180_000 }).toBe(true)
       return
     }
 
-    const uploadEnabled = (await uploadBtn.count().catch(() => 0)) > 0 && (await uploadBtn.isEnabled().catch(() => false))
+    const uploadEnabled = (await uploadBtn.count().catch(() => 0)) > 0 && (await uploadBtn.evaluateAll((buttons) => buttons.length === 1 && buttons[0].matches(':enabled')).catch(() => false))
     if (uploadEnabled) {
       await uploadBtn.click({ force: true })
     }
@@ -271,4 +271,22 @@ test.describe('mode2 setup bump live', () => {
       fileVisibleInUi: await fileRow.isVisible().catch(() => false),
     })
   })
+})
+
+test('upload completion polling observes removed controls', async ({ page }) => {
+  test.setTimeout(5_000)
+  await page.setContent(`
+    <div data-testid="mdu-upload-card" data-panel-state="uploading"></div>
+    <button data-testid="mdu-commit" disabled>Confirming...</button>
+  `)
+  const commitBtn = page.getByTestId('mdu-commit')
+  await commitBtn.evaluate((button) => button.remove())
+  // Missing controls alone are not completion and must not block the next poll.
+  expect(await isCommitCompleteOrReset(page, commitBtn, 'uploaded.bin')).toBe(false)
+
+  await page.getByTestId('mdu-upload-card').evaluate((card) => card.setAttribute('data-panel-state', 'success'))
+
+  await expect.poll(() => isCommitCompleteOrReset(page, commitBtn, 'uploaded.bin'), { timeout: 1_000 }).toBe(true)
+  await page.setContent('')
+  expect(await isCommitCompleteOrReset(page, commitBtn, 'uploaded.bin')).toBe(false)
 })

--- a/polystore-website/tests/mode2-stripe.spec.ts
+++ b/polystore-website/tests/mode2-stripe.spec.ts
@@ -43,7 +43,7 @@ function extractManifestRoot(text: string): string {
 async function readDealManifestRoot(page: Page, dealId: string): Promise<string> {
   const cell = page.getByTestId(`deal-manifest-${dealId}`)
   if ((await cell.count().catch(() => 0)) === 0) return ''
-  const text = (await cell.first().textContent().catch(() => '')) || ''
+  const text = (await cell.first().allTextContents().then((texts) => texts[0] || '').catch(() => '')) || ''
   return extractManifestRoot(text)
 }
 
@@ -222,11 +222,11 @@ async function readDownloadBytesMaybe(page: Page, button: Locator, timeout = 90_
 }
 
 async function isUploaderResetToInitialState(page: Page): Promise<boolean> {
-  const panelState = await page.getByTestId('mdu-upload-card').getAttribute('data-panel-state').catch(() => null)
+  const panelState = await page.getByTestId('mdu-upload-card').evaluateAll((nodes) => nodes[0]?.getAttribute('data-panel-state') ?? null).catch(() => null)
   if (panelState !== 'idle') return false
-  const step2State = await page.getByTestId('workflow-step-2').getAttribute('data-step-state').catch(() => null)
-  const step3State = await page.getByTestId('workflow-step-3').getAttribute('data-step-state').catch(() => null)
-  const step4State = await page.getByTestId('workflow-step-4').getAttribute('data-step-state').catch(() => null)
+  const step2State = await page.getByTestId('workflow-step-2').evaluateAll((nodes) => nodes[0]?.getAttribute('data-step-state') ?? null).catch(() => null)
+  const step3State = await page.getByTestId('workflow-step-3').evaluateAll((nodes) => nodes[0]?.getAttribute('data-step-state') ?? null).catch(() => null)
+  const step4State = await page.getByTestId('workflow-step-4').evaluateAll((nodes) => nodes[0]?.getAttribute('data-step-state') ?? null).catch(() => null)
   const fileInputCount = await page.getByTestId('mdu-file-input').count().catch(() => 0)
   return step2State === 'idle' && step3State === 'idle' && step4State === 'idle' && fileInputCount > 0
 }
@@ -258,9 +258,9 @@ async function isCommitCompleteOrReset(
   if (allowFileRowCompletion && expectedFilePath) {
     if (await hasDealFileRow(page, expectedFilePath)) return true
   }
-  const panelState = await page.getByTestId('mdu-upload-card').getAttribute('data-panel-state').catch(() => null)
+  const panelState = await page.getByTestId('mdu-upload-card').evaluateAll((nodes) => nodes[0]?.getAttribute('data-panel-state') ?? null).catch(() => null)
   if (allowFileRowCompletion && panelState === 'success') return true
-  const text = ((await commitBtn.textContent().catch(() => '')) || '').trim()
+  const text = ((await commitBtn.allTextContents().then((texts) => texts[0] || '').catch(() => '')) || '').trim()
   if (/Committed!/i.test(text)) return true
   if (allowFileRowCompletion && allowReset && (await isUploaderResetToInitialState(page))) return true
   return false
@@ -294,7 +294,7 @@ async function completeUploadAndCommit(
     ) return
 
     const commitCount = await commitBtn.count().catch(() => 0)
-    const commitEnabled = commitCount > 0 && (await commitBtn.isEnabled().catch(() => false))
+    const commitEnabled = commitCount > 0 && (await commitBtn.evaluateAll((buttons) => buttons.length === 1 && buttons[0].matches(':enabled')).catch(() => false))
     if (commitEnabled) {
       await commitBtn.click()
       await expect
@@ -317,7 +317,7 @@ async function completeUploadAndCommit(
 
     const uploadCount = await uploadBtn.count().catch(() => 0)
     const uploadVisible = uploadCount > 0 && (await uploadBtn.isVisible().catch(() => false))
-    const uploadEnabled = uploadVisible && (await uploadBtn.isEnabled().catch(() => false))
+    const uploadEnabled = uploadVisible && (await uploadBtn.evaluateAll((buttons) => buttons.length === 1 && buttons[0].matches(':enabled')).catch(() => false))
     if (uploadEnabled) {
       await uploadBtn.click({ force: true })
       await expect
@@ -333,9 +333,9 @@ async function completeUploadAndCommit(
               allowFileRowCompletion,
             )
           ) return true
-          const enabled = await commitBtn.isEnabled().catch(() => false)
+          const enabled = await commitBtn.evaluateAll((buttons) => buttons.length === 1 && buttons[0].matches(':enabled')).catch(() => false)
           if (enabled) return true
-          const text = ((await uploadBtn.textContent().catch(() => '')) || '').trim()
+          const text = ((await uploadBtn.allTextContents().then((texts) => texts[0] || '').catch(() => '')) || '').trim()
           return /Upload Complete/i.test(text)
         }, { timeout: 120_000 })
         .toBe(true)
@@ -1370,15 +1370,15 @@ async function ensureWalletConnected(page: Page): Promise<void> {
 
     await waitForUploadControls(uploadBtn, commitBtn, 300_000)
     if ((await uploadBtn.count().catch(() => 0)) > 0 && (await uploadBtn.isVisible().catch(() => false))) {
-      const preUploadText = ((await uploadBtn.textContent().catch(() => '')) || '').trim()
+      const preUploadText = ((await uploadBtn.allTextContents().then((texts) => texts[0] || '').catch(() => '')) || '').trim()
       if (!/Upload Complete/i.test(preUploadText)) {
         await expect(uploadBtn).toBeEnabled({ timeout: 300_000 })
         await uploadBtn.click()
       }
       await expect
         .poll(async () => {
-          const text = (await uploadBtn.textContent().catch(() => '')) || ''
-          const committed = await commitBtn.isEnabled().catch(() => false)
+          const text = (await uploadBtn.allTextContents().then((texts) => texts[0] || '').catch(() => '')) || ''
+          const committed = await commitBtn.evaluateAll((buttons) => buttons.length === 1 && buttons[0].matches(':enabled')).catch(() => false)
           return /Upload Complete/i.test(text) || committed
         }, { timeout: 300_000 })
         .toBe(true)
@@ -1397,4 +1397,45 @@ async function ensureWalletConnected(page: Page): Promise<void> {
       })`,
     )
   })
+})
+
+test('upload completion polling observes removed controls', async ({ page }) => {
+  test.setTimeout(5_000)
+  await page.setContent(`
+    <div data-testid="mdu-upload-card" data-panel-state="uploading"></div>
+    <button data-testid="mdu-commit" disabled>Confirming...</button>
+  `)
+  const commitBtn = page.getByTestId('mdu-commit')
+  await commitBtn.evaluate((button) => button.remove())
+  // Missing controls alone are not completion and must not block the next poll.
+  expect(await isCommitCompleteOrReset(page, commitBtn, 'uploaded.bin', '', '', true)).toBe(false)
+
+  await page.setContent(`
+    <div data-testid="mdu-upload-card" data-panel-state="idle"></div>
+    <div data-testid="workflow-step-2" data-step-state="idle"></div>
+    <div data-testid="workflow-step-3" data-step-state="idle"></div>
+    <div data-testid="workflow-step-4" data-step-state="idle"></div>
+    <input data-testid="mdu-file-input" type="file">
+  `)
+
+  await expect.poll(() => isCommitCompleteOrReset(page, commitBtn, 'uploaded.bin', '', '', true), { timeout: 1_000 }).toBe(true)
+  expect(await isCommitCompleteOrReset(page, commitBtn, 'uploaded.bin', '', '', false)).toBe(false)
+  expect(await isCommitCompleteOrReset(page, commitBtn, 'uploaded.bin', '', '', true, false)).toBe(false)
+  await page.setContent('')
+  expect(await isCommitCompleteOrReset(page, commitBtn, 'uploaded.bin', '', '', true)).toBe(false)
+})
+
+test('upload completion polling survives automatic commit after upload removal', async ({ page }) => {
+  test.setTimeout(5_000)
+  await page.setContent(`
+    <div data-testid="mdu-upload-card" data-panel-state="uploading"></div>
+    <button data-testid="mdu-upload" onclick="this.remove(); setTimeout(() => {
+      const row = document.createElement('div');
+      row.dataset.testid = 'deal-detail-file-row';
+      row.dataset.filePath = 'uploaded.bin';
+      document.body.append(row);
+    }, 250)">Upload</button>
+  `)
+  await completeUploadAndCommit(page.getByTestId('mdu-upload'), page.getByTestId('mdu-commit'), 'uploaded.bin', '', 2_000)
+  await expect(page.getByTestId('deal-detail-file-row')).toHaveAttribute('data-file-path', 'uploaded.bin')
 })

--- a/polystore-website/tests/mode2-stripe.spec.ts
+++ b/polystore-website/tests/mode2-stripe.spec.ts
@@ -222,11 +222,11 @@ async function readDownloadBytesMaybe(page: Page, button: Locator, timeout = 90_
 }
 
 async function isUploaderResetToInitialState(page: Page): Promise<boolean> {
-  const panelState = await page.getByTestId('mdu-upload-card').evaluateAll((nodes) => nodes[0]?.getAttribute('data-panel-state') ?? null).catch(() => null)
+  const panelState = await page.getByTestId('mdu-upload-card').evaluateAll((nodes) => nodes.length === 1 ? nodes[0].getAttribute('data-panel-state') : null).catch(() => null)
   if (panelState !== 'idle') return false
-  const step2State = await page.getByTestId('workflow-step-2').evaluateAll((nodes) => nodes[0]?.getAttribute('data-step-state') ?? null).catch(() => null)
-  const step3State = await page.getByTestId('workflow-step-3').evaluateAll((nodes) => nodes[0]?.getAttribute('data-step-state') ?? null).catch(() => null)
-  const step4State = await page.getByTestId('workflow-step-4').evaluateAll((nodes) => nodes[0]?.getAttribute('data-step-state') ?? null).catch(() => null)
+  const step2State = await page.getByTestId('workflow-step-2').evaluateAll((nodes) => nodes.length === 1 ? nodes[0].getAttribute('data-step-state') : null).catch(() => null)
+  const step3State = await page.getByTestId('workflow-step-3').evaluateAll((nodes) => nodes.length === 1 ? nodes[0].getAttribute('data-step-state') : null).catch(() => null)
+  const step4State = await page.getByTestId('workflow-step-4').evaluateAll((nodes) => nodes.length === 1 ? nodes[0].getAttribute('data-step-state') : null).catch(() => null)
   const fileInputCount = await page.getByTestId('mdu-file-input').count().catch(() => 0)
   return step2State === 'idle' && step3State === 'idle' && step4State === 'idle' && fileInputCount > 0
 }
@@ -258,9 +258,9 @@ async function isCommitCompleteOrReset(
   if (allowFileRowCompletion && expectedFilePath) {
     if (await hasDealFileRow(page, expectedFilePath)) return true
   }
-  const panelState = await page.getByTestId('mdu-upload-card').evaluateAll((nodes) => nodes[0]?.getAttribute('data-panel-state') ?? null).catch(() => null)
+  const panelState = await page.getByTestId('mdu-upload-card').evaluateAll((nodes) => nodes.length === 1 ? nodes[0].getAttribute('data-panel-state') : null).catch(() => null)
   if (allowFileRowCompletion && panelState === 'success') return true
-  const text = ((await commitBtn.allTextContents().then((texts) => texts[0] || '').catch(() => '')) || '').trim()
+  const text = ((await commitBtn.allTextContents().then((texts) => texts.length === 1 ? texts[0] : '').catch(() => '')) || '').trim()
   if (/Committed!/i.test(text)) return true
   if (allowFileRowCompletion && allowReset && (await isUploaderResetToInitialState(page))) return true
   return false
@@ -335,7 +335,7 @@ async function completeUploadAndCommit(
           ) return true
           const enabled = await commitBtn.evaluateAll((buttons) => buttons.length === 1 && buttons[0].matches(':enabled')).catch(() => false)
           if (enabled) return true
-          const text = ((await uploadBtn.allTextContents().then((texts) => texts[0] || '').catch(() => '')) || '').trim()
+          const text = ((await uploadBtn.allTextContents().then((texts) => texts.length === 1 ? texts[0] : '').catch(() => '')) || '').trim()
           return /Upload Complete/i.test(text)
         }, { timeout: 120_000 })
         .toBe(true)
@@ -1370,14 +1370,14 @@ async function ensureWalletConnected(page: Page): Promise<void> {
 
     await waitForUploadControls(uploadBtn, commitBtn, 300_000)
     if ((await uploadBtn.count().catch(() => 0)) > 0 && (await uploadBtn.isVisible().catch(() => false))) {
-      const preUploadText = ((await uploadBtn.allTextContents().then((texts) => texts[0] || '').catch(() => '')) || '').trim()
+      const preUploadText = ((await uploadBtn.allTextContents().then((texts) => texts.length === 1 ? texts[0] : '').catch(() => '')) || '').trim()
       if (!/Upload Complete/i.test(preUploadText)) {
         await expect(uploadBtn).toBeEnabled({ timeout: 300_000 })
         await uploadBtn.click()
       }
       await expect
         .poll(async () => {
-          const text = (await uploadBtn.allTextContents().then((texts) => texts[0] || '').catch(() => '')) || ''
+          const text = (await uploadBtn.allTextContents().then((texts) => texts.length === 1 ? texts[0] : '').catch(() => '')) || ''
           const committed = await commitBtn.evaluateAll((buttons) => buttons.length === 1 && buttons[0].matches(':enabled')).catch(() => false)
           return /Upload Complete/i.test(text) || committed
         }, { timeout: 300_000 })
@@ -1408,6 +1408,19 @@ test('upload completion polling observes removed controls', async ({ page }) => 
   const commitBtn = page.getByTestId('mdu-commit')
   await commitBtn.evaluate((button) => button.remove())
   // Missing controls alone are not completion and must not block the next poll.
+  expect(await isCommitCompleteOrReset(page, commitBtn, 'uploaded.bin', '', '', true)).toBe(false)
+
+  // Duplicate locators remain invalid, matching the previous strict reads.
+  await page.setContent(`
+    <div data-testid="mdu-upload-card" data-panel-state="uploading"></div>
+    <button data-testid="mdu-commit" disabled>Committed!</button>
+    <button data-testid="mdu-commit" disabled>Committed!</button>
+  `)
+  expect(await isCommitCompleteOrReset(page, commitBtn, 'uploaded.bin', '', '', true)).toBe(false)
+  await page.setContent(`
+    <div data-testid="mdu-upload-card" data-panel-state="success"></div>
+    <div data-testid="mdu-upload-card" data-panel-state="success"></div>
+  `)
   expect(await isCommitCompleteOrReset(page, commitBtn, 'uploaded.bin', '', '', true)).toBe(false)
 
   await page.setContent(`


### PR DESCRIPTION
Conditional upload and commit controls disappear during automatic completion. The E2E helpers could wait for those missing controls inside a completion poll, preventing a later completed/reset state from being observed until the test timed out.

Use immediate Playwright text/attribute/enabled snapshots in the existing Mode2, gateway-absent and setup-bump upload helpers. Preserve the existing manifest, file-row, panel-success and permitted reset conditions. Four DOM-only browser regressions cover missing controls while still incomplete, completion after removal, strict reset restrictions and automatic commit after the upload control disappears. Run those regressions in the existing Playwright CI job before starting the dev server.

Validation:

- The four browser regressions fail against the original helpers at their five-second test bounds; all four pass after the fix (2.2 seconds total).
- Locally exercised with Playwright 1.57.0 and installed headless Chrome 152.0.7977.77 using a temporary configuration. CI uses its installed Chromium with the normal repository configuration.
- `git diff --check` passes. The exact CI regression command is:

```sh
cd polystore-website
npx playwright test tests/mode2-stripe.spec.ts tests/gateway-absent-ui.spec.ts tests/mode2-setup-bump-live.spec.ts --grep 'upload completion polling'
```

Related to #254. This repairs an existing synchronization defect exposed during #268 validation; it does not change retrieval or cryptographic behavior. The failed CI artifacts showed successful upload and reset, but did not retain a trace proving the exact blocked locator call. Full devnet retrieval coverage remains with the existing CI suites.
