### PR TITLE
bench: retain native K8 pilot diagnostic

### DIFF
--- a/bench/retrieval_session_capacity/native-k8-290/README.md
+++ b/bench/retrieval_session_capacity/native-k8-290/README.md
@@ -79,6 +79,12 @@ safety margin for a sustained K8 run. Do not reuse the K2 limit as a K8 capacity
 denominator, lower proof checks or audits, or raise block limits to obtain a
 larger number.
 
+The [retained pilot 002 artifact](pilot-002/README.md) records one successful
+four-second-per-step path and gas diagnostic across all twelve assignments. It
+is not capacity evidence; its 20M declared proof gas limited proposal packing to
+at most three proof transactions under the unchanged 64M block limit even though
+each transaction used about 4.13M gas.
+
 The existing absolute phase and overall deadlines, bounded queue, signer
 quarantine, port reservations, and process-group cleanup remain unchanged. The
 scheduler writes a progress record every 60 seconds while active, plus its final

--- a/bench/retrieval_session_capacity/native-k8-290/pilot-002/README.md
+++ b/bench/retrieval_session_capacity/native-k8-290/pilot-002/README.md
@@ -1,0 +1,43 @@
+# Native K8 pilot 002
+
+This is the retained result of one bounded path and gas diagnostic for
+[issue #290](https://github.com/Polynomialstore/polystore/issues/290). It is not
+a capacity qualification. The five offered-rate steps lasted four seconds each,
+and the run used four validator processes plus twelve provider-daemons on one
+nonquiet Apple workstation.
+
+The run opened 39 sessions in one atomic preparation transaction. Its 400,000
+gas allowance per message produced 15,600,000 gas wanted and 14,924,033 gas
+used. Eight warmup and 31 measured `MsgSubmitRetrievalSessionProof`
+transactions committed successfully. Each K8 transaction carried eight chained
+openings, for 64 warmup and 248 measured openings. Every one of the twelve
+assignments received at least two committed-valid bundles, and the final normal
+audit observation recorded 12 accepted samples for 12 finalized assignments.
+
+The 31 measured bundles committed over the 20-second offered window plus a
+3.714-second drain. That eventual rate and the aggregate result do not establish
+that any offered step was sustainable. The approximately 416-second wall time
+also includes setup, proof preparation, warmup, audit observation, and cleanup;
+it is not a throughput denominator.
+
+Proof transactions declared a 20,000,000 gas ceiling while using
+4,131,357–4,134,092 gas. With the retained 64,000,000 block gas limit and the
+SDK default proposal selection used by this app, the declaration allows at most
+three proof transactions per proposal: a fourth declaration would exceed the
+block limit. This declared-gas packing constraint applies even though execution
+used much less gas. The pilot therefore does not provide a capacity result. A
+sustained run must first select and document a measured K8 safety margin without
+changing proof checks, audits, or block limits.
+
+The [summary](summary.json), [execution plan](plan.json), and
+[runtime provenance](runtime-provenance.json) are the only published run files.
+The [manifest](manifest.json) records their original hashes, published hashes,
+path substitutions, and the private files intentionally excluded. The source
+run home, keyrings, SQLite journals, raw evidence, provider and validator logs,
+payload, proof inventory, and private driver log remain local.
+
+The plan uses `$SOURCE_CHECKOUT`, `$REUSED_CORE_RELEASE`, and `$ARTIFACT_ROOT`
+in place of machine-specific absolute paths. Runtime provenance replaces the
+local hostname with `<redacted-host>`. These substitutions remove local identity
+and layout details while retaining exact commits, Git objects, component hashes,
+commands, gas settings, workload geometry, and toolchain versions.

--- a/bench/retrieval_session_capacity/native-k8-290/pilot-002/manifest.json
+++ b/bench/retrieval_session_capacity/native-k8-290/pilot-002/manifest.json
@@ -26,8 +26,8 @@
       "bytes": 4475
     },
     "plan.json": {
-      "sha256": "73e76bf314b1c7d503bdffef33a426fe8999908a0f1e29c06ea1969478be4b11",
-      "bytes": 4975
+      "sha256": "432b88ab67b84ad3794167093f24b6d010bc0d9758a925cef0de19af1c8ba74e",
+      "bytes": 4988
     },
     "runtime-provenance.json": {
       "sha256": "f83c7af3118c07c93781f05ae52c4b67791a5b5c6c1b115414e2de6bcc61645c",
@@ -35,7 +35,7 @@
     }
   },
   "sanitization": {
-    "method": "JSON parse plus exact string replacement; numeric results, hashes, commits, Git objects, commands, workload geometry, and toolchain versions retained",
+    "method": "JSON parse plus documented string replacement and one unit-label correction; numeric results, hashes, commits, Git objects, commands, workload geometry, and toolchain versions retained",
     "replacements": [
       {
         "original": "K8 harness checkout absolute path",
@@ -56,6 +56,10 @@
       {
         "original": "summary links to local plan and provenance",
         "published": "sibling plan.json and runtime-provenance.json"
+      },
+      {
+        "original": "400000 preparation gas per opening",
+        "published": "400000 preparation gas per session-open message"
       }
     ]
   },

--- a/bench/retrieval_session_capacity/native-k8-290/pilot-002/manifest.json
+++ b/bench/retrieval_session_capacity/native-k8-290/pilot-002/manifest.json
@@ -1,0 +1,79 @@
+{
+  "schema": "polystore.issue290.k8-pilot-publication.v1",
+  "artifact": "native K8 pilot 002 path and gas diagnostic",
+  "qualification": false,
+  "source_run": "$ARTIFACT_ROOT/290-k8-all-assignment-4s-pilot-002",
+  "original_sources": {
+    "summary.json": {
+      "source_name": "290-k8-all-assignment-4s-pilot-002.summary.json",
+      "sha256": "b1cc40f15dc79b373edc784ce74c7ff42be7305d512a9503eef2d49ca2035095",
+      "bytes": 4200
+    },
+    "plan.json": {
+      "source_name": "290-pilot-002-plan.json",
+      "sha256": "5981a3e36e732b091e8bb2c2a8b1d9f0740684f51cee1752684fcf18ab237fac",
+      "bytes": 5291
+    },
+    "runtime-provenance.json": {
+      "source_name": "local290-build-provenance.json",
+      "sha256": "2f4631e4abcdea604537d177445115caf1b203bb85f43267ba3b4f69f59b5580",
+      "bytes": 7486
+    }
+  },
+  "published_files": {
+    "summary.json": {
+      "sha256": "1811293d5c4724c7f760dc6a1762aa38c19acaccd391b3df9a96470b1f824b59",
+      "bytes": 4475
+    },
+    "plan.json": {
+      "sha256": "73e76bf314b1c7d503bdffef33a426fe8999908a0f1e29c06ea1969478be4b11",
+      "bytes": 4975
+    },
+    "runtime-provenance.json": {
+      "sha256": "f83c7af3118c07c93781f05ae52c4b67791a5b5c6c1b115414e2de6bcc61645c",
+      "bytes": 6462
+    }
+  },
+  "sanitization": {
+    "method": "JSON parse plus exact string replacement; numeric results, hashes, commits, Git objects, commands, workload geometry, and toolchain versions retained",
+    "replacements": [
+      {
+        "original": "K8 harness checkout absolute path",
+        "published": "$SOURCE_CHECKOUT"
+      },
+      {
+        "original": "reused core release absolute path",
+        "published": "$REUSED_CORE_RELEASE"
+      },
+      {
+        "original": "private artifact-root absolute path",
+        "published": "$ARTIFACT_ROOT"
+      },
+      {
+        "original": "local host name",
+        "published": "<redacted-host>"
+      },
+      {
+        "original": "summary links to local plan and provenance",
+        "published": "sibling plan.json and runtime-provenance.json"
+      }
+    ]
+  },
+  "validated_private_artifacts": {
+    "count": 8,
+    "result": "all byte counts and SHA-256 hashes in summary.json matched the retained local files",
+    "published": false
+  },
+  "excluded": [
+    "run home and test keyrings",
+    "raw evidence and proof inventory",
+    "warmup and sustained SQLite journals",
+    "validator, provider, exporter, and private driver logs",
+    "generated payload and storage data"
+  ],
+  "limits": [
+    "The publication is a bounded path and gas diagnostic, not a capacity qualification.",
+    "No raw transaction bodies, credentials, authentication material, private logs, wallets, or keyrings are published.",
+    "The separate sustained result pending at publication time is not included or described."
+  ]
+}

--- a/bench/retrieval_session_capacity/native-k8-290/pilot-002/plan.json
+++ b/bench/retrieval_session_capacity/native-k8-290/pilot-002/plan.json
@@ -1,0 +1,137 @@
+{
+  "schema": "polystore.issue290.k8-pilot-plan.v1",
+  "prepared_at_utc": "2026-09-09T04:26:31Z",
+  "status": "executed_once_completed_diagnostic_only",
+  "purpose": "One bounded K8 full-row proof-submission path and gas diagnostic across all assignments under normal audits; not a capacity qualification.",
+  "source": {
+    "checkout": "$SOURCE_CHECKOUT",
+    "merged_harness_source": "81ed30f6173416c3d9c001f7c22b96874ab3ea99",
+    "reviewed_head": "48889159cbf7d271dec12d9ee1dd04e6efa5985f",
+    "merged_vs_reviewed_relevant_paths": "identical",
+    "inspected_files": {
+      "scripts/retrieval_four_validator_workload.py": {
+        "git_object": "8129bc5cc3a5f0ec17aba5ec7c7c56e05efaab65",
+        "sha256": "80dd29217c5e131760995ca0ae2f9fe376bdf792d1ceab1ed1efff464ba9e48f"
+      },
+      "scripts/retrieval_bench_artifact.py": {
+        "git_object": "9d9d40a8a5e553ee0abd3340985415abe91e72be",
+        "sha256": "c1254269dd05e4cfb1256ae6cd72c07f763bbbd5f865a9dc0e9a6e98d75b4ef2"
+      },
+      "scripts/retrieval_fresh_proof.py": {
+        "git_object": "502c1d56af256203ad73f0d7c70293a9342fd3c6",
+        "sha256": "74ced497d80442a7d463872623879737b7775ad2a49ec4c5a53ced8a8650e67b"
+      }
+    }
+  },
+  "runtime_provenance": {
+    "verified_manifest": "runtime-provenance.json",
+    "gateway_and_exporter_build_source": "f0f8fab53178cb37a34d21e35200ec1d6ec0fa89",
+    "reused_chain_cli_core_build_source": "76653383b04fbd8c971cc4839f831ca0bf15ca2c",
+    "merged_source_tree_comparison": {
+      "polystore_gateway": {
+        "merged": "6d0c3bfc9147565180931347ef979113d5983b8a",
+        "built": "6d0c3bfc9147565180931347ef979113d5983b8a",
+        "status": "exact"
+      },
+      "polystorechain": {
+        "merged": "d002c6f58a35d9cfa80f104b413ef5a7b478c764",
+        "built": "0253e79d531087c16b1b879ec5960cd7ba3ec6de",
+        "status": "runtime source unchanged; merged delta contains tests only"
+      },
+      "polystore_cli": {
+        "merged": "4303dc86c58cbbb7f1076f1916f1de691bf7694c",
+        "built": "4303dc86c58cbbb7f1076f1916f1de691bf7694c",
+        "status": "exact"
+      },
+      "polystore_core": {
+        "merged": "7989fed8d5a5877e74bc0e2c71aa60b6f8747653",
+        "built": "7989fed8d5a5877e74bc0e2c71aa60b6f8747653",
+        "status": "exact"
+      }
+    }
+  },
+  "invocation": {
+    "cwd": "$SOURCE_CHECKOUT",
+    "environment": {
+      "GOMAXPROCS": "2",
+      "POLYSTORE_TRUSTED_SETUP": "$SOURCE_CHECKOUT/polystorechain/trusted_setup.txt",
+      "DYLD_LIBRARY_PATH_prepend": "$REUSED_CORE_RELEASE",
+      "LD_LIBRARY_PATH_prepend": "$REUSED_CORE_RELEASE"
+    },
+    "argv": [
+      "/usr/bin/python3",
+      "$SOURCE_CHECKOUT/scripts/retrieval_four_validator_workload.py",
+      "--mode",
+      "sustained-providers",
+      "--audit-profile",
+      "normal",
+      "--sustained-k",
+      "8",
+      "--binary",
+      "$ARTIFACT_ROOT/260-saturation-polystorechaind",
+      "--library",
+      "$REUSED_CORE_RELEASE/libpolystore_core.dylib",
+      "--gateway-binary",
+      "$ARTIFACT_ROOT/290-polystore-gateway",
+      "--cli-binary",
+      "$ARTIFACT_ROOT/260-final-polystore_cli",
+      "--product-source",
+      "$SOURCE_CHECKOUT",
+      "--proof-exporter",
+      "$ARTIFACT_ROOT/290-retrieval-exporter.test",
+      "--proof-gas",
+      "20000000",
+      "--step-seconds",
+      "4",
+      "--timeout",
+      "600",
+      "--home",
+      "$ARTIFACT_ROOT/290-k8-all-assignment-4s-pilot-002"
+    ],
+    "absolute_timeout_seconds": 600,
+    "attempt_limit": 1
+  },
+  "expected_workload": {
+    "k": 8,
+    "m": 4,
+    "assignments_and_provider_daemons": 12,
+    "deputy_signers": 8,
+    "openings_per_submission_bundle": 8,
+    "warmup_bundles": 8,
+    "measured_bundles": 31,
+    "total_bundles": 39,
+    "warmup_openings": 64,
+    "measured_openings": 248,
+    "total_openings": 312,
+    "offered_bundle_rates_per_second": [
+      0.25,
+      0.5,
+      1,
+      2,
+      4
+    ],
+    "seconds_per_rate_step": 4,
+    "offered_measurement_window_seconds": 20,
+    "audit_profile": "normal",
+    "normal_audit_samples_per_epoch": 12,
+    "open_session_gas_limit_per_message": 400000,
+    "proof_submission_gas_ceiling": 20000000
+  },
+  "preflight_observation": {
+    "fresh_home": true,
+    "free_bytes": 4204896256,
+    "required_ports_bindable": "32 of 32",
+    "benchmark_or_polystore_service_load": "none observed",
+    "host_load_average": [
+      3.1,
+      3.67,
+      3.47
+    ],
+    "reproducibility_status": "unqualified_path_gas_diagnostic_only"
+  },
+  "interpretation_limits": [
+    "Four validator processes and twelve provider daemons on one local Apple workstation do not represent a realistic deployment.",
+    "The 20000000 proof gas setting and 400000 preparation gas per opening are conservative pilot ceilings, not measured requirements or capacity denominators.",
+    "This pilot cannot qualify production capacity, download targets, hardware minimums, WAN behavior, or client delivery and acknowledgement."
+  ]
+}

--- a/bench/retrieval_session_capacity/native-k8-290/pilot-002/plan.json
+++ b/bench/retrieval_session_capacity/native-k8-290/pilot-002/plan.json
@@ -131,7 +131,7 @@
   },
   "interpretation_limits": [
     "Four validator processes and twelve provider daemons on one local Apple workstation do not represent a realistic deployment.",
-    "The 20000000 proof gas setting and 400000 preparation gas per opening are conservative pilot ceilings, not measured requirements or capacity denominators.",
+    "The 20000000 proof gas setting and 400000 preparation gas per session-open message are conservative pilot ceilings, not measured requirements or capacity denominators.",
     "This pilot cannot qualify production capacity, download targets, hardware minimums, WAN behavior, or client delivery and acknowledgement."
   ]
 }

