### PR TITLE
e2e: budget fixed gas for open-session batches

### DIFF
--- a/performance/README.md
+++ b/performance/README.md
@@ -171,10 +171,12 @@ The final evidence and its revised disposition are summarized below and in the
 [qualification report](retrieval-v2-qualification.md).
 
 For the #290 native K8 pilot, inventory preparation uses a conservative 400,000
-gas allowance per session-open message: 15.6M for 39 sessions and at most 25.6M
-for a 64-message atomic batch. Before broadcast the harness verifies that the
-SDK appended the generated gas sum. This is a pilot ceiling, not measured full
-execution cost, and does not change proof, audit or block gas limits.
+gas allowance per session-open message plus 100,000 once per transaction: 15.7M
+for 39 sessions and at most 25.7M for a 64-message atomic batch. The transaction
+allowance covers fixed transaction work that a two-message tail batch exhausted
+when only the per-message sum was declared. Before broadcast the harness verifies
+the exact generated and signed batch limit. These are conservative ceilings, not
+measured full execution costs, and do not change proof, audit or block gas limits.
 
 One [retained K8 pilot](../bench/retrieval_session_capacity/native-k8-290/pilot-002/README.md)
 completed the all-assignment path and measured proof gas. Its four-second steps

--- a/scripts/retrieval_four_validator_workload.py
+++ b/scripts/retrieval_four_validator_workload.py
@@ -35,8 +35,9 @@ SUSTAINED_RATES = (0.25, 0.5, 1, 2, 4)
 SUSTAINED_RATE_SCALES = (1, 4)
 SUSTAINED_DEPUTY_COUNTS = (8, 32)
 OPEN_SESSION_PREPARATION_GAS = 400_000
+OPEN_SESSION_BATCH_BASE_GAS = 100_000
 OPEN_SESSION_BATCH_MAX = 64
-OPEN_SESSION_BATCH_GAS_CAP = OPEN_SESSION_PREPARATION_GAS * OPEN_SESSION_BATCH_MAX
+OPEN_SESSION_BATCH_GAS_CAP = OPEN_SESSION_BATCH_BASE_GAS + OPEN_SESSION_PREPARATION_GAS * OPEN_SESSION_BATCH_MAX
 
 
 def mode2_layout(k, deputy_count=8):
