### PR TITLE
e2e: retain storage auditing throughout streamed retrieval

### DIFF
--- a/scripts/e2e_mode2_stripe_multi_sp.sh
+++ b/scripts/e2e_mode2_stripe_multi_sp.sh
@@ -79,6 +79,9 @@ if [ "${E2E_MODE2_STREAMED:-0}" = "1" ]; then
   export CGO_ENABLED=1 POLYSTORE_CORE_LIB_DIR="$ROOT_DIR/polystore_core/target/release"
   export POLYSTORE_POLYCE=0 POLYSTORE_FAKE_INGEST=0 POLYSTORE_FAST_INGEST=0
   export POLYSTORE_MODE2_ENCODE_PARALLELISM=1 POLYSTORE_MODE2_UPLOAD_PARALLELISM=2
+  # Large retrievals span audit epochs; providers must retain their assignments
+  # by answering normal storage challenges throughout the download.
+  export POLYSTORE_DISABLE_SYSTEM_LIVENESS=0
   export E2E_MODE2_GREP='mode2 streamed authenticated retrieval'
 fi
 


### PR DESCRIPTION
The streamed 1 GiB browser run inherited the short smoke profile's disabled storage prover. In [run 34261186636](https://github.com/Polynomialstore/polystore/actions/runs/34261186636), providers missed three audit epochs, the chain began slot repairs, and the browser correctly refused new payment against the changed assignment after 208 proof requests. The download did not complete.

Enable the existing provider storage prover for the streamed profile so long downloads must coexist with normal audit requirements. Ordinary short smoke settings and protocol quotas, repair thresholds and browser assignment checks remain unchanged. This is part of #260; it does not close its delivery qualification gate.

Validation: shell syntax and whitespace checks pass. A bounded shell check executes the existing profile block with streamed enabled/disabled and verifies storage proving is enabled only for the streamed profile. Local full E2E is deferred because the final capacity measurement owns the host; the existing hosted large workflow must still demonstrate complete bytes/hash and session outcomes after this harness lands.
