### PR TITLE
bench: retain native K8 sustained diagnostic

### DIFF
--- a/bench/retrieval_session_capacity/native-k8-290/README.md
+++ b/bench/retrieval_session_capacity/native-k8-290/README.md
@@ -85,6 +85,13 @@ is not capacity evidence; its 20M declared proof gas limited proposal packing to
 at most three proof transactions under the unchanged 64M block limit even though
 each transaction used about 4.13M gas.
 
+The [retained sustained 001 diagnostic](sustained-001/README.md) uses the measured
+5M proof-gas ceiling and 60-second steps. All 465 measured K8 bundles eventually
+committed with normal audits, and the final 4 bundles/s step reached the configured
+offered ceiling without filling the queue or block gas. This is a workload-limited
+local lower bound, not a chain-saturation or deployment-capacity result. Issue
+#290 remains open for a higher offered workload and realistic deployment evidence.
+
 The existing absolute phase and overall deadlines, bounded queue, signer
 quarantine, port reservations, and process-group cleanup remain unchanged. The
 scheduler writes a progress record every 60 seconds while active, plus its final

--- a/bench/retrieval_session_capacity/native-k8-290/sustained-001/README.md
+++ b/bench/retrieval_session_capacity/native-k8-290/sustained-001/README.md
@@ -1,0 +1,81 @@
+# Native K8 sustained diagnostic 001
+
+This is the retained result of one bounded local diagnostic for
+[issue #290](https://github.com/Polynomialstore/polystore/issues/290). It is not
+a capacity qualification. The five offered-rate steps lasted 60 seconds each,
+and the run used four validator processes plus twelve provider-daemons on one
+nonquiet Apple workstation because realistic dedicated deployment infrastructure
+was unavailable.
+
+Preparation opened 473 sessions in eight committed atomic transactions. The
+400,000 gas ceiling per session-open message produced 189,200,000 total gas
+wanted and 180,665,709 gas used. Eight warmup and 465 measured
+`MsgSubmitRetrievalSessionProof` transactions committed successfully. Each K8
+transaction carried eight chained openings, for 64 warmup and 3,720 measured
+openings. Every assignment received 38 or 39 committed-valid bundles.
+
+## Offered window and drain
+
+The measured window offered 465 bundles across 300 seconds:
+
+| Offered bundles/s | Offered bundles | Same cohort observed committed by step end | All client completion observations during step | Pending at boundary | Eventual committed-valid | Terminal p95 |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 0.25 | 15 | 15 | 15 | 0 | 15 | 2.093 s |
+| 0.5 | 30 | 30 | 30 | 0 | 30 | 2.010 s |
+| 1 | 60 | 59 | 59 | 1 | 60 | 2.015 s |
+| 2 | 120 | 117 | 118 | 3 | 120 | 2.013 s |
+| 4 | 240 | 236 | 239 | 4 | 240 | 2.299 s |
+
+The p95 values above are terminal observation latencies; the exact millisecond
+values are in the summary. At the 300-second boundary, 461 of 465 transaction
+completion observations had finished. All 465 transactions eventually committed;
+the scheduler finished 1.244220 seconds after the offered window, while the
+separately fenced scheduler-and-drain interval was 301.326692 seconds. These are
+client observations around committed transactions. Consensus reconciliation
+independently records the actual workload transactions in blocks 411 through
+636 and agreement on headers and results across all four validators.
+
+The 4 bundles/s step reached the configured offered ceiling with a bounded queue:
+peak queued work was three, peak in-flight work was eight, and each 60-second
+heartbeat reported zero queued work. The four pending observations at the final
+boundary drained immediately afterward. This supports a workload-limited local
+lower bound at the maximum offered rate; it does not identify chain saturation
+or qualify 4 bundles/s as production capacity.
+
+## Gas, validators, and audits
+
+Proof transactions declared 5,000,000 gas and used 4,131,317–4,134,115 gas.
+The busiest observed workload block held six transactions, with 30,000,000 gas
+wanted and 24,804,642 gas used under the unchanged 64,000,000 block limit. The
+SDK default proposal path admits against declared gas, so 5,000,000 permits at
+most twelve such transactions by arithmetic. The observed maximum of six and
+the unused block-gas headroom are further evidence that this workload did not
+measure the chain limit.
+
+Continuous Commit-step streams covered 226 blocks on each validator and reported
+conservative p95 upper bounds of 155.971–160.498 ms, within the fixed 700 ms
+budget. The separate two-scrape CPU bounds accumulated 14.755–15.190 CPU-seconds
+per validator over about 301.6 seconds, or 4.89–5.04% of one core. They do not
+establish CPU p95 or reconcile exact workload block boundaries. Validator
+lifetime peak RSS was 295,223,296–309,968,896 bytes.
+
+The final normal audit observation at height 701 recorded one accepted sample
+for each of twelve finalized assignments, with zero missed epochs. This is the
+normal-audit K8 profile; it is not the C6 full-small-population profile.
+
+## Publication boundary
+
+The [summary](summary.json), [execution plan](plan.json), and
+[runtime provenance](runtime-provenance.json) are the only published run files.
+The [manifest](manifest.json) records original and published hashes, path
+substitutions, the seven independently hash-checked private artifacts, and the
+excluded files. The source run home, keyrings, SQLite journals, raw evidence,
+provider and validator logs, payload, proof inventory, and private driver log
+remain local.
+
+The result ends at committed `PROOF_SUBMITTED` state. It does not measure
+confirmation, completed sessions, client acknowledgement, byte delivery, WAN
+behavior, a hardware minimum, or a realistic deployment. Issue #290 remains open:
+a higher offered workload with enough signer/driver concurrency is needed to
+locate a limiter, followed by equivalent measurement on dedicated deployment
+resources before any capacity claim.

--- a/bench/retrieval_session_capacity/native-k8-290/sustained-001/README.md
+++ b/bench/retrieval_session_capacity/native-k8-290/sustained-001/README.md
@@ -54,9 +54,10 @@ measure the chain limit.
 
 Continuous Commit-step streams covered 226 blocks on each validator and reported
 conservative p95 upper bounds of 155.971–160.498 ms, within the fixed 700 ms
-budget. The separate two-scrape CPU bounds accumulated 14.755–15.190 CPU-seconds
-per validator over about 301.6 seconds, or 4.89–5.04% of one core. They do not
-establish CPU p95 or reconcile exact workload block boundaries. Validator
+budget. The separate two-scrape deltas accumulated 14.755–15.190 seconds of Commit-step
+elapsed time per validator over about 301.6 seconds, or 4.89–5.04% wall-time
+occupancy. This elapsed time may include waiting; it is not measured process
+CPU usage. These wide scrapes do not reconcile exact workload block boundaries. Validator
 lifetime peak RSS was 295,223,296–309,968,896 bytes.
 
 The final normal audit observation at height 701 recorded one accepted sample

--- a/bench/retrieval_session_capacity/native-k8-290/sustained-001/manifest.json
+++ b/bench/retrieval_session_capacity/native-k8-290/sustained-001/manifest.json
@@ -1,0 +1,84 @@
+{
+  "schema": "polystore.issue290.k8-sustained-publication.v1",
+  "artifact": "native K8 sustained 001 local diagnostic",
+  "qualification": false,
+  "issue_status": "open",
+  "source_run": "$ARTIFACT_ROOT/290-k8-all-assignment-60s-001",
+  "original_sources": {
+    "summary.json": {
+      "source_name": "290-k8-all-assignment-60s-001.summary.json",
+      "sha256": "943a156909e632c74ee70d8cba4b000d508374d509a784da61d0376a6d7efe4d",
+      "bytes": 9559
+    },
+    "plan.json": {
+      "source_name": "290-k8-all-assignment-60s-001-plan.json",
+      "sha256": "bfc8318480ccdee58d13222a5df33ca6f7124226b87659b9509a4defb2bfb719",
+      "bytes": 5850
+    },
+    "runtime-provenance.json": {
+      "source_name": "local290-build-provenance.json",
+      "sha256": "2f4631e4abcdea604537d177445115caf1b203bb85f43267ba3b4f69f59b5580",
+      "bytes": 7486
+    }
+  },
+  "published_files": {
+    "summary.json": {
+      "sha256": "768e2b2adab5bf1205fecc9832eab30f7b564e3f9f0a030fcaaffc07b43e0340",
+      "bytes": 9515
+    },
+    "plan.json": {
+      "sha256": "b74545e34a4f77bbb6872995938da995dd0bc67ae546442a9a617f067951d0f1",
+      "bytes": 5210
+    },
+    "runtime-provenance.json": {
+      "sha256": "f83c7af3118c07c93781f05ae52c4b67791a5b5c6c1b115414e2de6bcc61645c",
+      "bytes": 6462
+    }
+  },
+  "sanitization": {
+    "method": "JSON parse plus documented field removal and string replacement; numeric results, hashes, commits, Git objects, commands, workload geometry, and toolchain versions retained",
+    "replacements": [
+      {
+        "original": "K8 harness checkout absolute path",
+        "published": "$SOURCE_CHECKOUT"
+      },
+      {
+        "original": "reused core release absolute path",
+        "published": "$REUSED_CORE_RELEASE"
+      },
+      {
+        "original": "private artifact-root absolute path",
+        "published": "$ARTIFACT_ROOT"
+      },
+      {
+        "original": "local host name",
+        "published": "<redacted-host>"
+      },
+      {
+        "original": "summary links to local plan and provenance",
+        "published": "sibling plan.json and runtime-provenance.json"
+      },
+      {
+        "original": "private driver log path and hash in local summary",
+        "published": "excluded_private_sources label only"
+      }
+    ]
+  },
+  "validated_private_artifacts": {
+    "count": 7,
+    "result": "all byte counts and SHA-256 hashes in summary.json matched the retained local files before publication",
+    "published": false
+  },
+  "excluded": [
+    "run home and test keyrings",
+    "raw evidence and proof inventory",
+    "warmup and sustained SQLite journals",
+    "validator, provider, exporter, and private driver logs",
+    "generated payload and storage data"
+  ],
+  "limits": [
+    "This publication is a bounded local diagnostic, not a capacity qualification.",
+    "No raw transaction bodies, credentials, authentication material, private logs, wallets, or keyrings are published.",
+    "Issue #290 remains open because the maximum offered rate did not locate a chain limiter and realistic deployment infrastructure was unavailable."
+  ]
+}

--- a/bench/retrieval_session_capacity/native-k8-290/sustained-001/manifest.json
+++ b/bench/retrieval_session_capacity/native-k8-290/sustained-001/manifest.json
@@ -23,8 +23,8 @@
   },
   "published_files": {
     "summary.json": {
-      "sha256": "768e2b2adab5bf1205fecc9832eab30f7b564e3f9f0a030fcaaffc07b43e0340",
-      "bytes": 9515
+      "sha256": "60e865a76cb50945d31e84f87ceb300f050b594f5d7d138df103a827b1e8d1fa",
+      "bytes": 9641
     },
     "plan.json": {
       "sha256": "b74545e34a4f77bbb6872995938da995dd0bc67ae546442a9a617f067951d0f1",
@@ -61,6 +61,10 @@
       {
         "original": "private driver log path and hash in local summary",
         "published": "excluded_private_sources label only"
+      },
+      {
+        "original": "summary resources commit_cpu_limit, commit_step_cpu_wide_scrape, and one_core_percent mislabeled elapsed Commit-step time as CPU usage",
+        "published": "commit_elapsed_time_limit, commit_step_elapsed_wide_scrape, and wall_time_occupancy_percent; elapsed-time semantics clarified, numeric measurements unchanged"
       }
     ]
   },

