### PR TITLE
e2e: raise sustained open-session batch gas ceiling

### DIFF
--- a/performance/README.md
+++ b/performance/README.md
@@ -170,6 +170,12 @@ unqualified and is retained as preparation for the later final C6 measurement.
 The final evidence and its revised disposition are summarized below and in the
 [qualification report](retrieval-v2-qualification.md).
 
+For the #290 native K8 pilot, inventory preparation uses a conservative 400,000
+gas allowance per session-open message: 15.6M for 39 sessions and at most 25.6M
+for a 64-message atomic batch. Before broadcast the harness verifies that the
+SDK appended the generated gas sum. This is a pilot ceiling, not measured full
+execution cost, and does not change proof, audit or block gas limits.
+
 
 ## Historical streamed browser retrieval (#260)
 

--- a/scripts/retrieval_four_validator_workload.py
+++ b/scripts/retrieval_four_validator_workload.py
@@ -32,6 +32,9 @@ API = "/polystorechain/polystorechain/v1"
 ENV_KEYS = ("GOMAXPROCS", "POLYSTORE_TRUSTED_SETUP", "LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH")
 COUNTS = (1, 2, 8)
 SUSTAINED_RATES = (0.25, 0.5, 1, 2, 4)
+OPEN_SESSION_PREPARATION_GAS = 400_000
+OPEN_SESSION_BATCH_MAX = 64
+OPEN_SESSION_BATCH_GAS_CAP = OPEN_SESSION_PREPARATION_GAS * OPEN_SESSION_BATCH_MAX
 
 
 def mode2_layout(k):
@@ -62,7 +65,10 @@ def sustained_profile(k, step_seconds, offsets, proof_gas):
         proofs_per_session_unit="individual chained openings (legacy field name)",
         warmup_openings=8 * openings, measured_openings=len(offsets) * openings,
         bundle_opening_distribution={str(openings): inventory},
