### PR TITLE
bench: publish Linux K8 chain throughput and overload evidence

### DIFF
--- a/bench/retrieval_session_capacity/native-k8-290/README.md
+++ b/bench/retrieval_session_capacity/native-k8-290/README.md
@@ -134,3 +134,9 @@ progress. A 600-second no-progress watchdog aborts pending scheduler work; the
 overall deadline remains the shorter authority. Setup and the single bounded
 exporter subprocess remain visible through their existing phase and log artifacts;
 they do not yet emit periodic heartbeat records or make extra LCD queries.
+
+The [Linux high-load diagnostic 002](linux-highload-30s-002/README.md) reconciles 842 successful K8
+proof-submission transactions (6,736 openings) with normal audits. At the final
+16/s offered step, 88 offers hit the bounded queue; its consensus-header-time
+window recorded 8.8 bundles/s. This is a single-host, 30-second-per-step result,
+not a production-capacity or byte-delivery qualification.

--- a/bench/retrieval_session_capacity/native-k8-290/linux-highload-30s-002/README.md
+++ b/bench/retrieval_session_capacity/native-k8-290/linux-highload-30s-002/README.md
@@ -38,6 +38,35 @@ Proof transactions declared 5,000,000 gas each and used 4,131,317–4,134,115 ga
 
 Continuous Commit-step streams covered 124 blocks on every validator. Their conservative p95 execution upper bounds were 285.975–346.072 ms. Validator lifetime peak RSS was 381,140,992–393,928,704 bytes, measured by `wait4 ru_maxrss`; this is not CPU usage. At height 701, all twelve normal-audit assignments were finalized with one accepted sample and zero missed epochs.
 
+## Assignment distribution and carryover
+
+Measurement-only counts by pinned K8 slot are below. Submitted bundles all committed valid; every bundle carries eight openings. Warmup is excluded.
+
+| Slot | Offered bundles | Submitted / committed-valid bundles | Queue full | Committed-valid openings |
+| ---: | ---: | ---: | ---: | ---: |
+| 0 | 78 | 71 | 7 | 568 |
+| 1 | 78 | 70 | 8 | 560 |
+| 2 | 77 | 70 | 7 | 560 |
+| 3 | 77 | 70 | 7 | 560 |
+| 4 | 77 | 70 | 7 | 560 |
+| 5 | 77 | 70 | 7 | 560 |
+| 6 | 77 | 70 | 7 | 560 |
+| 7 | 77 | 70 | 7 | 560 |
+| 8 | 78 | 69 | 9 | 552 |
+| 9 | 78 | 70 | 8 | 560 |
+| 10 | 78 | 70 | 8 | 560 |
+| 11 | 78 | 72 | 6 | 576 |
+
+The cross-tabulation counts committed-valid bundles by offered cohort (rows) and consensus header-time window (columns). It shows carryover explicitly; header time retains the limitations above. Multiply each cell by eight for chained openings.
+
+| Offered bundles/s | Before start | 0–30 s | 30–60 s | 60–90 s | 90–120 s | 120–150 s | After 150 s |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 1 | 29 | 0 | 0 | 0 | 0 | 0 |
+| 2 | 0 | 0 | 60 | 0 | 0 | 0 | 0 |
+| 4 | 0 | 0 | 0 | 120 | 0 | 0 | 0 |
+| 8 | 0 | 0 | 0 | 7 | 222 | 11 | 0 |
+| 16 | 0 | 0 | 0 | 0 | 0 | 253 | 139 |
+
 ## Publication boundary
 
 The [summary](summary.json), [execution plan](plan.json), and [runtime provenance](runtime-provenance.json) are the only published run files. The [manifest](manifest.json) records source and published hashes plus the path substitutions. Raw evidence, block and audit streams, SQLite journals, proof inventory, logs, keyrings, generated payloads, and storage data remain private.

--- a/bench/retrieval_session_capacity/native-k8-290/linux-highload-30s-002/README.md
+++ b/bench/retrieval_session_capacity/native-k8-290/linux-highload-30s-002/README.md
@@ -18,19 +18,21 @@ The 150-second measurement offered 930 proof-submission transactions carrying 7,
 
 Terminal latency runs from the scheduled offer through the final client observation, including driver queue time; percentiles use linear interpolation between sorted successful observations. It is not isolated chain inclusion latency. Client completion observations include carryover from earlier cohorts and are not block-commit rates. The scheduler took 168.783641 seconds from the first measured offer through drain, 18.783641 seconds beyond the offered window. It reached the configured limits of 32 in-flight and 128 queued operations. These results locate a driver-queue and declared-gas boundary at high load; they do not establish a stable 8 or 16 bundles/s chain rate.
 
+At the five scheduled step-end fences, queued/in-flight operations were respectively 0/1, 0/3, 0/7, 0/23, and 124/32. These client scheduler counts exclude already-terminal `queue_full` offers and are not chain mempool counts. The final 156 pending operations completed during drain.
+
 ## Consensus, gas, and audits
 
 All 842 successful transactions reconciled to blocks 556 through 679. Headers and transaction results agreed across all four validators. The median of four pre-measurement metric captures mapped scheduler start to wall time; the capture offsets spanned 512,720 ns. Applying 30-second fences to consensus `header.Time` accounted for one transaction before the mapped start, 29, 60, 127, 222, and 264 transactions in the five windows, and 139 afterward:
 
-| Offered cohort rate | Header-time transactions in window | Header-time bundles/s | Header-time openings/s |
-| ---: | ---: | ---: | ---: |
-| 1 | 29 | 0.967 | 7.733 |
-| 2 | 60 | 2.000 | 16.000 |
-| 4 | 127 | 4.233 | 33.867 |
-| 8 | 222 | 7.400 | 59.200 |
-| 16 | 264 | 8.800 | 70.400 |
+| Offered cohort rate | Header-time transactions in window | Header-time bundles/s | Header-time openings/s | Gas wanted | Gas used |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 29 | 0.967 | 7.733 | 145,000,000 | 119,856,991 |
+| 2 | 60 | 2.000 | 16.000 | 300,000,000 | 247,988,704 |
+| 4 | 127 | 4.233 | 33.867 | 635,000,000 | 524,918,308 |
+| 8 | 222 | 7.400 | 59.200 | 1,110,000,000 | 917,565,637 |
+| 16 | 264 | 8.800 | 70.400 | 1,320,000,000 | 1,091,165,320 |
 
-These windows contain carryover across offered cohorts. Comet `header.Time` is a consensus timestamp rather than the wall-clock completion time of `FinalizeBlock` or `Commit`; one header timestamp also predates its client offer. The rates describe header-time windows only and are not production-capacity or exact commit-completion rates. The capture-offset spread shows agreement among the four mapping samples, not a complete clock-error bound.
+These windows contain carryover across offered cohorts. Comet `header.Time` is a consensus timestamp rather than the wall-clock completion time of `FinalizeBlock` or `Commit`; header timestamps can predate their client offers. The rates describe header-time windows only and are not production-capacity or exact commit-completion rates. The capture-offset spread shows agreement among the four mapping samples, not a complete clock-error bound.
 
 Proof transactions declared 5,000,000 gas each and used 4,131,317–4,134,115 gas. Median gas used was 516,758.75 per chained opening. The peak workload block at height 652 contained twelve transactions, 60,000,000 gas wanted, and 49,609,028 gas used under the 64,000,000 block limit. A thirteenth transaction at the declared ceiling would exceed the proposal gas cap even though execution used less gas.
 