--- a/bench/retrieval_session_capacity/native-k8-290/sustained-001/plan.json
+++ b/bench/retrieval_session_capacity/native-k8-290/sustained-001/plan.json
@@ -1,0 +1,161 @@
+{
+  "claim_limits": [
+    "No production, WAN, hardware-minimum, or deployment-capacity qualification",
+    "Eventual completion alone does not establish the stable offered-load rate",
+    "Committed-inside-300-seconds and post-window drain must be reported separately",
+    "A workload-limited 4 bundle/s plateau establishes only a tested local lower bound"
+  ],
+  "completed_at_utc": "2026-09-09T05:50:14.696450Z",
+  "completion_timestamp_basis": "private log final mtime; evidence.json finalized 0.001685s earlier",
+  "infrastructure": {
+    "fallback": "four validator processes and twelve provider daemons on one nonquiet local Apple workstation; diagnostic only",
+    "reason": "Repository configuration does not supply a dedicated multi-host four-validator and twelve-provider deployment inventory; using the explicitly authorized one-host fallback.",
+    "status": "INFRASTRUCTURE_UNAVAILABLE"
+  },
+  "invocation": {
+    "absolute_timeout_seconds": 1500,
+    "argv": [
+      "/usr/bin/python3",
+      "$SOURCE_CHECKOUT/scripts/retrieval_four_validator_workload.py",
+      "--mode",
+      "sustained-providers",
+      "--audit-profile",
+      "normal",
+      "--sustained-k",
+      "8",
+      "--binary",
+      "$ARTIFACT_ROOT/260-saturation-polystorechaind",
+      "--library",
+      "$REUSED_CORE_RELEASE/libpolystore_core.dylib",
+      "--gateway-binary",
+      "$ARTIFACT_ROOT/290-polystore-gateway",
+      "--cli-binary",
+      "$ARTIFACT_ROOT/260-final-polystore_cli",
+      "--product-source",
+      "$SOURCE_CHECKOUT",
+      "--proof-exporter",
+      "$ARTIFACT_ROOT/290-retrieval-exporter.test",
+      "--proof-gas",
+      "5000000",
+      "--step-seconds",
+      "60",
+      "--timeout",
+      "1500",
+      "--home",
+      "$ARTIFACT_ROOT/290-k8-all-assignment-60s-001"
+    ],
+    "attempt_limit": 1,
+    "cwd": "$SOURCE_CHECKOUT",
+    "disk_abort_floor_bytes": 805306368,
+    "environment": {
+      "DYLD_LIBRARY_PATH_prepend": "$REUSED_CORE_RELEASE",
+      "GOMAXPROCS": "2",
+      "LD_LIBRARY_PATH_prepend": "$REUSED_CORE_RELEASE",
+      "POLYSTORE_TRUSTED_SETUP": "$SOURCE_CHECKOUT/polystorechain/trusted_setup.txt"
+    }
+  },
+  "launched_at_utc": "2026-09-09T05:34:26Z",
+  "launcher_exit_code": 0,
+  "preflight": {
+    "free_bytes": 3128614912,
+    "fresh_home": true,
+    "host": "nonquiet",
+    "load_average": [
+      2.72607421875,
+      3.28173828125,
+      3.330078125
+    ],
+    "minimum_free_bytes": 2147483648,
+    "ports": [
+      26657,
+      26656,
+      9090,
+      1317,
+      26660,
+      26654,
+      26653,
+      9088,
+      1316,
+      26661,
+      26651,
+      26650,
+      9086,
+      1315,
+      26662,
+      26648,
+      26647,
+      9084,
+      1314,
+      26663,
+      19091,
+      19092,
+      19093,
+      19094,
+      19095,
+      19096,
+      19097,
+      19098,
+      19099,
+      19100,
+      19101,
+      19102
+    ],
+    "ports_bindable": 32,
+    "user_processes_left_untouched": true
+  },
+  "prepared_at_utc": "2026-09-09T05:34:04Z",
+  "purpose": "One bounded local K8 sustained diagnostic with normal audits; diagnostic fallback because realistic dedicated deployment infrastructure is unavailable.",
+  "runtime_provenance": {
+    "artifact_sha256": {
+      "chain": "7d6b2e136de42af5590e112668ab0538f5053ac3b16372ab3ceae5ae68e56fba",
+      "cli": "78f520b01226feef0788a3ad84aa1ba830bf9fd2031956d22dc7649e4c80b370",
+      "exporter": "8f7dbb5f20b2adca24492d51c8bacb0d1786a62da2e9e1ae3a3c369f392885fc",
+      "gateway": "3d9578613b3fea2810c19a7019ec7d676c918cfcd83fd42fe8f159ba1bf31a6e",
+      "library": "60a9ade6c13a4be8f71a1970fac2b5b1eed73751ecb91f3c4a2537187087b59b",
+      "trusted_setup": "d39b9f2d047cc9dca2de58f264b6a09448ccd34db967881a6713eacacf0f26b7"
+    },
+    "chain_cli_core_build_source": "76653383b04fbd8c971cc4839f831ca0bf15ca2c",
+    "gateway_exporter_build_source": "f0f8fab53178cb37a34d21e35200ec1d6ec0fa89",
+    "verified_manifest": "runtime-provenance.json"
+  },
+  "schema": "polystore.issue290.k8-sustained-plan.v1",
+  "source": {
+    "checkout": "$SOURCE_CHECKOUT",
+    "merged_harness_source": "81ed30f6173416c3d9c001f7c22b96874ab3ea99",
+    "origin_main": "81ed30f6173416c3d9c001f7c22b96874ab3ea99",
+    "relevant_harness_sha256": {
+      "artifact_helper": "c1254269dd05e4cfb1256ae6cd72c07f763bbbd5f865a9dc0e9a6e98d75b4ef2",
+      "driver": "80dd29217c5e131760995ca0ae2f9fe376bdf792d1ceab1ed1efff464ba9e48f",
+      "proof_helper": "74ced497d80442a7d463872623879737b7775ad2a49ec4c5a53ced8a8650e67b"
+    },
+    "tracked_runtime_status": ""
+  },
+  "status": "completed_once_diagnostic_only",
+  "summary_path": "summary.json",
+  "workload": {
+    "assignments": 12,
+    "audit_profile": "normal",
+    "deputy_signers": 8,
+    "gas_margin_over_pilot002_max": 865908,
+    "k": 8,
+    "m": 4,
+    "measured_bundles": 465,
+    "measured_openings": 3720,
+    "measured_window_seconds": 300,
+    "offered_bundle_rates_per_second": [
+      0.25,
+      0.5,
+      1,
+      2,
+      4
+    ],
+    "openings_per_bundle": 8,
+    "pilot002_max_gas_used": 4134092,
+    "proof_gas_wanted_per_tx": 5000000,
+    "seconds_per_step": 60,
+    "total_bundles": 473,
+    "total_openings": 3784,
+    "warmup_bundles": 8,
+    "warmup_openings": 64
+  }
+}