--- a/bench/retrieval_session_capacity/native-k8-290/pilot-002/runtime-provenance.json
+++ b/bench/retrieval_session_capacity/native-k8-290/pilot-002/runtime-provenance.json
@@ -1,0 +1,120 @@
+{
+  "created_utc": "2026-09-09T02:54:15Z",
+  "status": "build complete; no workload launched",
+  "source": {
+    "worktree": "$SOURCE_CHECKOUT",
+    "branch": "e2e/retrieval-k8-capacity-290",
+    "commit": "f0f8fab53178cb37a34d21e35200ec1d6ec0fa89",
+    "commit_date": "2026-09-08T16:45:06-10:00",
+    "commit_subject": "docs: require heartbeat before sustained collection",
+    "status_porcelain": "",
+    "tree_ids": {
+      "polystore_gateway": "6d0c3bfc9147565180931347ef979113d5983b8a",
+      "polystorechain": "d002c6f58a35d9cfa80f104b413ef5a7b478c764",
+      "polystore_core": "7989fed8d5a5877e74bc0e2c71aa60b6f8747653",
+      "polystore_cli": "4303dc86c58cbbb7f1076f1916f1de691bf7694c"
+    },
+    "source_sha256": {
+      "polystore_gateway/retrieval_inventory_export_test.go": "6011daa40fb3f50ed9711e1e8e52ebaa407a918e2903c765596991746cec11f2",
+      "scripts/retrieval_four_validator_workload.py": "f609f8e678b433dc8994c325d80dabc9a00e82153cde396e14e74cc10c6b01b7",
+      "scripts/retrieval_bench_artifact.py": "66e3da7fd6024874fc2650355ec429af1285c3ceba1ca07d9e73785ae67e1b6e",
+      "polystore_gateway/go.mod": "8f0b81dfc08d3fdd9ee5c4f57e85cb58aa552e38049de5f5b66339020b73700b",
+      "polystore_gateway/go.sum": "2cd0063522925eab5306c7909d5f7ef112b6245e046f1ff52d9f31e42c02035f"
+    },
+    "export_test": {
+      "package": "./polystore_gateway",
+      "name": "TestExportFrozenRetrievalInventory",
+      "git_blob": "196f391d03a1ea17e106e9adfdbfbebe54ad30b6"
+    }
+  },
+  "disk_preflight": {
+    "filesystem": "/System/Volumes/Data",
+    "available_bytes_before": 2172764160,
+    "available_bytes_after": 1959796736,
+    "decision": "sufficient for two warm-cache Go outputs of approximately 80 MB each; no Rust build or workload"
+  },
+  "host": {
+    "uname": "Darwin <redacted-host> 25.2.0 Darwin Kernel Version 25.2.0: Tue Nov 18 21:03:25 PST 2025; root:xnu-12377.61.12~1/RELEASE_ARM64_T8122 arm64",
+    "go_version": "go version go1.25.5 darwin/arm64",
+    "rustc_version": "rustc 1.90.0 (1159e78c4 2025-09-14)",
+    "python_version": "Python 3.9.6"
+  },
+  "builds": [
+    {
+      "artifact": "gateway",
+      "working_directory": "$SOURCE_CHECKOUT/polystore_gateway",
+      "command": "env GOMAXPROCS=2 CGO_LDFLAGS=-L$REUSED_CORE_RELEASE go build -p 2 -o $ARTIFACT_ROOT/290-polystore-gateway .",
+      "path": "$ARTIFACT_ROOT/290-polystore-gateway",
+      "sha256": "3d9578613b3fea2810c19a7019ec7d676c918cfcd83fd42fe8f159ba1bf31a6e",
+      "bytes": 79738802,
+      "file": "Mach-O 64-bit executable arm64",
+      "exit_code": 0
+    },
+    {
+      "artifact": "retrieval inventory exporter test",
+      "working_directory": "$SOURCE_CHECKOUT/polystore_gateway",
+      "command": "env GOMAXPROCS=2 CGO_LDFLAGS=-L$REUSED_CORE_RELEASE go test -c -p 2 -o $ARTIFACT_ROOT/290-retrieval-exporter.test .",
+      "path": "$ARTIFACT_ROOT/290-retrieval-exporter.test",
+      "sha256": "8f7dbb5f20b2adca24492d51c8bacb0d1786a62da2e9e1ae3a3c369f392885fc",
+      "bytes": 82303442,
+      "file": "Mach-O 64-bit executable arm64",
+      "exit_code": 0
+    }
+  ],
+  "linkage": {
+    "build_warning": "The checkout-local polystore_core target/release directory is absent; CGO_LDFLAGS supplied the retained exact library directory.",
+    "dylib_path": "$REUSED_CORE_RELEASE/libpolystore_core.dylib",
+    "loaded_install_name": "$REUSED_CORE_RELEASE/deps/libpolystore_core.dylib",
+    "sha256": "60a9ade6c13a4be8f71a1970fac2b5b1eed73751ecb91f3c4a2537187087b59b",
+    "bytes": 1210128,
+    "source_tree": "7989fed8d5a5877e74bc0e2c71aa60b6f8747653",
+    "otool_checked_for": [
+      "$ARTIFACT_ROOT/290-polystore-gateway",
+      "$ARTIFACT_ROOT/290-retrieval-exporter.test"
+    ]
+  },
+  "smoke_checks": [
+    {
+      "command": "env DYLD_LIBRARY_PATH=$REUSED_CORE_RELEASE $ARTIFACT_ROOT/290-retrieval-exporter.test -test.list '^TestExportFrozenRetrievalInventory$'",
+      "result": "exit 0; listed TestExportFrozenRetrievalInventory"
+    },
+    {
+      "command": "env DYLD_LIBRARY_PATH=$REUSED_CORE_RELEASE $ARTIFACT_ROOT/290-retrieval-exporter.test -test.run '^TestExportFrozenRetrievalInventory$' -test.v",
+      "result": "exit 0; expected SKIP because POLYSTORE_RETRIEVAL_EXPORT_MANIFEST was not supplied"
+    },
+    {
+      "command": "env DYLD_LIBRARY_PATH=$REUSED_CORE_RELEASE $ARTIFACT_ROOT/290-polystore-gateway --help",
+      "result": "this is a startup smoke, not a help pass: it initialized KZG from the current checkout trusted setup and reached the LibP2P listen state; the bounded command invocation ended after startup output, and no gateway process remained",
+      "side_effect": "created ignored runtime database $SOURCE_CHECKOUT/uploads/sp-8080/sessions.db (131072 bytes); retained because cleanup was outside this task"
+    }
+  ],
+  "reused_artifacts": {
+    "provenance": "$ARTIFACT_ROOT/260-saturation-final-c6-retry1-build-provenance.json",
+    "build_source_commit": "76653383b04fbd8c971cc4839f831ca0bf15ca2c",
+    "build_source_commit_date": "2026-09-08T06:37:11-10:00",
+    "chain": {
+      "path": "$ARTIFACT_ROOT/260-saturation-polystorechaind",
+      "sha256": "7d6b2e136de42af5590e112668ab0538f5053ac3b16372ab3ceae5ae68e56fba",
+      "bytes": 179688642,
+      "build_source_tree": "0253e79d531087c16b1b879ec5960cd7ba3ec6de"
+    },
+    "cli": {
+      "path": "$ARTIFACT_ROOT/260-final-polystore_cli",
+      "sha256": "78f520b01226feef0788a3ad84aa1ba830bf9fd2031956d22dc7649e4c80b370",
+      "bytes": 5001552,
+      "build_source_tree": "4303dc86c58cbbb7f1076f1916f1de691bf7694c"
+    },
+    "library": {
+      "path": "$REUSED_CORE_RELEASE/libpolystore_core.dylib",
+      "sha256": "60a9ade6c13a4be8f71a1970fac2b5b1eed73751ecb91f3c4a2537187087b59b",
+      "bytes": 1210128,
+      "build_source_tree": "7989fed8d5a5877e74bc0e2c71aa60b6f8747653"
+    },
+    "identity_note": "Chain and CLI retain their actual earlier build identity. Core and CLI source trees are unchanged at the current source; current chain changes from the build source are test-only. Gateway and exporter were rebuilt from the current source above."
+  },
+  "trusted_setup": {
+    "path": "$SOURCE_CHECKOUT/polystorechain/trusted_setup.txt",
+    "sha256": "d39b9f2d047cc9dca2de58f264b6a09448ccd34db967881a6713eacacf0f26b7"
+  },
+  "scope": "Build and provenance only. No workload, secrets, or runtime logs were published. No tracked writer-worktree file was edited by this build task; the gateway startup smoke created the ignored runtime database recorded above."
+}

