### PR TITLE
e2e: retain bounded retrieval transaction failure evidence

### DIFF
--- a/polystore-website/scripts/test_retrieval_failure_evidence.ts
+++ b/polystore-website/scripts/test_retrieval_failure_evidence.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { retrievalFailureEvidence } from '../tests/utils/retrievalFailureEvidence'
+
+const hash = '0x' + '11'.repeat(32), blockHash = '0x' + '22'.repeat(32)
+const transaction = { hash, blockHash, blockNumber: '0x80', from: '0x' + '33'.repeat(20),
+  to: '0x' + '44'.repeat(20), input: '0x12345678', gas: '0x10000', value: '0x0' }
+const receipt = { transactionHash: hash, blockHash, blockNumber: '0x80', status: '0x0', gasUsed: '0x10000' }
+const block = { hash: blockHash, number: '0x80', gasLimit: '0x1c9c380' }
+
+function mockRpc(replies: Record<string, unknown>) {
+  const calls: Array<{ method: string; params: any[] }> = []
+  const request: typeof fetch = async (_url, init) => {
+    assert.ok(init?.signal)
+    assert.equal(init.method, 'POST')
+    const body = JSON.parse(String(init.body))
+    calls.push(body)
+    const response = body.method === 'eth_call' ? { error: { code: 3, message: 'execution reverted', data: '0xdeadbeef' } } : { result: replies[body.method] }
+    return new Response(JSON.stringify({ jsonrpc: '2.0', id: body.id, ...response }))
+  }
+  return { request, calls }
+}
+const replies = { eth_getTransactionByHash: transaction, eth_getTransactionReceipt: receipt, eth_getBlockByHash: block }
+
+test('retains matching reverted transaction and bounded historical/current calls, never broadcasts', async () => {
+  const { request, calls } = mockRpc(replies)
+  const result = await retrievalFailureEvidence(hash, 'http://example.invalid', request)
+  assert.deepEqual(result.transaction?.result, transaction)
+  assert.deepEqual(result.receipt?.result, receipt)
+  assert.deepEqual(result.block?.result, block)
+  assert.equal(result.calls.length, 4)
+  const replay = calls.filter(c => c.method === 'eth_call')
+  assert.deepEqual(replay.map(c => c.params[1]), ['0x7f', '0x80', 'latest', '0x80'])
+  assert.deepEqual(replay.map(c => c.params[0].gas), ['0x10000', '0x10000', '0x10000', '0x20000'])
+  assert.ok(replay.every(c => c.params[0].data === transaction.input && c.params[0].from === transaction.from))
+  assert.deepEqual((result.calls[0] as { error: unknown }).error, { code: 3, message: 'execution reverted', data: '0xdeadbeef' })
+  assert.ok(calls.every(c => ['eth_getTransactionByHash', 'eth_getTransactionReceipt', 'eth_getBlockByHash', 'eth_call'].includes(c.method)))
+})
+
+test('missing or mismatched receipt and excessive gas never trigger speculative calls', async () => {
+  for (const wrong of [null, { ...receipt, transactionHash: '0x' + '55'.repeat(32) }, { ...receipt, blockNumber: '0x81' }]) {
+    const { request, calls } = mockRpc({ ...replies, eth_getTransactionReceipt: wrong })
+    assert.equal((await retrievalFailureEvidence(hash, 'http://example.invalid', request)).calls.length, 0)
+    assert.equal(calls.length, 2)
+  }
+  const { request, calls } = mockRpc({ ...replies, eth_getTransactionByHash: { ...transaction, gas: '0xffffffff' } })
+  assert.equal((await retrievalFailureEvidence(hash, 'http://example.invalid', request)).calls.length, 0)
+  assert.equal(calls.length, 3)
+})
+
+test('transport, oversized and malformed responses retain bounded errors without credentials', async () => {
+  for (const request of [
+    async () => { throw new Error('http://user:secret@example.invalid') },
+    async () => new Response('x'.repeat(1024 * 1024 + 1)),
+    async () => new Response(JSON.stringify({ jsonrpc: '2.0', id: 999, result: transaction })),
+  ]) {
+    const result = await retrievalFailureEvidence(hash, 'http://example.invalid', request)
+    assert.ok(result.transaction?.error)
+    assert.equal(result.calls.length, 0)
+    assert.ok(!JSON.stringify(result).includes('secret'))
+  }
+})