-        native_message_batching=dict(open_session_messages_per_preparation_transaction_max=64,
+        native_message_batching=dict(open_session_messages_per_preparation_transaction_max=OPEN_SESSION_BATCH_MAX,
+            open_session_gas_limit_per_message=OPEN_SESSION_PREPARATION_GAS,
+            open_session_batch_gas_limit_max=OPEN_SESSION_BATCH_GAS_CAP,
+            open_session_gas_limit_note="conservative pilot ceiling, not measured full execution cost",
             proof_sessions_per_submission_transaction=1, cross_provider_crypto_aggregation=False),
         k=k, m=layout["m"], assignment_count=layout["assignments"],
         provider_daemon_count=layout["assignments"],
@@ -819,13 +825,14 @@ def sustained_offsets(step_seconds):
 
 def open_session_batch(lifecycle, operations, directory, command):
     """SDK append signs one atomic transaction with one owner sequence."""
-    if not 1 <= len(operations) <= 64:
+    if not 1 <= len(operations) <= OPEN_SESSION_BATCH_MAX:
         raise ValueError("open batch must contain 1..64 sessions")
     owner = operations[0]["open-session"]["signer"]
     if any(op["open-session"]["signer"] != owner for op in operations):
         raise ValueError("atomic batch requires one owner")
     unsigned, signed = directory / "unsigned.jsonl", directory / "signed.json"
     directory.mkdir(mode=0o700)
+    generated_gas = 0
     with unsigned.open("x") as output:
         for operation in operations:
             args = operation["open-session"]["submit"] + ["--generate-only"]
@@ -833,6 +840,10 @@ def open_session_batch(lifecycle, operations, directory, command):
             messages = tx["body"]["messages"]
             if len(messages) != 1 or messages[0]["@type"] != "/polystorechain.polystorechain.v1.MsgOpenRetrievalSession":
                 raise ValueError("generated open transaction has unexpected messages")
+            gas = producer.uint(tx.get("auth_info", {}).get("fee", {}).get("gas_limit", 0))
+            if gas != OPEN_SESSION_PREPARATION_GAS:
+                raise ValueError("generated open transaction has unexpected gas limit")
+            generated_gas += gas
             message, expected = messages[0], operation["proof_expectation"]["session"]
             if (message["creator"] != owner or message["provider"] != expected["provider"] or
                     message["authorized_proof_provider"] != expected["authorized_proof_provider"] or
@@ -851,6 +862,9 @@ def open_session_batch(lifecycle, operations, directory, command):
     original = [json.loads(line)["body"]["messages"][0] for line in unsigned.read_text().splitlines()]
     if value["body"]["messages"] != original or len(value["signatures"]) != 1:
         raise ValueError("signed batch differs from ordered open intent")
+    signed_gas = producer.uint(value.get("auth_info", {}).get("fee", {}).get("gas_limit", 0))
+    if signed_gas != generated_gas or signed_gas > OPEN_SESSION_BATCH_GAS_CAP:
+        raise ValueError("signed batch gas differs from bounded generated gas sum")
     job = dict(operations[0]["open-session"], kind="open-session-batch",
                submit=[str(lifecycle.binary), "tx", "broadcast", str(signed), *common,
                        "--broadcast-mode", "sync", "--output", "json"])
@@ -986,7 +1000,7 @@ def build_sustained_operations(lifecycle, deal, providers, deputies, offsets, mi
         opening = transaction_job(lifecycle, owner, ["open-retrieval-session", "--deal-id", deal["id"],
             "--provider", assigned, "--manifest-root", "0x" + root, "--start-mdu-index", "2", "--start-blob-index", str(start_blob_index),
             "--blob-count", str(openings), "--nonce", index + 1, "--expires-at", end, "--challenge-version", "2",
-            "--authorized-proof-provider", payee], kind="open-session", gas="300000")
+            "--authorized-proof-provider", payee], kind="open-session", gas=str(OPEN_SESSION_PREPARATION_GAS))
         proof = transaction_job(lifecycle, payee, ["submit-retrieval-proof", "{proof_path}"], gas=str(proof_gas))
         operations.append(dict(operation_id=f"sustained-{index}", phase="warmup" if index < 8 else "measurement",
             offered_offset_ns=offset, **{"open-session": opening, "submit-proof": proof},
@@ -1069,10 +1083,10 @@ def run_sustained(lifecycle, deal, providers, send, command, audits, wait, expor
         inventory = lifecycle.home / "inventory"
         inventory.mkdir(mode=0o700)
         requests = []
-        for start in range(0, len(operations), 64):
+        for start in range(0, len(operations), OPEN_SESSION_BATCH_MAX):
             if failures:
                 raise failures[0]
-            batch = operations[start:start + 64]
+            batch = operations[start:start + OPEN_SESSION_BATCH_MAX]
             ids, opened_height = open_session_batch(lifecycle, batch, inventory / f"batch-{start}", command)
             wait(opened_height + 3)
             for operation, sid in zip(batch, ids):

--- a/scripts/test_retrieval_sustained.py
+++ b/scripts/test_retrieval_sustained.py
@@ -85,6 +85,9 @@ class SustainedTest(unittest.TestCase):
                                  dict(gas=20_000_000, openings=want["openings"]))
                 self.assertEqual(profile["native_message_batching"]["proof_sessions_per_submission_transaction"], 1)
                 self.assertFalse(profile["native_message_batching"]["cross_provider_crypto_aggregation"])
+                self.assertEqual(profile["native_message_batching"]["open_session_gas_limit_per_message"], 400_000)
+                self.assertEqual(profile["native_message_batching"]["open_session_batch_gas_limit_max"], 25_600_000)
+                self.assertIn("not measured", profile["native_message_batching"]["open_session_gas_limit_note"])
         for k in (0, 2.0, 4, 16, True, "8"):
             with self.subTest(k=k), self.assertRaises(ValueError):
                 workload.mode2_layout(k)
@@ -126,6 +129,7 @@ class SustainedTest(unittest.TestCase):
             self.assertEqual(submit[submit.index("--provider") + 1], providers[slot])
             self.assertEqual(submit[submit.index("--start-blob-index") + 1], str(slot * 8))
             self.assertEqual(submit[submit.index("--blob-count") + 1], "8")
+            self.assertEqual(submit[submit.index("--gas") + 1], "400000")
             self.assertEqual(operation["submit-proof"]["submit"][
                 operation["submit-proof"]["submit"].index("--gas") + 1], "9000000")
         self.assertEqual([row["phase"] for row in operations], ["warmup"] * 8 + ["measurement"] * 2)
@@ -229,7 +233,7 @@ class SustainedTest(unittest.TestCase):
             artifact.opened_session_ids(dict(data=OPEN_RESPONSE_DATA), 65)
 
     def test_batch_pins_unsigned_signed_and_committed_order_before_proofs(self):
-        for corruption in (None, 'generated_nonce', 'signed_order', 'unknown'):
+        for corruption in (None, 'generated_nonce', 'generated_gas', 'signed_order', 'signed_gas', 'unknown'):
             life, _, _, operations = fixture_state()
             operations = operations[:2]
             life.doc, life.save = {}, Mock()
@@ -244,14 +248,19 @@ class SustainedTest(unittest.TestCase):
                         **{'@type': '/polystorechain.polystorechain.v1.MsgOpenRetrievalSession'})
                     if corruption == 'generated_nonce':
                         message['nonce'] = '999'
-                    tx = dict(body=dict(messages=[message]))
+                    gas = 400001 if corruption == 'generated_gas' else 400000
+                    tx = dict(body=dict(messages=[message]), auth_info=dict(fee=dict(gas_limit=str(gas))))
                     generated.append(tx)
                     return json.dumps(tx)
                 self.assertIn('--append', args)
                 messages = [copy.deepcopy(tx['body']['messages'][0]) for tx in generated]
                 if corruption == 'signed_order':
                     messages.reverse()
-                Path(args[args.index('--output-document') + 1]).write_text(json.dumps(dict(body=dict(messages=messages), signatures=['signed'])))
+                gas = sum(int(tx['auth_info']['fee']['gas_limit']) for tx in generated)
+                if corruption == 'signed_gas':
+                    gas -= 1
+                Path(args[args.index('--output-document') + 1]).write_text(json.dumps(dict(
+                    body=dict(messages=messages), auth_info=dict(fee=dict(gas_limit=str(gas))), signatures=['signed'])))
                 return ''
             response = dict(outcome='unknown' if corruption == 'unknown' else 'committed_success', height=12,
                             data=OPEN_RESPONSE_DATA + OPEN_RESPONSE_DATA[:-64] + '31' * 32)
@@ -260,6 +269,8 @@ class SustainedTest(unittest.TestCase):
                     with self.assertRaises(ValueError):
                         workload.open_session_batch(life, operations, Path(home) / 'batch', command)
                     self.assertEqual(submit.call_count, int(corruption == 'unknown'))
+                    if corruption == 'signed_gas':
+                        submit.assert_not_called()
                 else:
                     ids, height = workload.open_session_batch(life, operations, Path(home) / 'batch', command)
                     self.assertEqual((len(ids), height), (2, 12))


### PR DESCRIPTION
The first native K8 pilot stopped while preparing its 39-session inventory: the fixed 300,000 gas allowance per open produced an 11.7M atomic transaction, below the observed 11,730,500 execution lower bound, so no proof load ran. This raises only the preparation open allowance to 400,000 per message (15.6M for 39; maximum 25.6M for 64) and verifies before broadcast that the SDK-appended signed gas equals the bounded generated sum.

The proof-submission gas, normal audit settings, and 64M block limit are unchanged. The 400,000 value is a conservative pilot ceiling, not a measured full execution cost. Existing `preparation_transactions` continue to retain the committed setup gas evidence.

Validation:

- Native-enabled retrieval suite: 62/62 passed
- Scheduler/artifact suite: 70/70 passed
- Python compile and `git diff --check` passed

Part of #290. No live pilot retry was run in this PR.