--- a/bench/retrieval_session_capacity/native-k8-290/pilot-002/summary.json
+++ b/bench/retrieval_session_capacity/native-k8-290/pilot-002/summary.json
@@ -1,0 +1,136 @@
+{
+  "schema": "polystore.issue290.k8-pilot-result.v1",
+  "status": "completed_successfully_once",
+  "qualification": false,
+  "attempts": 1,
+  "started_at_utc": "2026-09-09T04:26:31Z",
+  "finished_at_utc": "2026-09-09T04:33:27Z",
+  "wall_elapsed_seconds_approx": 416,
+  "source": {
+    "merged_harness_source": "81ed30f6173416c3d9c001f7c22b96874ab3ea99",
+    "reviewed_head": "48889159cbf7d271dec12d9ee1dd04e6efa5985f",
+    "merged_vs_reviewed_relevant_paths": "identical",
+    "plan": "plan.json",
+    "runtime_provenance": "runtime-provenance.json"
+  },
+  "preparation": {
+    "outcome": "committed_success",
+    "transaction_hash": "91DF8D36F569D863399F7513E459A512EA6673E8D0AB7C5B2B82C28A4C081214",
+    "height": 213,
+    "code": 0,
+    "sessions_opened": 39,
+    "gas_limit_per_open_message": 400000,
+    "gas_wanted": 15600000,
+    "gas_used": 14924033
+  },
+  "proof_submissions": {
+    "openings_per_bundle": 8,
+    "warmup": {
+      "bundles": 8,
+      "openings": 64,
+      "committed_success": 8,
+      "gas_used_sum": 33072539,
+      "gas_used_min": 4133940,
+      "gas_used_median": 4134084.5,
+      "gas_used_max": 4134092
+    },
+    "measured": {
+      "bundles": 31,
+      "openings": 248,
+      "committed_success": 31,
+      "gas_used_sum": 128123531,
+      "gas_used_min": 4131357,
+      "gas_used_median": 4134077,
+      "gas_used_max": 4134092,
+      "height_first": 232,
+      "height_last": 249
+    },
+    "total": {
+      "bundles": 39,
+      "openings": 312,
+      "committed_success": 39
+    },
+    "proof_gas_ceiling_per_bundle": 20000000,
+    "measured_mean_gas_per_opening": 516627.14112903224
+  },
+  "scheduler": {
+    "offered_measurement_window_seconds": 20,
+    "measured_scheduler_and_drain_seconds": 23.714082,
+    "eventual_measured_bundle_rate_per_second": 1.3072401453279954,
+    "eventual_measured_opening_rate_per_second": 10.457921162623963,
+    "peak_in_flight": 8,
+    "peak_queued": 3,
+    "automatic_retries": false,
+    "quarantined_signers": 0,
+    "completion_basis": "committed transaction plus pinned PROOF_SUBMITTED state; no confirmations or completed sessions"
+  },
+  "assignments": {
+    "count": 12,
+    "provider_daemons": 12,
+    "all_received_committed_valid_bundles": true,
+    "bundle_counts_by_slot": {
+      "0": 3,
+      "1": 3,
+      "2": 3,
+      "3": 2,
+      "4": 2,
+      "5": 2,
+      "6": 2,
+      "7": 2,
+      "8": 3,
+      "9": 3,
+      "10": 3,
+      "11": 3
+    }
+  },
+  "normal_audit": {
+    "coverage_verified": true,
+    "height": 301,
+    "epoch": 3,
+    "assignments": 12,
+    "finalized": 12,
+    "sample_count_sum": 12,
+    "accepted_count_sum": 12,
+    "missed_epochs_sum": 0
+  },
+  "artifacts": {
+    "evidence.json": {
+      "sha256": "9f6bc3b04a1213809c23347483df3d6e5366bddc895aa9ee27dffcde0d1094d2",
+      "bytes": 318353
+    },
+    "warmup.sqlite": {
+      "sha256": "b43e1db577c809ed14dd8135a24d780ab37625ee11049ff20d3644dd6f17c940",
+      "bytes": 81920
+    },
+    "sustained.sqlite": {
+      "sha256": "c0e4ea251614d00e738f60abe58a7d5ff6fe842a7b131cd3ac8301b8d11e8200",
+      "bytes": 212992
+    },
+    "sustained-audits.jsonl": {
+      "sha256": "606dc7c2bf7229dae126e295e721276adf29a231b7acb29c72a4e6cb88ab0e68",
+      "bytes": 26283
+    },
+    "sustained-blocks.jsonl": {
+      "sha256": "3eae569d2eb5ec979bdf7792ab407740947f88c904fab04d1186db273b6d06e1",
+      "bytes": 11333
+    },
+    "sustained-progress.jsonl": {
+      "sha256": "3f363dbd3427f5a47fb3d75710c6afdff676d6c34cff36a6ce1b86d9a6e6cb9e",
+      "bytes": 303
+    },
+    "inventory/manifest.json": {
+      "sha256": "633b38bf55f2a682d07a2affdbe4c36040d9b18df26e0e8a4ae613a941bc5524",
+      "bytes": 115117
+    },
+    "inventory/manifest.json.result.json": {
+      "sha256": "af0ed9536fdd106d5a11ae48b62207d5eb9035f95012f2bec300fecb4a364d20",
+      "bytes": 23283
+    }
+  },
+  "limits": [
+    "This was a path and gas diagnostic on a nonquiet single Apple host with four validator processes and twelve provider daemons; it is not a realistic deployment or capacity result.",
+    "The 31 measured bundles were eventually committed across the 20-second offered window plus drain; this artifact does not claim all 31 committed inside the offered window.",
+    "Completion ended at PROOF_SUBMITTED and did not measure confirmation, completed sessions, client delivery or acknowledgement, WAN behavior, or downloads."
+  ],
+  "cleanup": "owned workload, validator, gateway, and provider processes stopped; run home retained"
+}