--- a/bench/retrieval_session_capacity/native-k8-290/linux-highload-30s-002/README.md
+++ b/bench/retrieval_session_capacity/native-k8-290/linux-highload-30s-002/README.md
@@ -1,0 +1,43 @@
+# Linux K8 high-load diagnostic 002
+
+This retains one bounded single-host diagnostic for [issue #290](https://github.com/Polynomialstore/polystore/issues/290). It is not a production-capacity qualification. The recorded host was Linux x86_64 on an AMD Ryzen 7 9700X (16 logical CPUs), with `GOMAXPROCS=2` per Go process. The run used four validator processes and twelve provider-daemons on one Linux host, normal audits, K8 proofs, 32 deputy signers, and five 30-second offered-rate steps.
+
+Preparation opened 962 sessions in sixteen committed atomic transactions: fifteen batches of 64 plus a final batch of two. Preparation declared 386,400,000 gas and used 367,420,844. All 32 warmup transactions committed valid, carrying 256 chained openings.
+
+## Measured workload
+
+The 150-second measurement offered 930 proof-submission transactions carrying 7,440 chained openings. Of those, 842 transactions committed valid, carrying 6,736 openings. The bounded driver queue rejected 88 offers as `queue_full`; there were no retries.
+
+| Offered bundles/s | Offered bundles | Same cohort observed by step end | All client completion observations during step | Eventual committed valid | Queue full | Terminal p95 / p99 |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 30 | 29 | 29 | 30 | 0 | 1.934 / 1.944 s |
+| 2 | 60 | 57 | 58 | 60 | 0 | 1.991 / 2.026 s |
+| 4 | 120 | 113 | 116 | 120 | 0 | 2.104 / 2.259 s |
+| 8 | 240 | 217 | 224 | 240 | 0 | 3.386 / 4.285 s |
+| 16 | 480 | 236 | 259 | 392 | 88 | 20.445 / 21.501 s |
+
+Terminal latency runs from the scheduled offer through the final client observation, including driver queue time; percentiles use linear interpolation between sorted successful observations. It is not isolated chain inclusion latency. Client completion observations include carryover from earlier cohorts and are not block-commit rates. The scheduler took 168.783641 seconds from the first measured offer through drain, 18.783641 seconds beyond the offered window. It reached the configured limits of 32 in-flight and 128 queued operations. These results locate a driver-queue and declared-gas boundary at high load; they do not establish a stable 8 or 16 bundles/s chain rate.
+
+## Consensus, gas, and audits
+
+All 842 successful transactions reconciled to blocks 556 through 679. Headers and transaction results agreed across all four validators. The median of four pre-measurement metric captures mapped scheduler start to wall time; the capture offsets spanned 512,720 ns. Applying 30-second fences to consensus `header.Time` accounted for one transaction before the mapped start, 29, 60, 127, 222, and 264 transactions in the five windows, and 139 afterward:
+
+| Offered cohort rate | Header-time transactions in window | Header-time bundles/s | Header-time openings/s |
+| ---: | ---: | ---: | ---: |
+| 1 | 29 | 0.967 | 7.733 |
+| 2 | 60 | 2.000 | 16.000 |
+| 4 | 127 | 4.233 | 33.867 |
+| 8 | 222 | 7.400 | 59.200 |
+| 16 | 264 | 8.800 | 70.400 |
+
+These windows contain carryover across offered cohorts. Comet `header.Time` is a consensus timestamp rather than the wall-clock completion time of `FinalizeBlock` or `Commit`; one header timestamp also predates its client offer. The rates describe header-time windows only and are not production-capacity or exact commit-completion rates. The capture-offset spread shows agreement among the four mapping samples, not a complete clock-error bound.
+
+Proof transactions declared 5,000,000 gas each and used 4,131,317–4,134,115 gas. Median gas used was 516,758.75 per chained opening. The peak workload block at height 652 contained twelve transactions, 60,000,000 gas wanted, and 49,609,028 gas used under the 64,000,000 block limit. A thirteenth transaction at the declared ceiling would exceed the proposal gas cap even though execution used less gas.
+
+Continuous Commit-step streams covered 124 blocks on every validator. Their conservative p95 execution upper bounds were 285.975–346.072 ms. Validator lifetime peak RSS was 381,140,992–393,928,704 bytes, measured by `wait4 ru_maxrss`; this is not CPU usage. At height 701, all twelve normal-audit assignments were finalized with one accepted sample and zero missed epochs.
+
+## Publication boundary
+
+The [summary](summary.json), [execution plan](plan.json), and [runtime provenance](runtime-provenance.json) are the only published run files. The [manifest](manifest.json) records source and published hashes plus the path substitutions. Raw evidence, block and audit streams, SQLite journals, proof inventory, logs, keyrings, generated payloads, and storage data remain private.
+
+The result ends at committed `PROOF_SUBMITTED` state. It does not measure confirmation, completed sessions, client acknowledgement, byte delivery, WAN behavior, a hardware minimum, or a realistic distributed deployment. This completes the immediate bounded measurement. Longer steady-state and distributed capacity remain unqualified; #291 owns the next native large-session contract. No additional run of the retired serial-download workload is warranted.

--- a/bench/retrieval_session_capacity/native-k8-290/linux-highload-30s-002/manifest.json
+++ b/bench/retrieval_session_capacity/native-k8-290/linux-highload-30s-002/manifest.json
@@ -2,8 +2,8 @@
   "schema": "polystore.retained-publication.v1",
   "published_files": {
     "summary.json": {
-      "sha256": "33bf37040a2197fbcf29f8d3f26e1743bf07ac44096a924b52e1b4f5d889d3cf",
-      "bytes": 10646
+      "sha256": "f5154c3c6ede8511adeea635c8a87353cb598bd32e8afdfbed5c32fd6313f40f",
+      "bytes": 15651
     },
     "plan.json": {
       "sha256": "a7b52025a5293e4c7bcb7ba113ec7959d3ce76e33aeac29a28e31304af4c9e9a",
@@ -14,8 +14,8 @@
       "bytes": 2954
     },
     "README.md": {
-      "sha256": "e896a2073d2e24eb4752177051a02d0d021e1424e5fd1253dc8bbea62a825b52",
-      "bytes": 5528
+      "sha256": "6a033b1dacfd23a1af245b58a89595e1fea7d84066cffa18bea566520a415a00",
+      "bytes": 6777
     }
   },
   "private_source_artifacts": {
@@ -66,6 +66,10 @@
     "raw-hash-manifest.json": {
       "sha256": "965f63e15ac880ed0ac7c733e36d5f52788e9e7dbf84746ecb13086c1769f9b5",
       "bytes": 3731
+    },
+    "inventory/manifest.json": {
+      "sha256": "d85a62674258dfc99b057bfb75881f9390551d9850791b822e8c6517c116503e",
+      "bytes": 2810145
     }
   },
   "transformations": [

--- a/bench/retrieval_session_capacity/native-k8-290/linux-highload-30s-002/manifest.json
+++ b/bench/retrieval_session_capacity/native-k8-290/linux-highload-30s-002/manifest.json
@@ -2,8 +2,8 @@
   "schema": "polystore.retained-publication.v1",
   "published_files": {
     "summary.json": {
-      "sha256": "d9c38d2adb3c161e9b7317f14414d6aeb983d9d0098b325c6c0ca8cf70c591aa",
-      "bytes": 9562
+      "sha256": "33bf37040a2197fbcf29f8d3f26e1743bf07ac44096a924b52e1b4f5d889d3cf",
+      "bytes": 10646
     },
     "plan.json": {
       "sha256": "a7b52025a5293e4c7bcb7ba113ec7959d3ce76e33aeac29a28e31304af4c9e9a",
@@ -14,8 +14,8 @@
       "bytes": 2954
     },
     "README.md": {
-      "sha256": "e1cc216e31bae46870eb733ff8d54fe4d43f37811b56d73f3fd13e38d600e933",
-      "bytes": 5061
+      "sha256": "e896a2073d2e24eb4752177051a02d0d021e1424e5fd1253dc8bbea62a825b52",
+      "bytes": 5528
     }
   },
   "private_source_artifacts": {

--- a/bench/retrieval_session_capacity/native-k8-290/linux-highload-30s-002/manifest.json
+++ b/bench/retrieval_session_capacity/native-k8-290/linux-highload-30s-002/manifest.json
@@ -1,0 +1,84 @@
+{
+  "schema": "polystore.retained-publication.v1",
+  "published_files": {
+    "summary.json": {
+      "sha256": "d9c38d2adb3c161e9b7317f14414d6aeb983d9d0098b325c6c0ca8cf70c591aa",
+      "bytes": 9562
+    },
+    "plan.json": {
+      "sha256": "a7b52025a5293e4c7bcb7ba113ec7959d3ce76e33aeac29a28e31304af4c9e9a",
+      "bytes": 12589
+    },
+    "runtime-provenance.json": {
+      "sha256": "4a8b2b44dd282752c72137bf2715f74596fb1952b8db0358facfdfb14b5688c5",
+      "bytes": 2954
+    },
+    "README.md": {
+      "sha256": "e1cc216e31bae46870eb733ff8d54fe4d43f37811b56d73f3fd13e38d600e933",
+      "bytes": 5061
+    }
+  },
+  "private_source_artifacts": {
+    "evidence.json": {
+      "sha256": "1e7a734501edb2fca46a2c96e7026b9236740611ee939915eb53d90faa62eb10",
+      "bytes": 856286
+    },
+    "sustained-audits.jsonl": {
+      "sha256": "d8dc096dbc2a3ba77f655bf369e79e54e0f643497a19e13de360a6df0ab9e15a",
+      "bytes": 131415
+    },
+    "commit-0391653b8a4084c15a19351f7ce87629506890c4.jsonl": {
+      "sha256": "32b04622e428784eb9c119c2d941ef32092fff421f9874e0fc3e13277dfc373c",
+      "bytes": 157925
+    },
+    "sustained-blocks.jsonl": {
+      "sha256": "2783baf3281fca08b28928484e2529e869dd283eec1bcd81440c5a376490c273",
+      "bytes": 195525
+    },
+    "commit-2fbc437bef549a79becefda16b365a339cd188ef.jsonl": {
+      "sha256": "d326ace1635a6aad46e2a219b016bb7be6842e27bdad153aa545dd5384fb5a19",
+      "bytes": 157753
+    },
+    "build-manifest.json": {
+      "sha256": "ae65fe3174c6260f8c3dc2aa954b552227d02300d32ca772863a8ecbe3c9f97f",
+      "bytes": 3962
+    },
+    "commit-31fa8b94c45a55c5eb3c9c8773ecebe88daae459.jsonl": {
+      "sha256": "0e821f6d0041d047edde287976ce85e658818ee95ab548000786b21c8191e9cd",
+      "bytes": 157890
+    },
+    "sustained-progress.jsonl": {
+      "sha256": "7ddaf0aef293f3adb774293b13225d9e5214367451123778c43344145065ae42",
+      "bytes": 923
+    },
+    "commit-cb835dbb9f04aa3ed59bb771b390d15394fe6b9a.jsonl": {
+      "sha256": "d116e8b57c4b53bc8893a7deabf68124c838ee94f3a7bda7eafcd4ecb2a0a83f",
+      "bytes": 158167
+    },
+    "run-once-supervisor-highload-30s-002.sh": {
+      "sha256": "5cf72bb8a5acd5df9b685cec37281046ea11650d092b0dff30ca9bcce2191b2d",
+      "bytes": 2415
+    },
+    "sustained.sqlite": {
+      "sha256": "bb20ad784082787c09cf6eb89f29cb016eded3c93f24dae0b96b1889f000f957",
+      "bytes": 5173248
+    },
+    "raw-hash-manifest.json": {
+      "sha256": "965f63e15ac880ed0ac7c733e36d5f52788e9e7dbf84746ecb13086c1769f9b5",
+      "bytes": 3731
+    }
+  },
+  "transformations": [
+    "Summary derived from retained evidence, SQLite transaction outcomes and reconciled blocks; consensus header-time fences use the documented wall/monotonic mapping.",
+    "Plan updated with final merged harness identity and completion status; absolute paths replaced with named placeholders.",
+    "Runtime provenance preserves build component hashes, toolchains and commands; absolute paths replaced with named placeholders."
+  ],
+  "excluded": [
+    "keyrings",
+    "payload and storage data",
+    "proof inventory",
+    "raw evidence and journals",
+    "provider and validator logs"
+  ],
+  "scope": "Only these published report files are committed. Private artifacts remain retained on the measurement host and coordinator."
+}

--- a/bench/retrieval_session_capacity/native-k8-290/linux-highload-30s-002/plan.json
+++ b/bench/retrieval_session_capacity/native-k8-290/linux-highload-30s-002/plan.json
@@ -1,0 +1,271 @@
+{
+  "bounds": {
+    "base_expiry_height_delta": 4000,
+    "deal_end_block": 100016,
+    "deal_escrow_stake": 100000000,
+    "deal_lifetime_guard": "harness rejects unless base expiry plus 7 is below deal end",
+    "funding_assessment": "7696 stake total session locks fit the 100000000 stake deal escrow; identity funding remains unchanged",
+    "last_expiry_bucket_increment": 7,
+    "maximum_expiry_height_delta": 4007,
+    "post_inventory_guard": "harness requires current height + 150s offered window + 120s drain below first expiry and at least 270s deadline remaining",
+    "retrieval_price_per_opening_stake": 1,
+    "session_ttl_limit": 4096,
+    "total_session_lock_stake": 7696
+  },
+  "claim_limits": [
+    "Single host with four validator processes; not realistic distributed deployment capacity.",
+    "Client completion observations remain distinct from reconciled block commit timestamps.",
+    "Declared 5M proof gas governs proposal admission even when used gas is lower.",
+    "No delivery, settlement, browser or completed-session throughput claim.",
+    "A plateau is chain-capacity evidence only if actual block commits, queues, signer activity, gas wanted/used and all-validator audit agreement exclude offered-workload and driver ceilings."
+  ],
+  "completed_at_utc": "2026-09-09T08:59:25Z",
+  "invocation": {
+    "absolute_timeout_seconds": 1800,
+    "argv": [
+      "/usr/bin/python3",
+      "$HARNESS_CHECKOUT/scripts/retrieval_four_validator_workload.py",
+      "--mode",
+      "sustained-providers",
+      "--audit-profile",
+      "normal",
+      "--sustained-k",
+      "8",
+      "--sustained-rate-scale",
+      "4",
+      "--sustained-deputies",
+      "32",
+      "--binary",
+      "$ARTIFACT_ROOT/bin/polystorechaind",
+      "--library",
+      "$PRODUCT_SOURCE/polystore_core/target/release/libpolystore_core.so",
+      "--gateway-binary",
+      "$ARTIFACT_ROOT/bin/polystore_gateway",
+      "--cli-binary",
+      "$ARTIFACT_ROOT/bin/polystore_cli",
+      "--product-source",
+      "$PRODUCT_SOURCE",
+      "--proof-exporter",
+      "$ARTIFACT_ROOT/bin/retrieval-exporter.test",
+      "--proof-gas",
+      "5000000",
+      "--step-seconds",
+      "30",
+      "--timeout",
+      "1800",
+      "--home",
+      "$ARTIFACT_ROOT/runs/k8-highload-30s-002"
+    ],
+    "attempt_limit": 1,
+    "cwd": "$HARNESS_CHECKOUT",
+    "environment": {
+      "GOMAXPROCS": "2",
+      "LD_LIBRARY_PATH_prepend": "$PRODUCT_SOURCE/polystore_core/target/release",
+      "POLYSTORE_TRUSTED_SETUP_effective": "$HARNESS_CHECKOUT/polystorechain/trusted_setup.txt",
+      "PYTHONUNBUFFERED": "1"
+    }
+  },
+  "launched_at_utc": "2026-09-09T08:43:19Z",
+  "launcher_exit_code": 0,
+  "measurement_reporting": {
+    "audit_rule": "Require all four validators at the same final height/state and retain normal audit agreement independently of proof throughput.",
+    "block_time_precision": "Comet header.Time is a consensus block timestamp, not the wall-clock instant when FinalizeBlock/Commit completed; label rates as header-time-fenced reconciled block rates.",
+    "carryover_rule": "Do not credit a client completion observed in a later rate step to that later step. Attribute each operation by offered step and report its actual block-commit step separately.",
+    "client_observation_rule": "Keep scheduler finished_ns/client observations as latency and driver evidence only; do not use them as the chain block-commit throughput denominator.",
+    "drain_rule": "Report commits after the 150-second offered window separately from every in-window rate result; eventual completion is not an in-window throughput rate.",
+    "per_rate_required": [
+      "offered proof-submission transactions",
+      "actual block commits inside the rate fence",
+      "reconciled openings inside the rate fence",
+      "declared gas wanted inside the rate fence",
+      "gas used inside the rate fence",
+      "end-of-fence pending and in-flight counts"
+    ],
+    "primary_denominator": "Successful DeliverTx outcomes reconciled to blocks; no per-rate block throughput is published because Comet header.Time is not a wall-clock Commit completion timestamp."
+  },
+  "next_action": "Retain and review this single diagnostic; do not infer production capacity.",
+  "prelaunch_required": [
+    "Root supplies and verifies the exact merged PR297 commit; no launch from reviewed head alone.",
+    "Create a separate clean detached harness checkout at that merge commit and verify the four recorded harness file hashes.",
+    "Verify runtime component trees and all five artifact hashes remain identical to build-manifest.json at source a6e130af.",
+    "Verify the harness-checkout trusted_setup.txt and immutable product-source trusted_setup.txt both match the recorded setup hash.",
+    "Verify the product source tracked component paths remain clean at a6e130af.",
+    "Verify the run parent exists, the new run home is absent, required ports are free, no competing benchmark/service load exists, and at least 2 GiB is free.",
+    "Materialize and inspect the run-002 supervisor with all source, home and log paths updated and both the harness and outer hard cap set to 1800 seconds.",
+    "Receive explicit root launch authorization after all prior gates pass."
+  ],
+  "prepared_at_utc": "2026-09-09T08:31:43.221804+00:00",
+  "purpose": "One 30-second-per-rate K8 single-host chain-throughput attempt after the batch base-gas fix; diagnostic until retained evidence is reviewed.",
+  "runtime": {
+    "artifact_sha256": {
+      "$ARTIFACT_ROOT/bin/polystore_cli": "46864fd4f12fee3d470a4fcebbf326aab88b2c6e39b9012610278cea6417b28a",
+      "$ARTIFACT_ROOT/bin/polystore_gateway": "7fcfbb428e1c1ad0ed33c059ed8118c1868b56fd4bc9cf7bdde092cb1272778c",
+      "$ARTIFACT_ROOT/bin/polystorechaind": "433de9e70274b057bebd24dd3fd29f7089074f96f919e3658daf32944137c34a",
+      "$ARTIFACT_ROOT/bin/retrieval-exporter.test": "394f064ac6aea84c2e98f89921677483989a207092979c230b8e51284b3068a9",
+      "$PRODUCT_SOURCE/polystore_core/target/release/libpolystore_core.so": "d50bf0a1bf1f79a2ad1b7ace17a91951ed0e9dcb5a405bdd1125723fabff9c27"
+    },
+    "build_manifest": "$ARTIFACT_ROOT/provenance/build-manifest.json",
+    "build_source_commit": "a6e130af3accb3ab9634d6ae04959e612653193a",
+    "library_path": "$PRODUCT_SOURCE/polystore_core/target/release/libpolystore_core.so",
+    "product_source_path": "$PRODUCT_SOURCE",
+    "reuse": "unchanged Linux x86-64 binaries/library; no rebuild authorized",
+    "trusted_setup_actual_path": "$HARNESS_CHECKOUT/polystorechain/trusted_setup.txt",
+    "trusted_setup_sha256": "d39b9f2d047cc9dca2de58f264b6a09448ccd34db967881a6713eacacf0f26b7"
+  },
+  "schema": "polystore.issue290.k8-highload-sustained-plan.v2",
+  "source_gate": {
+    "expected_harness_hashes_at_reviewed_content": {
+      "scripts/retrieval_bench_artifact.py": "68966919f33bd84a3132fa08b78c8886270cd587731f5c3df5cff9a2584f09dd",
+      "scripts/retrieval_commit_metrics.py": "e8b272852684639efe6292d3b72eb2396fee0c2bdb99558d52c611b7d638e11f",
+      "scripts/retrieval_four_validator_workload.py": "9d6eb11e86f537bf49d464f322a1e0fd64652b60ee3a3e52b253d0aa84320d49",
+      "scripts/retrieval_fresh_proof.py": "74ced497d80442a7d463872623879737b7775ad2a49ec4c5a53ced8a8650e67b"
+    },
+    "harness_checkout": "$HARNESS_CHECKOUT",
+    "harness_checkout_requirement": "fresh clean checkout detached at the exact PR297 merge commit; do not reuse the current patched checkout",
+    "merge_commit": "07b1c626fa230dfe348fe72aa1ef00354ca7501f",
+    "merge_commit_status": "VERIFIED_MERGED_EXACT_REVIEWED_CONTENT",
+    "pr": 297,
+    "product_component_trees": {
+      "polystore_cli": "4303dc86c58cbbb7f1076f1916f1de691bf7694c",
+      "polystore_core": "7989fed8d5a5877e74bc0e2c71aa60b6f8747653",
+      "polystore_gateway": "6d0c3bfc9147565180931347ef979113d5983b8a",
+      "polystorechain": "d002c6f58a35d9cfa80f104b413ef5a7b478c764"
+    },
+    "product_source_checkout": "$PRODUCT_SOURCE",
+    "product_source_commit": "a6e130af3accb3ab9634d6ae04959e612653193a",
+    "product_source_role": "immutable source identity for the already-built CLI, core, gateway, chain and provider runtime",
+    "reviewed_head": "f73ff0b8c0cf67ff79b9d8d07ae543acf6e590ea",
+    "split_source_validation": {
+      "reason": "FourValidatorLifecycle records source_checkout from the executing harness root, while run_healthy independently records product_source, product_source_commit, product source status and CLI source hash. It accepts supplied absolute runtime artifacts and does not require the two commits to match.",
+      "result": "SUPPORTED_BY_INSPECTED_HARNESS",
+      "runtime_correspondence_limit": "The evidence labels supplied binary/library build correspondence as not attested; build-manifest.json and prelaunch hash checks provide that separate correspondence.",
+      "trusted_setup_behavior": "FourValidatorLifecycle resets POLYSTORE_TRUSTED_SETUP to the executing harness checkout. Require that file to match the immutable build setup SHA-256 before launch; an exported old-source path alone does not control it."
+    }
+  },
+  "status": "completed_once_diagnostic_only",
+  "supervision": {
+    "hard_cap_seconds": 1800,
+    "heartbeat_fields": [
+      "timestamp_utc",
+      "elapsed_seconds",
+      "phase",
+      "setup_committed_count",
+      "inventory_total",
+      "inventory_exported_count",
+      "warmup_committed_count",
+      "measured_finished_count",
+      "measured_committed_success_count",
+      "pending_count",
+      "in_flight_count",
+      "free_bytes"
+    ],
+    "heartbeat_requirement": "Emit machine-derived phase and counts from retained evidence, manifest/result files and scheduler journals/progress, plus elapsed and free bytes; process liveness or log-tail text alone is insufficient.",
+    "heartbeat_seconds": 60,
+    "minimum_free_bytes_before_launch": 2147483648,
+    "new_run_home": "$ARTIFACT_ROOT/runs/k8-highload-30s-002",
+    "no_automatic_retry": true,
+    "planned_supervisor": "$ARTIFACT_ROOT/provenance/run-once-supervisor-highload-30s-002.sh",
+    "runtime_abort_floor_bytes": 805306368,
+    "supervisor_sha256": "5cf72bb8a5acd5df9b685cec37281046ea11650d092b0dff30ca9bcce2191b2d",
+    "supervisor_template": "$ARTIFACT_ROOT/provenance/run-once-supervisor-highload-30s-001.sh"
+  },
+  "workload": {
+    "assignment_indices": [
+      0,
+      11
+    ],
+    "assignments_and_provider_daemons": 12,
+    "block_limits": {
+      "max_bytes": 2097152,
+      "max_gas": 64000000
+    },
+    "calibration_evidence": {
+      "limit": "These calibrations validate one- and two-message transactions only; they do not measure a 64-message batch cost or chain throughput.",
+      "one_message": {
+        "gas_used": 430165,
+        "gas_wanted": 500000,
+        "outcome": "committed_success"
+      },
+      "two_messages": {
+        "gas_used": 811146,
+        "gas_wanted": 900000,
+        "outcome": "committed_success"
+      }
+    },
+    "deputy_indices": [
+      12,
+      43
+    ],
+    "deputy_signers": 32,
+    "k": 8,
+    "m": 4,
+    "max_active_per_signer": 1,
+    "max_in_flight": 32,
+    "max_queued": 128,
+    "measured_bundles": 930,
+    "measured_openings": 7440,
+    "normal_audit_samples_per_epoch": 12,
+    "offered_bundle_rates_per_second": [
+      1,
+      2,
+      4,
+      8,
+      16
+    ],
+    "offered_window_seconds": 150,
+    "open_session_preparation_scope": "962 session-open messages in 16 atomic transactions; excludes provider/deal lifecycle setup transactions",
+    "open_session_preparation_transactions": 16,
+    "openings_per_bundle": 8,
+    "preparation_batch_sizes": [
+      64,
+      64,
+      64,
+      64,
+      64,
+      64,
+      64,
+      64,
+      64,
+      64,
+      64,
+      64,
+      64,
+      64,
+      64,
+      2
+    ],
+    "preparation_declared_gas": [
+      25700000,
+      25700000,
+      25700000,
+      25700000,
+      25700000,
+      25700000,
+      25700000,
+      25700000,
+      25700000,
+      25700000,
+      25700000,
+      25700000,
+      25700000,
+      25700000,
+      25700000,
+      900000
+    ],
+    "preparation_declared_gas_total": 386400000,
+    "preparation_gas_formula": "100000 transaction base + 400000 per open-session message",
+    "proof_declared_gas_per_bundle": 5000000,
+    "proof_submission_scope": {
+      "measured_openings": 7440,
+      "measured_transactions": 930,
+      "openings_per_transaction": 8,
+      "warmup_openings": 256,
+      "warmup_transactions": 32
+    },
+    "seconds_per_step": 30,
+    "total_bundles": 962,
+    "total_openings": 7696,
+    "warmup_bundles": 32,
+    "warmup_openings": 256
+  }
+}

--- a/bench/retrieval_session_capacity/native-k8-290/linux-highload-30s-002/runtime-provenance.json
+++ b/bench/retrieval_session_capacity/native-k8-290/linux-highload-30s-002/runtime-provenance.json
@@ -1,0 +1,75 @@
+{
+  "artifacts": {
+    "$ARTIFACT_ROOT/bin/polystore_cli": "46864fd4f12fee3d470a4fcebbf326aab88b2c6e39b9012610278cea6417b28a",
+    "$ARTIFACT_ROOT/bin/polystore_gateway": "7fcfbb428e1c1ad0ed33c059ed8118c1868b56fd4bc9cf7bdde092cb1272778c",
+    "$ARTIFACT_ROOT/bin/polystorechaind": "433de9e70274b057bebd24dd3fd29f7089074f96f919e3658daf32944137c34a",
+    "$ARTIFACT_ROOT/bin/retrieval-exporter.test": "394f064ac6aea84c2e98f89921677483989a207092979c230b8e51284b3068a9",
+    "$PRODUCT_SOURCE/polystore_core/target/release/libpolystore_core.so": "d50bf0a1bf1f79a2ad1b7ace17a91951ed0e9dcb5a405bdd1125723fabff9c27"
+  },
+  "builds": [
+    {
+      "command": "cargo build --release -j2",
+      "component": "core"
+    },
+    {
+      "command": "GOMAXPROCS=2 ../scripts/chain_go.sh build -p2 -o $ARTIFACT_ROOT/bin/polystorechaind ./cmd/polystorechaind",
+      "component": "chain",
+      "tracked_vendor_aggregate_sha256": "3d7c2c1e942561891678309f991eb9318b47db69f699bff469d184e489c3460e",
+      "tracked_vendor_file_count": 8,
+      "vendor_marker": [
+        "95f585d11945153c8e22c737684f58975640c2be",
+        "2ca9b5fd8541bc9b40893aa6e66b5c6a9578ce5a"
+      ]
+    },
+    {
+      "command": "GOFLAGS=-mod=mod GOMAXPROCS=2 go build -p2 -o $ARTIFACT_ROOT/bin/polystore_gateway .",
+      "component": "gateway"
+    },
+    {
+      "command": "GOFLAGS=-mod=mod GOMAXPROCS=2 go test -c -p2 -o $ARTIFACT_ROOT/bin/retrieval-exporter.test",
+      "component": "exporter"
+    },
+    {
+      "command": "cargo build --release -j2",
+      "component": "cli"
+    }
+  ],
+  "host": {
+    "cpu": "AMD Ryzen 7 9700X",
+    "kernel": "7.0.0-30-generic",
+    "logical_cpus": 16,
+    "platform": "Linux x86_64"
+  },
+  "recorded_at_utc": "2026-09-09T07:29:27.136485+00:00",
+  "runtime": {
+    "LD_LIBRARY_PATH_prepend": "$PRODUCT_SOURCE/polystore_core/target/release",
+    "smokes": [
+      "chain version --long",
+      "CLI --help",
+      "exporter test listing",
+      "process group TERM/wait"
+    ]
+  },
+  "schema": "polystore.issue290.linux-build-provenance.v1",
+  "source": {
+    "agents_sha256": "74243cf59c52bc6ad3c38b4e9b39f6f43ea5acec5080036fd8999096639cf023",
+    "checkout": "$PRODUCT_SOURCE",
+    "component_trees": {
+      "polystore_cli": "4303dc86c58cbbb7f1076f1916f1de691bf7694c",
+      "polystore_core": "7989fed8d5a5877e74bc0e2c71aa60b6f8747653",
+      "polystore_gateway": "6d0c3bfc9147565180931347ef979113d5983b8a",
+      "polystorechain": "d002c6f58a35d9cfa80f104b413ef5a7b478c764"
+    },
+    "head": "a6e130af3accb3ab9634d6ae04959e612653193a",
+    "tracked_status": "clean",
+    "transport": "public GitHub clone",
+    "trusted_setup_sha256": "d39b9f2d047cc9dca2de58f264b6a09448ccd34db967881a6713eacacf0f26b7"
+  },
+  "status": "BUILD_COMPLETE_SMOKES_PASSED_REUSED_FOR_ONE_DIAGNOSTIC",
+  "toolchains": {
+    "cargo": "1.98.1 (797e8a9bc 2026-08-05)",
+    "go": "go1.25.5 linux/amd64",
+    "python": "3.14.4",
+    "rustc": "1.98.1 (48a229cea 2026-09-01)"
+  }
+}

--- a/bench/retrieval_session_capacity/native-k8-290/linux-highload-30s-002/summary.json
+++ b/bench/retrieval_session_capacity/native-k8-290/linux-highload-30s-002/summary.json
@@ -1,0 +1,290 @@
+{
+  "artifacts": {
+    "commit-0391653b8a4084c15a19351f7ce87629506890c4.jsonl": {
+      "bytes": 157925,
+      "sha256": "32b04622e428784eb9c119c2d941ef32092fff421f9874e0fc3e13277dfc373c"
+    },
+    "commit-2fbc437bef549a79becefda16b365a339cd188ef.jsonl": {
+      "bytes": 157753,
+      "sha256": "d326ace1635a6aad46e2a219b016bb7be6842e27bdad153aa545dd5384fb5a19"
+    },
+    "commit-31fa8b94c45a55c5eb3c9c8773ecebe88daae459.jsonl": {
+      "bytes": 157890,
+      "sha256": "0e821f6d0041d047edde287976ce85e658818ee95ab548000786b21c8191e9cd"
+    },
+    "commit-cb835dbb9f04aa3ed59bb771b390d15394fe6b9a.jsonl": {
+      "bytes": 158167,
+      "sha256": "d116e8b57c4b53bc8893a7deabf68124c838ee94f3a7bda7eafcd4ecb2a0a83f"
+    },
+    "evidence.json": {
+      "bytes": 856286,
+      "sha256": "1e7a734501edb2fca46a2c96e7026b9236740611ee939915eb53d90faa62eb10"
+    },
+    "sustained-audits.jsonl": {
+      "bytes": 131415,
+      "sha256": "d8dc096dbc2a3ba77f655bf369e79e54e0f643497a19e13de360a6df0ab9e15a"
+    },
+    "sustained-blocks.jsonl": {
+      "bytes": 195525,
+      "sha256": "2783baf3281fca08b28928484e2529e869dd283eec1bcd81440c5a376490c273"
+    },
+    "sustained-progress.jsonl": {
+      "bytes": 923,
+      "sha256": "7ddaf0aef293f3adb774293b13225d9e5214367451123778c43344145065ae42"
+    },
+    "sustained.sqlite": {
+      "bytes": 5173248,
+      "sha256": "bb20ad784082787c09cf6eb89f29cb016eded3c93f24dae0b96b1889f000f957"
+    }
+  },
+  "attempts": 1,
+  "audits": {
+    "accepted": 12,
+    "assignments": 12,
+    "coverage_verified": true,
+    "epoch": 7,
+    "finalized": 12,
+    "height": 701,
+    "missed_epochs_total": 0
+  },
+  "consensus": {
+    "all_four_headers_agree": true,
+    "all_four_results_agree": true,
+    "header_time_mapping": {
+      "capture_offset_spread_ns": 512720,
+      "limit": "The spread describes agreement among the four mapping samples; it is not a full clock-error bound. Comet header.Time is not wall-clock FinalizeBlock or Commit completion.",
+      "method": "median across four pre-measurement metric captures of wall_time_ns minus the monotonic sample midpoint, plus scheduler started_ns",
+      "scheduler_start_wall_time_ns": 1788944161270079657
+    },
+    "header_time_windows": {
+      "accounted_transactions": 842,
+      "after_offered_window": 139,
+      "before_measurement": 1,
+      "interpretation": "Windows contain carryover across offered cohorts and are keyed by consensus header.Time, not actual Commit completion.",
+      "thirty_second_windows": [
+        {
+          "header_time_rate_bundles_per_s": 0.967,
+          "header_time_rate_openings_per_s": 7.733,
+          "offered_rate_bundles_per_s": 1,
+          "reconciled_openings": 232,
+          "reconciled_transactions": 29
+        },
+        {
+          "header_time_rate_bundles_per_s": 2.0,
+          "header_time_rate_openings_per_s": 16.0,
+          "offered_rate_bundles_per_s": 2,
+          "reconciled_openings": 480,
+          "reconciled_transactions": 60
+        },
+        {
+          "header_time_rate_bundles_per_s": 4.233,
+          "header_time_rate_openings_per_s": 33.867,
+          "offered_rate_bundles_per_s": 4,
+          "reconciled_openings": 1016,
+          "reconciled_transactions": 127
+        },
+        {
+          "header_time_rate_bundles_per_s": 7.4,
+          "header_time_rate_openings_per_s": 59.2,
+          "offered_rate_bundles_per_s": 8,
+          "reconciled_openings": 1776,
+          "reconciled_transactions": 222
+        },
+        {
+          "header_time_rate_bundles_per_s": 8.8,
+          "header_time_rate_openings_per_s": 70.4,
+          "offered_rate_bundles_per_s": 16,
+          "reconciled_openings": 2112,
+          "reconciled_transactions": 264
+        }
+      ]
+    },
+    "reconciled_successful_transactions": 842,
+    "workload_height_range": [
+      556,
+      679
+    ]
+  },
+  "gas": {
+    "admission_interpretation": "At 5,000,000 declared gas, twelve proof transactions use 60,000,000 of the 64,000,000 proposal cap; a thirteenth would exceed it. Gas used does not replace declared gas for proposal admission.",
+    "block_max_gas": 64000000,
+    "declared_per_proof_transaction": 5000000,
+    "median_used_per_opening": 516758.75,
+    "peak_workload_block": {
+      "gas_used": 49609028,
+      "gas_wanted": 60000000,
+      "height": 652,
+      "transactions": 12
+    },
+    "used_per_proof_transaction_range": [
+      4131317,
+      4134115
+    ]
+  },
+  "interpretation": {
+    "basis": "The 8/s cohort developed client-observed carryover; at 16/s the bounded 128-entry driver queue rejected 88 offers, while reconciled blocks reached twelve 5M-gas transactions (60M declared gas).",
+    "claim_limit": "Single Linux host with four validator processes and twelve provider daemons. This diagnostic does not establish production capacity, WAN performance, completed-session throughput, or byte delivery.",
+    "classification": "driver_queue_and_declared_gas_limited_at_highest_offered_steps"
+  },
+  "measurement": {
+    "client_completion_observations_after_150s": 156,
+    "committed_valid_bundles": 842,
+    "committed_valid_openings": 6736,
+    "offered_bundles": 930,
+    "offered_openings": 7440,
+    "queue_full_not_submitted": 88,
+    "steps": [
+      {
+        "all_client_completion_observations_during_step": 29,
+        "eventual_committed_valid_bundles": 30,
+        "offered_bundles": 30,
+        "offered_rate_bundles_per_s": 1,
+        "queue_full_not_submitted": 0,
+        "same_cohort_client_observed_by_step_end": 29,
+        "terminal_observation_latency_ms": {
+          "max": 1947.417,
+          "p50": 1282.211,
+          "p95": 1933.821,
+          "p99": 1944.427
+        }
+      },
+      {
+        "all_client_completion_observations_during_step": 58,
+        "eventual_committed_valid_bundles": 60,
+        "offered_bundles": 60,
+        "offered_rate_bundles_per_s": 2,
+        "queue_full_not_submitted": 0,
+        "same_cohort_client_observed_by_step_end": 57,
+        "terminal_observation_latency_ms": {
+          "max": 2030.68,
+          "p50": 1409.1,
+          "p95": 1990.806,
+          "p99": 2025.739
+        }
+      },
+      {
+        "all_client_completion_observations_during_step": 116,
+        "eventual_committed_valid_bundles": 120,
+        "offered_bundles": 120,
+        "offered_rate_bundles_per_s": 4,
+        "queue_full_not_submitted": 0,
+        "same_cohort_client_observed_by_step_end": 113,
+        "terminal_observation_latency_ms": {
+          "max": 2274.078,
+          "p50": 1452.992,
+          "p95": 2103.979,
+          "p99": 2258.661
+        }
+      },
+      {
+        "all_client_completion_observations_during_step": 224,
+        "eventual_committed_valid_bundles": 240,
+        "offered_bundles": 240,
+        "offered_rate_bundles_per_s": 8,
+        "queue_full_not_submitted": 0,
+        "same_cohort_client_observed_by_step_end": 217,
+        "terminal_observation_latency_ms": {
+          "max": 5092.606,
+          "p50": 1755.151,
+          "p95": 3386.195,
+          "p99": 4284.979
+        }
+      },
+      {
+        "all_client_completion_observations_during_step": 259,
+        "eventual_committed_valid_bundles": 392,
+        "offered_bundles": 480,
+        "offered_rate_bundles_per_s": 16,
+        "queue_full_not_submitted": 88,
+        "same_cohort_client_observed_by_step_end": 236,
+        "terminal_observation_latency_ms": {
+          "max": 22782.641,
+          "p50": 13381.66,
+          "p95": 20445.364,
+          "p99": 21500.649
+        }
+      }
+    ]
+  },
+  "preparation": {
+    "batch_sizes": [
+      64,
+      64,
+      64,
+      64,
+      64,
+      64,
+      64,
+      64,
+      64,
+      64,
+      64,
+      64,
+      64,
+      64,
+      64,
+      2
+    ],
+    "committed_success": 16,
+    "gas_used_total": 367420844,
+    "gas_wanted_total": 386400000,
+    "sessions_opened": 962,
+    "setup_committed_success": 46,
+    "transactions": 16
+  },
+  "qualification": false,
+  "resources": {
+    "commit_stream_observed_blocks_each": [
+      124,
+      124,
+      124,
+      124
+    ],
+    "commit_stream_p95_upper_bound_seconds": [
+      0.3389775400041074,
+      0.33529044500514354,
+      0.3460720980048709,
+      0.2859745970043405
+    ],
+    "commit_stream_qualified_all_four": true,
+    "rss_source": "wait4 ru_maxrss, converted from KiB; not CPU usage",
+    "validator_peak_rss_bytes": [
+      393928704,
+      381997056,
+      381140992,
+      386924544
+    ]
+  },
+  "run": {
+    "completed_at_utc": "2026-09-09T08:59:25Z",
+    "completion_basis": "retained supervisor completion record; elapsed 966 seconds from launch timestamp",
+    "launched_at_utc": "2026-09-09T08:43:19Z",
+    "offered_window_seconds": 150,
+    "post_window_drain_seconds": 18.783641163,
+    "retries": 0,
+    "scheduler_elapsed_seconds": 168.783641163,
+    "supervisor_exit_code": 0
+  },
+  "scheduler": {
+    "automatic_submission_retries": false,
+    "max_in_flight": 32,
+    "max_queued": 128,
+    "peak_in_flight": 32,
+    "peak_queued": 128,
+    "peak_queued_per_signer": 6,
+    "quarantined_signers": []
+  },
+  "schema": "polystore.issue290.linux-k8-highload-summary.v1",
+  "source": {
+    "harness_merge": "07b1c626fa230dfe348fe72aa1ef00354ca7501f",
+    "reviewed_head": "f73ff0b8c0cf67ff79b9d8d07ae543acf6e590ea",
+    "runtime_product_source": "a6e130af3accb3ab9634d6ae04959e612653193a"
+  },
+  "status": "SUCCESS_DIAGNOSTIC_ONLY",
+  "summary_generated_at_utc": "2026-09-09T09:14:48.736049Z",
+  "warmup": {
+    "committed_valid_bundles": 32,
+    "offered_bundles": 32,
+    "openings": 256
+  }
+}

--- a/bench/retrieval_session_capacity/native-k8-290/linux-highload-30s-002/summary.json
+++ b/bench/retrieval_session_capacity/native-k8-290/linux-highload-30s-002/summary.json
@@ -60,6 +60,73 @@
       "accounted_transactions": 842,
       "after_offered_window": 139,
       "before_measurement": 1,
+      "cohort_cross_tabulation": {
+        "columns": [
+          "before_start",
+          "0_to_30s",
+          "30_to_60s",
+          "60_to_90s",
+          "90_to_120s",
+          "120_to_150s",
+          "after_150s"
+        ],
+        "committed_valid_bundles": [
+          [
+            1,
+            29,
+            0,
+            0,
+            0,
+            0,
+            0
+          ],
+          [
+            0,
+            0,
+            60,
+            0,
+            0,
+            0,
+            0
+          ],
+          [
+            0,
+            0,
+            0,
+            120,
+            0,
+            0,
+            0
+          ],
+          [
+            0,
+            0,
+            0,
+            7,
+            222,
+            11,
+            0
+          ],
+          [
+            0,
+            0,
+            0,
+            0,
+            0,
+            253,
+            139
+          ]
+        ],
+        "interpretation": "Rows use scheduled client offer time; columns use consensus header.Time, not actual wall-clock Commit completion. Negative relative header times are possible.",
+        "offered_rates_bundles_per_s": [
+          1,
+          2,
+          4,
+          8,
+          16
+        ],
+        "openings_per_bundle": 8
+      },
       "interpretation": "Windows contain carryover across offered cohorts and are keyed by consensus header.Time, not actual Commit completion.",
       "thirty_second_windows": [
         {
@@ -137,6 +204,129 @@
     "classification": "driver_queue_and_declared_gas_limited_at_highest_offered_steps"
   },
   "measurement": {
+    "assignment_basis": "Pinned session snapshot slot from hash-verified preparation inventory; measurement only, excluding warmup. Submitted means worker started and transaction subsequently committed; there are no failed or unknown submissions in this run.",
+    "assignments": [
+      {
+        "committed_valid_bundles": 71,
+        "committed_valid_openings": 568,
+        "offered_bundles": 78,
+        "offered_openings": 624,
+        "queue_full_not_submitted": 7,
+        "slot": 0,
+        "submitted_bundles": 71,
+        "submitted_openings": 568
+      },
+      {
+        "committed_valid_bundles": 70,
+        "committed_valid_openings": 560,
+        "offered_bundles": 78,
+        "offered_openings": 624,
+        "queue_full_not_submitted": 8,
+        "slot": 1,
+        "submitted_bundles": 70,
+        "submitted_openings": 560
+      },
+      {
+        "committed_valid_bundles": 70,
+        "committed_valid_openings": 560,
+        "offered_bundles": 77,
+        "offered_openings": 616,
+        "queue_full_not_submitted": 7,
+        "slot": 2,
+        "submitted_bundles": 70,
+        "submitted_openings": 560
+      },
+      {
+        "committed_valid_bundles": 70,
+        "committed_valid_openings": 560,
+        "offered_bundles": 77,
+        "offered_openings": 616,
+        "queue_full_not_submitted": 7,
+        "slot": 3,
+        "submitted_bundles": 70,
+        "submitted_openings": 560
+      },
+      {
+        "committed_valid_bundles": 70,
+        "committed_valid_openings": 560,
+        "offered_bundles": 77,
+        "offered_openings": 616,
+        "queue_full_not_submitted": 7,
+        "slot": 4,
+        "submitted_bundles": 70,
+        "submitted_openings": 560
+      },
+      {
+        "committed_valid_bundles": 70,
+        "committed_valid_openings": 560,
+        "offered_bundles": 77,
+        "offered_openings": 616,
+        "queue_full_not_submitted": 7,
+        "slot": 5,
+        "submitted_bundles": 70,
+        "submitted_openings": 560
+      },
+      {
+        "committed_valid_bundles": 70,
+        "committed_valid_openings": 560,
+        "offered_bundles": 77,
+        "offered_openings": 616,
+        "queue_full_not_submitted": 7,
+        "slot": 6,
+        "submitted_bundles": 70,
+        "submitted_openings": 560
+      },
+      {
+        "committed_valid_bundles": 70,
+        "committed_valid_openings": 560,
+        "offered_bundles": 77,
+        "offered_openings": 616,
+        "queue_full_not_submitted": 7,
+        "slot": 7,
+        "submitted_bundles": 70,
+        "submitted_openings": 560
+      },
+      {
+        "committed_valid_bundles": 69,
+        "committed_valid_openings": 552,
+        "offered_bundles": 78,
+        "offered_openings": 624,
+        "queue_full_not_submitted": 9,
+        "slot": 8,
+        "submitted_bundles": 69,
+        "submitted_openings": 552
+      },
+      {
+        "committed_valid_bundles": 70,
+        "committed_valid_openings": 560,
+        "offered_bundles": 78,
+        "offered_openings": 624,
+        "queue_full_not_submitted": 8,
+        "slot": 9,
+        "submitted_bundles": 70,
+        "submitted_openings": 560
+      },
+      {
+        "committed_valid_bundles": 70,
+        "committed_valid_openings": 560,
+        "offered_bundles": 78,
+        "offered_openings": 624,
+        "queue_full_not_submitted": 8,
+        "slot": 10,
+        "submitted_bundles": 70,
+        "submitted_openings": 560
+      },
+      {
+        "committed_valid_bundles": 72,
+        "committed_valid_openings": 576,
+        "offered_bundles": 78,
+        "offered_openings": 624,
+        "queue_full_not_submitted": 6,
+        "slot": 11,
+        "submitted_bundles": 72,
+        "submitted_openings": 576
+      }
+    ],
     "client_completion_observations_after_150s": 156,
     "committed_valid_bundles": 842,
     "committed_valid_openings": 6736,

--- a/bench/retrieval_session_capacity/native-k8-290/linux-highload-30s-002/summary.json
+++ b/bench/retrieval_session_capacity/native-k8-290/linux-highload-30s-002/summary.json
@@ -63,6 +63,8 @@
       "interpretation": "Windows contain carryover across offered cohorts and are keyed by consensus header.Time, not actual Commit completion.",
       "thirty_second_windows": [
         {
+          "gas_used": 119856991,
+          "gas_wanted": 145000000,
           "header_time_rate_bundles_per_s": 0.967,
           "header_time_rate_openings_per_s": 7.733,
           "offered_rate_bundles_per_s": 1,
@@ -70,6 +72,8 @@
           "reconciled_transactions": 29
         },
         {
+          "gas_used": 247988704,
+          "gas_wanted": 300000000,
           "header_time_rate_bundles_per_s": 2.0,
           "header_time_rate_openings_per_s": 16.0,
           "offered_rate_bundles_per_s": 2,
@@ -77,6 +81,8 @@
           "reconciled_transactions": 60
         },
         {
+          "gas_used": 524918308,
+          "gas_wanted": 635000000,
           "header_time_rate_bundles_per_s": 4.233,
           "header_time_rate_openings_per_s": 33.867,
           "offered_rate_bundles_per_s": 4,
@@ -84,6 +90,8 @@
           "reconciled_transactions": 127
         },
         {
+          "gas_used": 917565637,
+          "gas_wanted": 1110000000,
           "header_time_rate_bundles_per_s": 7.4,
           "header_time_rate_openings_per_s": 59.2,
           "offered_rate_bundles_per_s": 8,
@@ -91,6 +99,8 @@
           "reconciled_transactions": 222
         },
         {
+          "gas_used": 1091165320,
+          "gas_wanted": 1320000000,
           "header_time_rate_bundles_per_s": 8.8,
           "header_time_rate_openings_per_s": 70.4,
           "offered_rate_bundles_per_s": 16,
@@ -130,12 +140,16 @@
     "client_completion_observations_after_150s": 156,
     "committed_valid_bundles": 842,
     "committed_valid_openings": 6736,
+    "fence_backlog_definition": "At each scheduled 30-second end fence: offered but not terminal; queued has not started, in-flight has started. Terminal queue_full offers are excluded. These are client scheduler states, not chain mempool counts.",
     "offered_bundles": 930,
     "offered_openings": 7440,
     "queue_full_not_submitted": 88,
     "steps": [
       {
         "all_client_completion_observations_during_step": 29,
+        "end_fence_in_flight": 1,
+        "end_fence_pending": 1,
+        "end_fence_queued": 0,
         "eventual_committed_valid_bundles": 30,
         "offered_bundles": 30,
         "offered_rate_bundles_per_s": 1,
@@ -150,6 +164,9 @@
       },
       {
         "all_client_completion_observations_during_step": 58,
+        "end_fence_in_flight": 3,
+        "end_fence_pending": 3,
+        "end_fence_queued": 0,
         "eventual_committed_valid_bundles": 60,
         "offered_bundles": 60,
         "offered_rate_bundles_per_s": 2,
@@ -164,6 +181,9 @@
       },
       {
         "all_client_completion_observations_during_step": 116,
+        "end_fence_in_flight": 7,
+        "end_fence_pending": 7,
+        "end_fence_queued": 0,
         "eventual_committed_valid_bundles": 120,
         "offered_bundles": 120,
         "offered_rate_bundles_per_s": 4,
@@ -178,6 +198,9 @@
       },
       {
         "all_client_completion_observations_during_step": 224,
+        "end_fence_in_flight": 23,
+        "end_fence_pending": 23,
+        "end_fence_queued": 0,
         "eventual_committed_valid_bundles": 240,
         "offered_bundles": 240,
         "offered_rate_bundles_per_s": 8,
@@ -192,6 +215,9 @@
       },
       {
         "all_client_completion_observations_during_step": 259,
+        "end_fence_in_flight": 32,
+        "end_fence_pending": 156,
+        "end_fence_queued": 124,
         "eventual_committed_valid_bundles": 392,
         "offered_bundles": 480,
         "offered_rate_bundles_per_s": 16,

--- a/performance/README.md
+++ b/performance/README.md
@@ -287,3 +287,9 @@ a disk guard interrupted a later audit wait after measurement and drain.
 The artifact separates that interruption and supplementary recovery from the
 measured window. These are prepared-proof transaction acceptance results, not
 generation, delivery or paid lifecycle throughput.
+
+The [Linux high-load diagnostic 002](../bench/retrieval_session_capacity/native-k8-290/linux-highload-30s-002/README.md) reconciles 842 successful K8
+proof-submission transactions (6,736 openings) with normal audits. At the final
+16/s offered step, 88 offers hit the bounded queue; its consensus-header-time
+window recorded 8.8 bundles/s. This is a single-host, 30-second-per-step result,
+not a production-capacity or byte-delivery qualification.


### PR DESCRIPTION
Publishes the bounded Linux K8 chain-throughput measurement for #290 after the session-open gas fix in #297. Of 930 offered proof submissions, 842 committed valid (6,736 chained openings) and 88 were not submitted because the bounded driver queue was full. All four validators agreed on headers/results and all twelve normal audit samples were accepted.

The report distinguishes offered cohorts, client-observed completions, and consensus-header-time rates. The final 30-second header-time window recorded 8.8 bundles/s; this is not a production capacity or download claim. It records declared/used gas, conservative Commit p95 upper bounds, peak RSS, source/build identities and publication hashes. Raw keys, proof inventories, journals and logs remain private. No product or harness code changes.

Validation: independently reconciled raw SQLite outcomes, all-validator block evidence, audit coverage, resource values, p50/p95/p99 calculations, JSON parsing and published-file SHA-256 hashes; `git diff --check` passed. Runtime collection used merged harness 07b1c626 and unchanged a6e130af runtime artifacts, completed in 966 seconds, and stopped owned processes. #290 remains open pending the report's final disposition; no further benchmark is running.
