### PR TITLE
website: overlap two retrieval windows with ordered durable consumption

### DIFF
--- a/performance/README.md
+++ b/performance/README.md
@@ -258,3 +258,22 @@ a disk guard interrupted a later audit wait after measurement and drain.
 The artifact separates that interruption and supplementary recovery from the
 measured window. These are prepared-proof acceptance results, not delivery or
 paid lifecycle throughput.
+
+### Bounded retrieval transport overlap (#260)
+
+The browser normal retrieval loop permits two fetch-and-verify calls within the
+already opened wave. The existing single crypto worker still verifies each
+window; network delivery can overlap that work. Consumption stays in requested
+order, followed by durable flush and the existing ACK/settlement path. No next
+MDU or payment wave is opened early. There are at most two encoded window
+results (2 MiB at the current K=8 window size), in addition to existing transport,
+worker, decoder and context allocations. This is a bound on window results, not
+a claim that the entire browser uses only 2 MiB.
+
+On fetch, verification, consume or cancellation failure, all started fetches
+are observed and drained before the caller can enter recovery. Draining relies
+on the existing fetch deadlines and cancellation signal; no new worker or
+independent timeout is introduced. Local order/boundedness/failure tests do not
+establish a throughput improvement. Compare the existing 15.5 MiB public-path
+fixture before advancing to larger measurements. This change alone cannot
+establish the 30-minute 1 GiB qualification budget.

--- a/polystore-website/src/hooks/useFetch.ts
+++ b/polystore-website/src/hooks/useFetch.ts
@@ -6,7 +6,7 @@ import { appConfig } from '../config'
 import { BLOB_SIZE_BYTES, RAW_MDU_CAPACITY_BYTES } from '../domain/polyfsLayout'
 import { resolveProviderEndpointByAddress, type ProviderEndpoint } from '../lib/providerDiscovery'
 import { account, fetchActiveRetrievalGeneration, planRetrievalWindows, u64, type FrozenSession, type RetrievalWindow } from '../lib/retrieval'
-import { decodeRetrievalOutput, executeRetrievalWindows, validateRetrievalAllocation, validateRetrievalMduPacking } from '../lib/retrievalFlow'
+import { RetrievalFetchError, decodeRetrievalOutput, executeRetrievalWindows, validateRetrievalAllocation, validateRetrievalMduPacking } from '../lib/retrievalFlow'
 import { createRecoveryCommitmentReader, recoverRetrievalMdu, recoveryWindows } from '../lib/retrievalRecovery'
 import { readLocalGatewayConnectedHint } from '../lib/retrievalMode'
 import { confirmAndRequestRetrievalProofs, type RetrievalSettlementOutcome } from '../lib/retrievalSettlement'
@@ -234,16 +234,15 @@ export function useFetch() {
           if (job.state.pending.ordinal !== ordinal) throw new Error('saved retrieval cursor does not match file')
           await confirm(job.state.pending.sessions); return
         }
-        let fetchFailed = false
         if (windows.every((w) => pin.assignments[w.slot].active)) {
           try {
             await executeRetrievalWindows(windows, {
               open: async (wave) => { setProgress((p) => ({ ...p, phase: 'opening_session_tx' })); return payment.open(pin, wave, input.sponsoredAuth, signal, deputy, job.key) },
-              fetchAndVerify: async (session) => { try { return await fetchSession(session) } catch (error) { fetchFailed = true; throw error } },
+              fetchAndVerify: fetchSession,
               consume, flush: flushOutput, confirm,
             }, signal, 64)
             return
-          } catch (error) { signal.throwIfAborted(); if (!fetchFailed) throw error }
+          } catch (error) { signal.throwIfAborted(); if (!(error instanceof RetrievalFetchError)) throw error }
         }
         if (input.sponsoredAuth?.type === 'voucher') throw new Error('failed retrieval needs a fresh voucher for separately funded recovery')
         recoveryWindows(pin, ordinal)