--- a/bench/retrieval_session_capacity/native-k8-290/sustained-001/runtime-provenance.json
+++ b/bench/retrieval_session_capacity/native-k8-290/sustained-001/runtime-provenance.json
@@ -1,0 +1,120 @@
+{
+  "created_utc": "2026-09-09T02:54:15Z",
+  "status": "build complete; no workload launched",
+  "source": {
+    "worktree": "$SOURCE_CHECKOUT",
+    "branch": "e2e/retrieval-k8-capacity-290",
+    "commit": "f0f8fab53178cb37a34d21e35200ec1d6ec0fa89",
+    "commit_date": "2026-09-08T16:45:06-10:00",
+    "commit_subject": "docs: require heartbeat before sustained collection",
+    "status_porcelain": "",
+    "tree_ids": {
+      "polystore_gateway": "6d0c3bfc9147565180931347ef979113d5983b8a",
+      "polystorechain": "d002c6f58a35d9cfa80f104b413ef5a7b478c764",
+      "polystore_core": "7989fed8d5a5877e74bc0e2c71aa60b6f8747653",
+      "polystore_cli": "4303dc86c58cbbb7f1076f1916f1de691bf7694c"
+    },
+    "source_sha256": {
+      "polystore_gateway/retrieval_inventory_export_test.go": "6011daa40fb3f50ed9711e1e8e52ebaa407a918e2903c765596991746cec11f2",
+      "scripts/retrieval_four_validator_workload.py": "f609f8e678b433dc8994c325d80dabc9a00e82153cde396e14e74cc10c6b01b7",
+      "scripts/retrieval_bench_artifact.py": "66e3da7fd6024874fc2650355ec429af1285c3ceba1ca07d9e73785ae67e1b6e",
+      "polystore_gateway/go.mod": "8f0b81dfc08d3fdd9ee5c4f57e85cb58aa552e38049de5f5b66339020b73700b",
+      "polystore_gateway/go.sum": "2cd0063522925eab5306c7909d5f7ef112b6245e046f1ff52d9f31e42c02035f"
+    },
+    "export_test": {
+      "package": "./polystore_gateway",
+      "name": "TestExportFrozenRetrievalInventory",
+      "git_blob": "196f391d03a1ea17e106e9adfdbfbebe54ad30b6"
+    }
+  },
+  "disk_preflight": {
+    "filesystem": "/System/Volumes/Data",
+    "available_bytes_before": 2172764160,
+    "available_bytes_after": 1959796736,
+    "decision": "sufficient for two warm-cache Go outputs of approximately 80 MB each; no Rust build or workload"
+  },
+  "host": {
+    "uname": "Darwin <redacted-host> 25.2.0 Darwin Kernel Version 25.2.0: Tue Nov 18 21:03:25 PST 2025; root:xnu-12377.61.12~1/RELEASE_ARM64_T8122 arm64",
+    "go_version": "go version go1.25.5 darwin/arm64",
+    "rustc_version": "rustc 1.90.0 (1159e78c4 2025-09-14)",
+    "python_version": "Python 3.9.6"
+  },
+  "builds": [
+    {
+      "artifact": "gateway",
+      "working_directory": "$SOURCE_CHECKOUT/polystore_gateway",
+      "command": "env GOMAXPROCS=2 CGO_LDFLAGS=-L$REUSED_CORE_RELEASE go build -p 2 -o $ARTIFACT_ROOT/290-polystore-gateway .",
+      "path": "$ARTIFACT_ROOT/290-polystore-gateway",
+      "sha256": "3d9578613b3fea2810c19a7019ec7d676c918cfcd83fd42fe8f159ba1bf31a6e",
+      "bytes": 79738802,
+      "file": "Mach-O 64-bit executable arm64",
+      "exit_code": 0
+    },
+    {
+      "artifact": "retrieval inventory exporter test",
+      "working_directory": "$SOURCE_CHECKOUT/polystore_gateway",
+      "command": "env GOMAXPROCS=2 CGO_LDFLAGS=-L$REUSED_CORE_RELEASE go test -c -p 2 -o $ARTIFACT_ROOT/290-retrieval-exporter.test .",
+      "path": "$ARTIFACT_ROOT/290-retrieval-exporter.test",
+      "sha256": "8f7dbb5f20b2adca24492d51c8bacb0d1786a62da2e9e1ae3a3c369f392885fc",
+      "bytes": 82303442,
+      "file": "Mach-O 64-bit executable arm64",
+      "exit_code": 0
+    }
+  ],
+  "linkage": {
+    "build_warning": "The checkout-local polystore_core target/release directory is absent; CGO_LDFLAGS supplied the retained exact library directory.",
+    "dylib_path": "$REUSED_CORE_RELEASE/libpolystore_core.dylib",
+    "loaded_install_name": "$REUSED_CORE_RELEASE/deps/libpolystore_core.dylib",
+    "sha256": "60a9ade6c13a4be8f71a1970fac2b5b1eed73751ecb91f3c4a2537187087b59b",
+    "bytes": 1210128,
+    "source_tree": "7989fed8d5a5877e74bc0e2c71aa60b6f8747653",
+    "otool_checked_for": [
+      "$ARTIFACT_ROOT/290-polystore-gateway",
+      "$ARTIFACT_ROOT/290-retrieval-exporter.test"
+    ]
+  },
+  "smoke_checks": [
+    {
+      "command": "env DYLD_LIBRARY_PATH=$REUSED_CORE_RELEASE $ARTIFACT_ROOT/290-retrieval-exporter.test -test.list '^TestExportFrozenRetrievalInventory$'",
+      "result": "exit 0; listed TestExportFrozenRetrievalInventory"
+    },
+    {
+      "command": "env DYLD_LIBRARY_PATH=$REUSED_CORE_RELEASE $ARTIFACT_ROOT/290-retrieval-exporter.test -test.run '^TestExportFrozenRetrievalInventory$' -test.v",
+      "result": "exit 0; expected SKIP because POLYSTORE_RETRIEVAL_EXPORT_MANIFEST was not supplied"
+    },
+    {
+      "command": "env DYLD_LIBRARY_PATH=$REUSED_CORE_RELEASE $ARTIFACT_ROOT/290-polystore-gateway --help",
+      "result": "this is a startup smoke, not a help pass: it initialized KZG from the current checkout trusted setup and reached the LibP2P listen state; the bounded command invocation ended after startup output, and no gateway process remained",
+      "side_effect": "created ignored runtime database $SOURCE_CHECKOUT/uploads/sp-8080/sessions.db (131072 bytes); retained because cleanup was outside this task"
+    }
+  ],
+  "reused_artifacts": {
+    "provenance": "$ARTIFACT_ROOT/260-saturation-final-c6-retry1-build-provenance.json",
+    "build_source_commit": "76653383b04fbd8c971cc4839f831ca0bf15ca2c",
+    "build_source_commit_date": "2026-09-08T06:37:11-10:00",
+    "chain": {
+      "path": "$ARTIFACT_ROOT/260-saturation-polystorechaind",
+      "sha256": "7d6b2e136de42af5590e112668ab0538f5053ac3b16372ab3ceae5ae68e56fba",
+      "bytes": 179688642,
+      "build_source_tree": "0253e79d531087c16b1b879ec5960cd7ba3ec6de"
+    },
+    "cli": {
+      "path": "$ARTIFACT_ROOT/260-final-polystore_cli",
+      "sha256": "78f520b01226feef0788a3ad84aa1ba830bf9fd2031956d22dc7649e4c80b370",
+      "bytes": 5001552,
+      "build_source_tree": "4303dc86c58cbbb7f1076f1916f1de691bf7694c"
+    },
+    "library": {
+      "path": "$REUSED_CORE_RELEASE/libpolystore_core.dylib",
+      "sha256": "60a9ade6c13a4be8f71a1970fac2b5b1eed73751ecb91f3c4a2537187087b59b",
+      "bytes": 1210128,
+      "build_source_tree": "7989fed8d5a5877e74bc0e2c71aa60b6f8747653"
+    },
+    "identity_note": "Chain and CLI retain their actual earlier build identity. Core and CLI source trees are unchanged at the current source; current chain changes from the build source are test-only. Gateway and exporter were rebuilt from the current source above."
+  },
+  "trusted_setup": {
+    "path": "$SOURCE_CHECKOUT/polystorechain/trusted_setup.txt",
+    "sha256": "d39b9f2d047cc9dca2de58f264b6a09448ccd34db967881a6713eacacf0f26b7"
+  },
+  "scope": "Build and provenance only. No workload, secrets, or runtime logs were published. No tracked writer-worktree file was edited by this build task; the gateway startup smoke created the ignored runtime database recorded above."
+}

