### PR TITLE
e2e: measure native chain proofs across provider assignments

### DIFF
--- a/bench/retrieval_session_capacity/native-k8-290/README.md
+++ b/bench/retrieval_session_capacity/native-k8-290/README.md
@@ -79,8 +79,7 @@ larger number.
 
 The existing absolute phase and overall deadlines, bounded queue, signer
 quarantine, port reservations, and process-group cleanup remain unchanged. This
-milestone does not add a parallel heartbeat because the audit monitor already
-performs bounded LCD reads and a second observer would add competing state reads
-during the small pilot. After the first pilot, add a single bounded progress
-record only if retained diagnostics show the existing scheduler state is
-insufficient to locate a stall.
+milestone does not yet add the requested 60-second progress heartbeat. The short
+pilot can use existing coordinator phase and log observations, but a heartbeat
+that reports existing scheduler counters and phase progress is required before
+sustained retained collection. It does not need another LCD observer.

--- a/bench/retrieval_session_capacity/native-k8-290/README.md
+++ b/bench/retrieval_session_capacity/native-k8-290/README.md
@@ -1,0 +1,81 @@
+# Native K8 sustained-harness milestone (#290)
+
+This milestone extends the existing four-validator sustained harness to create a
+native `General:rs=8+4` deal and eight-opening full-row submission bundles. It
+contains no new measurement and makes no K8 capacity claim. The default remains
+the retained K2 path.
+
+## Geometry and units
+
+The selectable profiles share the scheduler, transaction lifecycle, proof
+exporter, finite 64M gas / 2 MiB block limits, and five offered transaction rates
+of 0.25, 0.5, 1, 2, and 4 per second. Their storage and submission geometry is
+different:
+
+| Profile | Active storage assignments and provider-daemons | Deputy submitters | Openings in one submission transaction | Normal audit work | C6 audit work |
+| --- | ---: | --- | ---: | ---: | ---: |
+| K2 | 3 (`provider0`..`provider2`) | `provider3`..`provider10` | 32 | 3 samples/epoch | 96 samples/epoch |
+| K8 | 12 (`provider0`..`provider11`) | `provider12`..`provider19` | 8 | 12 samples/epoch | 96 samples/epoch |
+
+Storage providers run normal provider-daemon audit signing, while deputies own no
+storage slots. The sets are disjoint to prevent SDK account-sequence collisions.
+K8 consequently runs twelve provider-daemons instead of three and competes for
+host CPU and memory under a different normal-audit workload. Validator CPU/peak
+RSS and Commit metrics remain captured by the existing instrumentation; provider
+daemon CPU/RSS is not separately sampled. A K8/K2 comparison must report this
+topology difference and cannot be described as an equal-semantics speedup.
+
+One offered or committed **bundle** means one
+`MsgSubmitRetrievalSessionProof` transaction for one session. One K2 bundle holds
+32 individual chained openings; one K8 bundle holds eight. The evidence profile
+records offered bundles/s, derived offered openings/s, bundle/opening counts,
+declared gas limit per bundle and per opening, and the observed bundle-size
+distribution. Capacity analysis must derive committed bundles/s and openings/s
+from committed valid transaction outcomes. CheckTx acceptance, offered work, or
+a later state observation are not commit counts. Committed gas used must be reported
+separately from the declared gas limit.
+
+Both profiles currently load slot zero only. Twelve active K8 assignments and
+their audits establish the native placement topology, but do not establish
+many-provider proof throughput. A later measurement needs actual proof submissions
+across more than one assignment before making that claim.
+
+## Candidate pilot after review
+
+Before starting a new home, verify free space, the 600-second total budget, fixed
+ports, and exact source/binary hashes. K8 setup starts twelve provider-daemons and
+may not fit 600 seconds; a timeout is a failed pilot with retained diagnostics,
+not permission to extend the deadline.
+
+The first same-path command adds `--sustained-k 8` to the existing harness. The
+20M gas value below is the retained K2 safety ceiling for a path-validation pilot
+only. It is not a measured K8 gas requirement and the pilot is not capacity
+evidence:
+
+```sh
+df -h /tmp
+python3 scripts/retrieval_four_validator_workload.py \
+  --mode sustained-providers --audit-profile normal --sustained-k 8 \
+  --binary "$RETRIEVAL_BIN/polystorechaind" \
+  --library "$RETRIEVAL_LIBRARY" \
+  --gateway-binary "$RETRIEVAL_BIN/polystore_gateway" \
+  --cli-binary "$RETRIEVAL_REPO/polystore_cli/target/release/polystore_cli" \
+  --product-source "$RETRIEVAL_REPO" \
+  --proof-exporter "$RETRIEVAL_BIN/retrieval-exporter.test" \
+  --proof-gas 20000000 --step-seconds 4 --timeout 600 \
+  --home /tmp/polystore-k8-290-pilot-001 \
+  > /tmp/polystore-k8-290-pilot-001.log 2>&1
+```
+
+Inspect actual committed K8 gas used from the pilot, then select and document a
+safety margin for a sustained K8 run. Do not reuse the K2 limit as a K8 capacity
+denominator, lower proof checks or audits, or raise block limits to obtain a
+larger number.
+
+The existing absolute phase and overall deadlines, bounded queue, signer
+quarantine, port reservations, and process-group cleanup remain unchanged. This
+milestone does not add a parallel heartbeat because the audit monitor already
+performs bounded LCD reads and a second observer would add competing state reads
+during the small pilot. After the first pilot, add a single bounded progress
+record only if retained diagnostics show the existing scheduler state is
+insufficient to locate a stall.

--- a/bench/retrieval_session_capacity/native-k8-290/README.md
+++ b/bench/retrieval_session_capacity/native-k8-290/README.md
@@ -42,6 +42,11 @@ across more than one assignment before making that claim.
 
 ## Candidate pilot after review
 
+Retained performance collection must wait until this harness/schema has focused
+review and lands. After landing, freeze the product runtime and harness to exact
+commits and component hashes before collection; any relevant product or harness
+change requires another review, freeze, and collection.
+
 Before starting a new home, verify free space, the 600-second total budget, fixed
 ports, and exact source/binary hashes. K8 setup starts twelve provider-daemons and
 may not fit 600 seconds; a timeout is a failed pilot with retained diagnostics,

--- a/bench/retrieval_session_capacity/native-k8-290/README.md
+++ b/bench/retrieval_session_capacity/native-k8-290/README.md
@@ -35,10 +35,12 @@ from committed valid transaction outcomes. CheckTx acceptance, offered work, or
 a later state observation are not commit counts. Committed gas used must be reported
 separately from the declared gas limit.
 
-Both profiles currently load slot zero only. Twelve active K8 assignments and
-their audits establish the native placement topology, but do not establish
-many-provider proof throughput. A later measurement needs actual proof submissions
-across more than one assignment before making that claim.
+Both profiles submit full-row bundles round-robin across every active assignment.
+Each operation binds the assigned provider, that provider's artifact directory,
+the snapshot slot, and global `start_blob_index = slot * (64 / K)`. The retained
+report records offered, submitted, and committed-valid bundle and opening counts
+for every assignment. These mechanics allow a later many-provider measurement;
+this unmeasured milestone itself establishes no throughput.
 
 ## Candidate pilot after review
 
@@ -78,8 +80,11 @@ denominator, lower proof checks or audits, or raise block limits to obtain a
 larger number.
 
 The existing absolute phase and overall deadlines, bounded queue, signer
-quarantine, port reservations, and process-group cleanup remain unchanged. This
-milestone does not yet add the requested 60-second progress heartbeat. The short
-pilot can use existing coordinator phase and log observations, but a heartbeat
-that reports existing scheduler counters and phase progress is required before
-sustained retained collection. It does not need another LCD observer.
+quarantine, port reservations, and process-group cleanup remain unchanged. The
+scheduler writes a progress record every 60 seconds while active, plus its final
+state, using only its in-memory counters. It reports completed and committed-valid
+submissions, latest committed height, pending and in-flight work, and time since
+progress. A 600-second no-progress watchdog aborts pending scheduler work; the
+overall deadline remains the shorter authority. Setup and the single bounded
+exporter subprocess remain visible through their existing phase and log artifacts;
+they do not yet emit periodic heartbeat records or make extra LCD queries.

--- a/scripts/retrieval_bench_artifact.py
+++ b/scripts/retrieval_bench_artifact.py
@@ -786,7 +786,8 @@ class RetrievalLifecycleJournal:
 
 def schedule_retrieval_lifecycles(operations, *, journal_path, signers, prepare_session_proof=None,
                                  max_in_flight, max_queued, max_queued_per_signer,
-                                 mode="lifecycle", read_session_evidence=None):
+                                 mode="lifecycle", read_session_evidence=None,
+                                 progress_callback=None, heartbeat_seconds=60, stall_timeout_seconds=600):
     """Incremental open -> anchored proof -> confirm preparation; no runtime qualification.
 
     Operations arrive in absolute offered-offset order with one lookahead. The
@@ -803,15 +804,17 @@ def schedule_retrieval_lifecycles(operations, *, journal_path, signers, prepare_
     requests current state, otherwise exactly that committed height. The callback
     must honor the shared absolute deadline and cannot broadcast. Pre-opening and
     proof generation are excluded; fresh state reads and digest checks are included.
-    Prepared inputs retain the producer's slot-zero K8/K2 geometry restrictions;
-    payloads may come from authenticated real artifacts. This scheduler alone
+    Prepared inputs retain the producer's native per-assignment K8/K2 geometry
+    restrictions; payloads may come from authenticated real artifacts. This scheduler alone
     does not qualify delivered bytes or storage audits.
     """
     lifecycle = RetrievalLifecycleJournal(journal_path, signers, prepare_session_proof,
                                           mode=mode, read_session_evidence=read_session_evidence)
     try:
         result = schedule_transactions(operations, max_in_flight=max_in_flight, max_queued=max_queued,
-                                       max_queued_per_signer=max_queued_per_signer, _lifecycle=lifecycle)
+                                       max_queued_per_signer=max_queued_per_signer, _lifecycle=lifecycle,
+                                       progress_callback=progress_callback, heartbeat_seconds=heartbeat_seconds,
+                                       stall_timeout_seconds=stall_timeout_seconds)
         with lifecycle.db:
             lifecycle.db.execute("UPDATE run SET status='finished', result=?", (json.dumps(result),))
         return result