@@ -79,8 +80,9 @@ def sustained_profile(k, step_seconds, offsets, proof_gas, rate_scale=1, deputy_
         bundle_opening_distribution={str(openings): inventory},
         native_message_batching=dict(open_session_messages_per_preparation_transaction_max=OPEN_SESSION_BATCH_MAX,
             open_session_gas_limit_per_message=OPEN_SESSION_PREPARATION_GAS,
+            open_session_gas_limit_per_preparation_transaction=OPEN_SESSION_BATCH_BASE_GAS,
             open_session_batch_gas_limit_max=OPEN_SESSION_BATCH_GAS_CAP,
-            open_session_gas_limit_note="conservative pilot ceiling, not measured full execution cost",
+            open_session_gas_limit_note="conservative per-message and transaction-base ceilings, not measured full execution cost",
             proof_sessions_per_submission_transaction=1, cross_provider_crypto_aggregation=False),
         k=k, m=layout["m"], assignment_count=layout["assignments"], rate_scale=rate_scale,
         provider_daemon_count=layout["assignments"],
@@ -848,14 +850,18 @@ def open_session_batch(lifecycle, operations, directory, command):
     directory.mkdir(mode=0o700)
     generated_gas = 0
     with unsigned.open("x") as output:
-        for operation in operations:
-            args = operation["open-session"]["submit"] + ["--generate-only"]
+        for index, operation in enumerate(operations):
+            args = operation["open-session"]["submit"].copy()
+            gas_index = args.index("--gas") + 1
+            expected_gas = OPEN_SESSION_PREPARATION_GAS + (OPEN_SESSION_BATCH_BASE_GAS if index == 0 else 0)
+            args[gas_index] = str(expected_gas)
+            args.append("--generate-only")
             tx = json.loads(command(args))
             messages = tx["body"]["messages"]
             if len(messages) != 1 or messages[0]["@type"] != "/polystorechain.polystorechain.v1.MsgOpenRetrievalSession":
                 raise ValueError("generated open transaction has unexpected messages")
             gas = producer.uint(tx.get("auth_info", {}).get("fee", {}).get("gas_limit", 0))
-            if gas != OPEN_SESSION_PREPARATION_GAS:
+            if gas != expected_gas:
                 raise ValueError("generated open transaction has unexpected gas limit")
             generated_gas += gas
             message, expected = messages[0], operation["proof_expectation"]["session"]
@@ -877,7 +883,8 @@ def open_session_batch(lifecycle, operations, directory, command):
     if value["body"]["messages"] != original or len(value["signatures"]) != 1:
         raise ValueError("signed batch differs from ordered open intent")
     signed_gas = producer.uint(value.get("auth_info", {}).get("fee", {}).get("gas_limit", 0))
-    if signed_gas != generated_gas or signed_gas > OPEN_SESSION_BATCH_GAS_CAP:
+    expected_batch_gas = OPEN_SESSION_BATCH_BASE_GAS + OPEN_SESSION_PREPARATION_GAS * len(operations)
+    if generated_gas != expected_batch_gas or signed_gas != expected_batch_gas or signed_gas > OPEN_SESSION_BATCH_GAS_CAP:
         raise ValueError("signed batch gas differs from bounded generated gas sum")
     job = dict(operations[0]["open-session"], kind="open-session-batch",
                submit=[str(lifecycle.binary), "tx", "broadcast", str(signed), *common,

--- a/scripts/retrieval_four_validator_workload.py
+++ b/scripts/retrieval_four_validator_workload.py
@@ -80,7 +80,7 @@ def sustained_profile(k, step_seconds, offsets, proof_gas, rate_scale=1, deputy_
         bundle_opening_distribution={str(openings): inventory},
         native_message_batching=dict(open_session_messages_per_preparation_transaction_max=OPEN_SESSION_BATCH_MAX,
             open_session_gas_limit_per_message=OPEN_SESSION_PREPARATION_GAS,
-            open_session_gas_limit_per_preparation_transaction=OPEN_SESSION_BATCH_BASE_GAS,
+            open_session_base_gas_per_preparation_transaction=OPEN_SESSION_BATCH_BASE_GAS,
             open_session_batch_gas_limit_max=OPEN_SESSION_BATCH_GAS_CAP,
             open_session_gas_limit_note="conservative per-message and transaction-base ceilings, not measured full execution cost",
             proof_sessions_per_submission_transaction=1, cross_provider_crypto_aggregation=False),

--- a/scripts/test_retrieval_sustained.py
+++ b/scripts/test_retrieval_sustained.py
@@ -86,7 +86,7 @@ class SustainedTest(unittest.TestCase):
                 self.assertEqual(profile["native_message_batching"]["proof_sessions_per_submission_transaction"], 1)
                 self.assertFalse(profile["native_message_batching"]["cross_provider_crypto_aggregation"])
                 self.assertEqual(profile["native_message_batching"]["open_session_gas_limit_per_message"], 400_000)
-                self.assertEqual(profile["native_message_batching"]["open_session_gas_limit_per_preparation_transaction"], 100_000)
+                self.assertEqual(profile["native_message_batching"]["open_session_base_gas_per_preparation_transaction"], 100_000)
                 self.assertEqual(profile["native_message_batching"]["open_session_batch_gas_limit_max"], 25_700_000)
                 self.assertIn("not measured", profile["native_message_batching"]["open_session_gas_limit_note"])
         for k in (0, 2.0, 4, 16, True, "8"):
@@ -264,9 +264,20 @@ class SustainedTest(unittest.TestCase):
             artifact.opened_session_ids(dict(data=OPEN_RESPONSE_DATA), 65)
 
     def test_batch_pins_unsigned_signed_and_committed_order_before_proofs(self):
-        for corruption in (None, 'generated_nonce', 'generated_gas', 'signed_order', 'signed_gas', 'unknown'):
-            life, _, _, operations = fixture_state()
-            operations = operations[:2]
+        cases = [(None, count) for count in (1, 2, 64)] + [
+            (corruption, 2) for corruption in ('generated_nonce', 'generated_gas', 'signed_order', 'signed_gas', 'unknown')]
+        for corruption, count in cases:
+            life, _, _, source = fixture_state()
+            operations = []
+            for index in range(count):
+                operation = copy.deepcopy(source[0])
+                operation['proof_expectation']['session']['nonce'] = index + 1
+                submit = operation['open-session']['submit']
+                submit[submit.index('--nonce') + 1] = str(index + 1)
+                submit[submit.index('--gas') + 1] = '400000'
+                operations.append(operation)
+            original_gas = [op['open-session']['submit'][op['open-session']['submit'].index('--gas') + 1]
+                            for op in operations]
             life.doc, life.save = {}, Mock()
             generated = []
             def command(args):
@@ -296,7 +307,7 @@ class SustainedTest(unittest.TestCase):
                     body=dict(messages=messages), auth_info=dict(fee=dict(gas_limit=str(gas))), signatures=['signed'])))
                 return ''
             response = dict(outcome='unknown' if corruption == 'unknown' else 'committed_success', height=12,
-                            data=OPEN_RESPONSE_DATA + OPEN_RESPONSE_DATA[:-64] + '31' * 32)
+                            data=''.join(OPEN_RESPONSE_DATA[:-64] + f'{index + 1:02x}' * 32 for index in range(count)))
             with tempfile.TemporaryDirectory() as home, patch.object(artifact, 'scheduled_transaction', return_value=response) as submit:
                 if corruption:
                     with self.assertRaises(ValueError):