--- a/performance/README.md
+++ b/performance/README.md
@@ -176,6 +176,12 @@ for a 64-message atomic batch. Before broadcast the harness verifies that the
 SDK appended the generated gas sum. This is a pilot ceiling, not measured full
 execution cost, and does not change proof, audit or block gas limits.
 
+One [retained K8 pilot](../bench/retrieval_session_capacity/native-k8-290/pilot-002/README.md)
+completed the all-assignment path and measured proof gas. Its four-second steps
+are diagnostic only. The 20M declared proof gas constrained SDK proposal packing
+to at most three transactions under the unchanged 64M block limit despite about
+4.13M actual gas used per transaction, so it is not a chain-capacity result.
+
 
 ## Historical streamed browser retrieval (#260)
 


### PR DESCRIPTION
The native K8 harness completed one bounded all-assignment path and gas diagnostic, but its retained run home contains private keyrings, journals, logs, payload data, and full proof inventory. This PR publishes a compact sanitized summary, execution plan, runtime provenance, and manifest while leaving those raw files local.

The artifact records 39 committed proof bundles with eight openings each, representation across all 12 assignments, and normal audit coverage. It makes no capacity claim: each proof transaction declared 20M gas under a 64M block limit, which lets the SDK default proposal selection pack at most three even though actual execution used about 4.13M. The four-second rate steps also include drain and do not establish sustainable throughput. A separate sustained result is intentionally absent.

Part of #290.

Validation:
- `python3 -m unittest test_bench_retrieval_sessions` from `scripts/` (70 passed)
- JSON parse, manifest hash, K8 count, sanitizer, and local-link consistency checks
- all eight private source-artifact byte counts and SHA-256 hashes matched the compact summary
- `git diff --check`