@@ -823,7 +826,9 @@ def schedule_retrieval_lifecycles(operations, *, journal_path, signers, prepare_
         lifecycle.db.close()
 
 
-def schedule_transactions(jobs, *, max_in_flight, max_queued, max_queued_per_signer, record_transaction=None, _lifecycle=None):
+def schedule_transactions(jobs, *, max_in_flight, max_queued, max_queued_per_signer, record_transaction=None,
+                          _lifecycle=None, progress_callback=None, heartbeat_seconds=60,
+                          stall_timeout_seconds=600):
     """Bounded transaction scheduling foundation, not a runtime benchmark mode.
 
     Jobs are prepared in offered-offset order, with dependency IDs referring only
@@ -841,6 +846,10 @@ def schedule_transactions(jobs, *, max_in_flight, max_queued, max_queued_per_sig
         integer(len(jobs), "jobs", 1, 8192)
     if record_transaction is not None and not callable(record_transaction):
         raise ValueError("record_transaction must be callable")
+    if progress_callback is not None and not callable(progress_callback):
+        raise ValueError("progress_callback must be callable")
+    heartbeat_seconds = integer(heartbeat_seconds, "heartbeat_seconds", 1, 600)
+    stall_timeout_seconds = integer(stall_timeout_seconds, "stall_timeout_seconds", heartbeat_seconds, 3600)
     jobs = [dict(job) for job in jobs] if _lifecycle is None else iter(jobs)
     known, operation_phases, previous_offset, measurement_seen = set(), {}, 0, False
     for job in jobs if _lifecycle is None else ():
@@ -869,9 +878,23 @@ def schedule_transactions(jobs, *, max_in_flight, max_queued, max_queued_per_sig
     warmup_overlap = False
     latest_warmup_finished_ns = start
     followups = []
+    last_progress_ns = last_heartbeat_ns = start
+    completed_submissions = committed_submissions = committed_height = 0
+
+    def progress(force=False):
+        nonlocal last_heartbeat_ns
+        now = monotonic_ns()
+        if progress_callback is None or (not force and now - last_heartbeat_ns < heartbeat_seconds * 10**9):
+            return
+        progress_callback(dict(schema_version=1, phase="scheduler", monotonic_ns=now,
+            elapsed_ns=now - start, completed_submissions=completed_submissions,
+            committed_valid_submissions=committed_submissions, committed_height=committed_height,
+            pending=len(pending), in_flight=len(running), followups=len(followups),
+            next_offer_loaded=offered is not None, seconds_since_progress=(now - last_progress_ns) / 1e9))
+        last_heartbeat_ns = now
 
     def record(job, result, started=None):
-        nonlocal latest_warmup_finished_ns
+        nonlocal latest_warmup_finished_ns, last_progress_ns, completed_submissions, committed_submissions, committed_height
         # Only this coordinator mutates accounting. Duplicate hashes remain
         # visible but never produce another successful transaction/operation.
         item = {"id": job["id"], "operation_id": job["operation_id"], "phase": job["phase"],
@@ -887,6 +910,12 @@ def schedule_transactions(jobs, *, max_in_flight, max_queued, max_queued_per_sig
                 item["original_outcome"], item["outcome"] = item["outcome"], "duplicate"
             else:
                 seen_hashes.add(item["txhash"])
+        if item["kind"] == "submit-proof":
+            completed_submissions += 1
+            committed_submissions += item["outcome"] == "committed_success"
+            if item["outcome"] in ("committed_success", "committed_failure"):
+                committed_height = max(committed_height, integer(item["height"], "committed height", 1))
+                last_progress_ns = item["finished_ns"]
         item["queue_latency_ns"] = None if started is None else started - item["offered_ns"]
         item["terminal_latency_ns"] = item["finished_ns"] - item["offered_ns"]
         if _lifecycle is not None:
@@ -990,6 +1019,10 @@ def schedule_transactions(jobs, *, max_in_flight, max_queued, max_queued_per_sig
                 if _lifecycle is not None:
                     retained = pending + followups + [item for item, _ in running.values()] + ([offered] if offered else [])
                     peak_operation_states = max(peak_operation_states, len({id(item["_state"]) for item in retained}))
+                progress()
+                if (progress_callback is not None and monotonic_ns() - last_progress_ns >= stall_timeout_seconds * 10**9 and
+                        (pending or running or followups or offered is not None)):
+                    raise TimeoutError("scheduler made no submission progress before watchdog deadline")
                 if offered is not None or pending or running or followups:
                     delay = max(0, (start + offered["offered_offset_ns"] - monotonic_ns()) / 1e9) if offered is not None else 0.001
                     time.sleep(min(0.001 if running else 0.05, delay))
@@ -1003,6 +1036,8 @@ def schedule_transactions(jobs, *, max_in_flight, max_queued, max_queued_per_sig
                 job.setdefault("_enqueued_ns", monotonic_ns())
                 record(job, {"outcome": "not_submitted", "error": "run_aborted"})
             raise
+
+    progress(force=True)
 
     phases = {}
     for phase in ("warmup", "measurement"):

--- a/scripts/retrieval_bench_artifact.py
+++ b/scripts/retrieval_bench_artifact.py
@@ -1289,19 +1289,19 @@ class FourValidatorLifecycle:
                 reservation.bind(("127.0.0.1", node[name]))
                 reservation.listen(1)
 
-    def prepare(self, *, audit_profile="normal"):
+    def prepare(self, *, audit_profile="normal", provider_count=12):
         if audit_profile not in ("normal", "c6"):
             raise ValueError("unknown benchmark audit profile")
+        provider_count = integer(provider_count, "provider signer count", 12, 20)
         self.cli(self.home / "bootstrap", "multi-node", "--v", "4", "--output-dir", self.home / "nodes",
                  "--node-dir-prefix", "validator", "--chain-id", self.chain,
                  "--starting-ip-address", "127.0.0.1", "--list-ports", "26657,26654,26651,26648",
                  "--validators-stake-amount", "100000000,100000000,100000000,100000000",
                  "--keyring-backend", "test")
         first = Path(self.nodes[0]["home"])
-        # Sixteen independent owners can offer full lifecycle traffic while twelve
-        # providers cover the default RS(8,12) placement. Control transactions
-        # use their own signer and cannot race workload account sequences.
-        names = [f"owner{i}" for i in range(16)] + [f"provider{i}" for i in range(12)] + ["control"]
+        # Storage providers and deputy proof submitters use disjoint identities,
+        # so provider-daemon audits cannot race workload account sequences.
+        names = [f"owner{i}" for i in range(16)] + [f"provider{i}" for i in range(provider_count)] + ["control"]
         for name in names:
             self.cli(first, "keys", "add", name, "--keyring-backend", "test", "--output", "json")
             address = self.cli(first, "keys", "show", name, "-a", "--keyring-backend", "test")

--- a/scripts/retrieval_bench_artifact.py
+++ b/scripts/retrieval_bench_artifact.py
@@ -910,12 +910,6 @@ def schedule_transactions(jobs, *, max_in_flight, max_queued, max_queued_per_sig
                 item["original_outcome"], item["outcome"] = item["outcome"], "duplicate"
             else:
                 seen_hashes.add(item["txhash"])
-        if item["kind"] == "submit-proof":
-            completed_submissions += 1
-            committed_submissions += item["outcome"] == "committed_success"
-            if item["outcome"] in ("committed_success", "committed_failure"):
-                committed_height = max(committed_height, integer(item["height"], "committed height", 1))
-                last_progress_ns = item["finished_ns"]
         item["queue_latency_ns"] = None if started is None else started - item["offered_ns"]
         item["terminal_latency_ns"] = item["finished_ns"] - item["offered_ns"]
         if _lifecycle is not None:
@@ -929,6 +923,15 @@ def schedule_transactions(jobs, *, max_in_flight, max_queued, max_queued_per_sig
             next_job = _lifecycle.record(job, item)
             if next_job is not None:
                 followups.append(next_job)
+        if progress_callback is not None and item["kind"] == "submit-proof":
+            completed_submissions += 1
+            committed_valid = item["outcome"] == "committed_success" and (
+                _lifecycle is None or _lifecycle.mode != "prepared-proof-only" or
+                item.get("proof_state_verified") is True)
+            committed_submissions += committed_valid
+            if committed_valid:
+                committed_height = max(committed_height, integer(item["height"], "committed height", 1))
+                last_progress_ns = item["finished_ns"]
         if record_transaction is not None:
             record_transaction(dict(item))
 

--- a/scripts/retrieval_four_validator_workload.py
+++ b/scripts/retrieval_four_validator_workload.py
@@ -249,6 +249,53 @@ def journal_results(path, operations, *, proof_only=False):
     return rows, transactions
 
 
+def assignment_submission_counts(operations, transactions):
+    """Report bundle and opening outcomes per native storage assignment."""
+    expected = {operation["operation_id"]: operation for operation in operations}
+    counts = {}
+    for operation in operations:
+        slot = str(operation["proof_expectation"]["snapshot"]["slot"])
+        openings = producer.uint(operation["proof_expectation"]["session"]["blob_count"])
+        row = counts.setdefault(slot, dict(offered_bundles=0, offered_openings=0,
+            submitted_bundles=0, submitted_openings=0, committed_valid_bundles=0,
+            committed_valid_openings=0))
+        row["offered_bundles"] += 1
+        row["offered_openings"] += openings
+    seen = set()
+    for transaction in transactions:
+        identity = transaction.get("operation_id")
+        if identity not in expected or identity in seen:
+            raise ValueError("assignment accounting requires one transaction per operation")
+        seen.add(identity)
+        operation = expected[identity]
+        slot = str(operation["proof_expectation"]["snapshot"]["slot"])
+        openings = producer.uint(operation["proof_expectation"]["session"]["blob_count"])
+        row = counts[slot]
+        if transaction.get("outcome") not in ("not_submitted", "skipped"):
+            row["submitted_bundles"] += 1
+            row["submitted_openings"] += openings
+        if transaction.get("outcome") == "committed_success":
+            row["committed_valid_bundles"] += 1
+            row["committed_valid_openings"] += openings
+    if seen != set(expected):
+        raise ValueError("assignment accounting is missing transaction outcomes")
+    return counts
+
+
+def export_inventory_request(operation, session_id, evidence, output_path, directories):
+    """Bind an exported proof request to its assigned provider artifact."""
+    expectation = operation["proof_expectation"]
+    session, snapshot = expectation["session"], expectation["snapshot"]
+    rows = artifact.BLOBS_PER_MDU // producer.uint(snapshot["k"])
+    if producer.uint(session["start_blob_index"]) != producer.uint(snapshot["slot"]) * rows:
+        raise ValueError("full-row exporter request does not start at its assignment")
+    assigned = session["provider"]
+    if assigned not in directories:
+        raise ValueError("missing artifact directory for assigned provider")
+    return dict(artifact_directory=str(directories[assigned]), evidence=evidence,
+                expected=expectation, session_id=session_id, output_path=output_path)
+
+
 def retrieval_snapshot(lifecycle, height, deals, session_ids):
     bank = lifecycle.snapshot(height)
     rows = []
@@ -884,13 +931,19 @@ def build_sustained_operations(lifecycle, deal, providers, deputies, offsets, mi
     """Build one native full-row submission bundle per prepared session."""
     layout = mode2_layout(k)
     openings = layout["openings_per_bundle"]
-    owner, assigned = lifecycle.signers["owner0"], providers[0]
+    slots = sorted(providers)
+    if slots != list(range(layout["assignments"])):
+        raise ValueError("providers must cover every native assignment exactly once")
+    owner = lifecycle.signers["owner0"]
     root = producer.b64(deal["manifest_root"], 32).hex()
     operations = []
     for index, offset in enumerate([0] * 8 + offsets):
+        slot = slots[index % len(slots)]
+        assigned = providers[slot]
+        start_blob_index = slot * openings
         payee, end = deputies[index % len(deputies)], expiry + index // 128
         opening = transaction_job(lifecycle, owner, ["open-retrieval-session", "--deal-id", deal["id"],
-            "--provider", assigned, "--manifest-root", "0x" + root, "--start-mdu-index", "2", "--start-blob-index", "0",
+            "--provider", assigned, "--manifest-root", "0x" + root, "--start-mdu-index", "2", "--start-blob-index", str(start_blob_index),
             "--blob-count", str(openings), "--nonce", index + 1, "--expires-at", end, "--challenge-version", "2",
             "--authorized-proof-provider", payee], kind="open-session", gas="300000")
         proof = transaction_job(lifecycle, payee, ["submit-retrieval-proof", "{proof_path}"], gas=str(proof_gas))
@@ -898,17 +951,17 @@ def build_sustained_operations(lifecycle, deal, providers, deputies, offsets, mi
             offered_offset_ns=offset, **{"open-session": opening, "submit-proof": proof},
             proof_expectation=dict(minimum_opened_height=minimum,
                 session=dict(deal_id=deal["id"], owner=owner, provider=assigned, authorized_proof_provider=payee,
-                    manifest_root=root, nonce=index + 1, expires_at=end, start_mdu_index=2, start_blob_index=0,
+                    manifest_root=root, nonce=index + 1, expires_at=end, start_mdu_index=2, start_blob_index=start_blob_index,
                     blob_count=openings, total_bytes=layout["bytes_per_bundle"], funding=1,
                     locked_fee=str(price * openings)),
                 snapshot=dict(chain_id=lifecycle.chain, setup_digest=producer.SETUP_DIGEST,
-                    generation=deal.get("current_gen", "0"), layout=2, k=k, m=layout["m"], slot=0,
+                    generation=deal.get("current_gen", "0"), layout=2, k=k, m=layout["m"], slot=slot,
                     metadata_mdus=2, user_mdus=1, deal_end=deal["end_block"]))))
     return operations
 
 
 def run_sustained(lifecycle, deal, providers, send, command, audits, wait, exporter, step_seconds, proof_gas, k=2):
-    """Real slot-zero inventory and bounded existing scheduler; no client ACK claim."""
+    """Real per-assignment inventory and bounded scheduler; no client ACK claim."""
     import threading
     layout = mode2_layout(k)
     offsets = sustained_offsets(step_seconds)
@@ -924,11 +977,11 @@ def run_sustained(lifecycle, deal, providers, send, command, audits, wait, expor
     profile = sustained_profile(k, step_seconds, offsets, proof_gas)
     openings = profile["openings_per_bundle"]
     doc.update(mode="four-validator-sustained-retrieval",
-        workload=f"real K{k} slot zero, {openings} fresh openings/submission transaction; eight deputy signers",
+        workload=f"real K{k} assignment round-robin, {openings} fresh openings/submission transaction; eight deputy signers",
         sustained_profile=profile,
         limits=["Proof acceptance capacity only; no delivered bytes or client ACKs",
                 "Normal mint retained; raw economics are not a conservation assertion",
-                "Only slot zero is challenged; this is not a many-provider throughput claim",
+                "Assignment round-robin binds each proof to its provider artifact and snapshot slot",
                 "Four local processes do not establish WAN capacity", "No restart qualification"])
     epoch_length = producer.uint(doc["frozen_module_params"]["epoch_len_blocks"])
     monitor_stop, failures = threading.Event(), []
@@ -967,9 +1020,9 @@ def run_sustained(lifecycle, deal, providers, send, command, audits, wait, expor
         if expiry + (len(offsets) + 7) // 128 >= producer.uint(deal["end_block"]):
             raise ValueError("insufficient deal lifetime for inventory")
         price = producer.uint(doc["frozen_module_params"]["retrieval_price_per_blob"]["amount"], 256)
-        assigned = providers[0]
         root = producer.b64(deal["manifest_root"], 32).hex()
-        directory = next(Path(row["directory"]) for row in doc["providers"] if row["address"] == assigned) / "deals" / str(deal["id"]) / root
+        directories = {row["address"]: Path(row["directory"]) / "deals" / str(deal["id"]) / root
+                       for row in doc["providers"]}
         operations = build_sustained_operations(lifecycle, deal, providers, deputies, offsets, minimum, expiry,
                                                 price, proof_gas, k)
         inventory = lifecycle.home / "inventory"
@@ -988,8 +1041,7 @@ def run_sustained(lifecycle, deal, providers, send, command, audits, wait, expor
                 evidence = read_session_evidence(lifecycle, operation, sid, None, lifecycle.deadline)
                 operation["prepared"] = dict(session_id=sid, proof_path=path, evidence=evidence)
                 artifact.prepared_session_pin(operation, evidence)
-                requests.append(dict(artifact_directory=str(directory), evidence=evidence, expected=operation["proof_expectation"],
-                                     session_id=sid, output_path=path))
+                requests.append(export_inventory_request(operation, sid, evidence, path, directories))
         manifest = inventory / "manifest.json"
         manifest.write_text(json.dumps(dict(chain_id=lifecycle.chain, trusted_setup=lifecycle.env["POLYSTORE_TRUSTED_SETUP"],
             deadline_unix_ms=int(time.time() * 1000 + (lifecycle.deadline - artifact.monotonic_ns()) / 1e6), sessions=requests)))
@@ -1035,10 +1087,20 @@ def run_sustained(lifecycle, deal, providers, send, command, audits, wait, expor
         started = artifact.monotonic_ns()
         for operation in operations:
             operation["submit-proof"]["_deadline_ns"] = min(lifecycle.deadline, started + (duration + 120) * 10**9)
+        progress_path = lifecycle.home / "sustained-progress.jsonl"
+        def progress(row):
+            with progress_path.open("a") as output:
+                output.write(json.dumps(row, sort_keys=True) + "\n")
         doc["scheduler"] = artifact.schedule_retrieval_lifecycles(operations,
             journal_path=lifecycle.home / "sustained.sqlite", signers=deputies,
             max_in_flight=8, max_queued=128, max_queued_per_signer=16, mode="prepared-proof-only",
-            read_session_evidence=lambda operation, sid, height, deadline: read_session_evidence(lifecycle, operation, sid, height, deadline))
+            read_session_evidence=lambda operation, sid, height, deadline: read_session_evidence(lifecycle, operation, sid, height, deadline),
+            progress_callback=progress, heartbeat_seconds=60, stall_timeout_seconds=600)
+        doc["progress"] = dict(path=str(progress_path), sha256=artifact.sha256(progress_path),
+                               heartbeat_seconds=60, no_progress_timeout_seconds=600,
+                               source="scheduler in-memory counters; no additional chain query")
+        _, sustained_transactions = journal_results(lifecycle.home / "sustained.sqlite", operations, proof_only=True)
+        doc["assignment_submission_counts"] = assignment_submission_counts(operations, sustained_transactions)
         # The last offered operation precedes the declared end by one interval.
         while artifact.monotonic_ns() < started + duration * 10**9:
             time.sleep(min(0.2, lifecycle.remaining()))

--- a/scripts/retrieval_four_validator_workload.py
+++ b/scripts/retrieval_four_validator_workload.py
@@ -233,14 +233,45 @@ def build_operations(lifecycle, fixtures, deals, minimum_height):
     return operations
 
 
-def journal_results(path, operations, *, proof_only=False):
+def journal_results(path, operations, *, proof_only=False, require_all_committed=True):
     with sqlite3.connect(f"file:{path}?mode=ro", uri=True) as db:
         rows = {identity: json.loads(result) if result else None for identity, result in db.execute("SELECT id, result FROM operations")}
         transactions = [json.loads(row[0]) for row in db.execute("SELECT result FROM transactions ORDER BY rowid")]
-    if set(rows) != {op["operation_id"] for op in operations} or any(not row or row.get("all_transactions_committed") is not True for row in rows.values()):
+    expected = [op["operation_id"] for op in operations]
+    if len(set(expected)) != len(expected) or set(rows) != set(expected) or any(not row for row in rows.values()):
+        raise ValueError("incomplete lifecycle journal")
+    if require_all_committed and any(row.get("all_transactions_committed") is not True for row in rows.values()):
         raise ValueError("lifecycle did not commit every open/proof/confirmation; inspect retained journal")
-    if (len(transactions) != (1 if proof_only else 3) * len(operations) or
-            any(row["outcome"] != "committed_success" for row in transactions) or
+    if len(transactions) != (1 if proof_only else 3) * len(operations):
+        raise ValueError("unexpected transaction outcomes")
+    if proof_only:
+        outcomes = {"committed_success", "committed_failure", "checktx_rejected", "unknown",
+                    "not_submitted", "skipped", "duplicate"}
+        mapped = {}
+        hashes = set()
+        for transaction in transactions:
+            identity = transaction.get("operation_id")
+            if identity not in rows or identity in mapped or transaction.get("outcome") not in outcomes:
+                raise ValueError("unexpected transaction outcomes")
+            txhash = transaction.get("txhash")
+            if transaction["outcome"] == "duplicate":
+                if not txhash or txhash not in hashes:
+                    raise ValueError("inconsistent duplicate transaction outcome")
+            elif txhash:
+                if txhash in hashes:
+                    raise ValueError("duplicate transaction hash was counted twice")
+                hashes.add(txhash)
+            mapped[identity] = transaction
+        if set(mapped) != set(expected):
+            raise ValueError("unexpected transaction outcomes")
+        for identity, transaction in mapped.items():
+            valid = (transaction["outcome"] == "committed_success" and
+                     transaction.get("proof_state_verified") is True)
+            if (rows[identity].get("operation_id") != identity or
+                rows[identity].get("outcome") != transaction["outcome"] or
+                rows[identity].get("proof_submitted") is not valid):
+                raise ValueError("inconsistent proof lifecycle outcome")
+    if require_all_committed and (any(row["outcome"] != "committed_success" for row in transactions) or
             (proof_only and any(row.get("proof_submitted") is not True for row in rows.values()))):
         raise ValueError("unexpected transaction outcomes")
     ids = [row["session_id"] for row in rows.values()]
@@ -262,11 +293,20 @@ def assignment_submission_counts(operations, transactions):
         row["offered_bundles"] += 1
         row["offered_openings"] += openings
     seen = set()
+    hashes = set()
     for transaction in transactions:
         identity = transaction.get("operation_id")
         if identity not in expected or identity in seen:
             raise ValueError("assignment accounting requires one transaction per operation")
         seen.add(identity)
+        txhash = transaction.get("txhash")
+        if transaction.get("outcome") == "duplicate":
+            if not txhash or txhash not in hashes:
+                raise ValueError("assignment accounting has inconsistent duplicate transaction")
+        elif txhash:
+            if txhash in hashes:
+                raise ValueError("assignment accounting counted a transaction hash twice")
+            hashes.add(txhash)
         operation = expected[identity]
         slot = str(operation["proof_expectation"]["snapshot"]["slot"])
         openings = producer.uint(operation["proof_expectation"]["session"]["blob_count"])
@@ -274,7 +314,8 @@ def assignment_submission_counts(operations, transactions):
         if transaction.get("outcome") not in ("not_submitted", "skipped"):
             row["submitted_bundles"] += 1
             row["submitted_openings"] += openings
-        if transaction.get("outcome") == "committed_success":
+        if (transaction.get("outcome") == "committed_success" and
+                transaction.get("proof_state_verified") is True):
             row["committed_valid_bundles"] += 1
             row["committed_valid_openings"] += openings
     if seen != set(expected):
@@ -1099,7 +1140,8 @@ def run_sustained(lifecycle, deal, providers, send, command, audits, wait, expor
         doc["progress"] = dict(path=str(progress_path), sha256=artifact.sha256(progress_path),
                                heartbeat_seconds=60, no_progress_timeout_seconds=600,
                                source="scheduler in-memory counters; no additional chain query")
-        _, sustained_transactions = journal_results(lifecycle.home / "sustained.sqlite", operations, proof_only=True)
+        _, sustained_transactions = journal_results(lifecycle.home / "sustained.sqlite", operations,
+                                                     proof_only=True, require_all_committed=False)
         doc["assignment_submission_counts"] = assignment_submission_counts(operations, sustained_transactions)
         # The last offered operation precedes the declared end by one interval.
         while artifact.monotonic_ns() < started + duration * 10**9:

--- a/scripts/retrieval_four_validator_workload.py
+++ b/scripts/retrieval_four_validator_workload.py
@@ -3,7 +3,8 @@
 
 Settlement smoke uses exported K8/K2 fixtures without provider transport.
 Healthy-providers uses canonical K2 ingest and three provider-daemons to check
-normal storage audits. Sustained-providers adds finite real-artifact proof load.
+normal storage audits. Sustained-providers adds finite K2 or K8 real-artifact
+proof load.
 No mode verifies delivered files. Owned services
 start only when this command is explicitly invoked.
 """
@@ -30,6 +31,49 @@ import retrieval_fresh_proof as producer
 API = "/polystorechain/polystorechain/v1"
 ENV_KEYS = ("GOMAXPROCS", "POLYSTORE_TRUSTED_SETUP", "LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH")
 COUNTS = (1, 2, 8)
+SUSTAINED_RATES = (0.25, 0.5, 1, 2, 4)
+
+
+def mode2_layout(k):
+    """Return the complete supported full-row geometry for one Mode 2 MDU."""
+    if isinstance(k, bool) or k not in (2, 8):
+        raise ValueError("sustained retrieval requires native K2 or K8")
+    m = 1 if k == 2 else 4
+    openings = artifact.BLOBS_PER_MDU // k
+    assignments = k + m
+    return dict(k=k, m=m, assignments=assignments,
+                deputy_indices=list(range(assignments, assignments + 8)), openings_per_bundle=openings,
+                bytes_per_opening=artifact.ENCODED_BLOB_BYTES,
+                bytes_per_bundle=openings * artifact.ENCODED_BLOB_BYTES)
+
+
+def sustained_profile(k, step_seconds, offsets, proof_gas):
+    """Describe rates with explicit transaction-bundle and opening denominators."""
+    layout = mode2_layout(k)
+    rates = list(SUSTAINED_RATES)
+    inventory = len(offsets) + 8
+    openings = layout["openings_per_bundle"]
+    return dict(step_seconds=step_seconds, measurement_seconds=step_seconds * len(rates), rates=rates,
+        rate_unit="offered proof-submission transactions per second",
+        offered_openings_per_second=[rate * openings for rate in rates],
+        bundle_unit="one MsgSubmitRetrievalSessionProof transaction for one retrieval session",
+        inventory=inventory, warmup_sessions=8, measured_sessions=len(offsets),
+        proofs_per_session=openings, openings_per_bundle=openings,
+        proofs_per_session_unit="individual chained openings (legacy field name)",
+        warmup_openings=8 * openings, measured_openings=len(offsets) * openings,
+        bundle_opening_distribution={str(openings): inventory},
+        native_message_batching=dict(open_session_messages_per_preparation_transaction_max=64,
+            proof_sessions_per_submission_transaction=1, cross_provider_crypto_aggregation=False),
+        k=k, m=layout["m"], assignment_count=layout["assignments"],
+        provider_daemon_count=layout["assignments"],
+        deputy_signer_indices=layout["deputy_indices"],
+        provisioned_provider_signers=max(12, layout["assignments"] + len(layout["deputy_indices"])),
+        max_in_flight=8, max_queued=128, max_queued_per_signer=16,
+        proof_gas=proof_gas,
+        proof_gas_limit_per_submission_transaction=proof_gas,
+        proof_gas_limit_per_opening=dict(gas=proof_gas, openings=openings),
+        proof_gas_limit_note="declared transaction limit, not committed gas used",
+        qualification=False)
 
 
 def capture_workload_metrics(lifecycle, phase, *, fenced=False):
@@ -626,8 +670,9 @@ def run(lifecycle, fixture_k8, fixture_k2, *, proof_only=False):
     return lifecycle.home / "evidence.json"
 
 
-def healthy_audit_views(value, deal, providers, epoch, epoch_length, chain, *, finalized, expected_samples=None):
+def healthy_audit_views(value, deal, providers, epoch, epoch_length, chain, *, finalized, expected_samples=None, k=2):
     """Check committed inventory/coverage without treating absent audits as success."""
+    layout = mode2_layout(k)
     found = {}
     for view in value:
         audit = view["audit"]
@@ -641,12 +686,12 @@ def healthy_audit_views(value, deal, providers, epoch, epoch_length, chain, *, f
                 producer.uint(assignment.get("deal_start", 0)) != producer.uint(deal.get("start_block", 0)) or
                 assignment["manifest_root"] != deal["manifest_root"] or producer.uint(assignment["kind"]) != 2 or
                 snapshot["chain_id"] != chain or producer.uint(snapshot["generation"]) != producer.uint(deal["current_gen"]) or
-                [producer.uint(snapshot[n]) for n in ("layout", "k", "m", "metadata_mdus", "user_mdus")] != [2, 2, 1, 2, 1] or
+                [producer.uint(snapshot[n]) for n in ("layout", "k", "m", "metadata_mdus", "user_mdus")] != [2, k, layout["m"], 2, 1] or
                 snapshot["setup_digest"] != base64.b64encode(bytes.fromhex(producer.SETUP_DIGEST)).decode() or
                 producer.uint(snapshot["deal_end"]) != producer.uint(deal["end_block"])):
-            raise ValueError("audit differs from the committed K2 assignment")
+            raise ValueError(f"audit differs from the committed K{k} assignment")
         count = producer.uint(audit["sample_count"])
-        if not 1 <= count <= 32 or (expected_samples is not None and count != expected_samples):  # One K2 user MDU has 32 distinct rows per slot.
+        if not 1 <= count <= layout["openings_per_bundle"] or (expected_samples is not None and count != expected_samples):
             raise ValueError("invalid audit sample count")
         coverage = producer.b64(audit["coverage"], (count + 7) // 8)
         accepted = producer.uint(audit.get("accepted_count", 0))
@@ -658,7 +703,7 @@ def healthy_audit_views(value, deal, providers, epoch, epoch_length, chain, *, f
         expected = dict(version=2, chain_id=chain, setup_digest=producer.SETUP_DIGEST, kind=2,
             context_id="00" * 32, deal_id=producer.uint(deal["id"]), generation=producer.uint(deal["current_gen"]),
             root=producer.b64(deal["manifest_root"], 32).hex(), assigned=producer.account(providers[slot]).hex(),
-            payee=producer.account(providers[slot]).hex(), layout=2, k=2, m=1, slot=slot, metadata_mdus=2,
+            payee=producer.account(providers[slot]).hex(), layout=2, k=k, m=layout["m"], slot=slot, metadata_mdus=2,
             user_mdus=1, start_mdu=0, start_leaf=0, blob_count=0, epoch_id=epoch, epoch_length=epoch_length,
             sample_count=count, snapshot_height=snapshot_height, anchor_height=snapshot_height + 1,
             first_response_height=snapshot_height + 2, deadline_height=min(epoch * epoch_length, producer.uint(deal["end_block"]) - 1),
@@ -670,7 +715,7 @@ def healthy_audit_views(value, deal, providers, epoch, epoch_length, chain, *, f
         if finalized and (view.get("finalized") is not True or accepted != count or producer.uint(audit.get("missed_epochs", 0)) != 0):
             raise ValueError("normal audit did not finalize with complete coverage")
         found[slot] = view
-    if set(found) != set(providers) or len(found) != 3:
+    if set(found) != set(providers) or len(found) != layout["assignments"]:
         raise ValueError("missing or duplicate all-slot audit evidence")
     return found
 
@@ -679,7 +724,8 @@ def sustained_offsets(step_seconds):
     """Five fixed offered-rate steps; pilot scales duration, never the rates."""
     artifact.integer(step_seconds, "step seconds", 4, 180)
     return [(step * step_seconds * 10**9 + index * interval)
-            for step, interval in enumerate((4_000_000_000, 2_000_000_000, 1_000_000_000, 500_000_000, 250_000_000))
+            for step, rate in enumerate(SUSTAINED_RATES)
+            for interval in (int(10**9 / rate),)
             for index in range((step_seconds * 10**9 + interval - 1) // interval)]
 
 
@@ -834,25 +880,55 @@ def summarize_commit_streams(lifecycle, processes):
             raise ValueError("Commit samples do not cover the fenced workload blocks")
 
 
-def run_sustained(lifecycle, deal, providers, send, command, audits, wait, exporter, step_seconds, proof_gas):
+def build_sustained_operations(lifecycle, deal, providers, deputies, offsets, minimum, expiry, price, proof_gas, k):
+    """Build one native full-row submission bundle per prepared session."""
+    layout = mode2_layout(k)
+    openings = layout["openings_per_bundle"]
+    owner, assigned = lifecycle.signers["owner0"], providers[0]
+    root = producer.b64(deal["manifest_root"], 32).hex()
+    operations = []
+    for index, offset in enumerate([0] * 8 + offsets):
+        payee, end = deputies[index % len(deputies)], expiry + index // 128
+        opening = transaction_job(lifecycle, owner, ["open-retrieval-session", "--deal-id", deal["id"],
+            "--provider", assigned, "--manifest-root", "0x" + root, "--start-mdu-index", "2", "--start-blob-index", "0",
+            "--blob-count", str(openings), "--nonce", index + 1, "--expires-at", end, "--challenge-version", "2",
+            "--authorized-proof-provider", payee], kind="open-session", gas="300000")
+        proof = transaction_job(lifecycle, payee, ["submit-retrieval-proof", "{proof_path}"], gas=str(proof_gas))
+        operations.append(dict(operation_id=f"sustained-{index}", phase="warmup" if index < 8 else "measurement",
+            offered_offset_ns=offset, **{"open-session": opening, "submit-proof": proof},
+            proof_expectation=dict(minimum_opened_height=minimum,
+                session=dict(deal_id=deal["id"], owner=owner, provider=assigned, authorized_proof_provider=payee,
+                    manifest_root=root, nonce=index + 1, expires_at=end, start_mdu_index=2, start_blob_index=0,
+                    blob_count=openings, total_bytes=layout["bytes_per_bundle"], funding=1,
+                    locked_fee=str(price * openings)),
+                snapshot=dict(chain_id=lifecycle.chain, setup_digest=producer.SETUP_DIGEST,
+                    generation=deal.get("current_gen", "0"), layout=2, k=k, m=layout["m"], slot=0,
+                    metadata_mdus=2, user_mdus=1, deal_end=deal["end_block"]))))
+    return operations
+
+
+def run_sustained(lifecycle, deal, providers, send, command, audits, wait, exporter, step_seconds, proof_gas, k=2):
     """Real slot-zero inventory and bounded existing scheduler; no client ACK claim."""
     import threading
+    layout = mode2_layout(k)
     offsets = sustained_offsets(step_seconds)
     duration = step_seconds * 5
     exporter = Path(exporter).resolve(strict=True)
     if not exporter.is_file() or not os.access(exporter, os.X_OK):
         raise ValueError("proof exporter must be executable")
     artifact.integer(proof_gas, "proof gas", 1, 64000000)
-    for i in range(3, 11):  # Registration follows content placement; these own no storage slots.
+    for i in layout["deputy_indices"]:
         send(f"provider{i}", ["register-provider", "General", "100000000000", "--endpoint", "/ip4/127.0.0.1/tcp/1/http"])
-    deputies = [lifecycle.signers[f"provider{i}"] for i in range(3, 11)]
+    deputies = [lifecycle.signers[f"provider{i}"] for i in layout["deputy_indices"]]
     doc = lifecycle.doc
-    doc.update(mode="four-validator-sustained-retrieval", workload="real K2 slot-zero, 32 fresh openings/session; eight deputy signers",
-        sustained_profile=dict(step_seconds=step_seconds, measurement_seconds=duration, rates=[0.25, 0.5, 1, 2, 4],
-            inventory=len(offsets) + 8, warmup_sessions=8, measured_sessions=len(offsets), proofs_per_session=32, max_in_flight=8, max_queued=128,
-            max_queued_per_signer=16, proof_gas=proof_gas, qualification=False),
+    profile = sustained_profile(k, step_seconds, offsets, proof_gas)
+    openings = profile["openings_per_bundle"]
+    doc.update(mode="four-validator-sustained-retrieval",
+        workload=f"real K{k} slot zero, {openings} fresh openings/submission transaction; eight deputy signers",
+        sustained_profile=profile,
         limits=["Proof acceptance capacity only; no delivered bytes or client ACKs",
                 "Normal mint retained; raw economics are not a conservation assertion",
+                "Only slot zero is challenged; this is not a many-provider throughput claim",
                 "Four local processes do not establish WAN capacity", "No restart qualification"])
     epoch_length = producer.uint(doc["frozen_module_params"]["epoch_len_blocks"])
     monitor_stop, failures = threading.Event(), []
@@ -891,25 +967,11 @@ def run_sustained(lifecycle, deal, providers, send, command, audits, wait, expor
         if expiry + (len(offsets) + 7) // 128 >= producer.uint(deal["end_block"]):
             raise ValueError("insufficient deal lifetime for inventory")
         price = producer.uint(doc["frozen_module_params"]["retrieval_price_per_blob"]["amount"], 256)
-        owner, assigned = lifecycle.signers["owner0"], providers[0]
+        assigned = providers[0]
         root = producer.b64(deal["manifest_root"], 32).hex()
         directory = next(Path(row["directory"]) for row in doc["providers"] if row["address"] == assigned) / "deals" / str(deal["id"]) / root
-        operations = []
-        for index, offset in enumerate([0] * 8 + offsets):
-            payee, end = deputies[index % len(deputies)], expiry + index // 128
-            opening = transaction_job(lifecycle, owner, ["open-retrieval-session", "--deal-id", deal["id"],
-                "--provider", assigned, "--manifest-root", "0x" + root, "--start-mdu-index", "2", "--start-blob-index", "0",
-                "--blob-count", "32", "--nonce", index + 1, "--expires-at", end, "--challenge-version", "2",
-                "--authorized-proof-provider", payee], kind="open-session", gas="300000")
-            proof = transaction_job(lifecycle, payee, ["submit-retrieval-proof", "{proof_path}"], gas=str(proof_gas))
-            operations.append(dict(operation_id=f"sustained-{index}", phase="warmup" if index < 8 else "measurement", offered_offset_ns=offset,
-                **{"open-session": opening, "submit-proof": proof},
-                proof_expectation=dict(minimum_opened_height=minimum,
-                    session=dict(deal_id=deal["id"], owner=owner, provider=assigned, authorized_proof_provider=payee,
-                        manifest_root=root, nonce=index + 1, expires_at=end, start_mdu_index=2, start_blob_index=0,
-                        blob_count=32, total_bytes=4194304, funding=1, locked_fee=str(price * 32)),
-                    snapshot=dict(chain_id=lifecycle.chain, setup_digest=producer.SETUP_DIGEST, generation=deal.get("current_gen", "0"),
-                        layout=2, k=2, m=1, slot=0, metadata_mdus=2, user_mdus=1, deal_end=deal["end_block"]))))
+        operations = build_sustained_operations(lifecycle, deal, providers, deputies, offsets, minimum, expiry,
+                                                price, proof_gas, k)
         inventory = lifecycle.home / "inventory"
         inventory.mkdir(mode=0o700)
         requests = []
@@ -957,7 +1019,8 @@ def run_sustained(lifecycle, deal, providers, send, command, audits, wait, expor
             max_queued_per_signer=1, mode="prepared-proof-only",
             read_session_evidence=lambda operation, sid, height, deadline: read_session_evidence(lifecycle, operation, sid, height, deadline))
         _, warmup_transactions = journal_results(warmup_journal, warmup, proof_only=True)
-        doc["warmup"] = dict(journal=str(warmup_journal), sessions=8, proofs=256,
+        doc["warmup"] = dict(journal=str(warmup_journal), sessions=8, submission_transactions=8,
+                             proofs=profile["warmup_openings"], proof_unit="individual chained openings",
                              committed_transactions=warmup_transactions, all_committed=True)
         # One-second minimum local block time gives a conservative remaining-height floor.
         current = lifecycle.wait_height(3)
@@ -1002,7 +1065,8 @@ def run_sustained(lifecycle, deal, providers, send, command, audits, wait, expor
             artifact.stop_owned_process_groups(owned)
         finally:
             monitor_stop.set()
-            # A capture can have twelve bounded LCD reads plus four anchor reads.
+            # A capture can query every selected provider on each validator,
+            # plus four bounded anchor reads.
             stop_deadline = artifact.monotonic_ns() + 90 * 10**9
             while worker.is_alive() and artifact.monotonic_ns() < stop_deadline:
                 worker.join(timeout=1)
@@ -1014,6 +1078,8 @@ def run_sustained(lifecycle, deal, providers, send, command, audits, wait, expor
 
 def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustained=None, audit_profile="normal"):
     """Real canonical ingest and normal audits; optional bounded retrieval workload."""
+    k = sustained.get("k", 2) if sustained is not None else 2
+    layout = mode2_layout(k)
     gateway = Path(gateway_binary).resolve(strict=True)
     cli = Path(cli_binary).resolve(strict=True)
     source = Path(product_source).resolve(strict=True)
@@ -1041,7 +1107,7 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
     doc = lifecycle.doc
     doc.pop("transactions_submitted", None)
     doc.update(mode="four-validator-healthy-provider-diagnostic", setup_transactions=[], providers=[],
-        workload="one real K2 deal; three assigned provider-daemons; one normal audit epoch",
+        workload=f"one real K{k} deal; {layout['assignments']} assigned provider-daemons; one normal audit epoch",
         qualification=False, limits=["No capacity or delivered retrieval qualification", "No deputy retrieval yet",
             "Normal mint and audit parameters retained; no economic conservation assertion", "No restart qualification"])
     def command(args, timeout=60):
@@ -1077,7 +1143,7 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
         if sustained is not None and "--append" not in lifecycle.cli(lifecycle.home, "tx", "sign-batch", "--help").split():
             raise ValueError("sustained workload requires SDK sign-batch --append")
         lifecycle.reserve_ports()
-        for i in range(3):
+        for i in range(layout["assignments"]):
             reservation = socket.socket()
             reservations.append(reservation)
             reservation.bind(("127.0.0.1", 19091 + i))
@@ -1096,16 +1162,19 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
             artifact_source_match="supplied binaries/library; build correspondence not attested")
         if doc["provenance"]["trusted_setup_sha256"] != producer.SETUP_DIGEST:
             raise ValueError("diagnostic requires the maintained trusted setup")
-        lifecycle.prepare(audit_profile=audit_profile)  # Normal mint retained for both explicit audit profiles.
-        quotas = {min(32, producer.uint(doc["frozen_module_params"]["quota_max_blobs"]),
+        lifecycle.prepare(audit_profile=audit_profile,
+                          provider_count=max(12, layout["assignments"] + len(layout["deputy_indices"])))
+        # Normal mint is retained for both explicit audit profiles.
+        population = layout["openings_per_bundle"]
+        quotas = {min(population, producer.uint(doc["frozen_module_params"]["quota_max_blobs"]),
                       max(producer.uint(doc["frozen_module_params"]["quota_min_blobs"]),
-                          (32 * producer.uint(doc["frozen_module_params"][key]) + 9999) // 10000))
+                          (population * producer.uint(doc["frozen_module_params"][key]) + 9999) // 10000))
                   for key in ("quota_bps_per_epoch_hot", "quota_bps_per_epoch_cold")}
-        if len(quotas) != 1 or not 1 <= next(iter(quotas)) <= 32:
-            raise ValueError("K2 diagnostic requires an unambiguous nonzero frozen audit quota")
+        if len(quotas) != 1 or not 1 <= next(iter(quotas)) <= population:
+            raise ValueError(f"K{k} diagnostic requires an unambiguous nonzero frozen audit quota")
         expected_samples = quotas.pop()
-        doc["audit_sampling_profile"] = dict(name=audit_profile, population_per_slot=32, samples_per_slot=expected_samples,
-            samples_per_epoch=3 * expected_samples, qualification=False)
+        doc["audit_sampling_profile"] = dict(name=audit_profile, population_per_slot=population, samples_per_slot=expected_samples,
+            samples_per_epoch=layout["assignments"] * expected_samples, qualification=False)
         genesis = json.loads((Path(lifecycle.nodes[0]["home"]) / "config/genesis.json").read_text())
         doc["normal_mint_profile"] = genesis["app_state"]["mint"]
         epoch_length = producer.uint(doc["frozen_module_params"]["epoch_len_blocks"])
@@ -1114,7 +1183,7 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
         lifecycle.save()
         lifecycle.start("initial")
         lifecycle.wait_height(3)
-        for i in range(3):
+        for i in range(layout["assignments"]):
             send(f"provider{i}", ["register-provider", "General", "100000000000", "--endpoint", f"/ip4/127.0.0.1/tcp/{19091+i}/http"])
             directory = lifecycle.home / f"provider{i}"
             directory.mkdir(mode=0o700)
@@ -1145,7 +1214,7 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
                 signer_key=f"provider{i}", home=lifecycle.nodes[0]["home"], system_liveness_interval_seconds=10,
                 environment={key: value for key, value in env.items() if key.startswith("POLYSTORE_") and key != "POLYSTORE_GATEWAY_SP_AUTH"}))
             lifecycle.save()
-        for i in range(3):
+        for i in range(layout["assignments"]):
             while True:
                 check_providers()
                 try:
@@ -1153,7 +1222,7 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
                     break
                 except ValueError:
                     time.sleep(min(0.2, lifecycle.remaining()))
-        created = send("owner0", ["create-deal", "100000", "100000000", "10000000", "--service-hint", "General:rs=2+1"])
+        created = send("owner0", ["create-deal", "100000", "100000000", "10000000", "--service-hint", f"General:rs={k}+{layout['m']}"])
         wait(created["height"] + 1)
         owned = [d for d in lifecycle.query(lifecycle.nodes[0], API + "/deals", created["height"])["deals"]
                  if d["owner"] == lifecycle.signers["owner0"]]
@@ -1173,7 +1242,7 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
         if (not isinstance(root, str) or len(root) != 66 or root != "0x" + bytes.fromhex(root[2:]).hex() or
                 [producer.uint(uploaded[n]) for n in ("size_bytes", "file_size_bytes", "logical_size_bytes", "total_mdus", "witness_mdus")] != [8126464, 8126464, 8126464, 3, 1] or
                 uploaded.get("content_encoding") != "none"):
-            raise ValueError("canonical K2 ingest returned unexpected content")
+            raise ValueError(f"canonical K{k} ingest returned unexpected content")
         doc["ingest"] = uploaded
         updated = send("owner0", ["update-deal-content", "--deal-id", identity, "--cid", root,
             "--size", "8126464", "--total-mdus", "3", "--witness-mdus", "1"])
@@ -1187,17 +1256,18 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
         for slot in deal["mode2_slots"]:
             index = producer.uint(slot.get("slot", 0))
             if index in providers or slot["status"] != "SLOT_STATUS_ACTIVE" or slot.get("pending_provider"):
-                raise ValueError("K2 slots must be distinct and ACTIVE")
+                raise ValueError(f"K{k} slots must be distinct and ACTIVE")
             providers[index] = slot["provider"]
-        if set(providers) != {0, 1, 2} or set(providers.values()) != {lifecycle.signers[f"provider{i}"] for i in range(3)}:
-            raise ValueError("K2 placement differs from the three owned providers")
+        if (set(providers) != set(range(layout["assignments"])) or
+                set(providers.values()) != {lifecycle.signers[f"provider{i}"] for i in range(layout["assignments"])}):
+            raise ValueError(f"K{k} placement differs from the owned providers")
         doc["deal"] = deal
         doc["canonical_artifacts"] = []
         for slot, address in providers.items():
             provider = next(row for row in doc["providers"] if row["address"] == address)
             directory = Path(provider["directory"]) / "deals" / identity / root[2:]
             for filename, size in (("mdu_0.bin", 8388608), ("mdu_1.bin", 8388608),
-                                   (f"mdu_2_slot_{slot}.bin", 4194304)):
+                                   (f"mdu_2_slot_{slot}.bin", layout["bytes_per_bundle"])):
                 path = directory / filename
                 if path.stat().st_size != size:
                     raise ValueError("provider canonical artifact has wrong size")
@@ -1211,7 +1281,8 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
                 values = []
                 for address in providers.values():
                     values.extend(lifecycle.query(node, API + "/storage-audits/by-provider/" + address, at)["audits"])
-                checked = healthy_audit_views(values, deal, providers, selected_epoch, epoch_length, lifecycle.chain, finalized=finalized, expected_samples=expected_samples)
+                checked = healthy_audit_views(values, deal, providers, selected_epoch, epoch_length, lifecycle.chain,
+                                              finalized=finalized, expected_samples=expected_samples, k=k)
                 anchor_height = (selected_epoch - 1) * epoch_length + 1
                 anchor = lifecycle.query(node, f"/block?height={anchor_height}")
                 if (producer.uint(anchor["block"]["header"]["height"]) != anchor_height or
@@ -1280,7 +1351,9 @@ def main():
     parser.add_argument("--timeout", type=int, default=600)
     parser.add_argument("--audit-profile", choices=("normal", "c6"), default="normal")
     parser.add_argument("--step-seconds", type=int, default=180, help="Each of five offered-rate steps; 4 is a same-path pilot")
-    parser.add_argument("--proof-gas", type=int, help="Explicit locally validated fixed gas limit per32proof transaction")
+    parser.add_argument("--sustained-k", type=int, choices=(2, 8), default=2,
+                        help="Native Mode 2 data width; full-row bundles contain 64/K openings")
+    parser.add_argument("--proof-gas", type=int, help="Explicit locally validated fixed gas limit per proof-submission transaction")
     parser.add_argument("--proof-only", action="store_true", help="Prepare six sessions, verify rejected transactions, time proofs, then verify idempotent settlement retries")
     options = vars(parser.parse_args())
     k8, k2 = options.pop("fixture_k8"), options.pop("fixture_k2")
@@ -1290,13 +1363,14 @@ def main():
     cli, source = options.pop("cli_binary"), options.pop("product_source")
     exporter = options.pop("proof_exporter")
     step_seconds, proof_gas = options.pop("step_seconds"), options.pop("proof_gas")
+    sustained_k = options.pop("sustained_k")
     if mode == "sustained-providers":
         if not all((gateway, cli, source, exporter, proof_gas)) or k8 or k2 or proof_only or not 4 <= step_seconds <= 180 or not 1 <= proof_gas <= 64000000:
             parser.error("sustained-providers requires product binaries/source, --proof-exporter and --proof-gas; excludes fixtures/--proof-only")
         print(run_healthy(artifact.FourValidatorLifecycle(**options, sustained=True), gateway, cli, source,
-            sustained=dict(exporter=exporter, step_seconds=step_seconds, proof_gas=proof_gas), audit_profile=audit_profile))
-    elif exporter or proof_gas is not None or step_seconds != 180:
-        parser.error("exporter, proof gas and pilot duration require sustained-providers")
+            sustained=dict(exporter=exporter, step_seconds=step_seconds, proof_gas=proof_gas, k=sustained_k), audit_profile=audit_profile))
+    elif exporter or proof_gas is not None or step_seconds != 180 or sustained_k != 2:
+        parser.error("exporter, proof gas, sustained K and pilot duration require sustained-providers")
     elif mode == "healthy-providers":
         if not gateway or not cli or not source or k8 or k2 or proof_only or options["timeout"] > 600:
             parser.error("healthy-providers requires --gateway-binary/--cli-binary/--product-source, timeout <= 600, and excludes fixtures/--proof-only")

--- a/scripts/retrieval_four_validator_workload.py
+++ b/scripts/retrieval_four_validator_workload.py
@@ -36,7 +36,7 @@ SUSTAINED_RATES = (0.25, 0.5, 1, 2, 4)
 
 def mode2_layout(k):
     """Return the complete supported full-row geometry for one Mode 2 MDU."""
-    if isinstance(k, bool) or k not in (2, 8):
+    if type(k) is not int or k not in (2, 8):
         raise ValueError("sustained retrieval requires native K2 or K8")
     m = 1 if k == 2 else 4
     openings = artifact.BLOBS_PER_MDU // k

--- a/scripts/retrieval_fresh_proof.py
+++ b/scripts/retrieval_fresh_proof.py
@@ -3,7 +3,8 @@
 
 This module never signs or broadcasts. The scheduler invokes its child through
 run_bounded_command, which also bounds native initialization and HTTP draining.
-Only the Go exporter's nonconstant, slot-zero K8/K2 fixture is supported.
+The Go exporter supports nonconstant native K8/K2 assignment artifacts. The
+small Python known-answer fixture remains slot zero only.
 """
 import base64
 import copy
@@ -147,10 +148,14 @@ def frozen_context(view, expected, session_id, height):
     if not 1 <= uint(expected["minimum_opened_height"]) <= opened <= height <= expiry <= uint(x["deal_end"]) < 1 << 63 or opened + 2 > expiry or not opened <= updated <= height:
         raise ValueError("invalid committed response window")
     k, m, slot = uint(x["k"]), uint(x["m"]), uint(x.get("slot", 0))
-    if uint(x["layout"]) != 2 or (k, m) not in ((8, 4), (2, 1)) or slot != 0:
-        raise ValueError("fixture supports only slot-zero K8/K2")
+    if uint(x["layout"]) != 2 or (k, m) not in ((8, 4), (2, 1)) or slot >= k + m:
+        raise ValueError("unsupported native K8/K2 assignment")
     start, count = uint(s.get("start_blob_index", 0)), uint(s["blob_count"])
-    if uint(x["metadata_mdus"]) != 2 or uint(x["user_mdus"]) != 1 or uint(s["start_mdu_index"]) != 2 or not 1 <= count <= 64 // k - start or uint(s["total_bytes"]) != count * BLOB_BYTES:
+    rows = 64 // k
+    if (uint(x["metadata_mdus"]) != 2 or uint(x["user_mdus"]) != 1 or
+            uint(s["start_mdu_index"]) != 2 or not 1 <= count or
+            not slot * rows <= start < start + count <= (slot + 1) * rows or
+            uint(s["total_bytes"]) != count * BLOB_BYTES):
         raise ValueError("fixture range mismatch")
     c = dict(version=2, chain_id=chain, setup_digest=setup.hex(), kind=1, context_id=session_id,
              deal_id=uint(s.get("deal_id", 0)), generation=uint(x.get("generation", 0)), root=root.hex(),
@@ -186,6 +191,8 @@ def read_json(path):
 
 
 def native_proofs(config, c, digest, seed):
+    if c["slot"] != 0:
+        raise ValueError("Python known-answer fixture supports slot zero only")
     meta, _ = read_json(Path(config["fixture"]) / "fixture.json")
     payload, raw = read_json(Path(config["fixture"]) / "1.json")
     for name, expected in dict(schema_version=1, challenge_kind="legacy-fixed-z", data_pattern="be-fr-last-byte-cycle-1-through-251-v1",

--- a/scripts/retrieval_fresh_proof.py
+++ b/scripts/retrieval_fresh_proof.py
@@ -191,7 +191,7 @@ def read_json(path):
 
 
 def native_proofs(config, c, digest, seed):
-    if c["slot"] != 0:
+    if uint(c.get("slot", 0), 32) != 0:
         raise ValueError("Python known-answer fixture supports slot zero only")
     meta, _ = read_json(Path(config["fixture"]) / "fixture.json")
     payload, raw = read_json(Path(config["fixture"]) / "1.json")

--- a/scripts/test_bench_retrieval_sessions.py
+++ b/scripts/test_bench_retrieval_sessions.py
@@ -1179,6 +1179,41 @@ class PreparedRetrievalProofTest(unittest.TestCase):
                 self.assertFalse(row["proof_state_verified"])
                 self.assertTrue(row["state_evidence_error"])
 
+    def test_progress_counts_only_final_unique_verified_lifecycle_outcomes(self):
+        progress = []
+        one, two = self.operation("first"), self.operation("second")
+        def same_hash(job):
+            result = self.submit(job)
+            result["txhash"] = "AB" * 32
+            return result
+        with patch.object(artifact, "scheduled_transaction", side_effect=same_hash):
+            self.run_operations([one, two], progress_callback=progress.append)
+        self.assertEqual(progress[-1]["completed_submissions"], 2)
+        self.assertEqual(progress[-1]["committed_valid_submissions"], 1)
+        self.assertEqual([row["outcome"] for row in self.rows("transactions")],
+                         ["committed_success", "duplicate"])
+
+        progress.clear()
+        with patch.object(artifact, "scheduled_transaction",
+                          return_value=dict(outcome="committed_failure", height=104,
+                                            txhash="CD" * 32, code=7)):
+            self.run_operations([self.operation("failure")], progress_callback=progress.append)
+        self.assertEqual(progress[-1]["committed_valid_submissions"], 0)
+        self.assertEqual(progress[-1]["committed_height"], 0)
+
+        progress.clear()
+        def invalid_state(operation, sid, height, deadline):
+            value = self.read(operation, sid, height, deadline)
+            if height is not None:
+                value["view"]["session"]["status"] = 1
+            return value
+        with patch.object(artifact, "scheduled_transaction", side_effect=self.submit):
+            self.run_operations([self.operation("state-error")], reader=invalid_state,
+                                progress_callback=progress.append)
+        self.assertEqual(progress[-1]["committed_valid_submissions"], 0)
+        self.assertEqual(progress[-1]["committed_height"], 0)
+        self.assertFalse(self.rows("transactions")[0]["proof_state_verified"])
+
     def test_rejection_unknown_and_duplicate_session_are_not_proof_success(self):
         for outcome in ("checktx_rejected", "unknown", "committed_failure"):
             with patch.object(artifact, "scheduled_transaction", return_value=dict(outcome=outcome, txhash="AB" * 32)):

--- a/scripts/test_retrieval_four_validator_workload.py
+++ b/scripts/test_retrieval_four_validator_workload.py
@@ -17,6 +17,14 @@ import retrieval_fresh_proof as producer
 
 ADDRESSES = ["nil1qyqszqgpqyqszqgpqyqszqgpqyqszqgpdqqjtx", "nil1qgpqyqszqgpqyqszqgpqyqszqgpqyqszuyxhqs",
              "nil1xycnzvf3xycnzvf3xycnzvf3xycnzvf3ner3g8", "nil1xgeryv3jxgeryv3jxgeryv3jxgeryv3jza95r3"]
+AUDIT_ADDRESSES = [
+    "nil102e0z53k4ks07fffg4f5g9mm2ke0ppry6hldnq", "nil10489zrpfztul0avxgd0va5f0ru5wae2cjmhdtp",
+    "nil10y7kv0jqy2e7fnwuv39yga53u59j3e4tw4vdqc", "nil10yrlgscjqs3m5g4nd8uxfgde064ks347uzcvc7",
+    "nil12hdzex4uscgph556tlczw2lztdhgnlxvu4rm3s", "nil12lqej2x9de9t8mgk5e98huk7k2k6gagsr27awn",
+    "nil12nfaymvwcdhwka2jdcsl5ml2y6e76lkgsje38k", "nil12ueq7u6uqxjd35mc704sjamwwxydsgsytw9lfu",
+    "nil12v3u485sazwmfcnfah7dlvrtgkqlf5xkh5rthd", "nil137glcssk75ttt280qwyx4f3k8h5lgeu5s6rduh",
+    "nil139mxr38p09rxk56a0dej5asy3d2ww397fttud7", "nil140pc0w3z6x6f6dkme8eux8naw5wd6rmxm5gfh8",
+]
 
 
 def fixture_state():
@@ -318,20 +326,35 @@ class HealthyAuditViewsTest(unittest.TestCase):
             workload.main()
             run.assert_called_once_with(constructor.return_value, "/gateway", "/native-cli", "/source", audit_profile="normal")
 
-    def fixture(self, *, complete=True, counts=(1, 9, 32)):
+    def test_sustained_cli_defaults_k2_and_forwards_explicit_k8(self):
+        common = ["diagnostic", "--mode", "sustained-providers", "--binary", "/chain", "--library", "/lib",
+                  "--home", "/new-home", "--gateway-binary", "/gateway", "--cli-binary", "/native-cli",
+                  "--product-source", "/source", "--proof-exporter", "/exporter", "--proof-gas", "20000000",
+                  "--step-seconds", "4"]
+        for extra, k in (([], 2), (["--sustained-k", "8"], 8)):
+            with self.subTest(k=k), patch.object(workload.sys, "argv", common + extra), \
+                 patch.object(artifact, "FourValidatorLifecycle") as constructor, \
+                 patch.object(workload, "run_healthy", return_value="evidence") as run, patch("builtins.print"):
+                workload.main()
+                run.assert_called_once_with(constructor.return_value, "/gateway", "/native-cli", "/source",
+                    sustained=dict(exporter="/exporter", step_seconds=4, proof_gas=20000000, k=k), audit_profile="normal")
+
+    def fixture(self, *, complete=True, counts=None, k=2):
+        layout = workload.mode2_layout(k)
+        counts = (1, 9, 32) if counts is None and k == 2 else counts or (1,) * layout["assignments"]
         deal = dict(id="7", manifest_root=base64.b64encode(bytes([7]) * 32).decode(),
                     current_gen="1", start_block="5", end_block="1000")
-        providers = dict(enumerate(ADDRESSES[:3]))
+        providers = dict(enumerate(AUDIT_ADDRESSES[:layout["assignments"]]))
         values = []
         for slot, count in enumerate(counts):
             accepted = count if complete else 0
-            snapshot = dict(chain_id="polystore_260-1", generation="1", layout=2, k=2, m=1,
+            snapshot = dict(chain_id="polystore_260-1", generation="1", layout=2, k=k, m=layout["m"],
                             slot=slot, metadata_mdus="2", user_mdus="1", deal_end="1000",
                             setup_digest=base64.b64encode(bytes.fromhex(producer.SETUP_DIGEST)).decode())
             context = dict(version=2, chain_id="polystore_260-1", setup_digest=producer.SETUP_DIGEST,
                 kind=2, context_id="00"*32, deal_id=7, generation=1, root="07"*32,
                 assigned=producer.account(providers[slot]).hex(), payee=producer.account(providers[slot]).hex(),
-                layout=2, k=2, m=1, slot=slot, metadata_mdus=2, user_mdus=1, start_mdu=0, start_leaf=0,
+                layout=2, k=k, m=layout["m"], slot=slot, metadata_mdus=2, user_mdus=1, start_mdu=0, start_leaf=0,
                 blob_count=0, epoch_id=2, epoch_length=100, sample_count=count, snapshot_height=100,
                 anchor_height=101, first_response_height=102, deadline_height=200, deal_end=1000)
             values.append(dict(audit=dict(epoch_id="2", sample_count=str(count), accepted_count=str(accepted),
@@ -352,6 +375,16 @@ class HealthyAuditViewsTest(unittest.TestCase):
         values, deal, providers = self.fixture()
         with self.assertRaisesRegex(ValueError, "sample count"):
             workload.healthy_audit_views(values, deal, providers, 2, 100, "polystore_260-1", finalized=True, expected_samples=32)
+
+    def test_k8_audit_uses_twelve_assignments_and_eight_row_population(self):
+        values, deal, providers = self.fixture(k=8, counts=(8,) * 12)
+        checked = workload.healthy_audit_views(values, deal, providers, 2, 100, "polystore_260-1",
+                                               finalized=True, expected_samples=8, k=8)
+        self.assertEqual(set(checked), set(range(12)))
+        self.assertEqual(sum(int(v["audit"]["sample_count"]) for v in checked.values()), 96)
+        values[0]["audit"]["sample_count"] = "9"
+        with self.assertRaisesRegex(ValueError, "sample count"):
+            workload.healthy_audit_views(values, deal, providers, 2, 100, "polystore_260-1", finalized=True, k=8)
 
     def test_all_slots_include_parity_and_use_actual_sample_denominator(self):
         values, deal, providers = self.fixture()

--- a/scripts/test_retrieval_fresh_proof.py
+++ b/scripts/test_retrieval_fresh_proof.py
@@ -97,6 +97,36 @@ class FreshProofTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             producer.frozen_context(view, expected, sid, 151)
 
+    def test_frozen_context_accepts_only_the_assigned_slot_range(self):
+        view, expected, sid = fixture_view()
+        for target in (view, expected):
+            snapshot = target["session"]["challenge_snapshot"] if target is view else target["snapshot"]
+            snapshot["slot"] = 7
+            target["session"]["start_blob_index"] = 56
+            target["session"]["blob_count"] = "8"
+            target["session"]["total_bytes"] = str(8 * 131072)
+        fields = {name: value for name, _, value in GOLDEN["schema"]["fields"]}
+        c = dict(fields)
+        c.update(chain_id="polystore-test-1", setup_digest=producer.SETUP_DIGEST, context_id=sid,
+                 deal_id=9007199254740993, generation=7, root="cd" * 32,
+                 assigned="01" * 20, payee="02" * 20, layout=2, k=8, m=4, slot=7,
+                 metadata_mdus=2, user_mdus=1, start_mdu=2, start_leaf=56, blob_count=8,
+                 snapshot_height=100, anchor_height=101, first_response_height=102,
+                 deadline_height=150, deal_end=200)
+        raw = producer.context_bytes(c)
+        view["challenge_context"] = base64.b64encode(raw).decode()
+        view["challenge_context_hash"] = base64.b64encode(hashlib.sha256(raw).digest()).decode()
+        self.assertEqual(producer.frozen_context(view, expected, sid, 102)[0]["start_leaf"], 56)
+        for start, count in ((0, 8), (55, 8), (56, 9), (64, 1)):
+            bad = copy.deepcopy(view)
+            bad["session"]["start_blob_index"] = start
+            bad["session"]["blob_count"] = str(count)
+            bad["session"]["total_bytes"] = str(count * 131072)
+            wanted = copy.deepcopy(expected)
+            wanted["session"].update(start_blob_index=start, blob_count=str(count), total_bytes=str(count * 131072))
+            with self.subTest(start=start, count=count), self.assertRaises(ValueError):
+                producer.frozen_context(bad, wanted, sid, 102)
+
     def test_rows_use_global_scalar_index(self):
         for k in (2, 8):
             for row in (0, 1, 64 // k - 1):

--- a/scripts/test_retrieval_sustained.py
+++ b/scripts/test_retrieval_sustained.py
@@ -49,7 +49,7 @@ class SustainedTest(unittest.TestCase):
                                  dict(gas=20_000_000, openings=want["openings"]))
                 self.assertEqual(profile["native_message_batching"]["proof_sessions_per_submission_transaction"], 1)
                 self.assertFalse(profile["native_message_batching"]["cross_provider_crypto_aggregation"])
-        for k in (0, 4, 16, True, "8"):
+        for k in (0, 2.0, 4, 16, True, "8"):
             with self.subTest(k=k), self.assertRaises(ValueError):
                 workload.mode2_layout(k)
 

--- a/scripts/test_retrieval_sustained.py
+++ b/scripts/test_retrieval_sustained.py
@@ -11,11 +11,48 @@ from unittest.mock import Mock, patch
 
 import retrieval_bench_artifact as artifact
 import retrieval_four_validator_workload as workload
-from test_retrieval_four_validator_workload import fixture_state
+from test_retrieval_four_validator_workload import AUDIT_ADDRESSES, fixture_state
 from test_bench_retrieval_sessions import OPEN_RESPONSE_DATA
 
 
 class SustainedTest(unittest.TestCase):
+    def test_native_layout_and_reported_denominators_cannot_drift(self):
+        offsets = workload.sustained_offsets(4)
+        expected = {
+            2: dict(m=1, assignments=3, openings=32, bytes=4 * 1024 * 1024,
+                    rates=[8.0, 16.0, 32, 64, 128]),
+            8: dict(m=4, assignments=12, openings=8, bytes=1024 * 1024,
+                    rates=[2.0, 4.0, 8, 16, 32]),
+        }
+        for k, want in expected.items():
+            with self.subTest(k=k):
+                layout = workload.mode2_layout(k)
+                profile = workload.sustained_profile(k, 4, offsets, 20_000_000)
+                self.assertEqual((layout["m"], layout["assignments"], layout["openings_per_bundle"],
+                                  layout["bytes_per_bundle"]),
+                                 (want["m"], want["assignments"], want["openings"], want["bytes"]))
+                self.assertEqual(len(layout["deputy_indices"]), 8)
+                self.assertFalse(set(layout["deputy_indices"]) & set(range(layout["assignments"])))
+                self.assertEqual(layout["deputy_indices"], list(range(want["assignments"], want["assignments"] + 8)))
+                self.assertEqual(profile["openings_per_bundle"], want["openings"])
+                self.assertEqual(profile["proofs_per_session"], want["openings"])
+                self.assertEqual(profile["offered_openings_per_second"], want["rates"])
+                self.assertEqual(profile["proofs_per_session_unit"], "individual chained openings (legacy field name)")
+                self.assertEqual(profile["warmup_openings"], 8 * want["openings"])
+                self.assertEqual(profile["measured_openings"], 31 * want["openings"])
+                self.assertEqual(profile["bundle_opening_distribution"], {str(want["openings"]): 39})
+                self.assertEqual(profile["deputy_signer_indices"], layout["deputy_indices"])
+                self.assertEqual(profile["provider_daemon_count"], want["assignments"])
+                self.assertEqual(profile["provisioned_provider_signers"], max(12, want["assignments"] + 8))
+                self.assertEqual(profile["proof_gas_limit_per_submission_transaction"], 20_000_000)
+                self.assertEqual(profile["proof_gas_limit_per_opening"],
+                                 dict(gas=20_000_000, openings=want["openings"]))
+                self.assertEqual(profile["native_message_batching"]["proof_sessions_per_submission_transaction"], 1)
+                self.assertFalse(profile["native_message_batching"]["cross_provider_crypto_aggregation"])
+        for k in (0, 4, 16, True, "8"):
+            with self.subTest(k=k), self.assertRaises(ValueError):
+                workload.mode2_layout(k)
+
     def test_fixed_rates_and_pilot_are_absolute_and_bounded(self):
         for seconds, expected in ((4, 31), (180, 1395)):
             values = workload.sustained_offsets(seconds)
@@ -26,6 +63,31 @@ class SustainedTest(unittest.TestCase):
         for seconds in (0, 3, 181, True, 4.5):
             with self.assertRaises(ValueError):
                 workload.sustained_offsets(seconds)
+
+    def test_k8_operations_derive_full_row_fees_and_exporter_expectations(self):
+        owner = AUDIT_ADDRESSES[0]
+        life = SimpleNamespace(binary=Path("/chain"), chain="polystore_290-1",
+            deadline=artifact.monotonic_ns() + 60 * 10**9,
+            nodes=[dict(home="/home/validator0", rpc=26657)], env={},
+            signers={"owner0": owner})
+        deal = dict(id="7", manifest_root=base64.b64encode(bytes([8]) * 32).decode(),
+                    current_gen="1", end_block="5000")
+        providers = {0: AUDIT_ADDRESSES[1]}
+        deputies = AUDIT_ADDRESSES[2:10]
+        operations = workload.build_sustained_operations(
+            life, deal, providers, deputies, [0, 250_000_000], 10, 4000, 17, 9_000_000, 8)
+        self.assertEqual(len(operations), 10)
+        for index, operation in enumerate(operations):
+            session = operation["proof_expectation"]["session"]
+            snapshot = operation["proof_expectation"]["snapshot"]
+            submit = operation["open-session"]["submit"]
+            self.assertEqual((session["blob_count"], session["total_bytes"], session["locked_fee"]), (8, 1024 * 1024, "136"))
+            self.assertEqual((snapshot["k"], snapshot["m"], snapshot["slot"]), (8, 4, 0))
+            self.assertEqual(session["authorized_proof_provider"], deputies[index % 8])
+            self.assertEqual(submit[submit.index("--blob-count") + 1], "8")
+            self.assertEqual(operation["submit-proof"]["submit"][
+                operation["submit-proof"]["submit"].index("--gas") + 1], "9000000")
+        self.assertEqual([row["phase"] for row in operations], ["warmup"] * 8 + ["measurement"] * 2)
 
     def test_atomic_response_count_order_type_and_uniqueness(self):
         second = OPEN_RESPONSE_DATA[:-64] + '31' * 32

--- a/scripts/test_retrieval_sustained.py
+++ b/scripts/test_retrieval_sustained.py
@@ -16,6 +16,42 @@ from test_bench_retrieval_sessions import OPEN_RESPONSE_DATA
 
 
 class SustainedTest(unittest.TestCase):
+    def test_scheduler_progress_uses_existing_completion_counters(self):
+        job = dict(id="proof", operation_id="proof", phase="measurement", signer="deputy",
+                   kind="submit-proof", offered_offset_ns=0, timeout_seconds=1,
+                   submit=["chain", "submit", "--from", "deputy"], query=["chain", "query"])
+        progress = []
+        with patch.object(artifact, "execute_scheduled_transaction",
+                          return_value=dict(outcome="committed_success", height=17, txhash="AA" * 32)):
+            artifact.schedule_transactions([job], max_in_flight=1, max_queued=1,
+                max_queued_per_signer=1, progress_callback=progress.append)
+        self.assertEqual(len(progress), 1)
+        self.assertEqual((progress[0]["phase"], progress[0]["completed_submissions"],
+                          progress[0]["committed_valid_submissions"], progress[0]["committed_height"]),
+                         ("scheduler", 1, 1, 17))
+        self.assertEqual((progress[0]["pending"], progress[0]["in_flight"], progress[0]["followups"]),
+                         (0, 0, 0))
+
+    def test_scheduler_watchdog_uses_no_observer_reads_and_rejection_is_not_progress(self):
+        def job(identity, offset):
+            return dict(id=identity, operation_id=identity, phase="measurement", signer="deputy",
+                        kind="submit-proof", offered_offset_ns=offset, timeout_seconds=1,
+                        submit=["chain", "submit", "--from", "deputy"], query=["chain", "query"])
+        ticks = iter(range(0, 20_000_000_000, 250_000_000))
+        progress = []
+        with patch.object(artifact, "monotonic_ns", side_effect=lambda: next(ticks)), \
+             patch.object(artifact.time, "sleep"), \
+             patch.object(artifact, "execute_scheduled_transaction",
+                          return_value=dict(outcome="checktx_rejected", code=7)) as execute:
+            with self.assertRaisesRegex(TimeoutError, "no submission progress"):
+                artifact.schedule_transactions([job("rejected", 0), job("future", 10_000_000_000)],
+                    max_in_flight=1, max_queued=1, max_queued_per_signer=1,
+                    progress_callback=progress.append, heartbeat_seconds=1, stall_timeout_seconds=1)
+        self.assertEqual(execute.call_count, 1)
+        self.assertTrue(progress)
+        self.assertEqual(progress[-1]["committed_valid_submissions"], 0)
+        self.assertGreaterEqual(progress[-1]["seconds_since_progress"], 1)
+
     def test_native_layout_and_reported_denominators_cannot_drift(self):
         offsets = workload.sustained_offsets(4)
         expected = {
@@ -72,8 +108,8 @@ class SustainedTest(unittest.TestCase):
             signers={"owner0": owner})
         deal = dict(id="7", manifest_root=base64.b64encode(bytes([8]) * 32).decode(),
                     current_gen="1", end_block="5000")
-        providers = {0: AUDIT_ADDRESSES[1]}
-        deputies = AUDIT_ADDRESSES[2:10]
+        providers = {slot: f"provider{slot}" for slot in range(12)}
+        deputies = [f"deputy{index}" for index in range(8)]
         operations = workload.build_sustained_operations(
             life, deal, providers, deputies, [0, 250_000_000], 10, 4000, 17, 9_000_000, 8)
         self.assertEqual(len(operations), 10)
@@ -82,12 +118,58 @@ class SustainedTest(unittest.TestCase):
             snapshot = operation["proof_expectation"]["snapshot"]
             submit = operation["open-session"]["submit"]
             self.assertEqual((session["blob_count"], session["total_bytes"], session["locked_fee"]), (8, 1024 * 1024, "136"))
-            self.assertEqual((snapshot["k"], snapshot["m"], snapshot["slot"]), (8, 4, 0))
+            slot = index % 12
+            self.assertEqual((snapshot["k"], snapshot["m"], snapshot["slot"]), (8, 4, slot))
+            self.assertEqual((session["provider"], session["start_blob_index"]),
+                             (providers[slot], slot * 8))
             self.assertEqual(session["authorized_proof_provider"], deputies[index % 8])
+            self.assertEqual(submit[submit.index("--provider") + 1], providers[slot])
+            self.assertEqual(submit[submit.index("--start-blob-index") + 1], str(slot * 8))
             self.assertEqual(submit[submit.index("--blob-count") + 1], "8")
             self.assertEqual(operation["submit-proof"]["submit"][
                 operation["submit-proof"]["submit"].index("--gas") + 1], "9000000")
         self.assertEqual([row["phase"] for row in operations], ["warmup"] * 8 + ["measurement"] * 2)
+
+        transactions = [dict(operation_id=operation["operation_id"], outcome="committed_success")
+                        for operation in operations]
+        counts = workload.assignment_submission_counts(operations, transactions)
+        self.assertEqual(counts["0"], dict(offered_bundles=1, offered_openings=8,
+            submitted_bundles=1, submitted_openings=8, committed_valid_bundles=1,
+            committed_valid_openings=8))
+        self.assertEqual(set(counts), {str(slot) for slot in range(10)})
+        transactions[-1]["outcome"] = "not_submitted"
+        self.assertEqual(workload.assignment_submission_counts(operations, transactions)["9"],
+            dict(offered_bundles=1, offered_openings=8, submitted_bundles=0,
+                 submitted_openings=0, committed_valid_bundles=0, committed_valid_openings=0))
+        with self.assertRaises(ValueError):
+            workload.assignment_submission_counts(operations, transactions[:-1])
+
+        directories = {provider: Path(f"/artifacts/{slot}") for slot, provider in providers.items()}
+        for operation in operations:
+            request = workload.export_inventory_request(operation, "ab" * 32, {"height": 9}, "/proof", directories)
+            slot = operation["proof_expectation"]["snapshot"]["slot"]
+            self.assertEqual(request["artifact_directory"], f"/artifacts/{slot}")
+        bad = copy.deepcopy(operations[-1])
+        bad["proof_expectation"]["session"]["start_blob_index"] = 0
+        with self.assertRaises(ValueError):
+            workload.export_inventory_request(bad, "ab" * 32, {}, "/proof", directories)
+
+    def test_k2_operations_keep_default_geometry_and_disjoint_deputies(self):
+        life = SimpleNamespace(binary=Path("/chain"), chain="polystore_290-1",
+            deadline=artifact.monotonic_ns() + 60 * 10**9,
+            nodes=[dict(home="/home/validator0", rpc=26657)], env={}, signers={"owner0": "owner"})
+        deal = dict(id="7", manifest_root=base64.b64encode(bytes([2]) * 32).decode(),
+                    current_gen="1", end_block="5000")
+        providers = {slot: f"provider{slot}" for slot in range(3)}
+        deputies = [f"provider{index}" for index in range(3, 11)]
+        operations = workload.build_sustained_operations(
+            life, deal, providers, deputies, [0], 10, 4000, 17, 20_000_000, 2)
+        self.assertEqual([(row["proof_expectation"]["snapshot"]["slot"],
+                           row["proof_expectation"]["session"]["start_blob_index"])
+                          for row in operations],
+                         [(index % 3, (index % 3) * 32) for index in range(9)])
+        self.assertEqual({row["proof_expectation"]["session"]["blob_count"] for row in operations}, {32})
+        self.assertFalse(set(providers.values()) & set(deputies))
 
     def test_atomic_response_count_order_type_and_uniqueness(self):
         second = OPEN_RESPONSE_DATA[:-64] + '31' * 32

--- a/scripts/test_retrieval_sustained.py
+++ b/scripts/test_retrieval_sustained.py
@@ -130,7 +130,8 @@ class SustainedTest(unittest.TestCase):
                 operation["submit-proof"]["submit"].index("--gas") + 1], "9000000")
         self.assertEqual([row["phase"] for row in operations], ["warmup"] * 8 + ["measurement"] * 2)
 
-        transactions = [dict(operation_id=operation["operation_id"], outcome="committed_success")
+        transactions = [dict(operation_id=operation["operation_id"], outcome="committed_success",
+                             proof_state_verified=True)
                         for operation in operations]
         counts = workload.assignment_submission_counts(operations, transactions)
         self.assertEqual(counts["0"], dict(offered_bundles=1, offered_openings=8,
@@ -153,6 +154,47 @@ class SustainedTest(unittest.TestCase):
         bad["proof_expectation"]["session"]["start_blob_index"] = 0
         with self.assertRaises(ValueError):
             workload.export_inventory_request(bad, "ab" * 32, {}, "/proof", directories)
+
+    def test_sustained_mixed_outcomes_reach_assignment_accounting(self):
+        outcomes = [
+            dict(outcome="committed_success", proof_state_verified=True, txhash="AA" * 32),
+            dict(outcome="not_submitted", error="queue_full"),
+            dict(outcome="checktx_rejected", code=7),
+            dict(outcome="unknown", txhash="BB" * 32),
+            dict(outcome="committed_success", proof_state_verified=False, txhash="CC" * 32),
+            dict(outcome="duplicate", txhash="AA" * 32, original_outcome="committed_success"),
+        ]
+        operations = [dict(operation_id=f"proof-{index}", proof_expectation=dict(
+            snapshot=dict(slot=0), session=dict(blob_count=8))) for index in range(len(outcomes))]
+        with tempfile.TemporaryDirectory() as home:
+            journal = Path(home) / "sustained.sqlite"
+            with sqlite3.connect(journal) as db:
+                db.executescript("CREATE TABLE operations(id TEXT, result TEXT); CREATE TABLE transactions(result TEXT);")
+                for index, (operation, transaction) in enumerate(zip(operations, outcomes)):
+                    transaction.update(operation_id=operation["operation_id"])
+                    valid = transaction["outcome"] == "committed_success" and transaction.get("proof_state_verified") is True
+                    result = dict(operation_id=operation["operation_id"], session_id=f"{index + 1:064x}",
+                                  outcome=transaction["outcome"], proof_submitted=valid,
+                                  all_transactions_committed=transaction["outcome"] == "committed_success")
+                    db.execute("INSERT INTO operations VALUES (?, ?)",
+                               (operation["operation_id"], json.dumps(result)))
+                    db.execute("INSERT INTO transactions VALUES (?)", (json.dumps(transaction),))
+            with self.assertRaisesRegex(ValueError, "did not commit"):
+                workload.journal_results(journal, operations, proof_only=True)
+            _, transactions = workload.journal_results(
+                journal, operations, proof_only=True, require_all_committed=False)
+            self.assertEqual([row["outcome"] for row in transactions],
+                             [row["outcome"] for row in outcomes])
+            counts = workload.assignment_submission_counts(operations, transactions)["0"]
+            self.assertEqual(counts, dict(offered_bundles=6, offered_openings=48,
+                submitted_bundles=5, submitted_openings=40,
+                committed_valid_bundles=1, committed_valid_openings=8))
+
+            corrupt = json.loads(json.dumps(transactions))
+            corrupt[5]["outcome"] = "committed_success"
+            corrupt[5]["proof_state_verified"] = True
+            with self.assertRaisesRegex(ValueError, "counted.*twice"):
+                workload.assignment_submission_counts(operations, corrupt)
 
     def test_k2_operations_keep_default_geometry_and_disjoint_deputies(self):
         life = SimpleNamespace(binary=Path("/chain"), chain="polystore_290-1",


### PR DESCRIPTION
The sustained chain harness previously exercised only K2 slot zero. It now supports native K8 and distributes independent sessions across every data and parity assignment, while keeping proof submitters separate from provider-daemon audit signers.

Each session binds its assigned provider, global blob range, frozen challenge slot and provider artifact directory. Evidence distinguishes offered, submitted and committed-valid transaction bundles from individual openings, including per-assignment counts. A 60-second scheduler heartbeat reports verified committed progress and a 10-minute watchdog rejects stalls; duplicates, failed transactions and failed proof-state checks cannot reset it.

Warmup retains its all-success gate; sustained measurement preserves validated rejection, queue-drop, unknown and unverified outcomes so saturation does not abort evidence collection. Only verified committed proof state contributes to valid counts.

The default remains K2. K8 uses 12 assignments and eight openings per transaction; K2 uses three assignments and 32. Collection notes document their different audit/host loads, gas preflight, bounded 600-second pilot and the requirement to land the reviewed harness before expensive retained collection. Setup/proof-export still uses bounded phase deadlines without a periodic heartbeat. No live pilot or capacity claim is included.

Validation at `31263e11a1a79660e6b72bf0046fa52a4040ab23`:

- Native-enabled retrieval suite: 62 passed, no skips.
- Scheduler/lifecycle suite: 70 passed, including duplicate, transaction-failure and proof-state-failure regressions.
- Python compilation and diff checks passed; independent Sol review accepted this exact head.

Part of #290. That issue remains open for retained measurement and interpretation; this PR supplies the harness. Native large retrieval sessions remain separately tracked in #291.