--- a/bench/retrieval_session_capacity/native-k8-290/sustained-001/summary.json
+++ b/bench/retrieval_session_capacity/native-k8-290/sustained-001/summary.json
@@ -1,0 +1,283 @@
+{
+  "artifacts": {
+    "evidence.json": {
+      "bytes": 656104,
+      "sha256": "4718d5e368d49f5c394cf2e6da94f735d8e0fbc4b2d8635287587761b6de06ff"
+    },
+    "inventory/manifest.json": {
+      "bytes": 1390206,
+      "sha256": "c7bb1eee0208731180b3fb1ceaa830e2e378293e5ae2d3ecc9a7588afbcc4755"
+    },
+    "sustained-audits.jsonl": {
+      "bytes": 131415,
+      "sha256": "6c9e25fe9fc49a7b1e0da3acf36bc12c3cae5ef574b882f756df4b4127b424f0"
+    },
+    "sustained-blocks.jsonl": {
+      "bytes": 159431,
+      "sha256": "04033d61b8e5557648b6fc0b0a800b65de5254416ce4e177c4654ed623ee830e"
+    },
+    "sustained-progress.jsonl": {
+      "bytes": 1826,
+      "sha256": "351108211b39d911e4b9afd846170fae561f717763554e7cee375725ab18e0ad"
+    },
+    "sustained.sqlite": {
+      "bytes": 2805760,
+      "sha256": "57640e06ea59f49542fdbd47c66c9929fe550b11562cdaef90676f65e355eb25"
+    },
+    "warmup.sqlite": {
+      "bytes": 81920,
+      "sha256": "7b5671f455730fc3d5578be881f2ec5db738af270d5b0f3fda3aa57c0937923d"
+    }
+  },
+  "assignments": {
+    "all_offered_submitted_committed": true,
+    "count": 12,
+    "eventual_bundle_counts": [
+      38,
+      38,
+      38,
+      39,
+      39,
+      39,
+      39,
+      39,
+      39,
+      39,
+      39,
+      39
+    ]
+  },
+  "attempts": 1,
+  "audits": {
+    "accepted": 12,
+    "assignments": 12,
+    "coverage_verified": true,
+    "epoch": 7,
+    "finalized": 12,
+    "height": 701,
+    "missed_epochs_total": 0
+  },
+  "consensus": {
+    "all_four_headers_agree": true,
+    "all_four_results_agree": true,
+    "same_height_reconciled": 636,
+    "workload_height_range": [
+      411,
+      636
+    ]
+  },
+  "excluded_private_sources": [
+    "private driver log and its hash",
+    "run home and test keyrings",
+    "raw evidence and proof inventory",
+    "warmup and sustained SQLite journals",
+    "validator, provider, exporter, and driver logs",
+    "generated payload and storage data"
+  ],
+  "gas": {
+    "admission_semantics": "Default proposal handler sums declared GasTx.GetGas limits against MaxGas.",
+    "block_max_gas": 64000000,
+    "declared_per_proof_transaction": 5000000,
+    "max_workload_gas_used_per_block": 24804642,
+    "max_workload_gas_wanted_per_block": 30000000,
+    "max_workload_transactions_per_block": 6,
+    "used_per_proof_transaction_range": [
+      4131317,
+      4134115
+    ],
+    "used_total": 1921920915,
+    "wanted_total": 2325000000,
+    "workload_blocks": 181
+  },
+  "infrastructure": {
+    "fallback": "four validator processes and twelve provider daemons on one nonquiet local Apple workstation; diagnostic only",
+    "reason": "Repository configuration does not supply a dedicated multi-host four-validator and twelve-provider deployment inventory; using the explicitly authorized one-host fallback.",
+    "status": "INFRASTRUCTURE_UNAVAILABLE"
+  },
+  "interpretation": {
+    "basis": "The 4/s step offered 240 bundles; 239 client completions were observed during that 60s interval, pending ended at 4, all 240 eventually committed within the bounded 1.327s drain, queues stayed bounded (peak 3), and observed max per-block declared/used gas was 30.0M/24.805M of 64M.",
+    "claim_limit": "Local one-host nonquiet diagnostic only. It does not establish chain saturation, production capacity, WAN behavior, or realistic dedicated deployment performance. Journal finished_ns is client observation time, while block reconciliation separately proves commits at heights 411-636.",
+    "classification": "workload_limited_at_max_offered_rate"
+  },
+  "launcher_exit_code": 0,
+  "measurement": {
+    "client_observed_committed_by_300s_end": 461,
+    "eventual_committed_valid_bundles": 465,
+    "eventual_committed_valid_openings": 3720,
+    "offered_bundles": 465,
+    "offered_openings": 3720,
+    "post_window_client_observations": 4,
+    "steps": [
+      {
+        "all_client_completions_observed_during_step": 15,
+        "eventual_committed_valid": 15,
+        "offered_bundles": 15,
+        "offered_rate_bundles_per_s": 0.25,
+        "pending_at_step_end": 0,
+        "same_cohort_client_observed_by_step_end": 15,
+        "terminal_latency_ms": {
+          "max": 2135.772,
+          "p50": 1929.602,
+          "p95": 2092.574,
+          "p99": 2127.132
+        }
+      },
+      {
+        "all_client_completions_observed_during_step": 30,
+        "eventual_committed_valid": 30,
+        "offered_bundles": 30,
+        "offered_rate_bundles_per_s": 0.5,
+        "pending_at_step_end": 0,
+        "same_cohort_client_observed_by_step_end": 30,
+        "terminal_latency_ms": {
+          "max": 2073.751,
+          "p50": 1466.861,
+          "p95": 2009.969,
+          "p99": 2067.974
+        }
+      },
+      {
+        "all_client_completions_observed_during_step": 59,
+        "eventual_committed_valid": 60,
+        "offered_bundles": 60,
+        "offered_rate_bundles_per_s": 1,
+        "pending_at_step_end": 1,
+        "same_cohort_client_observed_by_step_end": 59,
+        "terminal_latency_ms": {
+          "max": 2204.042,
+          "p50": 1397.677,
+          "p95": 2015.348,
+          "p99": 2111.971
+        }
+      },
+      {
+        "all_client_completions_observed_during_step": 118,
+        "eventual_committed_valid": 120,
+        "offered_bundles": 120,
+        "offered_rate_bundles_per_s": 2,
+        "pending_at_step_end": 3,
+        "same_cohort_client_observed_by_step_end": 117,
+        "terminal_latency_ms": {
+          "max": 2300.033,
+          "p50": 1473.953,
+          "p95": 2013.249,
+          "p99": 2139.637
+        }
+      },
+      {
+        "all_client_completions_observed_during_step": 239,
+        "eventual_committed_valid": 240,
+        "offered_bundles": 240,
+        "offered_rate_bundles_per_s": 4,
+        "pending_at_step_end": 4,
+        "same_cohort_client_observed_by_step_end": 236,
+        "terminal_latency_ms": {
+          "max": 2539.131,
+          "p50": 1687.826,
+          "p95": 2298.946,
+          "p99": 2427.317
+        }
+      }
+    ]
+  },
+  "plan": {
+    "path": "plan.json"
+  },
+  "preparation": {
+    "committed_success": 8,
+    "gas_ceiling_per_open_message": 400000,
+    "gas_used_range": [
+      9576879,
+      24450778
+    ],
+    "gas_used_total": 180665709,
+    "gas_wanted_total": 189200000,
+    "sessions_opened": 473,
+    "transactions": 8
+  },
+  "qualification": false,
+  "resources": {
+    "commit_cpu_limit": "Two wide scrapes do not establish p95 or reconcile workload block boundaries; trailing observations may be missing",
+    "commit_step_cpu_wide_scrape": [
+      {
+        "commit_step_sum_seconds_delta": 14.754940786,
+        "node_id": "d55ddc4f7844069eb3e5e9a52702250a30566732",
+        "one_core_percent": 4.893,
+        "wide_scrape_wall_seconds": 301.562276
+      },
+      {
+        "commit_step_sum_seconds_delta": 15.18994379,
+        "node_id": "950a80af5ef62b96f42256d033bf9b449596a575",
+        "one_core_percent": 5.037,
+        "wide_scrape_wall_seconds": 301.563285
+      },
+      {
+        "commit_step_sum_seconds_delta": 14.957921707,
+        "node_id": "18319fb99d7d5e66dbde4f2356aab541ea0cf507",
+        "one_core_percent": 4.96,
+        "wide_scrape_wall_seconds": 301.566726
+      },
+      {
+        "commit_step_sum_seconds_delta": 15.044792756,
+        "node_id": "547583d7cf158578863ee0b7afdb5e7a9fa89e4c",
+        "one_core_percent": 4.989,
+        "wide_scrape_wall_seconds": 301.567686
+      }
+    ],
+    "commit_stream_all_within_700ms_budget": true,
+    "commit_stream_boundary": "commit-step execution upper bound",
+    "commit_stream_excluded": "post-persistence state-transition tail, validator-key refresh, next-round scheduling",
+    "commit_stream_observed_blocks_each": [
+      226,
+      226,
+      226,
+      226
+    ],
+    "commit_stream_p95_upper_bound_seconds": [
+      0.15761854200412087,
+      0.15597108300416365,
+      0.15715154200406092,
+      0.160497834003784
+    ],
+    "final_free_bytes": 2822971392,
+    "retained_home_bytes": 204345344,
+    "validator_peak_rss_bytes": [
+      309968896,
+      297631744,
+      295223296,
+      297484288
+    ]
+  },
+  "run": {
+    "completed_at_utc": "2026-09-09T05:50:14.696450Z",
+    "fenced_interval_over_300s_seconds": 1.326692,
+    "fenced_scheduler_and_drain_seconds": 301.326692,
+    "launched_at_utc": "2026-09-09T05:34:26Z",
+    "offered_window_seconds": 300,
+    "peak_in_flight": 8,
+    "peak_queued": 3,
+    "quarantined_signers": [],
+    "retries": 0,
+    "scheduler_elapsed_seconds": 301.24422,
+    "scheduler_post_window_drain_seconds": 1.24422
+  },
+  "schema": "polystore.issue290.k8-sustained-summary.v1",
+  "source": {
+    "cli_sha256": "78f520b01226feef0788a3ad84aa1ba830bf9fd2031956d22dc7649e4c80b370",
+    "driver_sha256": "80dd29217c5e131760995ca0ae2f9fe376bdf792d1ceab1ed1efff464ba9e48f",
+    "driver_sha256_verified_current_file": true,
+    "gateway_sha256": "3d9578613b3fea2810c19a7019ec7d676c918cfcd83fd42fe8f159ba1bf31a6e",
+    "merged_harness_source": "81ed30f6173416c3d9c001f7c22b96874ab3ea99",
+    "native_library_sha256": "60a9ade6c13a4be8f71a1970fac2b5b1eed73751ecb91f3c4a2537187087b59b",
+    "runtime_binary_sha256": "7d6b2e136de42af5590e112668ab0538f5053ac3b16372ab3ceae5ae68e56fba",
+    "runtime_provenance": "runtime-provenance.json",
+    "trusted_setup_sha256": "d39b9f2d047cc9dca2de58f264b6a09448ccd34db967881a6713eacacf0f26b7"
+  },
+  "status": "SUCCESS_DIAGNOSTIC_ONLY",
+  "summary_generated_at_utc": "2026-09-09T05:59:47Z",
+  "warmup": {
+    "committed_valid_bundles": 8,
+    "offered_bundles": 8,
+    "openings": 64
+  }
+}