@@ -306,18 +317,16 @@ class SustainedTest(unittest.TestCase):
                         submit.assert_not_called()
                 else:
                     ids, height = workload.open_session_batch(life, operations, Path(home) / 'batch', command)
-                    self.assertEqual((len(ids), height), (2, 12))
+                    self.assertEqual((len(ids), height), (count, 12))
                     self.assertEqual(submit.call_count, 1)
                     self.assertEqual(life.doc['preparation_transactions'], [response])
-                    self.assertEqual([int(tx['auth_info']['fee']['gas_limit']) for tx in generated], [500_000, 400_000])
-
-    def test_open_session_batch_gas_boundaries_include_one_transaction_base(self):
-        for messages, expected in ((1, 500_000), (2, 900_000), (64, 25_700_000)):
-            with self.subTest(messages=messages):
-                self.assertEqual(workload.OPEN_SESSION_BATCH_BASE_GAS +
-                    workload.OPEN_SESSION_PREPARATION_GAS * messages, expected)
-                self.assertLessEqual(expected, workload.OPEN_SESSION_BATCH_GAS_CAP)
-                self.assertLess(expected, 64_000_000)
+                    generated_gas = [int(tx['auth_info']['fee']['gas_limit']) for tx in generated]
+                    self.assertEqual(generated_gas, [500_000] + [400_000] * (count - 1))
+                    signed = json.loads((Path(home) / 'batch/signed.json').read_text())
+                    self.assertEqual(int(signed['auth_info']['fee']['gas_limit']), sum(generated_gas))
+                    self.assertEqual(original_gas, ['400000'] * count)
+                    self.assertEqual([op['open-session']['submit'][op['open-session']['submit'].index('--gas') + 1]
+                                      for op in operations], original_gas)
 
 
     def test_block_reconciliation_rejects_missing_transaction_gas_and_header_drift(self):

