### PR TITLE
fix: buffer browser retrieval gas before broadcasting

### DIFF
--- a/polystore-website/src/hooks/useRetrievalSessions.ts
+++ b/polystore-website/src/hooks/useRetrievalSessions.ts
@@ -7,7 +7,7 @@ import { decodeComputeRetrievalSessionIdsResult, encodeConfirmRetrievalSessionsD
 import { account, fetchFrozenSession, fetchActiveRetrievalGeneration, fetchRetrievalAvailability, type FrozenSession, type PinnedGeneration, type RetrievalWindow, u64, uint, unhex } from '../lib/retrieval'
 import { waitForRetrievalChallenge } from '../lib/retrievalFlow'
 import type { SponsoredRetrievalAuth } from './useFetch'
-import { assertRetrievalWalletScope, browserRetrievalStore, retrievalIntentKey, settleBrowserTransaction, withRetrievalLock } from '../lib/retrievalTransactions'
+import { assertRetrievalWalletScope, browserRetrievalStore, retrievalIntentKey, retrievalGasLimit, settleBrowserTransaction, withRetrievalLock } from '../lib/retrievalTransactions'
 
 let lastBrowserNonce = 0n
 
@@ -49,6 +49,7 @@ export function useRetrievalSessions() {
       if (current.root !== pin.root || current.generation !== pin.generation || current.layout !== pin.layout || current.k !== pin.k || current.m !== pin.m || current.metadataMdus !== pin.metadataMdus || current.userMdus !== pin.userMdus || current.owner !== pin.owner || current.endHeight !== pin.endHeight || windows.some((w) => !current.assignments[w.slot]?.active || current.assignments[w.slot].provider !== w.provider)) throw new Error('committed generation or assignment changed before payment')
       const key = 'open:' + await retrievalIntentKey([scope(), recoveryKey, pin.dealId, pin.root, pin.generation, windows.map((w) => [w.mduIndex, w.startBlobIndex, w.blobCount, w.provider, w.slot]), deputy, auth])
       return withRetrievalLock(key, async () => {
+        let gas = 0n
         const transaction = await settleBrowserTransaction({
           key, store: browserRetrievalStore(), signal: deadline,
           prepare: async () => {
@@ -72,9 +73,11 @@ export function useRetrievalSessions() {
             const sponsored = requests.map((r) => ({ ...r, maxTotalFee: 0n, authType: auth.type === 'allowlist' ? 1 : auth.type === 'voucher' ? 2 : 0,
               allowlistLeafIndex: auth.type === 'allowlist' ? uint(auth.leafIndex) : 0, allowlistMerklePath: auth.type === 'allowlist' ? auth.merklePath : [],
               voucherRedeemer: voucher?.redeemer ?? '', voucherProvider: voucher?.provider ?? '', voucherExpiresAt: numberU64(voucher?.expiresAt), voucherNonce: numberU64(voucher?.nonce), voucherSignature: voucher?.signature ?? '0x' as Hex }))
-            return { data: encodeRetrievalV2Data(isOwner ? 'openRetrievalSessions' : 'openRetrievalSessionsSponsored', isOwner ? requests : sponsored), intent: { ids: ids.sessionIds, pin } }
+            const data = encodeRetrievalV2Data(isOwner ? 'openRetrievalSessions' : 'openRetrievalSessionsSponsored', isOwner ? requests : sponsored)
+            gas = retrievalGasLimit(await client.estimateGas({ account: address, to: appConfig.polystorePrecompile as Hex, data }))
+            return { data, intent: { ids: ids.sessionIds, pin } }
           },
-          send: (data) => wallet.sendTransaction({ chain: client.chain, account: address, to: appConfig.polystorePrecompile as Hex, data }),
+          send: (data) => wallet.sendTransaction({ chain: client.chain, account: address, to: appConfig.polystorePrecompile as Hex, data, gas }),
           receipt: (hash) => client.waitForTransactionReceipt({ hash, timeout: 120_000 }),
           reconcile: async (tx) => {
             const signal = AbortSignal.timeout(15_000)
@@ -91,10 +94,15 @@ export function useRetrievalSessions() {
       if (!sessions.length || sessions.length > 64) throw new Error('invalid confirmation wave')
       const { address, wallet, client } = requireWallet()
       const key = 'ack:' + await retrievalIntentKey([scope(), recoveryKey, sessions.map((s) => s.sessionId)])
+      let gas = 0n
       await withRetrievalLock(key, () => settleBrowserTransaction({
         key, store: browserRetrievalStore(), signal,
-        prepare: async () => ({ data: encodeConfirmRetrievalSessionsData(sessions.map((s) => s.sessionId)), intent: sessions.map((s) => s.sessionId) }),
-        send: (data) => wallet.sendTransaction({ chain: client.chain, account: address, to: appConfig.polystorePrecompile as Hex, data }),
+        prepare: async () => {
+          const data = encodeConfirmRetrievalSessionsData(sessions.map((s) => s.sessionId))
+          gas = retrievalGasLimit(await client.estimateGas({ account: address, to: appConfig.polystorePrecompile as Hex, data }))
+          return { data, intent: sessions.map((s) => s.sessionId) }
+        },
+        send: (data) => wallet.sendTransaction({ chain: client.chain, account: address, to: appConfig.polystorePrecompile as Hex, data, gas }),
         receipt: (hash) => client.waitForTransactionReceipt({ hash, timeout: 120_000 }),
         reconcile: async () => {
           const deadline = AbortSignal.timeout(15_000)

--- a/polystore-website/src/lib/retrievalGas.test.ts
+++ b/polystore-website/src/lib/retrievalGas.test.ts
@@ -1,0 +1,90 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import ts from 'typescript'
+import * as transactions from './retrievalTransactions'
+import type { FrozenSession, PinnedGeneration, RetrievalWindow } from './retrieval'
+
+// Execute both actual hook paths; replace only transport/storage boundaries.
+function fixture(mode: 'open' | 'ack') {
+  const records = new Map<string, unknown>()
+  const store: transactions.RetrievalStore = { get: <T>(key: string) => records.get(key) as T | undefined,
+    put: (key, value) => { records.set(key, value) }, remove: (key) => { records.delete(key) } }
+  const hash = `0x${'12'.repeat(32)}` as const, address = '0x1111111111111111111111111111111111111111'
+  const precompile = '0x2222222222222222222222222222222222222222'
+  let estimates = 0, sends = 0, failEstimate = false, loseHash = false, reverted = false
+  const pin = { dealId: 1n, owner: 'owner', root: hash, generation: 1n, layout: 'mode2', k: 2, m: 1,
+    metadataMdus: 2n, userMdus: 1n, endHeight: 1000n, height: 10n, assignments: [{ active: true, provider: 'provider' }] }
+  const window = { slot: 0, provider: 'provider', mduIndex: 2n, startBlobIndex: 0, blobCount: 1 }
+  const session = { sessionId: hash, pin, window, owner: 'owner', payee: 'provider', funding: 1, status: 2 }
+  const client = { chain: { id: 1 }, call: async () => ({ data: '0xab' }),
+    estimateGas: async (request: unknown) => {
+      estimates++
+      assert.deepEqual(request, { account: address, to: precompile, data: '0x1234' })
+      if (failEstimate) throw new Error('estimator unavailable')
+      return 226673n
+    },
+    waitForTransactionReceipt: async () => ({ transactionHash: hash, status: reverted ? 'reverted' : 'success', blockNumber: 128n }),
+  }
+  const wallet = { chain: client.chain, sendTransaction: async (request: unknown) => {
+    sends++
+    assert.deepEqual(request, { chain: client.chain, account: address, to: precompile, data: '0x1234', gas: 282008n })
+    if (loseHash) throw new Error('lost wallet hash')
+    return hash
+  } }
+  const modules: Record<string, unknown> = {
+    wagmi: { useAccount: () => ({ address }), usePublicClient: () => client, useWalletClient: () => ({ data: wallet }) },
+    '@tanstack/react-query': { useQuery: () => ({ data: null }) },
+    '../config': { appConfig: { chainId: 1, cosmosChainId: 'chain', polystorePrecompile: precompile } },
+    '../lib/address': { ethToPolystoreAddress: () => 'owner' },
+    '../lib/polystorePrecompile': { encodeRetrievalV2Data: () => '0x1234', encodeConfirmRetrievalSessionsData: () => '0x1234',
+      decodeComputeRetrievalSessionIdsResult: () => ({ providers: ['provider'], sessionIds: [hash] }) },
+    '../lib/retrieval': { fetchActiveRetrievalGeneration: async () => pin, fetchFrozenSession: async () => { if (loseHash) throw new Error('session not observed'); return session },
+      unhex: () => new Uint8Array(32) },
+    '../lib/retrievalFlow': { waitForRetrievalChallenge: async () => session },
+    '../lib/retrievalTransactions': { ...transactions, browserRetrievalStore: () => store,
+      retrievalIntentKey: async () => 'test', withRetrievalLock: (_key: string, work: () => unknown) => work() },
+  }
+  const source = readFileSync(new URL('../hooks/useRetrievalSessions.ts', import.meta.url), 'utf8')
+  const code = ts.transpileModule(source, { compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022 } }).outputText
+  const exports: { useRetrievalSessions?: typeof import('../hooks/useRetrievalSessions').useRetrievalSessions } = {}
+  new Function('require', 'exports', code)((name: string) => {
+    if (!(name in modules)) throw new Error('unexpected hook dependency: ' + name)
+    return modules[name]
+  }, exports)
+  const hook = exports.useRetrievalSessions!()
+  return { store, get estimates() { return estimates }, get sends() { return sends },
+    set failEstimate(value: boolean) { failEstimate = value }, set loseHash(value: boolean) { loseHash = value },
+    set reverted(value: boolean) { reverted = value },
+    run: () => mode === 'open' ? hook.open(pin as unknown as PinnedGeneration, [window as RetrievalWindow]) : hook.confirm([session as unknown as FrozenSession]),
+    key: mode === 'open' ? 'open:test' : 'ack:test' }
+}
+
+test('retrieval gas margin rounds upward without lossy number conversion', () => {
+  assert.equal(transactions.retrievalGasLimit(1n), 10002n)
+  const large = BigInt(Number.MAX_SAFE_INTEGER) + 42n
+  assert.equal(transactions.retrievalGasLimit(large), (large * 6n + 4n) / 5n + 10000n)
+  for (const bad of [0n, -1n]) assert.throws(() => transactions.retrievalGasLimit(bad))
+})
+
+for (const mode of ['open', 'ack'] as const) {
+  test(`${mode}: estimate failure stays pre-broadcast and explicit retry estimates again`, async () => {
+    const f = fixture(mode); f.failEstimate = true
+    await assert.rejects(f.run(), /estimator unavailable/)
+    assert.equal(f.sends, 0); assert.equal(f.store.get(f.key), undefined)
+    f.failEstimate = false
+    await f.run()
+    assert.equal(f.estimates, 2); assert.equal(f.sends, 1)
+  })
+  test(`${mode}: proven revert re-estimates, lost hash never re-estimates or resends`, async () => {
+    const f = fixture(mode); f.reverted = true
+    await assert.rejects(f.run(), /reverted/)
+    f.reverted = false
+    await f.run()
+    assert.equal(f.estimates, 2); assert.equal(f.sends, 2)
+    const lost = fixture(mode); lost.loseHash = true
+    await assert.rejects(lost.run(), /wallet returned no hash/)
+    await assert.rejects(lost.run(), /outcome is unresolved/)
+    assert.equal(lost.estimates, 1); assert.equal(lost.sends, 1)
+  })
+}

--- a/polystore-website/src/lib/retrievalTransactions.ts
+++ b/polystore-website/src/lib/retrievalTransactions.ts
@@ -1,5 +1,12 @@
 import type { Hex } from 'viem'
 
+// Cover modest state-dependent execution drift (including protobuf height
+// boundaries), not arbitrary state changes. Bigint keeps large estimates exact.
+export function retrievalGasLimit(estimate: bigint): bigint {
+  if (estimate <= 0n) throw new Error('invalid retrieval gas estimate')
+  return (estimate * 120n + 99n) / 100n + 10_000n
+}
+
 const PREFIX = 'polystore-retrieval-v1:'
 // A 1 GiB download has 133 MDU waves: one open, ACK, and settlement
 // record per wave, plus its output cursor. Never evict unresolved payments.

--- a/polystorechain/app/retrieval_ack_height_gas_test.go
+++ b/polystorechain/app/retrieval_ack_height_gas_test.go
@@ -1,0 +1,78 @@
+package app
+
+import (
+	"bytes"
+	"math/big"
+	"strings"
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
+	storetypes "cosmossdk.io/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	polystoreprecompile "polystorechain/precompiles/polystore"
+	"polystorechain/x/polystorechain/types"
+)
+
+// This isolates native settlement's height-dependent serialization cost. It is
+// not an eth_estimateGas RPC regression: transaction intrinsic gas is excluded.
+func TestRetrievalACKHeightVarintGasBoundary(t *testing.T) {
+	a, base := nativePrecompileApp(t)
+	caller := common.HexToAddress("0xac01")
+	owner := sdk.AccAddress(caller.Bytes()).String()
+	params := types.DefaultParams()
+	params.RetrievalV2ActivationHeight = 0 // Legacy fixture isolates the shared settlement write path.
+	require.NoError(t, a.PolyStoreChainKeeper.Params.Set(base, params))
+	api, err := abi.JSON(strings.NewReader(`[{"name":"confirmRetrievalSessions","type":"function","inputs":[{"type":"bytes32[]"}],"outputs":[{"type":"bool"}]}]`))
+	require.NoError(t, err)
+	for _, count := range []int{1, 64} {
+		t.Run(new(big.Int).SetInt64(int64(count)).String(), func(t *testing.T) {
+			prepared, _ := base.CacheContext()
+			ids := make([][32]byte, count)
+			for i := range ids {
+				copy(ids[i][:], bytes.Repeat([]byte{byte(i + 1)}, 32))
+				session := types.RetrievalSession{SessionId: ids[i][:], Owner: owner, Provider: owner,
+					DealId: uint64(i), ExpiresAt: 512, UpdatedHeight: 126, LockedFee: sdkmath.ZeroInt(),
+					Status: types.RetrievalSessionStatus_RETRIEVAL_SESSION_STATUS_PROOF_SUBMITTED, TotalBytes: 131072}
+				require.NoError(t, a.PolyStoreChainKeeper.RetrievalSessions.Set(prepared, ids[i][:], session))
+				require.NoError(t, a.PolyStoreChainKeeper.RetrievalSessionProofProvider.Set(prepared, ids[i][:], owner))
+			}
+			data, err := api.Pack("confirmRetrievalSessions", ids)
+			require.NoError(t, err)
+			call := func(height int64, gas uint64) (uint64, error) {
+				ctx, _ := prepared.CacheContext() // Identical pre-ACK state for every estimate/replay.
+				ctx = ctx.WithBlockHeight(height).WithGasMeter(storetypes.NewInfiniteGasMeter()).WithKVGasConfig(storetypes.KVGasConfig()).WithTransientKVGasConfig(storetypes.TransientGasConfig())
+				evm, state := nativeEVM(t, a, ctx)
+				evm.Context.BlockNumber = big.NewInt(height)
+				_, left, callErr := evm.Call(caller, polystoreprecompile.Address, data, gas, uint256.NewInt(0))
+				require.NoError(t, state.Commit())
+				for _, id := range ids {
+					session, getErr := a.PolyStoreChainKeeper.RetrievalSessions.Get(ctx, id[:])
+					require.NoError(t, getErr)
+					if callErr == nil {
+						require.Equal(t, types.RetrievalSessionStatus_RETRIEVAL_SESSION_STATUS_COMPLETED, session.Status)
+						require.Equal(t, height, session.UpdatedHeight)
+					} else {
+						require.Equal(t, types.RetrievalSessionStatus_RETRIEVAL_SESSION_STATUS_PROOF_SUBMITTED, session.Status)
+						require.Equal(t, int64(126), session.UpdatedHeight)
+					}
+				}
+				return gas - left, callErr
+			}
+			before, err := call(127, 20000000)
+			require.NoError(t, err)
+			after, err := call(128, 20000000)
+			require.NoError(t, err)
+			require.Greater(t, after, before)
+			_, err = call(127, before)
+			require.NoError(t, err, "measured H127 gas must suffice at H127")
+			_, err = call(128, before)
+			require.Error(t, err, "the same H127 gas limit must fail at H128")
+			t.Logf("sessions=%d gas127=%d gas128=%d delta=%d", count, before, after, after-before)
+		})
+	}
+}


### PR DESCRIPTION
Browser retrieval open and confirmation previously sent transactions with the wallet's exact gas estimate. A native EVM regression demonstrates a concrete failure: the same ACK requires 60 extra gas per session when its stored height crosses 127 to 128, so the earlier sufficient limit reverts at the later height.

Both browser paths now estimate their exact account, destination and calldata during preparation, then send with a bigint 20% margin plus 10,000 gas. Estimation failures occur before the durable broadcasting state. Explicit retries of proven reverted/prepared transactions estimate again; an unresolved transaction or lost wallet hash still cannot trigger a replacement send. This margin covers modest execution drift, not arbitrary state changes.

Validation: the native EVM regression passed with default KV gas charges and verified rollback (one session: 226,673 → 226,733 gas; 64 sessions: 1,637,054 → 1,640,894). It isolates shared settlement writes using a legacy fixture; it is not a full RPC estimator or v2 integration test. The actual browser-hook test failed on the old source and passes on the fix; all 18 relevant browser transaction tests pass. Focused lint and TypeScript checking pass. Root source review found no issues.

Related to #260. This fixes the independently reproduced height-boundary hazard. The original 1 GiB hosted revert remains unconfirmed because its receipt was not retained; #280 adds diagnostics before another large run. No delivery or capacity qualification is claimed here.