--- a/polystore-website/src/lib/retrievalFlow.test.ts
+++ b/polystore-website/src/lib/retrievalFlow.test.ts
@@ -159,12 +159,12 @@ test('1GiB planner/decoder reassembles exact nonconstant payload with bounded co
   await executeRetrievalWindows(planRetrievalWindows(pin, file, 0n, file.size_bytes), {
     open: async (windows) => { contexts = windows.length; peak = Math.max(peak, contexts); return windows.map((window) => ({ window }) as FrozenSession) },
     fetchAndVerify: async (s) => {
-      assert.equal(liveBytes, 0); liveBytes = s.window.blobCount * 131072; blobs += s.window.blobCount
-      assert.ok(liveBytes <= 8 * 131072)
+      liveBytes += s.window.blobCount * 131072; blobs += s.window.blobCount
+      assert.ok(liveBytes <= 2 * 8 * 131072)
       return encodedProviderWindow(file, s.window)
     },
     consume: async (window, bytes) => {
-      assert.equal(bytes.length, liveBytes)
+      assert.ok(bytes.length <= liveBytes)
       for (const part of decodeRetrievalOutput(pin, file, window, bytes)) {
         const position = Number(part.offset)
         if (position >= mduBase + rawMduBytes) flushMdu()
@@ -173,7 +173,7 @@ test('1GiB planner/decoder reassembles exact nonconstant payload with bounded co
         mdu.set(part.bytes, relative); spans.push([relative, relative + part.bytes.length]); total += part.bytes.length
         assert.ok(spans.length <= 64)
       }
-      liveBytes = 0
+      liveBytes -= bytes.length
     },
     flush: async () => { assert.equal(liveBytes, 0) },
     confirm: async (sessions) => { assert.equal(sessions.length, contexts); ack += sessions.length; contexts = 0 },
@@ -269,3 +269,47 @@ test('worker output writes in place, flushes before ACK and rejects partial pers
     else Reflect.deleteProperty(globalThis, 'navigator')
   }
 })
+
+test('prefetch is bounded to two windows and consumption stays ordered', async () => {
+  const selected = Array.from(windows()).slice(0, 4)
+  const gates = selected.map(() => deferredBytes())
+  const h = harness(), started: number[] = [], consumed: number[] = []
+  h.flow.fetchAndVerify = (s) => { const i = selected.indexOf(s.window); started.push(i); return gates[i].promise }
+  h.flow.consume = async (w) => { consumed.push(selected.indexOf(w)) }
+  const work = executeRetrievalWindows(selected, h.flow)
+  const tick = () => new Promise<void>((resolve) => setImmediate(resolve))
+  await tick(); assert.deepEqual(started, [0, 1])
+  gates[1].resolve(new Uint8Array(1)); await tick()
+  assert.deepEqual(consumed, []); assert.deepEqual(started, [0, 1])
+  gates[0].resolve(new Uint8Array(1)); await tick()
+  assert.deepEqual(consumed, [0, 1]); assert.deepEqual(started, [0, 1, 2, 3])
+  gates[3].resolve(new Uint8Array(1)); await tick(); assert.deepEqual(consumed, [0, 1])
+  gates[2].resolve(new Uint8Array(1)); await work
+  assert.deepEqual(consumed, [0, 1, 2, 3]); assert.deepEqual(h.events, ['open:4', 'flush', 'ack:4'])
+})
+
+for (const failure of ['fetch', 'ahead', 'consume', 'cancel']) test(`overlap drains outstanding work on ${failure} before recovery`, async () => {
+  const selected = Array.from(windows()).slice(0, 3)
+  const gates = selected.map(() => deferredBytes())
+  const h = harness()
+  let started = 0, returned = false, consumed = 0
+  h.flow.fetchAndVerify = () => gates[started++].promise
+  h.flow.consume = async () => { consumed++; if (failure === 'consume') throw new Error('consume failed') }
+  const checked = assert.rejects(executeRetrievalWindows(selected, h.flow, h.controller.signal), failure === 'ahead' ? /ahead failed/ : /failed|abort/i).then(() => { returned = true })
+  const tick = () => new Promise<void>((resolve) => setImmediate(resolve))
+  await tick()
+  if (failure === 'ahead') gates[1].reject(new Error('ahead failed'))
+  else if (failure === 'fetch') gates[0].reject(new Error('fetch failed'))
+  else { if (failure === 'cancel') h.controller.abort(); gates[0].resolve(new Uint8Array(1)) }
+  await tick(); assert.equal(returned, false); assert.equal(started, 2)
+  if (failure === 'ahead') gates[0].resolve(new Uint8Array(1))
+  else gates[1].reject(new Error('late sibling failure'))
+  await checked
+  assert.equal(returned, true); assert.equal(started, 2); assert.equal(consumed, failure === 'consume' ? 1 : 0); assert.deepEqual(h.events, ['open:3'])
+})
+
+function deferredBytes() {
+  let resolve!: (bytes: Uint8Array) => void, reject!: (error: unknown) => void
+  const promise = new Promise<Uint8Array>((yes, no) => { resolve = yes; reject = no })
+  return { promise, resolve, reject }
+}

--- a/polystore-website/src/lib/retrievalFlow.test.ts
+++ b/polystore-website/src/lib/retrievalFlow.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { createCipheriv, createHash } from 'node:crypto'
-import { decodeRetrievalOutput, decodeRetrievalSlice, executeRetrievalWindows, validateRetrievalAllocation, validateRetrievalMduPacking, type RetrievalFlow } from './retrievalFlow'
+import { RetrievalFetchError, decodeRetrievalOutput, decodeRetrievalSlice, executeRetrievalWindows, validateRetrievalAllocation, validateRetrievalMduPacking, type RetrievalFlow } from './retrievalFlow'
 import { planRetrievalWindows, type PinnedGeneration, type FrozenSession, type RetrievalFile, type RetrievalWindow } from './retrieval'
 
 const pin = { layout: 2, k: 8, m: 4, rows: 8, leafCount: 96, metadataMdus: 2n, userMdus: 133n, assignments: Array.from({ length: 12 }, (_, i) => ({ provider: `provider${i}`, active: true })) } as unknown as PinnedGeneration
@@ -313,3 +313,36 @@ function deferredBytes() {
   const promise = new Promise<Uint8Array>((yes, no) => { resolve = yes; reject = no })
   return { promise, resolve, reject }
 }
+
+for (const primary of ['consume', 'fetch', 'open', 'flush', 'cancel']) test(`only primary fetch failure permits paid recovery: ${primary}`, async () => {
+  const selected = Array.from(windows()).slice(0, 2), h = harness()
+  const sibling = deferredBytes(), consuming = deferredBytes()
+  const original = new Error(`${primary} failed`)
+  let fetched = 0, recovery = 0
+  h.flow.fetchAndVerify = async () => {
+    if (fetched++ === 1) return sibling.promise
+    if (primary === 'fetch') throw original
+    return new Uint8Array(1)
+  }
+  if (primary === 'open') h.flow.open = async () => { throw original }
+  h.flow.consume = async () => {
+    if (primary === 'consume') { consuming.resolve(new Uint8Array()); throw original }
+    if (primary === 'cancel') h.controller.abort(original)
+  }
+  if (primary === 'flush') h.flow.flush = async () => { throw original }
+  // Same primary-error classification as useFetch's recovery gate.
+  const work = executeRetrievalWindows(selected, h.flow, h.controller.signal).catch((error) => {
+    h.controller.signal.throwIfAborted()
+    if (!(error instanceof RetrievalFetchError)) throw error
+    assert.equal(error.cause, original); assert.equal(error.message, original.message)
+    recovery++
+  })
+  const checked = primary === 'fetch' ? work : assert.rejects(work, (error) => error === original)
+  if (primary === 'consume') {
+    await consuming.promise
+    sibling.reject(new Error('late sibling fetch failure'))
+  } else sibling.resolve(new Uint8Array(1))
+  await checked
+  assert.equal(recovery, primary === 'fetch' ? 1 : 0)
+  assert.ok(!h.events.some((event) => event.startsWith('ack:')))
+})

--- a/polystore-website/src/lib/retrievalFlow.ts
+++ b/polystore-website/src/lib/retrievalFlow.ts
@@ -65,6 +65,18 @@ export async function waitForRetrievalChallenge(lcd: string, expected: Parameter
   }
 }
 
+// Recovery eligibility belongs to the primary thrown error, never to a sibling
+// that happens to fail while outstanding work is drained.
+export class RetrievalFetchError extends Error {
+  readonly cause: unknown
+
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause))
+    this.cause = cause
+    this.name = 'RetrievalFetchError'
+  }
+}
+
 export interface RetrievalFlow {
   open(windows: readonly RetrievalWindow[]): Promise<readonly FrozenSession[]>
   fetchAndVerify(session: FrozenSession): Promise<Uint8Array>
@@ -100,7 +112,11 @@ export async function executeRetrievalWindows(windows: Iterable<RetrievalWindow>
         throwIfFailed()
         while (pending.length < 2 && next < sessions.length) {
           const session = sessions[next++]
-          pending.push(Promise.resolve().then(() => { signal?.throwIfAborted(); return flow.fetchAndVerify(session) }).then(
+          pending.push(Promise.resolve().then(async () => {
+            signal?.throwIfAborted()
+            try { return await flow.fetchAndVerify(session) }
+            catch (error) { signal?.throwIfAborted(); throw new RetrievalFetchError(error) }
+          }).then(
             (bytes): Result => ({ ok: true, bytes }),
             (error): Result => { state.failure ??= { error }; return { ok: false, error } },
           ))

--- a/polystore-website/src/lib/retrievalFlow.ts
+++ b/polystore-website/src/lib/retrievalFlow.ts
@@ -73,8 +73,9 @@ export interface RetrievalFlow {
   confirm(sessions: readonly FrozenSession[]): Promise<void>
   progress?(windows: number, encodedBytes: bigint): void
 }
-// At most waveLimit contexts (default 16, maximum 64) plus one encoded
-// window are live. Output is consumed immediately; neither grows with the file.
+// At most waveLimit contexts (default 16, maximum 64) plus two encoded
+// windows are live. Fetch/verification overlaps; consumption stays ordered.
+// No new wave or receipt starts until this wave is consumed and flushed.
 export async function executeRetrievalWindows(windows: Iterable<RetrievalWindow>, flow: RetrievalFlow, signal?: AbortSignal, waveLimit = 16): Promise<void> {
   if (!Number.isSafeInteger(waveLimit) || waveLimit < 1 || waveLimit > 64) throw new Error('invalid wave bound')
   const iterator = windows[Symbol.iterator]()
@@ -86,13 +87,34 @@ export async function executeRetrievalWindows(windows: Iterable<RetrievalWindow>
     signal?.throwIfAborted()
     const sessions = await flow.open(wave)
     if (sessions.length !== wave.length || sessions.some((s, i) => s.window.mduIndex !== wave[i].mduIndex || s.window.startBlobIndex !== wave[i].startBlobIndex || s.window.blobCount !== wave[i].blobCount || s.window.provider !== wave[i].provider)) throw new Error('opened windows do not match requested order')
-    for (let i = 0; i < sessions.length; i++) {
-      signal?.throwIfAborted()
-      const bytes = await flow.fetchAndVerify(sessions[i])
-      signal?.throwIfAborted()
-      await flow.consume(wave[i], bytes)
-      completed++; encodedBytes += BigInt(bytes.length)
-      flow.progress?.(completed, encodedBytes)
+    // Observe rejections immediately, even when the preceding window is slow.
+    // Drain before returning so recovery cannot race a prior fetch/verifier.
+    type Result = { ok: true; bytes: Uint8Array } | { ok: false; error: unknown }
+    const pending: Promise<Result>[] = []
+    let next = 0
+    const state: { failure?: { error: unknown } } = {}
+    const throwIfFailed = () => { if (state.failure) throw state.failure.error }
+    try {
+      for (let i = 0; i < sessions.length; i++) {
+        signal?.throwIfAborted()
+        throwIfFailed()
+        while (pending.length < 2 && next < sessions.length) {
+          const session = sessions[next++]
+          pending.push(Promise.resolve().then(() => { signal?.throwIfAborted(); return flow.fetchAndVerify(session) }).then(
+            (bytes): Result => ({ ok: true, bytes }),
+            (error): Result => { state.failure ??= { error }; return { ok: false, error } },
+          ))
+        }
+        const result = await pending.shift()!
+        if (!result.ok) throw result.error
+        signal?.throwIfAborted()
+        throwIfFailed()
+        await flow.consume(wave[i], result.bytes)
+        completed++; encodedBytes += BigInt(result.bytes.length)
+        flow.progress?.(completed, encodedBytes)
+      }
+    } finally {
+      await Promise.all(pending)
     }
     await flow.flush()
     signal?.throwIfAborted()


### PR DESCRIPTION
Browser retrieval previously waited for each window to finish fetching and verification before starting the next request. Permit at most two fetch-and-verify calls within the existing opened wave, so transport can overlap verification in the existing crypto worker.

Consumption remains in requested order, followed by durable flush and the existing ACK/settlement path. Started promises are observed immediately and drained before errors or cancellation return to recovery. This retains the one-MDU payment journal and bounds retained encoded window results to two (2 MiB for K=8), independent of file size.

Validation: 30 focused retrieval flow, settlement and recovery tests pass, including ordered output, two-window boundedness, ahead/late rejection, consume failure, cancellation, and the existing exact 1 GiB planner/decoder hash test. Full website `tsc --noEmit`, targeted ESLint, and `git diff --check` pass.

Part of #260. Draft pending public-path measurement and review; no throughput improvement is claimed from unit tests. Use the existing 15.5 MiB fixture first. This bounded change alone cannot establish the 30-minute 1 GiB budget. No larger hosted qualification was launched.
