### PR TITLE
test: connect browser retrieval delivery to authorized deputy payout

### DIFF
--- a/.github/workflows/e2e_heavy_nightly.yml
+++ b/.github/workflows/e2e_heavy_nightly.yml
@@ -111,6 +111,7 @@ jobs:
           path: |
             _artifacts/devnet_alpha_multi_sp/*.log
             polystore-website/test-results/**/retrieval-summary.json
+            polystore-website/test-results/**/retrieval-delivery-accounting.json
             polystore-website/test-results/**/error-context.md
             ${{ !inputs.run_mode2_large && 'polystore-website/test-results/**/*.png' || '' }}
             ${{ !inputs.run_mode2_large && 'polystore-website/test-results/**/*.zip' || '' }}

--- a/polystore-website/tests/mode2-stripe.spec.ts
+++ b/polystore-website/tests/mode2-stripe.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Download, type Locator, type Page } from '@playwright/test'
 import crypto from 'node:crypto'
+import { execFileSync } from 'node:child_process'
 import fs from 'node:fs/promises'
 import { createWriteStream } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -769,7 +770,7 @@ test.describe('mode2 streamed retrieval', () => {
   test.use({ acceptDownloads: true })
   test.describe.configure({ retries: process.env.CI && !isMode2Fast ? 1 : 0 })
 
-  test('mode2 deal → shard → upload → commit → retrieve', async ({ page }) => {
+  test('mode2 deal → shard → upload → commit → retrieve', async ({ page }, testInfo) => {
     test.setTimeout(mode2FastTestTimeoutMs)
 
     // The deployed default is disabled. The UI must wait for committed
@@ -839,21 +840,113 @@ test.describe('mode2 streamed retrieval', () => {
         windows.push({ gateway: isGatewayOrigin(new URL(request.url()).origin), session })
       }
     })
+    const lcd = process.env.VITE_LCD_BASE || `http://localhost:${process.env.LCD_PORT || 1317}`
+    const api = '/polystorechain/polystorechain/v1'
+    const query = async (resource: string, height?: string) => {
+      const response = await page.request.get(lcd + resource, {
+        headers: height ? { 'x-cosmos-block-height': height } : {}, timeout: 15_000,
+      })
+      expect(response.ok()).toBe(true)
+      const observedHeight = response.headers()['x-cosmos-block-height']
+      expect(observedHeight).toMatch(/^[1-9][0-9]*$/)
+      if (height) expect(observedHeight).toBe(height)
+      return { body: await response.json(), height: observedHeight }
+    }
+    const sessionPath = (id: string) => `${api}/retrieval-sessions/${encodeURIComponent(Buffer.from(id.slice(2), 'hex').toString('base64url') + '=')}`
+    const stake = async (payee: string, height: string) => {
+      const { body } = await query(`/cosmos/bank/v1beta1/balances/${payee}/by_denom?denom=stake`, height)
+      expect(body.balance.denom).toBe('stake')
+      return String(body.balance.amount)
+    }
+    type Opened = { id: string; payee: string; assigned: string; root: string; height: string; locked: string; stake: string; mdu: string; startBlob: number; blobs: number; contextHash: string }
+    const opened = new Map<string, Opened>()
+    const proofOutcomes = new Map<string, { tx_hash: string; provider: string; ackHeight: string }>()
+    const settlements: object[] = []
+    let rejectedWindow: { session: string; status: number; error: string } | undefined
+    // Inspect live authority before forwarding a paid window. No response or
+    // authorization is fabricated; the negative request changes only a hint.
+    await page.route(/\/(?:gateway|sp\/retrieval)\/mdu\//, async (route) => {
+      const request = route.request(), headers = request.headers(), id = headers['x-polystore-session-id']
+      if (!id) return route.continue()
+      expect(id).toMatch(/^0x[0-9a-f]{64}$/)
+      if (!opened.has(id)) {
+        const { body: { session, challenge_context_hash }, height } = await query(sessionPath(id))
+        expect(session.status).toBe('RETRIEVAL_SESSION_STATUS_OPEN')
+        expect(Buffer.from(session.session_id, 'base64').toString('hex')).toBe(id.slice(2))
+        expect(String(session.deal_id ?? 0)).toBe(dealId)
+        opened.set(id, { id, payee: session.authorized_proof_provider, assigned: session.provider,
+          root: session.manifest_root, height, locked: session.locked_fee,
+          mdu: String(session.start_mdu_index), startBlob: Number(session.start_blob_index), blobs: Number(session.blob_count),
+          contextHash: challenge_context_hash,
+          stake: await stake(session.authorized_proof_provider, height) })
+        if (!rejectedWindow) {
+          const bad = await page.request.get(request.url(), { headers: {
+            ...headers, 'x-polystore-blob-count': String(Number(session.blob_count) + 1),
+          } })
+          expect(bad.status()).toBe(400)
+          const rejection = await bad.json()
+          expect(rejection.error).toBe('window hint does not match frozen session')
+          rejectedWindow = { session: id, status: bad.status(), error: rejection.error }
+        }
+      }
+      await route.continue()
+    })
+    await page.route('**/gateway/session-proof?*', async (route) => {
+      const request = route.request()
+      if (request.method() !== 'POST') return route.continue()
+      const input = request.postDataJSON()
+      const { body: { session }, height: ackHeight } = await query(sessionPath(input.session_id))
+      expect(session.status).toBe('RETRIEVAL_SESSION_STATUS_USER_CONFIRMED')
+      expect(session.authorized_proof_provider).toBe(input.provider)
+      const response = await route.fetch({ timeout: 100_000 })
+      const result = await response.json()
+      expect(response.status()).toBe(200)
+      expect(result.session_id).toBe(input.session_id)
+      expect(result.tx_hash).toMatch(/^[0-9a-fA-F]{64}$/)
+      proofOutcomes.set(input.session_id, { tx_hash: result.tx_hash, provider: input.provider, ackHeight })
+      await route.fulfill({ response })
+    })
     const assertSettled = async () => {
       await expect(page.getByRole('status').filter({ hasText: /unsettled provider payment/ })).toHaveCount(0)
       const ids = [...new Set(windows.map((window) => window.session))]
       expect(ids.length).toBeGreaterThan(0)
-      await expect.poll(async () => Promise.all(ids.map(async (id) => {
-        expect(id).toMatch(/^0x[0-9a-f]{64}$/)
-        const encoded = Buffer.from(id.slice(2), 'hex').toString('base64').replace(/\+/g, '-').replace(/\//g, '_')
-        const lcd = process.env.VITE_LCD_BASE || `http://localhost:${process.env.LCD_PORT || 1317}`
-        const response = await page.request.get(`${lcd}/polystorechain/polystorechain/v1/retrieval-sessions/${encodeURIComponent(encoded)}`)
+      for (const id of ids) {
+        const before = opened.get(id)!, outcome = proofOutcomes.get(id)!
+        expect(before).toBeDefined(); expect(outcome).toBeDefined()
+        expect(outcome.provider).toBe(before.payee)
+        const response = await page.request.get(`${lcd}/cosmos/tx/v1beta1/txs/${outcome.tx_hash}`)
         expect(response.ok()).toBe(true)
-        expect(response.headers()['x-cosmos-block-height']).toMatch(/^[1-9][0-9]*$/)
-        const { session } = await response.json()
-        expect(Buffer.from(session.session_id, 'base64').toString('hex')).toBe(id.slice(2))
-        return session.status
-      })), { timeout: 30_000 }).toEqual(ids.map(() => 'RETRIEVAL_SESSION_STATUS_COMPLETED'))
+        const { tx, tx_response: committed } = await response.json()
+        expect(committed.txhash.toUpperCase()).toBe(outcome.tx_hash.toUpperCase())
+        expect(Number(committed.code)).toBe(0)
+        expect(committed.height).toMatch(/^[1-9][0-9]*$/)
+        expect(tx.body.messages).toHaveLength(1)
+        expect(tx.body.messages[0]['@type']).toBe('/polystorechain.polystorechain.v1.MsgSubmitRetrievalSessionProof')
+        expect(Buffer.from(tx.body.messages[0].session_id, 'base64').toString('hex')).toBe(id.slice(2))
+        expect(tx.body.messages[0].creator).toBe(before.payee)
+        const { body: { session } } = await query(sessionPath(id), committed.height)
+        expect(session.status).toBe('RETRIEVAL_SESSION_STATUS_COMPLETED')
+        expect(session.authorized_proof_provider).toBe(before.payee)
+        expect(session.provider).toBe(before.assigned)
+        expect(session.manifest_root).toBe(before.root)
+        expect(String(session.updated_height)).toBe(committed.height)
+        expect(session.locked_fee).toBe('0')
+        const { body: { params } } = await query(`${api}/params`, committed.height)
+        const locked = BigInt(before.locked), burn = (locked * BigInt(params.retrieval_burn_bps) + 9999n) / 10000n
+        const payout = locked - burn
+        expect(payout).toBeGreaterThan(0n)
+        const transfers = committed.events.filter((event: { type: string }) => event.type === 'transfer')
+          .map((event: { attributes: Array<{ key: string; value: string }> }) => Object.fromEntries(event.attributes.map(({ key, value }) => [key, value])))
+          .filter((event: Record<string, string>) => event.recipient === before.payee)
+        expect(transfers).toHaveLength(1)
+        expect(transfers[0].amount).toBe(`${payout}stake`)
+        settlements.push({ ...before, txHash: committed.txhash, ackHeight: outcome.ackHeight, settledHeight: committed.height,
+          status: session.status, burn: String(burn), payout: String(payout), transfer: transfers[0],
+          // Normal mint/reward accounting remains enabled. Balance change is
+          // corroboration only; the scoped committed transfer proves payout.
+          stakeAfter: await stake(before.payee, committed.height) })
+      }
+      return ids.map((id) => opened.get(id)!)
     }
     const gatewayButton = await openFileActionMenuItem(page, filePath, 'deal-detail-download-gateway-provider')
     const gatewayBytes = await readDownloadBytes(page, gatewayButton, mode2FastMaybeDownloadMs)
@@ -861,9 +954,34 @@ test.describe('mode2 streamed retrieval', () => {
     expect(gatewayBytes.equals(fileBytes)).toBe(true)
     expect(windows.length).toBeGreaterThan(0)
     expect(windows.every((window) => window.gateway)).toBe(true)
-    await assertSettled()
+    const primarySessions = await assertSettled()
     await expect(routeEl).toContainText(/gateway/i)
     await expect(fileRow).toBeVisible()
+    const expectedHash = crypto.createHash('sha256').update(fileBytes).digest('hex')
+    const dealView = await query(`${api}/deals/${dealId}`, primarySessions[0].height)
+    const deputy = dealView.body.deal.mode2_slots.find((slot: { provider: string }) => slot.provider !== primarySessions[0].assigned)?.provider
+    expect(deputy).toBeTruthy()
+    windows.length = 0
+    const deputyResult = await page.evaluate(async (input) => {
+      const modulePath = '/tests/utils/deputyRetrieval.tsx'
+      const { retrieveWithDeputy } = await import(/* @vite-ignore */ modulePath) as typeof import('./utils/deputyRetrieval')
+      return retrieveWithDeputy(input)
+    }, { dealId, owner: dealView.body.deal.owner, manifestRoot: '0x' + Buffer.from(primarySessions[0].root, 'base64').toString('hex'),
+      filePath, authorizedProofProvider: deputy, routePreference: 'prefer_gateway' as const })
+    expect(deputyResult).toEqual({ bytes: fileBytes.length, sha256: expectedHash })
+    const deputySessions = await assertSettled()
+    expect(deputySessions.every((session) => session.payee === deputy && session.assigned !== deputy)).toBe(true)
+    expect(rejectedWindow).toBeDefined()
+    await testInfo.attach('retrieval-delivery-accounting.json', { contentType: 'application/json', body: Buffer.from(JSON.stringify({
+      scope: '160 KiB live browser retrieval and explicit deputy; no capacity claim',
+      sourceRevision: execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim(),
+      runtimeTrees: Object.fromEntries(['polystorechain', 'polystore_core', 'polystore_gateway', 'polystore-website/src'].map((directory) => [directory, execFileSync('git', ['rev-parse', `HEAD:${directory}`], { encoding: 'utf8' }).trim()])),
+      runtimeDiffSha256: crypto.createHash('sha256').update(execFileSync('git', ['diff', 'HEAD', '--', '../polystorechain', '../polystore_core', '../polystore_gateway', 'src'])).digest('hex'),
+      harnessSha256: await Promise.all(['tests/mode2-stripe.spec.ts', 'tests/utils/deputyRetrieval.tsx'].map(async (file) => ({ file, sha256: crypto.createHash('sha256').update(await fs.readFile(file)).digest('hex') }))),
+      fixtureBytes: fileBytes.length, fixtureSha256: expectedHash,
+      gatewaySha256: crypto.createHash('sha256').update(gatewayBytes).digest('hex'), deputy: deputyResult,
+      rejectedWindow, sessions: settlements,
+    }, null, 2)) })
     if (isMode2Fast) return
 
     const gatewaySessions = new Set(windows.map((window) => window.session))

--- a/polystore-website/tests/mode2-stripe.spec.ts
+++ b/polystore-website/tests/mode2-stripe.spec.ts
@@ -772,10 +772,10 @@ test.describe('mode2 streamed retrieval', () => {
 
   test('mode2 deal → shard → upload → commit → retrieve', async ({ page }, testInfo) => {
     test.setTimeout(mode2FastTestTimeoutMs)
-    const sourcePaths = ['../polystorechain', '../polystore_core', '../polystore_gateway', 'src']
-    // git diff cannot record untracked runtime sources. Reject them before funding/upload.
+    const sourcePaths = ['../polystorechain', '../polystore_core', '../polystore_gateway', 'src', '../scripts']
+    // Include the runner, stack launchers and chain_go.sh; reject untracked sources before funding/upload.
     expect(execFileSync('git', ['ls-files', '--others', '--exclude-standard', '--', ...sourcePaths], { encoding: 'utf8' }),
-      'Track or remove untracked runtime sources before recording delivery provenance').toBe('')
+      'Track or remove untracked source or harness files before recording delivery provenance').toBe('')
 
     // The deployed default is disabled. The UI must wait for committed
     // activation before offering a paid download; only this isolated chain is active.
@@ -986,7 +986,7 @@ test.describe('mode2 streamed retrieval', () => {
       scope: '160 KiB live browser retrieval and explicit deputy; no capacity claim',
       provenanceScope: 'checkout source and harness files only; running executable, native library and WASM identities are not recorded',
       sourceRevision: execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim(),
-      sourceTrees: Object.fromEntries(['polystorechain', 'polystore_core', 'polystore_gateway', 'polystore-website/src'].map((directory) => [directory, execFileSync('git', ['rev-parse', `HEAD:${directory}`], { encoding: 'utf8' }).trim()])),
+      sourceTrees: Object.fromEntries(['polystorechain', 'polystore_core', 'polystore_gateway', 'polystore-website/src', 'scripts'].map((directory) => [directory, execFileSync('git', ['rev-parse', `HEAD:${directory}`], { encoding: 'utf8' }).trim()])),
       sourceDiffSha256: crypto.createHash('sha256').update(execFileSync('git', ['diff', 'HEAD', '--', ...sourcePaths])).digest('hex'),
       harnessSha256: await Promise.all(['tests/mode2-stripe.spec.ts', 'tests/utils/deputyRetrieval.tsx'].map(async (file) => ({ file, sha256: crypto.createHash('sha256').update(await fs.readFile(file)).digest('hex') }))),
       fixtureBytes: fileBytes.length, fixtureSha256: expectedHash,

--- a/polystore-website/tests/mode2-stripe.spec.ts
+++ b/polystore-website/tests/mode2-stripe.spec.ts
@@ -940,6 +940,10 @@ test.describe('mode2 streamed retrieval', () => {
           .filter((event: Record<string, string>) => event.recipient === before.payee)
         expect(transfers).toHaveLength(1)
         expect(transfers[0].amount).toBe(`${payout}stake`)
+        const { body: { account: moduleAccount } } = await query('/cosmos/auth/v1beta1/module_accounts/nilchain', committed.height)
+        expect(moduleAccount.name).toBe('nilchain')
+        expect(moduleAccount.base_account.address).toMatch(/^nil1[0-9a-z]+$/)
+        expect(transfers[0].sender).toBe(moduleAccount.base_account.address)
         settlements.push({ ...before, txHash: committed.txhash, ackHeight: outcome.ackHeight, settledHeight: committed.height,
           status: session.status, burn: String(burn), payout: String(payout), transfer: transfers[0],
           // Normal mint/reward accounting remains enabled. Balance change is
@@ -959,7 +963,8 @@ test.describe('mode2 streamed retrieval', () => {
     await expect(fileRow).toBeVisible()
     const expectedHash = crypto.createHash('sha256').update(fileBytes).digest('hex')
     const dealView = await query(`${api}/deals/${dealId}`, primarySessions[0].height)
-    const deputy = dealView.body.deal.mode2_slots.find((slot: { provider: string }) => slot.provider !== primarySessions[0].assigned)?.provider
+    const assignedProviders = new Set(primarySessions.map((session) => session.assigned))
+    const deputy = dealView.body.deal.mode2_slots.find((slot: { provider: string }) => !assignedProviders.has(slot.provider))?.provider
     expect(deputy).toBeTruthy()
     windows.length = 0
     const deputyResult = await page.evaluate(async (input) => {
@@ -974,9 +979,10 @@ test.describe('mode2 streamed retrieval', () => {
     expect(rejectedWindow).toBeDefined()
     await testInfo.attach('retrieval-delivery-accounting.json', { contentType: 'application/json', body: Buffer.from(JSON.stringify({
       scope: '160 KiB live browser retrieval and explicit deputy; no capacity claim',
+      provenanceScope: 'checkout source and harness files only; running executable, native library and WASM identities are not recorded',
       sourceRevision: execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim(),
-      runtimeTrees: Object.fromEntries(['polystorechain', 'polystore_core', 'polystore_gateway', 'polystore-website/src'].map((directory) => [directory, execFileSync('git', ['rev-parse', `HEAD:${directory}`], { encoding: 'utf8' }).trim()])),
-      runtimeDiffSha256: crypto.createHash('sha256').update(execFileSync('git', ['diff', 'HEAD', '--', '../polystorechain', '../polystore_core', '../polystore_gateway', 'src'])).digest('hex'),
+      sourceTrees: Object.fromEntries(['polystorechain', 'polystore_core', 'polystore_gateway', 'polystore-website/src'].map((directory) => [directory, execFileSync('git', ['rev-parse', `HEAD:${directory}`], { encoding: 'utf8' }).trim()])),
+      sourceDiffSha256: crypto.createHash('sha256').update(execFileSync('git', ['diff', 'HEAD', '--', '../polystorechain', '../polystore_core', '../polystore_gateway', 'src'])).digest('hex'),
       harnessSha256: await Promise.all(['tests/mode2-stripe.spec.ts', 'tests/utils/deputyRetrieval.tsx'].map(async (file) => ({ file, sha256: crypto.createHash('sha256').update(await fs.readFile(file)).digest('hex') }))),
       fixtureBytes: fileBytes.length, fixtureSha256: expectedHash,
       gatewaySha256: crypto.createHash('sha256').update(gatewayBytes).digest('hex'), deputy: deputyResult,

--- a/polystore-website/tests/mode2-stripe.spec.ts
+++ b/polystore-website/tests/mode2-stripe.spec.ts
@@ -7,7 +7,7 @@ import { tmpdir } from 'node:os'
 import { Readable } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
 import path from 'node:path'
-import { parsePinnedGeneration } from '../src/lib/retrieval'
+import { parsePinnedGeneration, RAW_BLOB_BYTES } from '../src/lib/retrieval'
 import { retrievalFailureEvidence } from './utils/retrievalFailureEvidence'
 import { dismissCreateDealDrawer, ensureCreateDealDrawerOpen } from './utils/dashboard'
 
@@ -770,7 +770,8 @@ test.describe('mode2 streamed retrieval', () => {
   test.use({ acceptDownloads: true })
   test.describe.configure({ retries: process.env.CI && !isMode2Fast ? 1 : 0 })
 
-  test('mode2 deal → shard → upload → commit → retrieve', async ({ page }, testInfo) => {
+  for (const fixtureKiB of [1, 160]) {
+  test(`mode2 deal → shard → upload → commit → retrieve (${fixtureKiB} KiB)`, async ({ page }, testInfo) => {
     test.setTimeout(mode2FastTestTimeoutMs)
     const sourcePaths = ['../polystorechain', '../polystore_core', '../polystore_gateway', 'src', '../scripts']
     // Include the runner, stack launchers and chain_go.sh; reject untracked sources before funding/upload.
@@ -787,8 +788,9 @@ test.describe('mode2 streamed retrieval', () => {
       body: JSON.stringify({ params: { retrieval_v2_activation_height: '0' } }),
     }))
 
-    const filePath = 'mode2-small.bin'
-    const fileBytes = crypto.randomBytes(160 * 1024) // spans multiple blobs without compressing to a tiny payload
+    const filePath = `mode2-small-${fixtureKiB}kib.bin`
+    const fileBytes = crypto.randomBytes(fixtureKiB * 1024) // nonconstant payload at both one-blob and cross-slot boundaries
+    const expectedBlobs = Math.ceil(fileBytes.length / RAW_BLOB_BYTES)
 
     await page.setViewportSize({ width: 1280, height: 720 })
     await page.goto(dashboardPath, { waitUntil: 'networkidle' })
@@ -963,6 +965,7 @@ test.describe('mode2 streamed retrieval', () => {
     expect(windows.length).toBeGreaterThan(0)
     expect(windows.every((window) => window.gateway)).toBe(true)
     const primarySessions = await assertSettled()
+    expect(primarySessions.reduce((total, session) => total + session.blobs, 0)).toBe(expectedBlobs)
     await expect(routeEl).toContainText(/gateway/i)
     await expect(fileRow).toBeVisible()
     const expectedHash = crypto.createHash('sha256').update(fileBytes).digest('hex')
@@ -979,11 +982,12 @@ test.describe('mode2 streamed retrieval', () => {
       filePath, authorizedProofProvider: deputy, routePreference: 'prefer_gateway' as const })
     expect(deputyResult).toEqual({ bytes: fileBytes.length, sha256: expectedHash })
     const deputySessions = await assertSettled()
+    expect(deputySessions.reduce((total, session) => total + session.blobs, 0)).toBe(expectedBlobs)
     expect(deputySessions.every((session) => session.payee === deputy && session.assigned !== deputy)).toBe(true)
     expect(rejectedWindow).toBeDefined()
     const accountingPath = testInfo.outputPath('retrieval-delivery-accounting.json')
     await fs.writeFile(accountingPath, JSON.stringify({
-      scope: '160 KiB live browser retrieval and explicit deputy; no capacity claim',
+      scope: `${fixtureKiB} KiB live browser retrieval and explicit deputy; no capacity claim`,
       provenanceScope: 'checkout source and harness files only; running executable, native library and WASM identities are not recorded',
       sourceRevision: execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim(),
       sourceTrees: Object.fromEntries(['polystorechain', 'polystore_core', 'polystore_gateway', 'polystore-website/src', 'scripts'].map((directory) => [directory, execFileSync('git', ['rev-parse', `HEAD:${directory}`], { encoding: 'utf8' }).trim()])),
@@ -994,7 +998,7 @@ test.describe('mode2 streamed retrieval', () => {
       rejectedWindow, sessions: settlements,
     }, null, 2))
     await testInfo.attach('retrieval-delivery-accounting.json', { contentType: 'application/json', path: accountingPath })
-    if (isMode2Fast) return
+    if (isMode2Fast || fixtureKiB === 1) return
 
     const gatewaySessions = new Set(windows.map((window) => window.session))
     windows.length = 0
@@ -1018,6 +1022,7 @@ test.describe('mode2 streamed retrieval', () => {
     expect(windows.some((window) => !window.gateway)).toBe(true)
     await expect(routeEl).toContainText(/Browser\s*->\s*Provider|direct sp/i)
   })
+  }
 
   test('mode2 upload without gateway supports verified provider download', async ({ page }) => {
     test.setTimeout(mode2FastTestTimeoutMs)

--- a/polystore-website/tests/mode2-stripe.spec.ts
+++ b/polystore-website/tests/mode2-stripe.spec.ts
@@ -965,6 +965,7 @@ test.describe('mode2 streamed retrieval', () => {
     expect(windows.length).toBeGreaterThan(0)
     expect(windows.every((window) => window.gateway)).toBe(true)
     const primarySessions = await assertSettled()
+    if (fixtureKiB === 1) expect(windows).toHaveLength(1)
     expect(primarySessions.reduce((total, session) => total + session.blobs, 0)).toBe(expectedBlobs)
     await expect(routeEl).toContainText(/gateway/i)
     await expect(fileRow).toBeVisible()
@@ -982,34 +983,41 @@ test.describe('mode2 streamed retrieval', () => {
       filePath, authorizedProofProvider: deputy, routePreference: 'prefer_gateway' as const })
     expect(deputyResult).toEqual({ bytes: fileBytes.length, sha256: expectedHash })
     const deputySessions = await assertSettled()
+    if (fixtureKiB === 1) expect(windows).toHaveLength(1)
     expect(deputySessions.reduce((total, session) => total + session.blobs, 0)).toBe(expectedBlobs)
     expect(deputySessions.every((session) => session.payee === deputy && session.assigned !== deputy)).toBe(true)
     expect(rejectedWindow).toBeDefined()
+    let directProvider: { bytes: number; sha256: string; sessions: string[] } | undefined
+    if (!isMode2Fast || fixtureKiB === 1) {
+      const gatewaySessions = new Set(windows.map((window) => window.session))
+      windows.length = 0
+      const providerButton = await openFileActionMenuItem(page, filePath, 'deal-detail-download-sp')
+      const providerBytes = await readDownloadBytes(page, providerButton)
+      console.log('[secured retrieval] provider bytes downloaded')
+      expect(providerBytes.equals(fileBytes)).toBe(true)
+      expect(windows.length).toBeGreaterThan(0)
+      expect(windows.every((window) => !window.gateway && !gatewaySessions.has(window.session))).toBe(true)
+      const directSessions = await assertSettled()
+      if (fixtureKiB === 1) expect(windows).toHaveLength(1)
+      expect(directSessions.reduce((total, session) => total + session.blobs, 0)).toBe(expectedBlobs)
+      directProvider = { bytes: providerBytes.length, sha256: crypto.createHash('sha256').update(providerBytes).digest('hex'),
+        sessions: directSessions.map((session) => session.id) }
+      await expect(routeEl).toContainText(/Browser\s*->\s*Provider|direct sp/i)
+    }
     const accountingPath = testInfo.outputPath('retrieval-delivery-accounting.json')
     await fs.writeFile(accountingPath, JSON.stringify({
-      scope: `${fixtureKiB} KiB live browser retrieval and explicit deputy; no capacity claim`,
+      scope: `${fixtureKiB} KiB live browser retrieval and explicit deputy${directProvider ? ' and direct provider' : ''}; no capacity claim`,
       provenanceScope: 'checkout source and harness files only; running executable, native library and WASM identities are not recorded',
       sourceRevision: execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim(),
       sourceTrees: Object.fromEntries(['polystorechain', 'polystore_core', 'polystore_gateway', 'polystore-website/src', 'scripts'].map((directory) => [directory, execFileSync('git', ['rev-parse', `HEAD:${directory}`], { encoding: 'utf8' }).trim()])),
       sourceDiffSha256: crypto.createHash('sha256').update(execFileSync('git', ['diff', 'HEAD', '--', ...sourcePaths])).digest('hex'),
       harnessSha256: await Promise.all(['tests/mode2-stripe.spec.ts', 'tests/utils/deputyRetrieval.tsx'].map(async (file) => ({ file, sha256: crypto.createHash('sha256').update(await fs.readFile(file)).digest('hex') }))),
       fixtureBytes: fileBytes.length, fixtureSha256: expectedHash,
-      gatewaySha256: crypto.createHash('sha256').update(gatewayBytes).digest('hex'), deputy: deputyResult,
+      gatewaySha256: crypto.createHash('sha256').update(gatewayBytes).digest('hex'), deputy: deputyResult, directProvider,
       rejectedWindow, sessions: settlements,
     }, null, 2))
     await testInfo.attach('retrieval-delivery-accounting.json', { contentType: 'application/json', path: accountingPath })
     if (isMode2Fast || fixtureKiB === 1) return
-
-    const gatewaySessions = new Set(windows.map((window) => window.session))
-    windows.length = 0
-    const providerButton = await openFileActionMenuItem(page, filePath, 'deal-detail-download-sp')
-    const providerBytes = await readDownloadBytes(page, providerButton)
-    console.log('[secured retrieval] provider bytes downloaded')
-    expect(providerBytes.equals(fileBytes)).toBe(true)
-    expect(windows.length).toBeGreaterThan(0)
-    expect(windows.every((window) => !window.gateway && !gatewaySessions.has(window.session))).toBe(true)
-    await assertSettled()
-    await expect(routeEl).toContainText(/Browser\s*->\s*Provider|direct sp/i)
 
     // Losing the user-gateway must still permit verified direct delivery.
     for (const origin of gatewayOrigins) await page.route(`${origin}/**`, (route) => route.abort('failed'))

--- a/polystore-website/tests/mode2-stripe.spec.ts
+++ b/polystore-website/tests/mode2-stripe.spec.ts
@@ -981,7 +981,8 @@ test.describe('mode2 streamed retrieval', () => {
     const deputySessions = await assertSettled()
     expect(deputySessions.every((session) => session.payee === deputy && session.assigned !== deputy)).toBe(true)
     expect(rejectedWindow).toBeDefined()
-    await testInfo.attach('retrieval-delivery-accounting.json', { contentType: 'application/json', body: Buffer.from(JSON.stringify({
+    const accountingPath = testInfo.outputPath('retrieval-delivery-accounting.json')
+    await fs.writeFile(accountingPath, JSON.stringify({
       scope: '160 KiB live browser retrieval and explicit deputy; no capacity claim',
       provenanceScope: 'checkout source and harness files only; running executable, native library and WASM identities are not recorded',
       sourceRevision: execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim(),
@@ -991,7 +992,8 @@ test.describe('mode2 streamed retrieval', () => {
       fixtureBytes: fileBytes.length, fixtureSha256: expectedHash,
       gatewaySha256: crypto.createHash('sha256').update(gatewayBytes).digest('hex'), deputy: deputyResult,
       rejectedWindow, sessions: settlements,
-    }, null, 2)) })
+    }, null, 2))
+    await testInfo.attach('retrieval-delivery-accounting.json', { contentType: 'application/json', path: accountingPath })
     if (isMode2Fast) return
 
     const gatewaySessions = new Set(windows.map((window) => window.session))

--- a/polystore-website/tests/mode2-stripe.spec.ts
+++ b/polystore-website/tests/mode2-stripe.spec.ts
@@ -772,6 +772,10 @@ test.describe('mode2 streamed retrieval', () => {
 
   test('mode2 deal → shard → upload → commit → retrieve', async ({ page }, testInfo) => {
     test.setTimeout(mode2FastTestTimeoutMs)
+    const sourcePaths = ['../polystorechain', '../polystore_core', '../polystore_gateway', 'src']
+    // git diff cannot record untracked runtime sources. Reject them before funding/upload.
+    expect(execFileSync('git', ['ls-files', '--others', '--exclude-standard', '--', ...sourcePaths], { encoding: 'utf8' }),
+      'Track or remove untracked runtime sources before recording delivery provenance').toBe('')
 
     // The deployed default is disabled. The UI must wait for committed
     // activation before offering a paid download; only this isolated chain is active.
@@ -982,7 +986,7 @@ test.describe('mode2 streamed retrieval', () => {
       provenanceScope: 'checkout source and harness files only; running executable, native library and WASM identities are not recorded',
       sourceRevision: execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim(),
       sourceTrees: Object.fromEntries(['polystorechain', 'polystore_core', 'polystore_gateway', 'polystore-website/src'].map((directory) => [directory, execFileSync('git', ['rev-parse', `HEAD:${directory}`], { encoding: 'utf8' }).trim()])),
-      sourceDiffSha256: crypto.createHash('sha256').update(execFileSync('git', ['diff', 'HEAD', '--', '../polystorechain', '../polystore_core', '../polystore_gateway', 'src'])).digest('hex'),
+      sourceDiffSha256: crypto.createHash('sha256').update(execFileSync('git', ['diff', 'HEAD', '--', ...sourcePaths])).digest('hex'),
       harnessSha256: await Promise.all(['tests/mode2-stripe.spec.ts', 'tests/utils/deputyRetrieval.tsx'].map(async (file) => ({ file, sha256: crypto.createHash('sha256').update(await fs.readFile(file)).digest('hex') }))),
       fixtureBytes: fileBytes.length, fixtureSha256: expectedHash,
       gatewaySha256: crypto.createHash('sha256').update(gatewayBytes).digest('hex'), deputy: deputyResult,

--- a/polystore-website/tests/utils/deputyRetrieval.tsx
+++ b/polystore-website/tests/utils/deputyRetrieval.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from 'react'
+import { createRoot } from 'react-dom/client'
+import { Web3Provider } from '../../src/context/Web3Provider'
+import { TransportProvider } from '../../src/context/TransportContext'
+import { useFetch, type FetchInput } from '../../src/hooks/useFetch'
+
+// Test driver for the existing explicit deputy API; all wallet, chain, worker,
+// provider and settlement operations still use the production hook.
+export async function retrieveWithDeputy(input: FetchInput): Promise<{ bytes: number; sha256: string }> {
+  const element = document.createElement('div')
+  document.body.append(element)
+  const root = createRoot(element)
+  try {
+    return await new Promise((resolve, reject) => {
+      function Retrieval() {
+        const { fetchFile, unavailableReason } = useFetch()
+        const started = useRef(false)
+        useEffect(() => {
+          if (started.current || unavailableReason) return
+          started.current = true
+          void fetchFile(input).then(async ({ blob }) => {
+            const bytes = await blob.arrayBuffer()
+            const digest = await crypto.subtle.digest('SHA-256', bytes)
+            resolve({ bytes: bytes.byteLength, sha256: Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, '0')).join('') })
+          }).catch(reject)
+        }, [fetchFile, unavailableReason])
+        return null
+      }
+      root.render(<Web3Provider><TransportProvider><Retrieval /></TransportProvider></Web3Provider>)
+    })
+  } finally {
+    root.unmount()
+    element.remove()
+  }
+}

--- a/scripts/e2e_mode2_stripe_multi_sp.sh
+++ b/scripts/e2e_mode2_stripe_multi_sp.sh
@@ -90,6 +90,10 @@ if [ -z "${E2E_STACK_PROFILE:-}" ]; then
     export E2E_STACK_PROFILE=fast
   fi
 fi
+if [ "$E2E_STACK_PROFILE" = "fast" ]; then
+  # One-blob sessions must pay after ceil(5% burn); 1stake would all burn.
+  export POLYSTORE_RETRIEVAL_PRICE_PER_BLOB=17stake
+fi
 "$STACK_UP_SCRIPT"
 
 wait_for_http "lcd" "http://localhost:${LCD_PORT}/cosmos/base/tendermint/v1beta1/node_info" "200" 60 1

--- a/scripts/e2e_mode2_stripe_multi_sp.sh
+++ b/scripts/e2e_mode2_stripe_multi_sp.sh
@@ -90,7 +90,7 @@ if [ -z "${E2E_STACK_PROFILE:-}" ]; then
     export E2E_STACK_PROFILE=fast
   fi
 fi
-if [ "$E2E_STACK_PROFILE" = "fast" ]; then
+if [ "${E2E_MODE2_STREAMED:-0}" != "1" ]; then
   # One-blob sessions must pay after ceil(5% burn); 1stake would all burn.
   export POLYSTORE_RETRIEVAL_PRICE_PER_BLOB=17stake
 fi


### PR DESCRIPTION
The 160 KiB browser smoke verified bytes and completed sessions without proving that the same delivery paid its authorized provider. It now observes live OPEN and USER_CONFIRMED state, verifies the committed proof transaction names the same session and immutable payee, and requires the exact nonzero stake transfer from the chain module account queried at that committed height, calculated from the locked fee and settlement-height burn parameter. Pinned bank balances are retained as corroboration; ordinary mint/reward accounting stays enabled. The existing isolated harness sets `POLYSTORE_RETRIEVAL_PRICE_PER_BLOB=17stake` before genesis initialization for all non-streamed Mode 2 profiles (fast and heavy), so each one-blob session pays 16stake after the default rounded 5% burn. Production defaults and the streamed profile are unchanged.

The same test runs nonconstant 1 KiB and 160 KiB fixtures, covering one-blob and cross-slot delivery without a new workflow or stack. Each ordinary and deputy download must settle exactly `ceil(fileBytes / RAW_BLOB_BYTES)` blobs. The 1 KiB case also runs the existing direct-provider download in fast mode and requires exactly one paid window request and one settled blob for each of its three deliveries. The artifact includes the direct delivery hash and session IDs, with all three deliveries' committed payout evidence. Sized test titles retain separate accounting JSON files. The 160 KiB case retains its heavy-only direct-provider and gateway-absent continuations; fast mode skips the gateway-absent continuation. No deadlines or retries are relaxed.

For each fixture, a second download invokes the existing `useFetch({ authorizedProofProvider })` API from a test-only React mount, selecting a deputy distinct from every provider assigned to the primary download sessions. The live test checks completed byte delivery, the final SHA-256, and real ACK/proof/payout for the same sessions. The final whole-file hash is checked after the hook completes. Existing `retrievalFlow` unit coverage separately verifies per-wave verification/write/flush-before-ACK ordering and no ACK on verification, write, flush, or cancellation failure; those failure paths are not injected into this live smoke. One live request with a mismatched blob-count hint must return the documented HTTP 400 before the original authorized window proceeds. No RPC, session, authorization, or data response is mocked for these checks.

The test writes `retrieval-delivery-accounting.json` directly into its Playwright output directory and attaches that path. The fast CI `test-results/**` upload and an explicit unconditional accounting JSON glob in the heavy workflow retain file hashes, frozen session/context identity, ACK and settlement heights, committed transaction/transfer details, balances, and source/harness identities independently of reporter attachment handling. Source hashes describe the checkout; this artifact does not record actual running executable, native-library, or WASM identities. Before wallet funding or upload, the test rejects non-ignored untracked files in the four runtime source paths and `scripts`; tracked changes remain covered by the source diff digest. The recorded `scripts` tree and diff cover the Mode 2 runner, stack up/down wrappers, devnet launcher, and `chain_go.sh` build wrapper. This is bounded delivery/payment evidence, not a throughput or capacity qualification. Refs #260, parent #254.

Validation:
- Focused ESLint for both TypeScript files: passed.
- `E2E_LOCAL_STACK=1 ./node_modules/.bin/playwright test tests/mode2-stripe.spec.ts --list --grep 'mode2 deal'`: both 1 KiB and 160 KiB tests discovered.
- `./node_modules/.bin/tsx --test src/lib/retrievalSettlement.test.ts src/lib/retrievalAbi.test.ts`: 14 passed.
- `./node_modules/.bin/tsx --test --test-name-pattern 'only fully verified, decoded and durably flushed waves are acknowledged' src/lib/retrievalFlow.test.ts`: passed.
- `bash -n scripts/e2e_mode2_stripe_multi_sp.sh`: passed.
- `git diff --check`: passed.
- Both fast and heavy workflow YAML parsed successfully; unconditional artifact globs matched the retained `3af3952d` live accounting JSON, covering scheduled and manually selected profile variants.
- `./node_modules/.bin/tsx --test src/lib/retrieval.test.ts`: 5 passed.
- Shell provenance probes: edits to each of the five runner/stack/build scripts changed the digest; an untracked script was detected; all probe files/edits were removed.
- Browser-free Playwright retention probe: passed; standalone JSON remained under `test-results` with the default reporter after a successful test.
- Untracked-source preflight probes: detected temporary Go, Rust, and TypeScript files in all four recorded source paths; clean paths passed.

Draft: the live multi-provider browser run has not been executed on this head. The hosted 160 KiB run at `3af3952de53838b7d7fe286e2559c1a43908739e` passed and retained accounting JSON for four completed sessions (two ordinary and two deputy), each with 17stake locked, 1stake burned, and 16stake paid. The new 1 KiB case and expanded shell-source provenance require current-head hosted qualification. Local heavy builds/E2E are intentionally deferred while the coordinator runs the isolated capacity measurement; use the existing hosted multi-SP harness with `E2E_MODE2_GREP='mode2 deal'`. Hosted current-head CI and clean Codex review remain required before coordinator merge. This PR changes tests, their harness, and artifact retention only; no product behavior or benchmark claim.