--- a/polystore-website/scripts/test_retrieval_failure_evidence.ts
+++ b/polystore-website/scripts/test_retrieval_failure_evidence.ts
@@ -9,7 +9,7 @@ const receipt = { transactionHash: hash, blockHash, blockNumber: '0x80', status:
 const block = { hash: blockHash, number: '0x80', gasLimit: '0x1c9c380' }
 
 function mockRpc(replies: Record<string, unknown>) {
-  const calls: Array<{ method: string; params: any[] }> = []
+  const calls: Array<{ method: string; params: [Record<string, string>, string] }> = []
   const request: typeof fetch = async (_url, init) => {
     assert.ok(init?.signal)
     assert.equal(init.method, 'POST')

--- a/polystore-website/tests/mode2-stripe.spec.ts
+++ b/polystore-website/tests/mode2-stripe.spec.ts
@@ -7,6 +7,7 @@ import { Readable } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
 import path from 'node:path'
 import { parsePinnedGeneration } from '../src/lib/retrieval'
+import { retrievalFailureEvidence } from './utils/retrievalFailureEvidence'
 import { dismissCreateDealDrawer, ensureCreateDealDrawerOpen } from './utils/dashboard'
 
 const dashboardPath = process.env.E2E_PATH || '/#/dashboard'
@@ -747,6 +748,15 @@ test.describe('mode2 streamed retrieval', () => {
       Object.assign(summary, { success: true, blobs, sessions: settled })
       console.log(`[streamed retrieval] ${size} bytes, ${expectedSessions} completed sessions, ${blobs} blobs, ${summary.retrievalMs}ms`)
     } finally {
+      // Collect before stack teardown, without retrying payment or masking failure.
+      if (summary.success !== true) {
+        try {
+          const failure = await readDownloadFailureBanner(page)
+          const hash = failure.match(/Retrieval transaction reverted \((0x[0-9a-f]{64})\)/i)?.[1]
+          if (hash) summary.failedTransaction = await retrievalFailureEvidence(hash,
+            process.env.VITE_EVM_RPC || `http://localhost:${process.env.EVM_RPC_PORT || '8545'}`)
+        } catch { summary.failedTransactionEvidenceError = 'Failure evidence unavailable' }
+      }
       try {
         await fs.writeFile(testInfo.outputPath('retrieval-summary.json'), JSON.stringify(summary, null, 2))
       } finally { await fs.rm(fixture, { force: true }) }

--- a/polystore-website/tests/utils/retrievalFailureEvidence.ts
+++ b/polystore-website/tests/utils/retrievalFailureEvidence.ts
@@ -4,7 +4,8 @@ const MAX_CALL_GAS = 30_000_000n
 const quantity = (value: unknown): value is string => typeof value === 'string' && /^0x(?:0|[1-9a-f][0-9a-f]*)$/i.test(value)
 const hex = (value: bigint) => `0x${value.toString(16)}`
 
-type Reply = { result?: any; error?: unknown }
+type Reply = { result?: unknown; error?: unknown }
+const record = (value: unknown): Record<string, unknown> => value !== null && typeof value === 'object' ? value as Record<string, unknown> : {}
 export async function retrievalFailureEvidence(hash: string, endpoint: string, request: typeof fetch = fetch) {
   const evidence: { hash: string; transaction?: Reply; receipt?: Reply; block?: Reply; calls: unknown[]; limitation: string } = {
     hash, calls: [], limitation: 'Diagnostic calls replay state at the selected block; they do not prove the original revert cause.',
@@ -24,7 +25,7 @@ export async function retrievalFailureEvidence(hash: string, endpoint: string, r
       const reader = response.body.getReader(), chunks: Uint8Array[] = []
       let size = 0
       try {
-        while (true) {
+        for (;;) {
           const { done, value } = await reader.read()
           if (done) break
           size += value.length
@@ -43,14 +44,14 @@ export async function retrievalFailureEvidence(hash: string, endpoint: string, r
   ;[evidence.transaction, evidence.receipt] = await Promise.all([
     rpc('eth_getTransactionByHash', [hash]), rpc('eth_getTransactionReceipt', [hash]),
   ])
-  const tx = evidence.transaction.result, receipt = evidence.receipt.result
-  if (tx?.hash?.toLowerCase() !== hash.toLowerCase() || receipt?.transactionHash?.toLowerCase() !== hash.toLowerCase() ||
+  const tx = record(evidence.transaction.result), receipt = record(evidence.receipt.result)
+  if ((typeof tx.hash === 'string' ? tx.hash.toLowerCase() : undefined) !== hash.toLowerCase() || (typeof receipt.transactionHash === 'string' ? receipt.transactionHash.toLowerCase() : undefined) !== hash.toLowerCase() ||
       !quantity(receipt.blockNumber) || BigInt(receipt.blockNumber) === 0n || tx.blockHash !== receipt.blockHash || tx.blockNumber !== receipt.blockNumber) return evidence
   evidence.block = await rpc('eth_getBlockByHash', [receipt.blockHash, false])
-  const block = evidence.block.result
+  const block = record(evidence.block.result)
   if (block?.hash !== receipt.blockHash || block?.number !== receipt.blockNumber || !quantity(block.gasLimit) ||
       !quantity(tx.gas) || !quantity(tx.value) || BigInt(tx.gas) > MAX_CALL_GAS ||
-      !/^0x[0-9a-f]{40}$/i.test(tx.from) || !/^0x[0-9a-f]{40}$/i.test(tx.to) ||
+      typeof tx.from !== 'string' || !/^0x[0-9a-f]{40}$/i.test(tx.from) || typeof tx.to !== 'string' || !/^0x[0-9a-f]{40}$/i.test(tx.to) ||
       typeof tx.input !== 'string' || tx.input.length > 262146 || !/^0x(?:[0-9a-f]{2})*$/i.test(tx.input)) return evidence
   const call = { from: tx.from, to: tx.to, data: tx.input, value: tx.value, gas: tx.gas }
   const largerGas = [BigInt(tx.gas) * 2n, BigInt(block.gasLimit), MAX_CALL_GAS].reduce((a, b) => a < b ? a : b)

--- a/polystore-website/tests/utils/retrievalFailureEvidence.ts
+++ b/polystore-website/tests/utils/retrievalFailureEvidence.ts
@@ -1,0 +1,69 @@
+// Read-only evidence for one failed transaction. Never resend or replace it.
+const MAX_RESPONSE_BYTES = 1024 * 1024
+const MAX_CALL_GAS = 30_000_000n
+const quantity = (value: unknown): value is string => typeof value === 'string' && /^0x(?:0|[1-9a-f][0-9a-f]*)$/i.test(value)
+const hex = (value: bigint) => `0x${value.toString(16)}`
+
+type Reply = { result?: any; error?: unknown }
+export async function retrievalFailureEvidence(hash: string, endpoint: string, request: typeof fetch = fetch) {
+  const evidence: { hash: string; transaction?: Reply; receipt?: Reply; block?: Reply; calls: unknown[]; limitation: string } = {
+    hash, calls: [], limitation: 'Diagnostic calls replay state at the selected block; they do not prove the original revert cause.',
+  }
+  if (!/^0x[0-9a-f]{64}$/i.test(hash)) return evidence
+  const deadline = AbortSignal.timeout(15_000)
+  let id = 0
+  const rpc = async (method: string, params: unknown[]): Promise<Reply> => {
+    const requestId = ++id
+    try {
+      const response = await request(endpoint, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: requestId, method, params }),
+        signal: AbortSignal.any([deadline, AbortSignal.timeout(3000)]),
+      })
+      if (!response.ok || !response.body) return { error: { httpStatus: response.status } }
+      const reader = response.body.getReader(), chunks: Uint8Array[] = []
+      let size = 0
+      try {
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) break
+          size += value.length
+          if (size > MAX_RESPONSE_BYTES) { await reader.cancel(); return { error: 'response exceeds 1 MiB' } }
+          chunks.push(value)
+        }
+      } finally { reader.releaseLock() }
+      const body = JSON.parse(Buffer.concat(chunks).toString('utf8'))
+      if (body.jsonrpc !== '2.0' || body.id !== requestId || ('result' in body) === ('error' in body)) return { error: 'malformed JSON-RPC response' }
+      return 'error' in body ? { error: body.error } : { result: body.result }
+    } catch (error) {
+      // Transport errors can contain credential-bearing URLs. Retain only their type.
+      return { error: error instanceof Error ? error.name : 'request failed' }
+    }
+  }
+  ;[evidence.transaction, evidence.receipt] = await Promise.all([
+    rpc('eth_getTransactionByHash', [hash]), rpc('eth_getTransactionReceipt', [hash]),
+  ])
+  const tx = evidence.transaction.result, receipt = evidence.receipt.result
+  if (tx?.hash?.toLowerCase() !== hash.toLowerCase() || receipt?.transactionHash?.toLowerCase() !== hash.toLowerCase() ||
+      !quantity(receipt.blockNumber) || BigInt(receipt.blockNumber) === 0n || tx.blockHash !== receipt.blockHash || tx.blockNumber !== receipt.blockNumber) return evidence
+  evidence.block = await rpc('eth_getBlockByHash', [receipt.blockHash, false])
+  const block = evidence.block.result
+  if (block?.hash !== receipt.blockHash || block?.number !== receipt.blockNumber || !quantity(block.gasLimit) ||
+      !quantity(tx.gas) || !quantity(tx.value) || BigInt(tx.gas) > MAX_CALL_GAS ||
+      !/^0x[0-9a-f]{40}$/i.test(tx.from) || !/^0x[0-9a-f]{40}$/i.test(tx.to) ||
+      typeof tx.input !== 'string' || tx.input.length > 262146 || !/^0x(?:[0-9a-f]{2})*$/i.test(tx.input)) return evidence
+  const call = { from: tx.from, to: tx.to, data: tx.input, value: tx.value, gas: tx.gas }
+  const largerGas = [BigInt(tx.gas) * 2n, BigInt(block.gasLimit), MAX_CALL_GAS].reduce((a, b) => a < b ? a : b)
+  const cases = [
+    { blockTag: hex(BigInt(receipt.blockNumber) - 1n), gas: tx.gas },
+    { blockTag: receipt.blockNumber, gas: tx.gas },
+    { blockTag: 'latest', gas: tx.gas },
+    ...(largerGas > BigInt(tx.gas) ? [{ blockTag: receipt.blockNumber, gas: hex(largerGas) }] : []),
+  ]
+  // Sequential calls avoid piling diagnostic EVM work onto the failed stack.
+  for (const row of cases) {
+    if (deadline.aborted) break
+    evidence.calls.push({ ...row, ...await rpc('eth_call', [{ ...call, gas: row.gas }, row.blockTag]) })
+  }
+  return evidence
+}


### PR DESCRIPTION
The streamed retrieval test previously retained only a reverted transaction hash before tearing down its isolated chain, leaving the original failure unexplained. Its existing failure cleanup now records that transaction, receipt and block in the already-uploaded `retrieval-summary.json`, followed by read-only diagnostic calls at the prior, receipt and latest heights and a capped larger-gas comparison.

Collection has a 15-second RPC deadline, a 3-second limit per request, a 1 MiB response limit and a 30M diagnostic gas ceiling. It does not retry transactions, read browser storage or change the original test failure. Diagnostic replays are explicitly not treated as proof of the original revert cause; the H127-to-H128 gas hypothesis remains unconfirmed.

Validation: three offline source tests passed with `tsx --test scripts/test_retrieval_failure_evidence.ts`; `git diff --check` passed. No builds, services or large retrieval reruns were performed. Actual hosted failure-artifact collection remains unvalidated.

Related to #260. This instrumentation does not complete its 1 GiB gate.
