### PR TITLE
Fix metadata replica fallback and concurrent proof preflight

### DIFF
--- a/polystore_gateway/router_proxy.go
+++ b/polystore_gateway/router_proxy.go
@@ -133,7 +133,7 @@ func proxyToProviderBaseURL(w http.ResponseWriter, r *http.Request, providerBase
 	}
 }
 
-func tryProxyToProviderBaseURL(w http.ResponseWriter, r *http.Request, providerBaseURL string) (bool, error) {
+func tryProxyToProviderBaseURL(w http.ResponseWriter, r *http.Request, providerBaseURL string, retryMissingMetadata bool) (bool, error) {
 	base := strings.TrimRight(strings.TrimSpace(providerBaseURL), "/")
 	if base == "" {
 		return false, fmt.Errorf("provider base url is empty")
@@ -161,6 +161,11 @@ func tryProxyToProviderBaseURL(w http.ResponseWriter, r *http.Request, providerB
 		return false, err
 	}
 	defer resp.Body.Close()
+
+	// Only the authority-checked metadata route can try another replica on 404.
+	if retryMissingMetadata && resp.StatusCode == http.StatusNotFound {
+		return false, fmt.Errorf("metadata replica missing requested MDU")
+	}
 
 	// Slot mismatch is a router concern (Mode 2): treat it as a routing miss so we can
 	// try another provider without leaking a confusing 400 back to the client.
@@ -391,7 +396,7 @@ func RouterGatewayFetch(w http.ResponseWriter, r *http.Request) {
 			lastErr = err
 			continue
 		}
-		ok, err := tryProxyToProviderBaseURL(w, r, baseURL)
+		ok, err := tryProxyToProviderBaseURL(w, r, baseURL, false)
 		if ok {
 			dealProviderCache.Store(dealID, &dealProviderCacheEntry{
 				provider: providerAddr,
@@ -422,7 +427,7 @@ func RouterGatewayFetch(w http.ResponseWriter, r *http.Request) {
 				lastErr = err
 				continue
 			}
-			ok, err := tryProxyToProviderBaseURL(w, r, baseURL)
+			ok, err := tryProxyToProviderBaseURL(w, r, baseURL, false)
 			if ok {
 				dealProviderCache.Store(dealID, &dealProviderCacheEntry{
 					provider: providerAddr,
@@ -597,7 +602,7 @@ func RouterGatewayMdu(w http.ResponseWriter, r *http.Request) {
 			lastErr = err
 			continue
 		}
-		handled, err := tryProxyToProviderBaseURL(w, r, base)
+		handled, err := tryProxyToProviderBaseURL(w, r, base, r.Header.Get("X-PolyStore-Session-Id") == "")
 		if handled {
 			return
 		}

--- a/polystore_gateway/router_retrieval_test.go
+++ b/polystore_gateway/router_retrieval_test.go
@@ -93,10 +93,10 @@ func TestGatewayMduFrozenPayeeRouting(t *testing.T) {
 			if got := invoke(nil); got.Code != 200 || got.Body.String() != "frozen response bytes" {
 				t.Fatalf("frozen routing failed: %d %s", got.Code, got.Body.String())
 			}
-			for _, status := range []int{http.StatusForbidden, http.StatusInternalServerError} {
+			for _, status := range []int{http.StatusNotFound, http.StatusForbidden, http.StatusInternalServerError} {
 				upstreamStatus = status
 				got := invoke(nil)
-				if got.Code == 200 {
+				if got.Code == 200 || (status == http.StatusNotFound && got.Code != http.StatusNotFound) {
 					t.Fatal("failed authorized provider fell back")
 				}
 			}
@@ -147,13 +147,14 @@ func TestGatewayMduPinnedMetadataRouting(t *testing.T) {
 			echo := "9"
 			requestedHeight := ""
 			allUnavailable := false
+			missingStatus := http.StatusInternalServerError
 			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				attempts++
 				if r.URL.Path != "/sp/retrieval/mdu/"+root.Canonical+"/0" || r.URL.Query().Get("committed_height") != "9" {
 					t.Errorf("unpinned metadata request: %s", r.URL)
 				}
 				if allUnavailable || attempts%2 == 1 {
-					w.WriteHeader(500)
+					w.WriteHeader(missingStatus)
 					return
 				}
 				w.Header().Set(committedHeightHeader, "9")
@@ -193,13 +194,17 @@ func TestGatewayMduPinnedMetadataRouting(t *testing.T) {
 				mode.handler(w, req)
 				return w
 			}
-			for _, height := range []string{"9", ""} {
-				attempts = 0
-				got := invoke(0, height)
-				if got.Code != 200 || got.Body.String() != "historical metadata" || got.Header().Get(committedHeightHeader) != "9" || requestedHeight != height || attempts != 2 {
-					t.Fatalf("metadata pin lost: code=%d body=%s query=%s attempts=%d", got.Code, got.Body.String(), requestedHeight, attempts)
+			for _, status := range []int{http.StatusInternalServerError, http.StatusNotFound} {
+				missingStatus = status
+				for _, height := range []string{"9", ""} {
+					attempts = 0
+					got := invoke(0, height)
+					if got.Code != 200 || got.Body.String() != "historical metadata" || got.Header().Get(committedHeightHeader) != "9" || requestedHeight != height || attempts != 2 {
+						t.Fatalf("metadata pin lost: code=%d body=%s query=%s attempts=%d", got.Code, got.Body.String(), requestedHeight, attempts)
+					}
 				}
 			}
+
 			attempts = 0
 			if got := invoke(2, "9"); got.Code != 400 || attempts != 0 {
 				t.Fatal("unfunded user MDU was proxied")

--- a/polystorechain/x/polystorechain/client/cli/tx_retrieval.go
+++ b/polystorechain/x/polystorechain/client/cli/tx_retrieval.go
@@ -477,9 +477,20 @@ func boundRetrievalProofTx(cmd *cobra.Command, clientCtx client.Context, msgs []
 		}
 		ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Second)
 		defer cancel()
-		result, err := querier.ConsensusParams(ctx, nil)
-		if err != nil || result == nil {
-			return clientCtx, fmt.Errorf("cannot obtain retrieval transaction block limits: %v", err)
+		var result *coretypes.ResultConsensusParams
+		for {
+			result, err = querier.ConsensusParams(ctx, nil)
+			if err == nil && result != nil {
+				break
+			}
+			// Comet's latest query uses BlockStore.Height()+1, which can advance
+			// before StateStore saves that height's parameters. Retry the current
+			// query within the existing deadline; never substitute stale limits.
+			select {
+			case <-ctx.Done():
+				return clientCtx, fmt.Errorf("cannot obtain retrieval transaction block limits: %v: %w", err, ctx.Err())
+			case <-time.After(50 * time.Millisecond):
+			}
 		}
 		block := result.ConsensusParams.Block
 		if block.MaxBytes <= retrievalSigningReserve+10 || block.MaxGas == 0 || block.MaxGas < -1 {

--- a/polystorechain/x/polystorechain/client/cli/tx_retrieval_submission_test.go
+++ b/polystorechain/x/polystorechain/client/cli/tx_retrieval_submission_test.go
@@ -182,13 +182,21 @@ func TestRetrievalProofLegacyShapesRemainSingleMessages(t *testing.T) {
 
 type retrievalTestRPC struct {
 	client.CometRPC
-	block        *cmttypes.BlockParams
-	err          error
-	broadcasts   []cmttypes.Tx
-	simulatedGas uint64
+	block         *cmttypes.BlockParams
+	err           error
+	broadcasts    []cmttypes.Tx
+	simulatedGas  uint64
+	missingParams int
 }
 
-func (r *retrievalTestRPC) ConsensusParams(context.Context, *int64) (*coretypes.ResultConsensusParams, error) {
+func (r *retrievalTestRPC) ConsensusParams(_ context.Context, height *int64) (*coretypes.ResultConsensusParams, error) {
+	if height != nil {
+		return nil, fmt.Errorf("must query current limits, not stale fallback")
+	}
+	if r.missingParams > 0 {
+		r.missingParams--
+		return nil, fmt.Errorf("could not find consensus params for height #8: value retrieved from db is empty")
+	}
 	return &coretypes.ResultConsensusParams{BlockHeight: 7, ConsensusParams: cmttypes.ConsensusParams{Block: *r.block}}, r.err
 }
 func (r *retrievalTestRPC) BroadcastTxSync(_ context.Context, bz cmttypes.Tx) (*coretypes.ResultBroadcastTx, error) {
@@ -215,14 +223,16 @@ func TestRetrievalProofSDKSignsOnceAndChecksFinalAutoGas(t *testing.T) {
 		name          string
 		gas           uint64
 		inflateSigned bool
+		missingParams int
 		wantError     string
 	}{
 		{name: "valid signed transaction", gas: 1_000_000},
+		{name: "concurrent commit delays current params", gas: 1_000_000, missingParams: 1},
 		{name: "final estimated gas exceeds cap", gas: uint64(types.MaxRetrievalV2BlockGas) + 1, wantError: "gas exceeds"},
 		{name: "final signed bytes exceed cap", gas: 1_000_000, inflateSigned: true, wantError: "protobuf bytes"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			rpc := &retrievalTestRPC{block: &cmttypes.BlockParams{MaxBytes: types.MaxRetrievalV2BlockBytes, MaxGas: types.MaxRetrievalV2BlockGas}, simulatedGas: tc.gas}
+			rpc := &retrievalTestRPC{block: &cmttypes.BlockParams{MaxBytes: types.MaxRetrievalV2BlockBytes, MaxGas: types.MaxRetrievalV2BlockGas}, simulatedGas: tc.gas, missingParams: tc.missingParams}
 			ctx := client.Context{}.WithCodec(cdc).WithTxConfig(config).WithFromAddress(signer).WithFromName("submitter").
 				WithKeyring(keys).WithChainID("cli-test").WithClient(rpc).WithAccountRetriever(client.MockAccountRetriever{ReturnAccNum: 2, ReturnAccSeq: 7}).
 				WithSkipConfirmation(true).WithBroadcastMode(flags.BroadcastSync).WithOutput(&bytes.Buffer{}).WithCmdContext(context.Background())
@@ -347,4 +357,11 @@ func TestRetrievalProofUnsignedAndSignedLimits(t *testing.T) {
 	bounded, err := boundRetrievalProofTx(cmd, ctx, []sdk.Msg{msg})
 	require.NoError(t, err)
 	require.Equal(t, 99990, bounded.TxConfig.(retrievalProofTxConfig).maxBytes)
+	rpc.err = fmt.Errorf("parameters remain unavailable")
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	cmd.SetContext(canceled)
+	_, err = boundRetrievalProofTx(cmd, ctx, []sdk.Msg{msg})
+	require.ErrorIs(t, err, context.Canceled)
+	require.Empty(t, rpc.broadcasts, "unavailable limits cannot reach signing/broadcast")
 }


### PR DESCRIPTION
Two qualification failures blocked healthy retrieval. A missing metadata replica returned 404 before the gateway tried another committed replica. During concurrent proof submission, Comet could publish a block height before persisting the next height's consensus parameters, causing the CLI's latest-limits query to fail before signing.

Metadata 404 now advances to the next bounded replica only on the authority-checked metadata route. Funded sessions retain their single frozen payee and forward its 404. The CLI retries the current consensus-parameter query within its existing five-second deadline; it does not substitute older limits, sign early, or retry a broadcast.

Validation: both regressions fail on the previous code. Gateway routing race tests pass (2.085 s), including ordinary/router entrypoints, pinned height, four-attempt bound and funded-payee isolation. The full CLI package passes (0.705 s), including actual SDK signing after a transient parameter failure and cancellation without broadcast. The original real four-validator pilot retained 26 accepted proofs, three unknown prebroadcast failures and two quarantined later operations; it remains unqualified. A fresh integrated pilot will validate the fix.

Addresses the metadata finding on #276 and the live pilot blocker in #260. Does not close #260 or claim sustained capacity.