--- a/bench/retrieval_session_capacity/native-k8-290/sustained-001/summary.json
+++ b/bench/retrieval_session_capacity/native-k8-290/sustained-001/summary.json
@@ -197,30 +197,30 @@
   },
   "qualification": false,
   "resources": {
-    "commit_cpu_limit": "Two wide scrapes do not establish p95 or reconcile workload block boundaries; trailing observations may be missing",
-    "commit_step_cpu_wide_scrape": [
+    "commit_elapsed_time_limit": "Two wide scrapes do not establish p95 or reconcile workload block boundaries; trailing observations may be missing; elapsed Commit time may include waiting and is not process CPU time",
+    "commit_step_elapsed_wide_scrape": [
       {
         "commit_step_sum_seconds_delta": 14.754940786,
         "node_id": "d55ddc4f7844069eb3e5e9a52702250a30566732",
-        "one_core_percent": 4.893,
+        "wall_time_occupancy_percent": 4.893,
         "wide_scrape_wall_seconds": 301.562276
       },
       {
         "commit_step_sum_seconds_delta": 15.18994379,
         "node_id": "950a80af5ef62b96f42256d033bf9b449596a575",
-        "one_core_percent": 5.037,
+        "wall_time_occupancy_percent": 5.037,
         "wide_scrape_wall_seconds": 301.563285
       },
       {
         "commit_step_sum_seconds_delta": 14.957921707,
         "node_id": "18319fb99d7d5e66dbde4f2356aab541ea0cf507",
-        "one_core_percent": 4.96,
+        "wall_time_occupancy_percent": 4.96,
         "wide_scrape_wall_seconds": 301.566726
       },
       {
         "commit_step_sum_seconds_delta": 15.044792756,
         "node_id": "547583d7cf158578863ee0b7afdb5e7a9fa89e4c",
-        "one_core_percent": 4.989,
+        "wall_time_occupancy_percent": 4.989,
         "wide_scrape_wall_seconds": 301.567686
       }
     ],

--- a/performance/README.md
+++ b/performance/README.md
@@ -182,6 +182,14 @@ are diagnostic only. The 20M declared proof gas constrained SDK proposal packing
 to at most three transactions under the unchanged 64M block limit despite about
 4.13M actual gas used per transaction, so it is not a chain-capacity result.
 
+The follow-up [60-second-step diagnostic](../bench/retrieval_session_capacity/native-k8-290/sustained-001/README.md)
+used a 5M declared ceiling and committed all 465 measured K8 bundles with normal
+audits. One local 4 bundles/s step reached the configured offered ceiling with
+four client completion observations draining after the boundary, peak queue
+three, and at most 30M declared gas in a block. It establishes a workload-limited
+local lower bound only. #290 remains open for higher offered load and realistic
+deployment measurement.
+
 
 ## Historical streamed browser retrieval (#260)
 


### PR DESCRIPTION
Publishes the sanitized artifact bundle for the local native K=8 sustained diagnostic tracked by #290. The bundle retains the plan, summary, runtime provenance, source-to-public transformation manifest, hashes, and explicit distinctions between client completion observations, consensus block commits, scheduler elapsed time, and the separately fenced interval.

This diagnostic completed 465 measured submission bundles (3,720 openings) with normal audits on a nonquiet four-process local validator setup. It reached the configured 4 bundles/s offered ceiling with bounded queues, so it is a workload-limited local lower bound; it does not qualify production capacity or realistic deployment throughput, and #290 remains open.

Validation:
- focused JSON, original/published hash, retained-private-artifact, SQLite journal, link, and sanitization validation (`PASS json=4 original_hashes=3 published_hashes=3 private_artifacts=7 journal=465 links=all sanitization=clean`)
- `git diff --cached --check`
- no benchmark rerun; raw logs and keyrings remain private