--- a/scripts/test_retrieval_sustained.py
+++ b/scripts/test_retrieval_sustained.py
@@ -86,7 +86,8 @@ class SustainedTest(unittest.TestCase):
                 self.assertEqual(profile["native_message_batching"]["proof_sessions_per_submission_transaction"], 1)
                 self.assertFalse(profile["native_message_batching"]["cross_provider_crypto_aggregation"])
                 self.assertEqual(profile["native_message_batching"]["open_session_gas_limit_per_message"], 400_000)
-                self.assertEqual(profile["native_message_batching"]["open_session_batch_gas_limit_max"], 25_600_000)
+                self.assertEqual(profile["native_message_batching"]["open_session_gas_limit_per_preparation_transaction"], 100_000)
+                self.assertEqual(profile["native_message_batching"]["open_session_batch_gas_limit_max"], 25_700_000)
                 self.assertIn("not measured", profile["native_message_batching"]["open_session_gas_limit_note"])
         for k in (0, 2.0, 4, 16, True, "8"):
             with self.subTest(k=k), self.assertRaises(ValueError):
@@ -278,7 +279,9 @@ class SustainedTest(unittest.TestCase):
                         **{'@type': '/polystorechain.polystorechain.v1.MsgOpenRetrievalSession'})
                     if corruption == 'generated_nonce':
                         message['nonce'] = '999'
-                    gas = 400001 if corruption == 'generated_gas' else 400000
+                    gas = int(args[args.index('--gas') + 1])
+                    if corruption == 'generated_gas':
+                        gas += 1
                     tx = dict(body=dict(messages=[message]), auth_info=dict(fee=dict(gas_limit=str(gas))))
                     generated.append(tx)
                     return json.dumps(tx)
@@ -306,6 +309,15 @@ class SustainedTest(unittest.TestCase):
                     self.assertEqual((len(ids), height), (2, 12))
                     self.assertEqual(submit.call_count, 1)
                     self.assertEqual(life.doc['preparation_transactions'], [response])
+                    self.assertEqual([int(tx['auth_info']['fee']['gas_limit']) for tx in generated], [500_000, 400_000])
+
+    def test_open_session_batch_gas_boundaries_include_one_transaction_base(self):
+        for messages, expected in ((1, 500_000), (2, 900_000), (64, 25_700_000)):
+            with self.subTest(messages=messages):
+                self.assertEqual(workload.OPEN_SESSION_BATCH_BASE_GAS +
+                    workload.OPEN_SESSION_PREPARATION_GAS * messages, expected)
+                self.assertLessEqual(expected, workload.OPEN_SESSION_BATCH_GAS_CAP)
+                self.assertLess(expected, 64_000_000)
 
 
     def test_block_reconciliation_rejects_missing_transaction_gas_and_header_drift(self):


### PR DESCRIPTION
The higher-load K8 diagnostic prepared fifteen full 64-message batches, then its final two-message open-session batch exhausted its exact `400,000 * message_count` gas limit at 800,151 gas used. Because execution stopped at the limit, that observation is only a lower bound and the run produced no proof measurement.

This adds 100,000 gas once per preparation transaction while retaining the 400,000 per-message allowance. The affected two-message batch is now signed for 900,000 gas, and the 64-message maximum is 25.7M under the unchanged 64M block limit. The harness verifies both generated and signed gas against that exact formula before broadcast. Proof gas, audit work, proof counts, and consensus limits are unchanged.

The 100,000 base allowance is a conservative trial ceiling based on the fixed transaction work visible across successful larger batches. A successful small-batch run after this change lands is still required before the higher-load diagnostic is repeated.

Part of #290.

Validation:

- `python3 scripts/test_retrieval_sustained.py`
- `python3 scripts/test_retrieval_four_validator_workload.py`
- `for test in scripts/test_retrieval_*.py; do python3 "$test" || exit; done` (62 passed, 2 environment-dependent skips)
- `git diff --check`
