### PR TITLE
chain: add inactive retrieval v3 primitives

### DIFF
--- a/polystore_core/src/integrity_v3.rs
+++ b/polystore_core/src/integrity_v3.rs
@@ -1,0 +1,78 @@
+//! SHA-256 duplicate-last integrity tree for inactive retrieval v3.
+use sha2::{Digest, Sha256};
+
+pub const ENCODED_BLOB_BYTES: usize = 131_072;
+pub const MAX_LEAVES: u64 = 65_536 * 96;
+fn lp(h: &mut Sha256, value: &[u8]) {
+    h.update((value.len() as u32).to_be_bytes());
+    h.update(value)
+}
+pub fn leaf(mdu: u64, index: u32, blob: &[u8]) -> Result<[u8; 32], String> {
+    if mdu == 0 || mdu > 65536 || index >= 96 || blob.len() != ENCODED_BLOB_BYTES {
+        return Err("invalid v3 integrity coordinate or blob length".into());
+    }
+    let mut h = Sha256::new();
+    lp(&mut h, b"polystore/integrity-leaf/v3");
+    h.update(mdu.to_be_bytes());
+    h.update(index.to_be_bytes());
+    h.update((ENCODED_BLOB_BYTES as u32).to_be_bytes());
+    h.update(blob);
+    Ok(h.finalize().into())
+}
+fn parent(left: &[u8; 32], right: &[u8; 32]) -> [u8; 32] {
+    let mut h = Sha256::new();
+    lp(&mut h, b"polystore/integrity-node/v3");
+    h.update(left);
+    h.update(right);
+    h.finalize().into()
+}
+pub fn root(leaves: &[[u8; 32]]) -> Result<[u8; 32], String> {
+    if leaves.is_empty() || leaves.len() as u64 > MAX_LEAVES {
+        return Err("invalid v3 integrity leaf count".into());
+    }
+    let mut level = leaves.to_vec();
+    while level.len() > 1 {
+        let mut write = 0;
+        for read in (0..level.len()).step_by(2) {
+            let right = if read + 1 < level.len() {
+                level[read + 1]
+            } else {
+                level[read]
+            };
+            level[write] = parent(&level[read], &right);
+            write += 1
+        }
+        level.truncate(write)
+    }
+    Ok(level[0])
+}
+pub fn verify_path(
+    value: [u8; 32],
+    mut position: u64,
+    mut count: u64,
+    siblings: &[[u8; 32]],
+    expected: [u8; 32],
+) -> bool {
+    if count == 0 || count > MAX_LEAVES || position >= count {
+        return false;
+    }
+    let mut current = value;
+    let mut used = 0;
+    while count > 1 {
+        let Some(sibling) = siblings.get(used) else {
+            return false;
+        };
+        if count % 2 == 1 && position == count - 1 && sibling != &current {
+            return false;
+        }
+        current = if position % 2 == 1 {
+            parent(sibling, &current)
+        } else {
+            parent(&current, sibling)
+        };
+        position /= 2;
+        count = (count + 1) / 2;
+        used += 1
+    }
+    used == siblings.len() && current == expected
+}

--- a/polystore_core/src/layout.rs
+++ b/polystore_core/src/layout.rs
@@ -2,6 +2,7 @@ pub const MAGIC_NILF: [u8; 4] = [0x4E, 0x49, 0x4C, 0x46]; // "NILF"
 pub const FILE_RECORD_SIZE: usize = 256;
 pub const FILE_RECORD_PATH_BYTES: usize = FILE_RECORD_SIZE - 24;
 pub const FAT_V3_INTEGRITY_LEAVES_PER_USER_MDU: u64 = 96;
+pub const FAT_V3_MAX_RECORDS: u32 = 23_807;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FileTableHeaderV3 {
@@ -12,11 +13,12 @@ pub struct FileTableHeaderV3 {
 impl FileTableHeaderV3 {
     pub const SIZE: usize = 128;
     pub fn to_bytes(&self) -> Result<[u8; 128], String> {
-        if self.integrity_leaf_count == 0
+        if self.record_count > FAT_V3_MAX_RECORDS
+            || self.integrity_leaf_count == 0
             || self.integrity_leaf_count > crate::integrity_v3::MAX_LEAVES
             || self.integrity_leaf_count % FAT_V3_INTEGRITY_LEAVES_PER_USER_MDU != 0
         {
-            return Err("invalid FAT v3 integrity leaf count".into());
+            return Err("invalid FAT v3 header bounds".into());
         }
         let mut b = [0; 128];
         b[..4].copy_from_slice(&MAGIC_NILF);

--- a/polystore_core/src/layout.rs
+++ b/polystore_core/src/layout.rs
@@ -1,6 +1,59 @@
 pub const MAGIC_NILF: [u8; 4] = [0x4E, 0x49, 0x4C, 0x46]; // "NILF"
 pub const FILE_RECORD_SIZE: usize = 256;
 pub const FILE_RECORD_PATH_BYTES: usize = FILE_RECORD_SIZE - 24;
+pub const FAT_V3_INTEGRITY_LEAVES_PER_USER_MDU: u64 = 96;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FileTableHeaderV3 {
+    pub record_count: u32,
+    pub integrity_leaf_count: u64,
+    pub integrity_root: [u8; 32],
+}
+impl FileTableHeaderV3 {
+    pub const SIZE: usize = 128;
+    pub fn to_bytes(&self) -> Result<[u8; 128], String> {
+        if self.integrity_leaf_count == 0
+            || self.integrity_leaf_count > crate::integrity_v3::MAX_LEAVES
+            || self.integrity_leaf_count % FAT_V3_INTEGRITY_LEAVES_PER_USER_MDU != 0
+        {
+            return Err("invalid FAT v3 integrity leaf count".into());
+        }
+        let mut b = [0; 128];
+        b[..4].copy_from_slice(&MAGIC_NILF);
+        b[4..6].copy_from_slice(&3u16.to_le_bytes());
+        b[6..8].copy_from_slice(&(FILE_RECORD_SIZE as u16).to_le_bytes());
+        b[8..12].copy_from_slice(&self.record_count.to_le_bytes());
+        b[12] = 1;
+        b[13] = 1;
+        b[16..20].copy_from_slice(&(crate::integrity_v3::ENCODED_BLOB_BYTES as u32).to_le_bytes());
+        b[20..28].copy_from_slice(&self.integrity_leaf_count.to_le_bytes());
+        b[28..60].copy_from_slice(&self.integrity_root);
+        Ok(b)
+    }
+    pub fn from_bytes(b: &[u8]) -> Result<Self, String> {
+        if b.len() != 128
+            || b[..4] != MAGIC_NILF
+            || u16::from_le_bytes(b[4..6].try_into().unwrap()) != 3
+            || u16::from_le_bytes(b[6..8].try_into().unwrap()) != FILE_RECORD_SIZE as u16
+            || b[12] != 1
+            || b[13] != 1
+            || b[14] != 0
+            || b[15] != 0
+            || u32::from_le_bytes(b[16..20].try_into().unwrap())
+                != crate::integrity_v3::ENCODED_BLOB_BYTES as u32
+            || b[60..].iter().any(|v| *v != 0)
+        {
+            return Err("invalid FAT v3 header".into());
+        }
+        let h = Self {
+            record_count: u32::from_le_bytes(b[8..12].try_into().unwrap()),
+            integrity_leaf_count: u64::from_le_bytes(b[20..28].try_into().unwrap()),
+            integrity_root: b[28..60].try_into().unwrap(),
+        };
+        h.to_bytes()?;
+        Ok(h)
+    }
+}
 
 pub const FLAG_ENCRYPTED: u8 = 0x80; // Bit 7
 pub const FLAG_HIDDEN: u8 = 0x40; // Bit 6

--- a/polystore_core/src/lib.rs
+++ b/polystore_core/src/lib.rs
@@ -2,9 +2,11 @@ pub mod builder;
 pub mod coding;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod ffi;
+pub mod integrity_v3;
 pub mod kzg;
 pub mod layout;
 pub mod retrieval_challenge;
+pub mod retrieval_v3;
 pub mod utils;
 #[cfg(target_arch = "wasm32")]
 pub mod wasm;

--- a/polystore_core/src/retrieval_challenge.rs
+++ b/polystore_core/src/retrieval_challenge.rs
@@ -44,7 +44,7 @@ impl<'a> Reader<'a> {
     pub fn u64(&mut self) -> Result<u64, KzgError> {
         Ok(u64::from_be_bytes(self.array()?))
     }
-    fn lp(&mut self) -> Result<&'a [u8], KzgError> {
+    pub(crate) fn lp(&mut self) -> Result<&'a [u8], KzgError> {
         let n = self.u32()? as usize;
         self.take(n)
     }
@@ -271,11 +271,34 @@ pub fn derive_z(
     mdu: u64,
     leaf: u32,
 ) -> Result<[u8; 32], KzgError> {
+    derive_z_with_domain(
+        b"polystore/blob-challenge/v2",
+        hash,
+        seed,
+        ordinal,
+        None,
+        mdu,
+        leaf,
+    )
+}
+
+pub(crate) fn derive_z_with_domain(
+    domain: &[u8],
+    hash: &[u8; 32],
+    seed: &[u8; 32],
+    ordinal: u64,
+    t: Option<u64>,
+    mdu: u64,
+    leaf: u32,
+) -> Result<[u8; 32], KzgError> {
     let mut transcript = Vec::with_capacity(128);
-    append_lp(&mut transcript, b"polystore/blob-challenge/v2");
+    append_lp(&mut transcript, domain);
     transcript.extend(hash);
     transcript.extend(seed);
     transcript.extend(ordinal.to_be_bytes());
+    if let Some(t) = t {
+        transcript.extend(t.to_be_bytes());
+    }
     transcript.extend(mdu.to_be_bytes());
     transcript.extend(leaf.to_be_bytes());
     hash_to_point(|retry| {
@@ -302,13 +325,31 @@ pub fn sample(
     population: u64,
     count: u64,
 ) -> Result<Vec<u64>, KzgError> {
-    if count > population || count > MAX_SAMPLES {
+    sample_with_domain(
+        b"polystore/audit-position/v2",
+        hash,
+        seed,
+        population,
+        count,
+        MAX_SAMPLES,
+    )
+}
+
+pub(crate) fn sample_with_domain(
+    domain: &[u8],
+    hash: &[u8; 32],
+    seed: &[u8; 32],
+    population: u64,
+    count: u64,
+    max_count: u64,
+) -> Result<Vec<u64>, KzgError> {
+    if count > population || count > max_count {
         return Err(invalid());
     }
     let mut positions = Vec::with_capacity(count as usize);
     let mut swaps = BTreeMap::new();
     let mut transcript = Vec::with_capacity(128);
-    append_lp(&mut transcript, b"polystore/audit-position/v2");
+    append_lp(&mut transcript, domain);
     transcript.extend(hash);
     transcript.extend(seed);
     for i in 0..count {

--- a/polystore_core/src/retrieval_v3.rs
+++ b/polystore_core/src/retrieval_v3.rs
@@ -1,0 +1,421 @@
+//! Inactive retrieval-v3 range, binding and challenge primitives.
+//! Authorization, state mutation and proof verification remain keeper concerns.
+use crate::kzg::KzgError;
+use crate::retrieval_challenge::{
+    Reader, append_lp, derive_z_with_domain, invalid, sample_with_domain,
+};
+use num_bigint::BigUint;
+use sha2::{Digest, Sha256};
+
+pub const VERSION: u32 = 3;
+pub const DATA_BLOB_PAYLOAD_BYTES: u64 = 126_976;
+pub const MAX_RANGE_BYTES: u64 = 1 << 30;
+pub const MAX_SAMPLES: u64 = 132;
+pub const MAX_CONTEXT_BYTES: usize = 734;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Range {
+    pub first: u64,
+    pub last: u64,
+    pub population: u64,
+}
+impl Range {
+    fn validate(&self) -> Result<(), KzgError> {
+        let expected = self
+            .last
+            .checked_sub(self.first)
+            .and_then(|v| v.checked_add(1))
+            .ok_or_else(invalid)?;
+        if self.population == 0 || self.population != expected {
+            return Err(invalid());
+        }
+        Ok(())
+    }
+}
+
+pub fn checked_range(
+    file_start: u64,
+    file_length: u64,
+    range_start: u64,
+    range_length: u64,
+    user_mdus: u64,
+) -> Result<Range, KzgError> {
+    if range_length == 0 || range_length > MAX_RANGE_BYTES || user_mdus == 0 {
+        return Err(invalid());
+    }
+    if range_start.checked_add(range_length).ok_or_else(invalid)? > file_length {
+        return Err(invalid());
+    }
+    let absolute = file_start.checked_add(range_start).ok_or_else(invalid)?;
+    let end = absolute.checked_add(range_length - 1).ok_or_else(invalid)?;
+    let first = absolute / DATA_BLOB_PAYLOAD_BYTES;
+    let last = end / DATA_BLOB_PAYLOAD_BYTES;
+    let capacity = user_mdus.checked_mul(64).ok_or_else(invalid)?;
+    if last >= capacity {
+        return Err(invalid());
+    }
+    Ok(Range {
+        first,
+        last,
+        population: last - first + 1,
+    })
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Obligation {
+    pub slot: u32,
+    pub assigned: [u8; 20],
+    pub payee: [u8; 20],
+    pub blob_count: u64,
+}
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Plan {
+    pub range: Range,
+    pub obligations: Vec<Obligation>,
+}
+
+fn residue_count(first: u64, last: u64, residue: u64) -> u64 {
+    let delta = (residue + 8 - first % 8) % 8;
+    if delta > last - first {
+        0
+    } else {
+        1 + (last - first - delta) / 8
+    }
+}
+impl Plan {
+    pub fn build(range: Range, providers: [[u8; 20]; 8]) -> Result<Self, KzgError> {
+        range.validate()?;
+        let obligations = (0..8)
+            .filter_map(|slot| {
+                let n = residue_count(range.first, range.last, slot);
+                (n > 0).then(|| Obligation {
+                    slot: slot as u32,
+                    assigned: providers[slot as usize],
+                    payee: providers[slot as usize],
+                    blob_count: n,
+                })
+            })
+            .collect();
+        Ok(Self { range, obligations })
+    }
+    pub fn bytes(&self) -> Result<Vec<u8>, KzgError> {
+        self.range.validate()?;
+        if self.obligations.is_empty() || self.obligations.len() > 8 {
+            return Err(invalid());
+        }
+        let mut total = 0;
+        let mut prior = None;
+        for o in &self.obligations {
+            if o.slot > 7
+                || o.assigned != o.payee
+                || o.blob_count != residue_count(self.range.first, self.range.last, o.slot as u64)
+                || o.blob_count == 0
+                || prior.is_some_and(|p| p >= o.slot)
+            {
+                return Err(invalid());
+            }
+            total += o.blob_count;
+            prior = Some(o.slot)
+        }
+        if total != self.range.population {
+            return Err(invalid());
+        }
+        let mut b = Vec::with_capacity(32 + 24 + self.obligations.len() * 52);
+        append_lp(&mut b, b"polystore/retrieval-plan/v3");
+        for v in [self.range.first, self.range.last, self.range.population] {
+            b.extend(v.to_be_bytes())
+        }
+        b.extend((self.obligations.len() as u32).to_be_bytes());
+        for o in &self.obligations {
+            b.extend(o.slot.to_be_bytes());
+            b.extend(o.assigned);
+            b.extend(o.payee);
+            b.extend(o.blob_count.to_be_bytes())
+        }
+        Ok(b)
+    }
+    pub fn hash(&self) -> Result<[u8; 32], KzgError> {
+        Ok(Sha256::digest(self.bytes()?).into())
+    }
+}
+
+pub fn session_id(
+    chain: &str,
+    owner: &[u8; 20],
+    deal: u64,
+    generation: u64,
+    record: u32,
+    range_start: u64,
+    range_length: u64,
+    plan_hash: &[u8; 32],
+    nonce: u64,
+) -> Result<[u8; 32], KzgError> {
+    if !valid_chain(chain.as_bytes()) || range_length == 0 || range_length > MAX_RANGE_BYTES {
+        return Err(invalid());
+    }
+    let mut b = Vec::new();
+    append_lp(&mut b, b"polystore/retrieval-session/v3");
+    b.extend(VERSION.to_be_bytes());
+    append_lp(&mut b, chain.as_bytes());
+    b.extend(owner);
+    b.extend(deal.to_be_bytes());
+    b.extend(generation.to_be_bytes());
+    b.extend(record.to_be_bytes());
+    b.extend(range_start.to_be_bytes());
+    b.extend(range_length.to_be_bytes());
+    b.extend(plan_hash);
+    b.extend(nonce.to_be_bytes());
+    Ok(Sha256::digest(b).into())
+}
+
+pub fn generation_acceptance(
+    chain: &str,
+    setup: &[u8; 32],
+    deal: u64,
+    generation: u64,
+    polyfs: &[u8; 32],
+    integrity: &[u8; 32],
+    metadata: u64,
+    users: u64,
+    slot: u32,
+    provider: &[u8; 20],
+) -> Result<Vec<u8>, KzgError> {
+    if !valid_chain(chain.as_bytes())
+        || metadata == 0
+        || metadata > 65537
+        || users == 0
+        || users > 65537 - metadata
+        || slot >= 12
+    {
+        return Err(invalid());
+    }
+    let mut b = Vec::new();
+    append_lp(&mut b, b"polystore/generation-acceptance/v3");
+    append_lp(&mut b, chain.as_bytes());
+    b.extend(setup);
+    b.extend(deal.to_be_bytes());
+    b.extend(generation.to_be_bytes());
+    b.extend(polyfs);
+    b.extend(integrity);
+    b.push(2);
+    b.extend(8u32.to_be_bytes());
+    b.extend(4u32.to_be_bytes());
+    b.extend(metadata.to_be_bytes());
+    b.extend(users.to_be_bytes());
+    b.extend(slot.to_be_bytes());
+    b.extend(provider);
+    Ok(b)
+}
+
+pub fn obligation_ack(
+    chain: &str,
+    session: &[u8; 32],
+    context: &[u8; 32],
+    plan: &[u8; 32],
+    obligation: &Obligation,
+    billed_encoded_bytes: u64,
+    integrity: &[u8; 32],
+) -> Result<Vec<u8>, KzgError> {
+    if !valid_chain(chain.as_bytes())
+        || obligation.slot >= 8
+        || obligation.assigned != obligation.payee
+        || obligation.blob_count == 0
+        || obligation.blob_count.checked_mul(131072) != Some(billed_encoded_bytes)
+    {
+        return Err(invalid());
+    }
+    let mut b = Vec::new();
+    append_lp(&mut b, b"polystore/retrieval-obligation-ack/v3");
+    append_lp(&mut b, chain.as_bytes());
+    b.extend(session);
+    b.extend(context);
+    b.extend(plan);
+    b.extend(obligation.slot.to_be_bytes());
+    b.extend(obligation.assigned);
+    b.extend(obligation.payee);
+    b.extend(obligation.blob_count.to_be_bytes());
+    b.extend(billed_encoded_bytes.to_be_bytes());
+    b.extend(integrity);
+    Ok(b)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Challenge {
+    pub ordinal: u64,
+    pub position: u64,
+    pub t: u64,
+    pub mdu_index: u64,
+    pub leaf_index: u32,
+    pub slot: u32,
+    pub z: [u8; 32],
+}
+#[derive(Debug)]
+pub struct Context {
+    hash: [u8; 32],
+    first: u64,
+    population: u64,
+    samples: u64,
+    metadata: u64,
+}
+
+fn valid_chain(v: &[u8]) -> bool {
+    !v.is_empty() && v.len() <= 50 && !v.contains(&0) && std::str::from_utf8(v).is_ok()
+}
+fn valid_denom(v: &[u8]) -> bool {
+    (3..=128).contains(&v.len())
+        && v[0].is_ascii_alphabetic()
+        && v[1..]
+            .iter()
+            .all(|b| b.is_ascii_alphanumeric() || b"/:._-".contains(b))
+}
+fn valid_amount(v: &[u8]) -> bool {
+    !v.is_empty()
+        && v.len() <= 78
+        && v.iter().all(u8::is_ascii_digit)
+        && (v == b"0" || v[0] != b'0')
+        && BigUint::parse_bytes(v, 10).is_some_and(|n| n.bits() <= 256)
+}
+
+impl Context {
+    pub fn parse(bytes: &[u8]) -> Result<Self, KzgError> {
+        if bytes.len() > MAX_CONTEXT_BYTES {
+            return Err(invalid());
+        }
+        let mut r = Reader { bytes };
+        if r.lp()? != b"polystore/challenge-context/v3" || r.u32()? != VERSION {
+            return Err(invalid());
+        }
+        let chain = r.lp()?;
+        if !valid_chain(chain) {
+            return Err(invalid());
+        }
+        r.take(32)?;
+        let sid = r.array::<32>()?;
+        let owner = r.array::<20>()?;
+        let deal = r.u64()?;
+        let generation = r.u64()?;
+        r.take(32)?;
+        r.take(32)?;
+        let record = r.u32()?;
+        let file_start = r.u64()?;
+        let file_length = r.u64()?;
+        let range_start = r.u64()?;
+        let range_length = r.u64()?;
+        if r.u8()? != 2 || r.u32()? != 8 || r.u32()? != 4 {
+            return Err(invalid());
+        }
+        let metadata = r.u64()?;
+        let users = r.u64()?;
+        let plan = r.array::<32>()?;
+        let population = r.u64()?;
+        let samples = r.u64()?;
+        let nonce = r.u64()?;
+        let denom = r.lp()?;
+        let price = r.lp()?;
+        let base = r.lp()?;
+        let burn = r.u32()?;
+        let funding = r.u8()?;
+        let payer = r.array::<20>()?;
+        let snapshot = r.u64()?;
+        let anchor = r.u64()?;
+        let first_response = r.u64()?;
+        let deadline = r.u64()?;
+        let deal_end = r.u64()?;
+        if !r.bytes.is_empty()
+            || metadata == 0
+            || metadata > 65537
+            || users == 0
+            || users > 65537 - metadata
+            || !valid_denom(denom)
+            || !valid_amount(price)
+            || !valid_amount(base)
+            || burn > 10000
+            || !(funding == 1 || funding == 2)
+            || payer != owner
+            || snapshot == 0
+            || snapshot > i64::MAX as u64 - 2
+            || deal_end == 0
+            || deal_end > i64::MAX as u64
+            || anchor != snapshot + 1
+            || first_response != snapshot + 2
+            || first_response > deadline
+            || deadline > deal_end
+            || snapshot >= deal_end
+        {
+            return Err(invalid());
+        }
+        let range = checked_range(file_start, file_length, range_start, range_length, users)?;
+        if population != range.population
+            || samples != population.min(MAX_SAMPLES)
+            || sid
+                != session_id(
+                    std::str::from_utf8(chain).map_err(|_| invalid())?,
+                    &owner,
+                    deal,
+                    generation,
+                    record,
+                    range_start,
+                    range_length,
+                    &plan,
+                    nonce,
+                )?
+        {
+            return Err(invalid());
+        }
+        Ok(Self {
+            hash: Sha256::digest(bytes).into(),
+            first: range.first,
+            population,
+            samples,
+            metadata,
+        })
+    }
+    pub fn hash(&self) -> [u8; 32] {
+        self.hash
+    }
+    pub fn seed(&self, anchor: &[u8; 32]) -> [u8; 32] {
+        let mut b = Vec::new();
+        append_lp(&mut b, b"polystore/challenge-seed/v3");
+        b.extend(self.hash);
+        b.extend(anchor);
+        Sha256::digest(b).into()
+    }
+    pub fn challenges(&self, seed: &[u8; 32]) -> Result<Vec<Challenge>, KzgError> {
+        let positions = sample_with_domain(
+            b"polystore/session-position/v3",
+            &self.hash,
+            seed,
+            self.population,
+            self.samples,
+            MAX_SAMPLES,
+        )?;
+        positions
+            .into_iter()
+            .enumerate()
+            .map(|(i, p)| {
+                let t = self.first + p;
+                let d = t % 64;
+                let slot = (d % 8) as u32;
+                let leaf = slot * 8 + (d / 8) as u32;
+                let mdu = self.metadata + t / 64;
+                Ok(Challenge {
+                    ordinal: i as u64,
+                    position: p,
+                    t,
+                    mdu_index: mdu,
+                    leaf_index: leaf,
+                    slot,
+                    z: derive_z_with_domain(
+                        b"polystore/blob-challenge/v3",
+                        &self.hash,
+                        seed,
+                        i as u64,
+                        Some(t),
+                        mdu,
+                        leaf,
+                    )?,
+                })
+            })
+            .collect()
+    }
+}

--- a/polystore_core/tests/retrieval_v3_vectors_test.rs
+++ b/polystore_core/tests/retrieval_v3_vectors_test.rs
@@ -1,4 +1,8 @@
-use polystore_core::{integrity_v3, layout::FileTableHeaderV3, retrieval_v3};
+use polystore_core::{
+    integrity_v3,
+    layout::{FAT_V3_MAX_RECORDS, FileTableHeaderV3},
+    retrieval_v3,
+};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::fs;
@@ -271,6 +275,25 @@ fn fat_and_integrity_match_merged_vectors_and_reject_bad_paths() {
         f["fat_header"]["header_hex"].as_str().unwrap()
     );
     assert_eq!(FileTableHeaderV3::from_bytes(&bytes).unwrap(), header);
+    let max_header = FileTableHeaderV3 {
+        record_count: FAT_V3_MAX_RECORDS,
+        ..header
+    };
+    let mut max_bytes = max_header.to_bytes().unwrap();
+    assert_eq!(
+        FileTableHeaderV3::from_bytes(&max_bytes).unwrap(),
+        max_header
+    );
+    assert!(
+        FileTableHeaderV3 {
+            record_count: FAT_V3_MAX_RECORDS + 1,
+            ..header
+        }
+        .to_bytes()
+        .is_err()
+    );
+    max_bytes[8..12].copy_from_slice(&(FAT_V3_MAX_RECORDS + 1).to_le_bytes());
+    assert!(FileTableHeaderV3::from_bytes(&max_bytes).is_err());
     let names = ["zero", "valid_incrementing", "valid_ff"];
     let leaves: Vec<_> = names
         .iter()

--- a/polystore_core/tests/retrieval_v3_vectors_test.rs
+++ b/polystore_core/tests/retrieval_v3_vectors_test.rs
@@ -1,0 +1,317 @@
+use polystore_core::{integrity_v3, layout::FileTableHeaderV3, retrieval_v3};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::fs;
+
+fn fixture() -> Value {
+    let p = format!(
+        "{}/../polystorechain/pkg/retrievalchallenge/testdata/large-session-v3-golden.json",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    serde_json::from_slice(&fs::read(p).unwrap()).unwrap()
+}
+fn hex32(v: &str) -> [u8; 32] {
+    hex::decode(v).unwrap().try_into().unwrap()
+}
+fn providers() -> [[u8; 20]; 8] {
+    std::array::from_fn(|i| [0x40 + i as u8; 20])
+}
+fn lp(out: &mut Vec<u8>, value: &[u8]) {
+    out.extend((value.len() as u32).to_be_bytes());
+    out.extend(value);
+}
+
+#[test]
+fn merged_transcripts_drive_range_plan_and_challenges() {
+    let f = fixture();
+    for name in ["small_transcript", "large_transcript", "offset_transcript"] {
+        let x = &f[name];
+        let first = x["first"].as_u64().unwrap();
+        let last = x["last"].as_u64().unwrap();
+        let range = retrieval_v3::Range {
+            first,
+            last,
+            population: last - first + 1,
+        };
+        let plan = retrieval_v3::Plan::build(range, providers()).unwrap();
+        assert_eq!(
+            hex::encode(plan.bytes().unwrap()),
+            x["plan_hex"].as_str().unwrap()
+        );
+        assert_eq!(
+            hex::encode(plan.hash().unwrap()),
+            x["plan_hash"].as_str().unwrap()
+        );
+        let context_bytes = hex::decode(x["context_hex"].as_str().unwrap()).unwrap();
+        let c = retrieval_v3::Context::parse(&context_bytes).unwrap();
+        assert_eq!(hex::encode(c.hash()), x["context_hash"].as_str().unwrap());
+        let anchor = hex32(x["anchor_hash"].as_str().unwrap());
+        let seed = c.seed(&anchor);
+        assert_eq!(hex::encode(seed), x["seed"].as_str().unwrap());
+        let challenges = c.challenges(&seed).unwrap();
+        assert_eq!(
+            challenges.len(),
+            x["sample_count"].as_u64().unwrap() as usize
+        );
+        if name == "large_transcript" {
+            let mut h = Sha256::new();
+            for c in &challenges {
+                h.update(c.position.to_be_bytes())
+            }
+            assert_eq!(
+                hex::encode(h.finalize()),
+                f["large_sample"]["positions_sha256"].as_str().unwrap()
+            );
+            for (i, w) in f["large_sample"]["first_eight"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .enumerate()
+            {
+                assert_eq!(challenges[i].position, w.as_u64().unwrap())
+            }
+        }
+        let samples = if name == "small_transcript" {
+            Some(&f["small_samples"])
+        } else if name == "offset_transcript" {
+            Some(&f["offset_samples"])
+        } else {
+            None
+        };
+        if let Some(samples) = samples {
+            for (i, w) in samples.as_array().unwrap().iter().enumerate() {
+                let c = &challenges[i];
+                assert_eq!(
+                    (
+                        c.ordinal,
+                        c.position,
+                        c.t,
+                        c.mdu_index,
+                        c.leaf_index,
+                        c.slot
+                    ),
+                    (
+                        w["ordinal"].as_u64().unwrap(),
+                        w["position"].as_u64().unwrap(),
+                        w["t"].as_u64().unwrap(),
+                        w["mdu_index"].as_u64().unwrap(),
+                        w["leaf_index"].as_u64().unwrap() as u32,
+                        w["slot"].as_u64().unwrap() as u32
+                    )
+                );
+                assert_eq!(hex::encode(c.z), w["z"].as_str().unwrap())
+            }
+        }
+        let acceptance = retrieval_v3::generation_acceptance(
+            "polystore-test-1",
+            &hex32("d39b9f2d047cc9dca2de58f264b6a09448ccd34db967881a6713eacacf0f26b7"),
+            42,
+            7,
+            &[0x22; 32],
+            &hex32("074c4b427382c9ff2e85f0fea1bc39a56bd58a3e3849e737e23faf15a2c67707"),
+            2,
+            (last + 64) / 64,
+            0,
+            &[0x40; 20],
+        )
+        .unwrap();
+        assert_eq!(
+            hex::encode(&acceptance),
+            x["acceptance_slot0_hex"].as_str().unwrap()
+        );
+        assert_eq!(
+            hex::encode(Sha256::digest(&acceptance)),
+            x["acceptance_slot0_hash"].as_str().unwrap()
+        );
+        let ack = retrieval_v3::obligation_ack(
+            "polystore-test-1",
+            &hex32(x["session_id"].as_str().unwrap()),
+            &c.hash(),
+            &plan.hash().unwrap(),
+            &plan.obligations[0],
+            plan.obligations[0].blob_count * 131072,
+            &hex32("074c4b427382c9ff2e85f0fea1bc39a56bd58a3e3849e737e23faf15a2c67707"),
+        )
+        .unwrap();
+        assert_eq!(
+            hex::encode(&ack),
+            x["ack_first_obligation_hex"].as_str().unwrap()
+        );
+        assert_eq!(
+            hex::encode(Sha256::digest(&ack)),
+            x["ack_first_obligation_hash"].as_str().unwrap()
+        );
+    }
+}
+
+#[test]
+fn v3_context_rejects_rebinding_malformed_and_overflow() {
+    let f = fixture();
+    let mut b = hex::decode(f["offset_transcript"]["context_hex"].as_str().unwrap()).unwrap();
+    assert!(retrieval_v3::Context::parse(&b).is_ok());
+    b[96] ^= 1;
+    assert!(retrieval_v3::Context::parse(&b).is_err());
+    assert!(retrieval_v3::checked_range(u64::MAX, 1, 1, 1, 1).is_err());
+    let obligation = retrieval_v3::Obligation {
+        slot: 0,
+        assigned: [1; 20],
+        payee: [1; 20],
+        blob_count: 1,
+    };
+    for range in [
+        retrieval_v3::Range {
+            first: 2,
+            last: 1,
+            population: 1,
+        },
+        retrieval_v3::Range {
+            first: 0,
+            last: u64::MAX,
+            population: u64::MAX,
+        },
+    ] {
+        let plan = retrieval_v3::Plan {
+            range,
+            obligations: vec![obligation.clone()],
+        };
+        assert!(plan.bytes().is_err());
+    }
+    let mut suffix = hex::decode(f["small_transcript"]["context_hex"].as_str().unwrap()).unwrap();
+    suffix.push(0);
+    assert!(retrieval_v3::Context::parse(&suffix).is_err());
+    let mut late_deal =
+        hex::decode(f["small_transcript"]["context_hex"].as_str().unwrap()).unwrap();
+    let n = late_deal.len();
+    late_deal[n - 8..].copy_from_slice(&((i64::MAX as u64) + 1).to_be_bytes());
+    assert!(retrieval_v3::Context::parse(&late_deal).is_err());
+}
+
+#[test]
+fn v3_context_accepts_exact_734_byte_chain_and_coin_limits() {
+    let f = fixture();
+    let x = &f["small_transcript"];
+    let chain = "a".repeat(50);
+    let denom = format!("a{}", "z".repeat(127));
+    let amount = b"115792089237316195423570985008687907853269984665640564039457584007913129639935";
+    let owner = [0x11; 20];
+    let plan = hex32(x["plan_hash"].as_str().unwrap());
+    let sid = retrieval_v3::session_id(&chain, &owner, 42, 7, 3, 0, 2_158_592, &plan, 9).unwrap();
+    let mut b = Vec::new();
+    lp(&mut b, b"polystore/challenge-context/v3");
+    b.extend(3u32.to_be_bytes());
+    lp(&mut b, chain.as_bytes());
+    b.extend(hex32(
+        "d39b9f2d047cc9dca2de58f264b6a09448ccd34db967881a6713eacacf0f26b7",
+    ));
+    b.extend(sid);
+    b.extend(owner);
+    b.extend(42u64.to_be_bytes());
+    b.extend(7u64.to_be_bytes());
+    b.extend([0x22; 32]);
+    b.extend(hex32(
+        "074c4b427382c9ff2e85f0fea1bc39a56bd58a3e3849e737e23faf15a2c67707",
+    ));
+    b.extend(3u32.to_be_bytes());
+    for v in [0u64, 2_158_592, 0, 2_158_592] {
+        b.extend(v.to_be_bytes());
+    }
+    b.push(2);
+    b.extend(8u32.to_be_bytes());
+    b.extend(4u32.to_be_bytes());
+    b.extend(2u64.to_be_bytes());
+    b.extend(1u64.to_be_bytes());
+    b.extend(plan);
+    b.extend(17u64.to_be_bytes());
+    b.extend(17u64.to_be_bytes());
+    b.extend(9u64.to_be_bytes());
+    lp(&mut b, denom.as_bytes());
+    lp(&mut b, amount);
+    lp(&mut b, amount);
+    b.extend(250u32.to_be_bytes());
+    b.push(1);
+    b.extend(owner);
+    for v in [100u64, 101, 102, 200, 300] {
+        b.extend(v.to_be_bytes());
+    }
+    assert_eq!(b.len(), retrieval_v3::MAX_CONTEXT_BYTES);
+    assert!(retrieval_v3::Context::parse(&b).is_ok());
+}
+
+fn pattern(name: &str) -> Vec<u8> {
+    let mut b = vec![0; 131072];
+    match name {
+        "valid_incrementing" => {
+            for i in 0..4096 {
+                for j in 0..31 {
+                    b[i * 32 + 1 + j] = (i + j) as u8
+                }
+            }
+        }
+        "valid_ff" => {
+            for i in 0..4096 {
+                b[i * 32 + 1..i * 32 + 32].fill(0xff)
+            }
+        }
+        _ => {}
+    }
+    b
+}
+#[test]
+fn fat_and_integrity_match_merged_vectors_and_reject_bad_paths() {
+    let f = fixture();
+    let root = hex32(f["integrity"]["root"].as_str().unwrap());
+    let header = FileTableHeaderV3 {
+        record_count: 2,
+        integrity_leaf_count: 96,
+        integrity_root: root,
+    };
+    let bytes = header.to_bytes().unwrap();
+    assert_eq!(
+        hex::encode(bytes),
+        f["fat_header"]["header_hex"].as_str().unwrap()
+    );
+    assert_eq!(FileTableHeaderV3::from_bytes(&bytes).unwrap(), header);
+    let names = ["zero", "valid_incrementing", "valid_ff"];
+    let leaves: Vec<_> = names
+        .iter()
+        .enumerate()
+        .map(|(i, n)| integrity_v3::leaf(10, i as u32, &pattern(n)).unwrap())
+        .collect();
+    for (i, l) in leaves.iter().enumerate() {
+        assert_eq!(
+            hex::encode(l),
+            f["integrity"]["leaf_hashes"][i].as_str().unwrap()
+        )
+    }
+    assert_eq!(integrity_v3::root(&leaves).unwrap(), root);
+    for (i, p) in f["integrity"]["paths"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .enumerate()
+    {
+        let mut path: Vec<[u8; 32]> = p
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| hex32(v.as_str().unwrap()))
+            .collect();
+        assert!(integrity_v3::verify_path(
+            leaves[i], i as u64, 3, &path, root
+        ));
+        if i == 2 {
+            path[0] = [0; 32];
+            assert!(!integrity_v3::verify_path(
+                leaves[i], i as u64, 3, &path, root
+            ))
+        }
+    }
+    assert!(!integrity_v3::verify_path(
+        leaves[2],
+        u64::MAX,
+        3,
+        &[],
+        root
+    ));
+    assert!(integrity_v3::leaf(10, 0, &[0]).is_err())
+}

--- a/polystorechain/pkg/retrievalchallenge/challenge.go
+++ b/polystorechain/pkg/retrievalchallenge/challenge.go
@@ -314,12 +314,16 @@ func hashToPoint(transcript []byte, hash func([]byte) [32]byte) ([32]byte, error
 // tail-swap Fisher-Yates variant in the RFC. It allocates O(count), never O(U).
 // The caller must authenticate hash/seed and freeze U/count before seed reveal.
 func Sample(hash [32]byte, seed []byte, population, count uint64) ([]uint64, error) {
-	if len(seed) != 32 || count > population || count > MaxSamples {
+	return sampleWithDomain(hash, seed, population, count, "polystore/audit-position/v2", MaxSamples)
+}
+
+func sampleWithDomain(hash [32]byte, seed []byte, population, count uint64, domain string, maxCount uint64) ([]uint64, error) {
+	if len(seed) != 32 || count > population || count > maxCount {
 		return nil, errors.New("invalid seed, population or bounded sample count")
 	}
 	positions := make([]uint64, count)
 	swaps := make(map[uint64]uint64, count)
-	transcript := appendLP(make([]byte, 0, 128), "polystore/audit-position/v2")
+	transcript := appendLP(make([]byte, 0, 128), domain)
 	transcript = append(transcript, hash[:]...)
 	transcript = append(transcript, seed...)
 	transcript = append(transcript, make([]byte, 12)...)

--- a/polystorechain/pkg/retrievalchallenge/v3.go
+++ b/polystorechain/pkg/retrievalchallenge/v3.go
@@ -1,0 +1,448 @@
+package retrievalchallenge
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"math"
+	"math/big"
+	"regexp"
+	"unicode/utf8"
+)
+
+const (
+	Version3               = uint32(3)
+	StripeK8M4             = uint8(2)
+	DataBlobPayloadBytes   = uint64(126976)
+	EncodedBlobBytes       = uint64(131072)
+	MaxLargeRangeBytes     = uint64(1 << 30)
+	MaxLargeSessionSamples = uint64(132)
+	FundingDealEscrow      = uint8(1)
+	FundingRequester       = uint8(2)
+	maxV3ContextBytes      = 734 // exact fixed bytes + chain(50), denom(128), and two uint256 decimals(78 each)
+)
+
+var denomRE = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9/:._-]{2,127}$`)
+
+type RangeV3 struct {
+	First, Last, Population uint64
+}
+
+// CheckedRangeV3 maps an authorized logical range to systematic encoded blobs.
+func CheckedRangeV3(fileStart, fileLength, rangeStart, rangeLength, userMDUs uint64) (RangeV3, error) {
+	if rangeLength == 0 || rangeLength > MaxLargeRangeBytes || userMDUs == 0 {
+		return RangeV3{}, errors.New("invalid v3 range length or allocation")
+	}
+	rangeEnd, ok := add64(rangeStart, rangeLength)
+	if !ok || rangeEnd > fileLength {
+		return RangeV3{}, errors.New("v3 range exceeds file")
+	}
+	abs, ok := add64(fileStart, rangeStart)
+	if !ok {
+		return RangeV3{}, errors.New("v3 range start overflow")
+	}
+	end, ok := add64(abs, rangeLength-1)
+	if !ok {
+		return RangeV3{}, errors.New("v3 range end overflow")
+	}
+	r := RangeV3{First: abs / DataBlobPayloadBytes, Last: end / DataBlobPayloadBytes}
+	r.Population = r.Last - r.First + 1
+	if userMDUs > math.MaxUint64/64 || r.Last >= userMDUs*64 {
+		return RangeV3{}, errors.New("v3 range exceeds generation")
+	}
+	return r, nil
+}
+
+func add64(a, b uint64) (uint64, bool) {
+	if b > math.MaxUint64-a {
+		return 0, false
+	}
+	return a + b, true
+}
+
+type ObligationV3 struct {
+	Slot            uint32
+	Assigned, Payee [20]byte
+	BlobCount       uint64
+}
+
+type PlanV3 struct {
+	RangeV3
+	Obligations []ObligationV3
+}
+
+// BuildPlanV3 derives its descriptor in O(8), independent of range size.
+func BuildPlanV3(r RangeV3, providers [8][20]byte) (PlanV3, error) {
+	if r.Last < r.First {
+		return PlanV3{}, errors.New("noncanonical v3 range")
+	}
+	expected, ok := add64(r.Last-r.First, 1)
+	if !ok || r.Population == 0 || r.Population != expected {
+		return PlanV3{}, errors.New("noncanonical v3 range")
+	}
+	p := PlanV3{RangeV3: r, Obligations: make([]ObligationV3, 0, 8)}
+	for slot := uint32(0); slot < 8; slot++ {
+		count := residueCount(r.First, r.Last, uint64(slot), 8)
+		if count != 0 {
+			p.Obligations = append(p.Obligations, ObligationV3{slot, providers[slot], providers[slot], count})
+		}
+	}
+	return p, nil
+}
+
+func residueCount(first, last, residue, modulus uint64) uint64 {
+	delta := (residue + modulus - first%modulus) % modulus
+	if delta > last-first {
+		return 0
+	}
+	return 1 + (last-first-delta)/modulus
+}
+
+func (p PlanV3) validate() error {
+	if p.Last < p.First {
+		return errors.New("invalid v3 plan range")
+	}
+	expected, ok := add64(p.Last-p.First, 1)
+	if !ok || p.Population == 0 || p.Population != expected || len(p.Obligations) < 1 || len(p.Obligations) > 8 {
+		return errors.New("invalid v3 plan range")
+	}
+	var total uint64
+	lastSlot := int64(-1)
+	for _, o := range p.Obligations {
+		if o.Slot > 7 || int64(o.Slot) <= lastSlot || o.Assigned != o.Payee || o.BlobCount != residueCount(p.First, p.Last, uint64(o.Slot), 8) || o.BlobCount == 0 {
+			return errors.New("invalid v3 obligation")
+		}
+		total += o.BlobCount
+		lastSlot = int64(o.Slot)
+	}
+	if total != p.Population {
+		return errors.New("v3 plan count mismatch")
+	}
+	return nil
+}
+
+func (p PlanV3) Bytes() ([]byte, error) {
+	if err := p.validate(); err != nil {
+		return nil, err
+	}
+	b := appendLP(nil, "polystore/retrieval-plan/v3")
+	for _, v := range []uint64{p.First, p.Last, p.Population} {
+		b = binary.BigEndian.AppendUint64(b, v)
+	}
+	b = binary.BigEndian.AppendUint32(b, uint32(len(p.Obligations)))
+	for _, o := range p.Obligations {
+		b = binary.BigEndian.AppendUint32(b, o.Slot)
+		b = append(b, o.Assigned[:]...)
+		b = append(b, o.Payee[:]...)
+		b = binary.BigEndian.AppendUint64(b, o.BlobCount)
+	}
+	return b, nil
+}
+func (p PlanV3) Hash() ([32]byte, error) {
+	b, e := p.Bytes()
+	if e != nil {
+		return [32]byte{}, e
+	}
+	return sha256.Sum256(b), nil
+}
+
+type SessionBindingV3 struct {
+	ChainID                 string
+	Owner                   [20]byte
+	DealID, Generation      uint64
+	FileRecordIndex         uint32
+	RangeStart, RangeLength uint64
+	PlanHash                [32]byte
+	Nonce                   uint64
+}
+
+func (s SessionBindingV3) Bytes() ([]byte, error) {
+	if !validChain(s.ChainID) || s.RangeLength == 0 || s.RangeLength > MaxLargeRangeBytes {
+		return nil, errors.New("invalid v3 session binding")
+	}
+	b := appendLP(nil, "polystore/retrieval-session/v3")
+	b = binary.BigEndian.AppendUint32(b, Version3)
+	b = appendLP(b, s.ChainID)
+	b = append(b, s.Owner[:]...)
+	for _, v := range []uint64{s.DealID, s.Generation} {
+		b = binary.BigEndian.AppendUint64(b, v)
+	}
+	b = binary.BigEndian.AppendUint32(b, s.FileRecordIndex)
+	for _, v := range []uint64{s.RangeStart, s.RangeLength} {
+		b = binary.BigEndian.AppendUint64(b, v)
+	}
+	b = append(b, s.PlanHash[:]...)
+	b = binary.BigEndian.AppendUint64(b, s.Nonce)
+	return b, nil
+}
+func (s SessionBindingV3) ID() ([32]byte, error) {
+	b, e := s.Bytes()
+	if e != nil {
+		return [32]byte{}, e
+	}
+	return sha256.Sum256(b), nil
+}
+
+type GenerationAcceptanceV3 struct {
+	ChainID                   string
+	SetupDigest               [32]byte
+	DealID, Generation        uint64
+	PolyFSRoot, IntegrityRoot [32]byte
+	MetadataMDUs, UserMDUs    uint64
+	Slot                      uint32
+	Provider                  [20]byte
+}
+
+func (a GenerationAcceptanceV3) Bytes() ([]byte, error) {
+	if !validChain(a.ChainID) || a.MetadataMDUs == 0 || a.MetadataMDUs > maxMDUs || a.UserMDUs == 0 || a.UserMDUs > maxMDUs-a.MetadataMDUs || a.Slot >= 12 {
+		return nil, errors.New("invalid v3 generation acceptance")
+	}
+	b := appendLP(nil, "polystore/generation-acceptance/v3")
+	b = appendLP(b, a.ChainID)
+	b = append(b, a.SetupDigest[:]...)
+	for _, v := range []uint64{a.DealID, a.Generation} {
+		b = binary.BigEndian.AppendUint64(b, v)
+	}
+	b = append(b, a.PolyFSRoot[:]...)
+	b = append(b, a.IntegrityRoot[:]...)
+	b = append(b, StripeK8M4)
+	b = binary.BigEndian.AppendUint32(b, 8)
+	b = binary.BigEndian.AppendUint32(b, 4)
+	b = binary.BigEndian.AppendUint64(b, a.MetadataMDUs)
+	b = binary.BigEndian.AppendUint64(b, a.UserMDUs)
+	b = binary.BigEndian.AppendUint32(b, a.Slot)
+	b = append(b, a.Provider[:]...)
+	return b, nil
+}
+func (a GenerationAcceptanceV3) Hash() ([32]byte, error) {
+	b, e := a.Bytes()
+	if e != nil {
+		return [32]byte{}, e
+	}
+	return sha256.Sum256(b), nil
+}
+
+type ObligationAckV3 struct {
+	ChainID                          string
+	SessionID, ContextHash, PlanHash [32]byte
+	Slot                             uint32
+	Assigned, Payee                  [20]byte
+	BlobCount, BilledEncodedBytes    uint64
+	IntegrityRoot                    [32]byte
+}
+
+func (a ObligationAckV3) Bytes() ([]byte, error) {
+	want, ok := mul64(a.BlobCount, EncodedBlobBytes)
+	if !validChain(a.ChainID) || a.Slot >= 8 || a.Assigned != a.Payee || a.BlobCount == 0 || !ok || a.BilledEncodedBytes != want {
+		return nil, errors.New("invalid v3 obligation ACK")
+	}
+	b := appendLP(nil, "polystore/retrieval-obligation-ack/v3")
+	b = appendLP(b, a.ChainID)
+	b = append(b, a.SessionID[:]...)
+	b = append(b, a.ContextHash[:]...)
+	b = append(b, a.PlanHash[:]...)
+	b = binary.BigEndian.AppendUint32(b, a.Slot)
+	b = append(b, a.Assigned[:]...)
+	b = append(b, a.Payee[:]...)
+	b = binary.BigEndian.AppendUint64(b, a.BlobCount)
+	b = binary.BigEndian.AppendUint64(b, a.BilledEncodedBytes)
+	b = append(b, a.IntegrityRoot[:]...)
+	return b, nil
+}
+func (a ObligationAckV3) Hash() ([32]byte, error) {
+	b, e := a.Bytes()
+	if e != nil {
+		return [32]byte{}, e
+	}
+	return sha256.Sum256(b), nil
+}
+func mul64(a, b uint64) (uint64, bool) {
+	if a != 0 && b > math.MaxUint64/a {
+		return 0, false
+	}
+	return a * b, true
+}
+
+type ContextV3 struct {
+	ChainID                                              string
+	SetupDigest, SessionID                               [32]byte
+	SessionOwner                                         [20]byte
+	DealID, Generation                                   uint64
+	PolyFSRoot, IntegrityRoot                            [32]byte
+	FileRecordIndex                                      uint32
+	FileStartOffset, FileLength, RangeStart, RangeLength uint64
+	MetadataMDUs, UserMDUs                               uint64
+	PlanHash                                             [32]byte
+	Population, SampleCount, Nonce                       uint64
+	PriceDenom, PricePerBlob, BaseFee                    string
+	CompletionBurnBPS                                    uint32
+	FundingKind                                          uint8
+	FundingPayer                                         [20]byte
+	Window                                               Window
+	DealEnd                                              uint64
+}
+
+func (c ContextV3) validate() error {
+	if !validChain(c.ChainID) || c.MetadataMDUs == 0 || c.MetadataMDUs > maxMDUs || c.UserMDUs == 0 || c.UserMDUs > maxMDUs-c.MetadataMDUs {
+		return errors.New("invalid v3 chain or MDU bounds")
+	}
+	r, e := CheckedRangeV3(c.FileStartOffset, c.FileLength, c.RangeStart, c.RangeLength, c.UserMDUs)
+	if e != nil || r.Population != c.Population {
+		return errors.New("invalid v3 frozen range")
+	}
+	if c.SampleCount != min(c.Population, MaxLargeSessionSamples) {
+		return errors.New("invalid v3 sample count")
+	}
+	if !denomRE.MatchString(c.PriceDenom) || !validUint256Decimal(c.PricePerBlob) || !validUint256Decimal(c.BaseFee) || c.CompletionBurnBPS > 10000 {
+		return errors.New("invalid v3 economics")
+	}
+	if c.FundingKind != FundingDealEscrow && c.FundingKind != FundingRequester {
+		return errors.New("invalid v3 funding")
+	}
+	if c.FundingPayer != c.SessionOwner {
+		return errors.New("v3 payer differs from owner")
+	}
+	sid, e := (SessionBindingV3{c.ChainID, c.SessionOwner, c.DealID, c.Generation, c.FileRecordIndex, c.RangeStart, c.RangeLength, c.PlanHash, c.Nonce}).ID()
+	if e != nil || sid != c.SessionID {
+		return errors.New("v3 session ID mismatch")
+	}
+	expected, e := SessionWindow(c.Window.Snapshot, c.Window.Deadline, c.DealEnd)
+	if e != nil || expected != c.Window {
+		return errors.New("noncanonical v3 window")
+	}
+	return nil
+}
+func validChain(s string) bool {
+	return len(s) > 0 && len(s) <= 50 && utf8.ValidString(s) && !containsNUL(s)
+}
+func containsNUL(s string) bool {
+	for _, b := range []byte(s) {
+		if b == 0 {
+			return true
+		}
+	}
+	return false
+}
+func validUint256Decimal(s string) bool {
+	if len(s) == 0 || len(s) > 78 || (len(s) > 1 && s[0] == '0') {
+		return false
+	}
+	for _, b := range []byte(s) {
+		if b < '0' || b > '9' {
+			return false
+		}
+	}
+	v, ok := new(big.Int).SetString(s, 10)
+	return ok && v.BitLen() <= 256
+}
+
+func (c ContextV3) Bytes() ([]byte, error) {
+	if err := c.validate(); err != nil {
+		return nil, err
+	}
+	b := appendLP(make([]byte, 0, maxV3ContextBytes), "polystore/challenge-context/v3")
+	b = binary.BigEndian.AppendUint32(b, Version3)
+	b = appendLP(b, c.ChainID)
+	b = append(b, c.SetupDigest[:]...)
+	b = append(b, c.SessionID[:]...)
+	b = append(b, c.SessionOwner[:]...)
+	for _, v := range []uint64{c.DealID, c.Generation} {
+		b = binary.BigEndian.AppendUint64(b, v)
+	}
+	b = append(b, c.PolyFSRoot[:]...)
+	b = append(b, c.IntegrityRoot[:]...)
+	b = binary.BigEndian.AppendUint32(b, c.FileRecordIndex)
+	for _, v := range []uint64{c.FileStartOffset, c.FileLength, c.RangeStart, c.RangeLength} {
+		b = binary.BigEndian.AppendUint64(b, v)
+	}
+	b = append(b, StripeK8M4)
+	b = binary.BigEndian.AppendUint32(b, 8)
+	b = binary.BigEndian.AppendUint32(b, 4)
+	for _, v := range []uint64{c.MetadataMDUs, c.UserMDUs} {
+		b = binary.BigEndian.AppendUint64(b, v)
+	}
+	b = append(b, c.PlanHash[:]...)
+	for _, v := range []uint64{c.Population, c.SampleCount, c.Nonce} {
+		b = binary.BigEndian.AppendUint64(b, v)
+	}
+	b = appendLP(b, c.PriceDenom)
+	b = appendLP(b, c.PricePerBlob)
+	b = appendLP(b, c.BaseFee)
+	b = binary.BigEndian.AppendUint32(b, c.CompletionBurnBPS)
+	b = append(b, c.FundingKind)
+	b = append(b, c.FundingPayer[:]...)
+	for _, v := range []uint64{c.Window.Snapshot, c.Window.Anchor, c.Window.First, c.Window.Deadline, c.DealEnd} {
+		b = binary.BigEndian.AppendUint64(b, v)
+	}
+	if len(b) > maxV3ContextBytes {
+		return nil, errors.New("v3 context exceeds derived bound")
+	}
+	return b, nil
+}
+func (c ContextV3) Hash() ([32]byte, error) {
+	b, e := c.Bytes()
+	if e != nil {
+		return [32]byte{}, e
+	}
+	return sha256.Sum256(b), nil
+}
+func (c ContextV3) Seed(anchor []byte) ([32]byte, error) {
+	if len(anchor) != 32 {
+		return [32]byte{}, errors.New("anchor must be 32 bytes")
+	}
+	h, e := c.Hash()
+	if e != nil {
+		return [32]byte{}, e
+	}
+	b := appendLP(nil, "polystore/challenge-seed/v3")
+	b = append(b, h[:]...)
+	b = append(b, anchor...)
+	return sha256.Sum256(b), nil
+}
+
+type ChallengeV3 struct {
+	Ordinal, Position, T, MDUIndex uint64
+	LeafIndex, Slot                uint32
+	Z                              [32]byte
+}
+
+func (c ContextV3) Challenges(seed []byte) ([]ChallengeV3, error) {
+	if len(seed) != 32 {
+		return nil, errors.New("seed must be 32 bytes")
+	}
+	h, e := c.Hash()
+	if e != nil {
+		return nil, e
+	}
+	positions, e := sampleWithDomain(h, seed, c.Population, c.SampleCount, "polystore/session-position/v3", MaxLargeSessionSamples)
+	if e != nil {
+		return nil, e
+	}
+	r, _ := CheckedRangeV3(c.FileStartOffset, c.FileLength, c.RangeStart, c.RangeLength, c.UserMDUs)
+	out := make([]ChallengeV3, len(positions))
+	for i, p := range positions {
+		t := r.First + p
+		mdu, leaf, slot := coordinateV3(t, c.MetadataMDUs)
+		v := ChallengeV3{uint64(i), p, t, mdu, leaf, slot, [32]byte{}}
+		b := appendLP(nil, "polystore/blob-challenge/v3")
+		b = append(b, h[:]...)
+		b = append(b, seed...)
+		for _, x := range []uint64{v.Ordinal, v.T, v.MDUIndex} {
+			b = binary.BigEndian.AppendUint64(b, x)
+		}
+		b = binary.BigEndian.AppendUint32(b, v.LeafIndex)
+		b = binary.BigEndian.AppendUint32(b, 0)
+		v.Z, e = hashToPoint(b, sha256.Sum256)
+		if e != nil {
+			return nil, e
+		}
+		out[i] = v
+	}
+	return out, nil
+}
+func coordinateV3(t, metadata uint64) (uint64, uint32, uint32) {
+	d := t % 64
+	slot := uint32(d % 8)
+	row := uint32(d / 8)
+	return metadata + t/64, slot*8 + row, slot
+}

--- a/polystorechain/pkg/retrievalchallenge/v3_integrity.go
+++ b/polystorechain/pkg/retrievalchallenge/v3_integrity.go
@@ -1,0 +1,133 @@
+package retrievalchallenge
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"hash"
+)
+
+const (
+	FATV3HeaderBytes          = 128
+	IntegrityLeavesPerUserMDU = uint64(96)
+	MaxIntegrityLeaves        = uint64(65536 * 96)
+)
+
+type FATV3Header struct {
+	RecordCount   uint32
+	LeafCount     uint64
+	IntegrityRoot [32]byte
+}
+
+func (h FATV3Header) Bytes() ([FATV3HeaderBytes]byte, error) {
+	var b [FATV3HeaderBytes]byte
+	if h.LeafCount == 0 || h.LeafCount > MaxIntegrityLeaves || h.LeafCount%IntegrityLeavesPerUserMDU != 0 {
+		return b, errors.New("invalid FAT v3 integrity leaf count")
+	}
+	copy(b[:4], "NILF")
+	binary.LittleEndian.PutUint16(b[4:6], 3)
+	binary.LittleEndian.PutUint16(b[6:8], 256)
+	binary.LittleEndian.PutUint32(b[8:12], h.RecordCount)
+	b[12] = 1
+	b[13] = 1
+	binary.LittleEndian.PutUint32(b[16:20], uint32(EncodedBlobBytes))
+	binary.LittleEndian.PutUint64(b[20:28], h.LeafCount)
+	copy(b[28:60], h.IntegrityRoot[:])
+	return b, nil
+}
+
+func ParseFATV3Header(b []byte) (FATV3Header, error) {
+	var h FATV3Header
+	if len(b) != FATV3HeaderBytes || string(b[:4]) != "NILF" || binary.LittleEndian.Uint16(b[4:6]) != 3 || binary.LittleEndian.Uint16(b[6:8]) != 256 || b[12] != 1 || b[13] != 1 || b[14] != 0 || b[15] != 0 || binary.LittleEndian.Uint32(b[16:20]) != uint32(EncodedBlobBytes) {
+		return h, errors.New("invalid FAT v3 header")
+	}
+	for _, v := range b[60:] {
+		if v != 0 {
+			return h, errors.New("nonzero FAT v3 reserved bytes")
+		}
+	}
+	h.RecordCount = binary.LittleEndian.Uint32(b[8:12])
+	h.LeafCount = binary.LittleEndian.Uint64(b[20:28])
+	copy(h.IntegrityRoot[:], b[28:60])
+	if h.LeafCount == 0 || h.LeafCount > MaxIntegrityLeaves || h.LeafCount%IntegrityLeavesPerUserMDU != 0 {
+		return FATV3Header{}, errors.New("invalid FAT v3 integrity leaf count")
+	}
+	return h, nil
+}
+
+func IntegrityLeafV3(mdu uint64, leaf uint32, blob []byte) ([32]byte, error) {
+	if mdu == 0 || mdu > 65536 || leaf >= 96 || len(blob) != int(EncodedBlobBytes) {
+		return [32]byte{}, errors.New("invalid v3 integrity coordinate or blob length")
+	}
+	h := sha256.New()
+	writeLPHash(h, "polystore/integrity-leaf/v3")
+	var fixed [16]byte
+	binary.BigEndian.PutUint64(fixed[:8], mdu)
+	binary.BigEndian.PutUint32(fixed[8:12], leaf)
+	binary.BigEndian.PutUint32(fixed[12:], uint32(EncodedBlobBytes))
+	h.Write(fixed[:])
+	h.Write(blob)
+	var out [32]byte
+	copy(out[:], h.Sum(nil))
+	return out, nil
+}
+func writeLPHash(h hash.Hash, value string) {
+	var n [4]byte
+	binary.BigEndian.PutUint32(n[:], uint32(len(value)))
+	h.Write(n[:])
+	h.Write([]byte(value))
+}
+func integrityParentV3(left, right [32]byte) [32]byte {
+	h := sha256.New()
+	writeLPHash(h, "polystore/integrity-node/v3")
+	h.Write(left[:])
+	h.Write(right[:])
+	var out [32]byte
+	copy(out[:], h.Sum(nil))
+	return out
+}
+
+func IntegrityRootV3(leaves [][32]byte) ([32]byte, error) {
+	if len(leaves) == 0 || uint64(len(leaves)) > MaxIntegrityLeaves {
+		return [32]byte{}, errors.New("invalid integrity leaf count")
+	}
+	level := append([][32]byte(nil), leaves...)
+	for len(level) > 1 {
+		write := 0
+		for read := 0; read < len(level); read += 2 {
+			right := level[read]
+			if read+1 < len(level) {
+				right = level[read+1]
+			}
+			level[write] = integrityParentV3(level[read], right)
+			write++
+		}
+		level = level[:write]
+	}
+	return level[0], nil
+}
+
+func VerifyIntegrityPathV3(value [32]byte, position, leafCount uint64, siblings [][32]byte, expected [32]byte) bool {
+	if leafCount == 0 || leafCount > MaxIntegrityLeaves || position >= leafCount {
+		return false
+	}
+	current, width, used := value, leafCount, 0
+	for width > 1 {
+		if used >= len(siblings) {
+			return false
+		}
+		s := siblings[used]
+		if width%2 == 1 && position == width-1 && s != current {
+			return false
+		}
+		if position%2 == 1 {
+			current = integrityParentV3(s, current)
+		} else {
+			current = integrityParentV3(current, s)
+		}
+		position /= 2
+		width = (width + 1) / 2
+		used++
+	}
+	return used == len(siblings) && current == expected
+}

--- a/polystorechain/pkg/retrievalchallenge/v3_integrity.go
+++ b/polystorechain/pkg/retrievalchallenge/v3_integrity.go
@@ -9,6 +9,7 @@ import (
 
 const (
 	FATV3HeaderBytes          = 128
+	FATV3MaxRecords           = uint32(23807)
 	IntegrityLeavesPerUserMDU = uint64(96)
 	MaxIntegrityLeaves        = uint64(65536 * 96)
 )
@@ -21,8 +22,8 @@ type FATV3Header struct {
 
 func (h FATV3Header) Bytes() ([FATV3HeaderBytes]byte, error) {
 	var b [FATV3HeaderBytes]byte
-	if h.LeafCount == 0 || h.LeafCount > MaxIntegrityLeaves || h.LeafCount%IntegrityLeavesPerUserMDU != 0 {
-		return b, errors.New("invalid FAT v3 integrity leaf count")
+	if h.RecordCount > FATV3MaxRecords || h.LeafCount == 0 || h.LeafCount > MaxIntegrityLeaves || h.LeafCount%IntegrityLeavesPerUserMDU != 0 {
+		return b, errors.New("invalid FAT v3 header bounds")
 	}
 	copy(b[:4], "NILF")
 	binary.LittleEndian.PutUint16(b[4:6], 3)
@@ -49,8 +50,8 @@ func ParseFATV3Header(b []byte) (FATV3Header, error) {
 	h.RecordCount = binary.LittleEndian.Uint32(b[8:12])
 	h.LeafCount = binary.LittleEndian.Uint64(b[20:28])
 	copy(h.IntegrityRoot[:], b[28:60])
-	if h.LeafCount == 0 || h.LeafCount > MaxIntegrityLeaves || h.LeafCount%IntegrityLeavesPerUserMDU != 0 {
-		return FATV3Header{}, errors.New("invalid FAT v3 integrity leaf count")
+	if h.RecordCount > FATV3MaxRecords || h.LeafCount == 0 || h.LeafCount > MaxIntegrityLeaves || h.LeafCount%IntegrityLeavesPerUserMDU != 0 {
+		return FATV3Header{}, errors.New("invalid FAT v3 header bounds")
 	}
 	return h, nil
 }

--- a/polystorechain/pkg/retrievalchallenge/v3_test.go
+++ b/polystorechain/pkg/retrievalchallenge/v3_test.go
@@ -282,6 +282,22 @@ func TestV3FATAndIntegrityGolden(t *testing.T) {
 	if got, e := ParseFATV3Header(b[:]); e != nil || got != h {
 		t.Fatalf("parse: %+v %v", got, e)
 	}
+	maxHeader := FATV3Header{FATV3MaxRecords, 96, root}
+	maxBytes, e := maxHeader.Bytes()
+	if e != nil {
+		t.Fatal("maximum record count rejected", e)
+	}
+	if got, e := ParseFATV3Header(maxBytes[:]); e != nil || got != maxHeader {
+		t.Fatalf("maximum record count parse: %+v %v", got, e)
+	}
+	tooMany := FATV3Header{FATV3MaxRecords + 1, 96, root}
+	if _, e := tooMany.Bytes(); e == nil {
+		t.Fatal("record 23808 encoded")
+	}
+	binary.LittleEndian.PutUint32(maxBytes[8:12], FATV3MaxRecords+1)
+	if _, e := ParseFATV3Header(maxBytes[:]); e == nil {
+		t.Fatal("record 23808 parsed")
+	}
 	names := []string{"zero", "valid_incrementing", "valid_ff"}
 	leaves := make([][32]byte, 3)
 	for i, n := range names {

--- a/polystorechain/pkg/retrievalchallenge/v3_test.go
+++ b/polystorechain/pkg/retrievalchallenge/v3_test.go
@@ -1,0 +1,384 @@
+package retrievalchallenge
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+type v3Golden struct {
+	FAT struct {
+		HeaderHex     string `json:"header_hex"`
+		IntegrityRoot string `json:"integrity_root"`
+	} `json:"fat_header"`
+	Integrity struct {
+		LeafHashes []string   `json:"leaf_hashes"`
+		Paths      [][]string `json:"paths"`
+		Root       string     `json:"root"`
+	} `json:"integrity"`
+	Small         v3Transcript `json:"small_transcript"`
+	Large         v3Transcript `json:"large_transcript"`
+	Offset        v3Transcript `json:"offset_transcript"`
+	SmallSamples  []v3Sample   `json:"small_samples"`
+	OffsetSamples []v3Sample   `json:"offset_samples"`
+	LargeSample   struct {
+		FirstEight      []uint64 `json:"first_eight"`
+		PositionsSHA256 string   `json:"positions_sha256"`
+	} `json:"large_sample"`
+}
+type v3Transcript struct {
+	FileStartOffset string `json:"file_start_offset"`
+	RangeStart      string `json:"range_start"`
+	RangeLength     string `json:"range_length"`
+	First           uint64 `json:"first"`
+	Last            uint64 `json:"last"`
+	Population      uint64 `json:"population"`
+	SampleCount     uint64 `json:"sample_count"`
+	PlanHex         string `json:"plan_hex"`
+	PlanHash        string `json:"plan_hash"`
+	SessionHex      string `json:"session_hex"`
+	SessionID       string `json:"session_id"`
+	ContextHex      string `json:"context_hex"`
+	ContextHash     string `json:"context_hash"`
+	AnchorHash      string `json:"anchor_hash"`
+	Seed            string `json:"seed"`
+	AcceptanceHex   string `json:"acceptance_slot0_hex"`
+	AcceptanceHash  string `json:"acceptance_slot0_hash"`
+	AckHex          string `json:"ack_first_obligation_hex"`
+	AckHash         string `json:"ack_first_obligation_hash"`
+	Obligations     []struct {
+		Slot      uint32 `json:"slot"`
+		Assigned  string `json:"assigned_provider"`
+		Payee     string `json:"payee"`
+		BlobCount uint64 `json:"blob_count"`
+	}
+}
+type v3Sample struct {
+	Ordinal   uint64 `json:"ordinal"`
+	Position  uint64 `json:"position"`
+	T         uint64 `json:"t"`
+	MDUIndex  uint64 `json:"mdu_index"`
+	LeafIndex uint32 `json:"leaf_index"`
+	Slot      uint32 `json:"slot"`
+	Z         string `json:"z"`
+}
+
+func loadV3Golden(t testing.TB) v3Golden {
+	b, err := os.ReadFile("testdata/large-session-v3-golden.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var g v3Golden
+	if err = json.Unmarshal(b, &g); err != nil {
+		t.Fatal(err)
+	}
+	return g
+}
+
+func fill20(v byte) (out [20]byte) {
+	for i := range out {
+		out[i] = v
+	}
+	return
+}
+func fill32(v byte) (out [32]byte) {
+	for i := range out {
+		out[i] = v
+	}
+	return
+}
+func mustHex32(t testing.TB, s string) (out [32]byte) {
+	b, e := hex.DecodeString(s)
+	if e != nil || len(b) != 32 {
+		t.Fatal(s)
+	}
+	copy(out[:], b)
+	return
+}
+func makeV3Case(t testing.TB, want v3Transcript) (PlanV3, SessionBindingV3, ContextV3, []byte) {
+	parse := func(s string) uint64 {
+		v, e := strconv.ParseUint(s, 10, 64)
+		if e != nil {
+			t.Fatal(e)
+		}
+		return v
+	}
+	fileStart, rangeStart, length := parse(want.FileStartOffset), parse(want.RangeStart), parse(want.RangeLength)
+	user := (want.Last + 64) / 64
+	r, e := CheckedRangeV3(fileStart, rangeStart+length, rangeStart, length, user)
+	if e != nil {
+		t.Fatal(e)
+	}
+	var providers [8][20]byte
+	for i := range providers {
+		providers[i] = fill20(byte(0x40 + i))
+	}
+	p, e := BuildPlanV3(r, providers)
+	if e != nil {
+		t.Fatal(e)
+	}
+	ph, _ := p.Hash()
+	s := SessionBindingV3{"polystore-test-1", fill20(0x11), 42, 7, 3, rangeStart, length, ph, 9}
+	sid, _ := s.ID()
+	setup := mustHex32(t, "d39b9f2d047cc9dca2de58f264b6a09448ccd34db967881a6713eacacf0f26b7")
+	c := ContextV3{ChainID: "polystore-test-1", SetupDigest: setup, SessionID: sid, SessionOwner: fill20(0x11), DealID: 42, Generation: 7, PolyFSRoot: fill32(0x22), IntegrityRoot: mustHex32(t, "074c4b427382c9ff2e85f0fea1bc39a56bd58a3e3849e737e23faf15a2c67707"), FileRecordIndex: 3, FileStartOffset: fileStart, FileLength: rangeStart + length, RangeStart: rangeStart, RangeLength: length, MetadataMDUs: 2, UserMDUs: user, PlanHash: ph, Population: r.Population, SampleCount: min(r.Population, MaxLargeSessionSamples), Nonce: 9, PriceDenom: "stake", PricePerBlob: "3", BaseFee: "5", CompletionBurnBPS: 250, FundingKind: FundingDealEscrow, FundingPayer: fill20(0x11), Window: Window{100, 101, 102, 200}, DealEnd: 300}
+	anchor, _ := hex.DecodeString(want.AnchorHash)
+	return p, s, c, anchor
+}
+
+func TestV3GoldenTranscriptsAndChallenges(t *testing.T) {
+	g := loadV3Golden(t)
+	for name, want := range map[string]v3Transcript{"small": g.Small, "large": g.Large, "offset": g.Offset} {
+		t.Run(name, func(t *testing.T) {
+			p, s, c, anchor := makeV3Case(t, want)
+			pb, _ := p.Bytes()
+			sb, _ := s.Bytes()
+			cb, e := c.Bytes()
+			if e != nil {
+				t.Fatal(e)
+			}
+			h, _ := c.Hash()
+			seed, _ := c.Seed(anchor)
+			for got, w := range map[string]string{hex.EncodeToString(pb): want.PlanHex, hex.EncodeToString(sb): want.SessionHex, hex.EncodeToString(cb): want.ContextHex, hex.EncodeToString(h[:]): want.ContextHash, hex.EncodeToString(seed[:]): want.Seed} {
+				if got != w {
+					t.Fatalf("transcript mismatch\ngot %s\nwant %s", got, w)
+				}
+			}
+			ch, e := c.Challenges(seed[:])
+			if e != nil {
+				t.Fatal(e)
+			}
+			if name == "large" {
+				if len(ch) != 132 {
+					t.Fatal(len(ch))
+				}
+				for i, w := range g.LargeSample.FirstEight {
+					if ch[i].Position != w {
+						t.Fatal(i)
+					}
+				}
+				sum := sha256.New()
+				var b [8]byte
+				for _, v := range ch {
+					binary.BigEndian.PutUint64(b[:], v.Position)
+					sum.Write(b[:])
+				}
+				if hex.EncodeToString(sum.Sum(nil)) != g.LargeSample.PositionsSHA256 {
+					t.Fatal("large positions digest")
+				}
+			}
+			accept := GenerationAcceptanceV3{c.ChainID, c.SetupDigest, c.DealID, c.Generation, c.PolyFSRoot, c.IntegrityRoot, c.MetadataMDUs, c.UserMDUs, 0, fill20(0x40)}
+			ab, e := accept.Bytes()
+			if e != nil {
+				t.Fatal(e)
+			}
+			ah, _ := accept.Hash()
+			first := p.Obligations[0]
+			ack := ObligationAckV3{c.ChainID, c.SessionID, h, c.PlanHash, first.Slot, first.Assigned, first.Payee, first.BlobCount, first.BlobCount * EncodedBlobBytes, c.IntegrityRoot}
+			kb, e := ack.Bytes()
+			if e != nil {
+				t.Fatal(e)
+			}
+			kh, _ := ack.Hash()
+			if hex.EncodeToString(ab) != want.AcceptanceHex || hex.EncodeToString(ah[:]) != want.AcceptanceHash || hex.EncodeToString(kb) != want.AckHex || hex.EncodeToString(kh[:]) != want.AckHash {
+				t.Fatal("acceptance or ACK binding mismatch")
+			}
+			var samples []v3Sample
+			if name == "small" {
+				samples = g.SmallSamples
+			} else if name == "offset" {
+				samples = g.OffsetSamples
+			}
+			for i, w := range samples {
+				v := ch[i]
+				if v.Ordinal != w.Ordinal || v.Position != w.Position || v.T != w.T || v.MDUIndex != w.MDUIndex || v.LeafIndex != w.LeafIndex || v.Slot != w.Slot || hex.EncodeToString(v.Z[:]) != w.Z {
+					t.Fatalf("challenge %d mismatch: %+v", i, v)
+				}
+			}
+		})
+	}
+}
+
+func TestV3RejectsRebindingOverflowAndMalformedEconomics(t *testing.T) {
+	g := loadV3Golden(t)
+	_, _, c, anchor := makeV3Case(t, g.Offset)
+	for name, mutate := range map[string]func(*ContextV3){"session": func(x *ContextV3) { x.SessionID[0] ^= 1 }, "file offset": func(x *ContextV3) { x.FileStartOffset = 0 }, "range offset": func(x *ContextV3) { x.RangeStart = 0 }, "sample count": func(x *ContextV3) { x.SampleCount-- }, "denom": func(x *ContextV3) { x.PriceDenom = "x" }, "amount leading zero": func(x *ContextV3) { x.BaseFee = "05" }, "uint256 overflow": func(x *ContextV3) {
+		x.BaseFee = "115792089237316195423570985008687907853269984665640564039457584007913129639936"
+	}, "funding": func(x *ContextV3) { x.FundingKind = 3 }} {
+		t.Run(name, func(t *testing.T) {
+			bad := c
+			mutate(&bad)
+			if _, e := bad.Bytes(); e == nil {
+				t.Fatal("accepted rebound context")
+			}
+		})
+	}
+	if _, e := c.Seed(anchor[:31]); e == nil {
+		t.Fatal("accepted short anchor")
+	}
+	if _, e := CheckedRangeV3(^uint64(0), 1, 1, 1, 1); e == nil {
+		t.Fatal("accepted overflow")
+	}
+	for _, p := range []PlanV3{{RangeV3{2, 1, 1}, nil}, {RangeV3{0, ^uint64(0), ^uint64(0)}, nil}} {
+		if _, e := p.Bytes(); e == nil {
+			t.Fatal("accepted malformed public plan")
+		}
+	}
+}
+
+func TestV3MaximumCanonicalContextIs734Bytes(t *testing.T) {
+	g := loadV3Golden(t)
+	_, _, c, _ := makeV3Case(t, g.Small)
+	c.ChainID = strings.Repeat("a", 50)
+	c.PriceDenom = "a" + strings.Repeat("z", 127)
+	max := "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+	c.PricePerBlob = max
+	c.BaseFee = max
+	s := SessionBindingV3{c.ChainID, c.SessionOwner, c.DealID, c.Generation, c.FileRecordIndex, c.RangeStart, c.RangeLength, c.PlanHash, c.Nonce}
+	c.SessionID, _ = s.ID()
+	b, e := c.Bytes()
+	if e != nil {
+		t.Fatal(e)
+	}
+	if len(b) != maxV3ContextBytes {
+		t.Fatalf("got %d, want %d", len(b), maxV3ContextBytes)
+	}
+}
+
+func pattern(name string) []byte {
+	b := make([]byte, EncodedBlobBytes)
+	switch name {
+	case "valid_incrementing":
+		for i := 0; i < 4096; i++ {
+			for j := 0; j < 31; j++ {
+				b[i*32+1+j] = byte(i + j)
+			}
+		}
+	case "valid_ff":
+		for i := 0; i < 4096; i++ {
+			for j := 1; j < 32; j++ {
+				b[i*32+j] = 0xff
+			}
+		}
+	}
+	return b
+}
+func TestV3FATAndIntegrityGolden(t *testing.T) {
+	g := loadV3Golden(t)
+	root := mustHex32(t, g.Integrity.Root)
+	h := FATV3Header{2, 96, root}
+	b, e := h.Bytes()
+	if e != nil {
+		t.Fatal(e)
+	}
+	if hex.EncodeToString(b[:]) != g.FAT.HeaderHex {
+		t.Fatal("header mismatch")
+	}
+	if got, e := ParseFATV3Header(b[:]); e != nil || got != h {
+		t.Fatalf("parse: %+v %v", got, e)
+	}
+	names := []string{"zero", "valid_incrementing", "valid_ff"}
+	leaves := make([][32]byte, 3)
+	for i, n := range names {
+		leaves[i], e = IntegrityLeafV3(10, uint32(i), pattern(n))
+		if e != nil || hex.EncodeToString(leaves[i][:]) != g.Integrity.LeafHashes[i] {
+			t.Fatal("leaf", i, e)
+		}
+	}
+	got, _ := IntegrityRootV3(leaves)
+	if got != root {
+		t.Fatal("root")
+	}
+	for i, pathHex := range g.Integrity.Paths {
+		path := make([][32]byte, len(pathHex))
+		for j, s := range pathHex {
+			path[j] = mustHex32(t, s)
+		}
+		if !VerifyIntegrityPathV3(leaves[i], uint64(i), 3, path, root) {
+			t.Fatal("path", i)
+		}
+		if i == 2 {
+			bad := append([][32]byte(nil), path...)
+			bad[0] = [32]byte{}
+			if VerifyIntegrityPathV3(leaves[i], uint64(i), 3, bad, root) {
+				t.Fatal("odd duplicate accepted")
+			}
+		}
+	}
+	if VerifyIntegrityPathV3(leaves[2], ^uint64(0), 3, nil, root) {
+		t.Fatal("negative-equivalent position accepted")
+	}
+	bad := b
+	bad[60] = 1
+	if _, e := ParseFATV3Header(bad[:]); e == nil {
+		t.Fatal("reserved bytes")
+	}
+	if _, e := IntegrityLeafV3(10, 0, pattern("zero")[:1]); e == nil {
+		t.Fatal("truncated blob")
+	}
+}
+
+func BenchmarkV3PlanOneKiB(b *testing.B)     { benchmarkPlan(b, 0, 0) }
+func BenchmarkV3PlanThreeBlobs(b *testing.B) { benchmarkPlan(b, 63, 65) }
+func BenchmarkV3PlanOneGiB(b *testing.B)     { benchmarkPlan(b, 0, 8456) }
+func benchmarkPlan(b *testing.B, first, last uint64) {
+	var p [8][20]byte
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, e := BuildPlanV3(RangeV3{first, last, last - first + 1}, p); e != nil {
+			b.Fatal(e)
+		}
+	}
+}
+func BenchmarkV3ChallengesOneKiB(b *testing.B)     { benchmarkChallenges(b, "one_kib") }
+func BenchmarkV3ChallengesThreeBlobs(b *testing.B) { benchmarkChallenges(b, "offset") }
+func BenchmarkV3ChallengesOneGiB(b *testing.B)     { benchmarkChallenges(b, "large") }
+func benchmarkChallenges(b *testing.B, name string) {
+	g := loadV3Golden(b)
+	var c ContextV3
+	var anchor []byte
+	switch name {
+	case "offset":
+		_, _, c, anchor = makeV3Case(b, g.Offset)
+	case "large":
+		_, _, c, anchor = makeV3Case(b, g.Large)
+	default:
+		_, _, c, anchor = makeV3Case(b, g.Small)
+		r, e := CheckedRangeV3(0, 1024, 0, 1024, 1)
+		if e != nil {
+			b.Fatal(e)
+		}
+		var providers [8][20]byte
+		for i := range providers {
+			providers[i] = fill20(byte(0x40 + i))
+		}
+		p, e := BuildPlanV3(r, providers)
+		if e != nil {
+			b.Fatal(e)
+		}
+		c.FileLength = 1024
+		c.RangeLength = 1024
+		c.UserMDUs = 1
+		c.PlanHash, _ = p.Hash()
+		c.Population = 1
+		c.SampleCount = 1
+		s := SessionBindingV3{c.ChainID, c.SessionOwner, c.DealID, c.Generation, c.FileRecordIndex, 0, 1024, c.PlanHash, c.Nonce}
+		c.SessionID, _ = s.ID()
+	}
+	seed, e := c.Seed(anchor)
+	if e != nil {
+		b.Fatal(e)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, e := c.Challenges(seed[:]); e != nil {
+			b.Fatal(e)
+		}
+	}
+}


### PR DESCRIPTION
Adds the first inactive implementation slice of #291: shared Go/Rust primitives for the reviewed retrieval-v3 contract. It derives checked logical ranges and compact fixed-provider plans, binds canonical session/acceptance/ACK/context transcripts, samples `Q=min(U,132)` challenges, and implements the FAT-v3 header plus SHA-256 duplicate-last byte-integrity tree. Existing retrieval-v2 transcripts and behavior remain unchanged; no keeper, protobuf, or runtime activation is included.

Tests consume the merged transcript, challenge and integrity vectors, including the nonzero file/range offsets and 1 GiB sample-position digest. Additional unit tests cover a 1 KiB range, the 734-byte maximum canonical context, the 23,807-record FAT capacity boundary in both encoding and parsing, and malformed/overflow/rebinding/integrity-path cases. Benchmarks compare 1 KiB, three-blob and 1 GiB ranges.

Validation:

- `cargo test` in `polystore_core` (local and SSH full suite; all nonignored tests pass)
- `GO_BIN=$(command -v go) scripts/chain_go.sh test ./pkg/retrievalchallenge -count=1`
- `python3 polystore_core/tests/testdata/check_session_batch_vectors.py`
- `python3 polystorechain/pkg/retrievalchallenge/testdata/check_vectors.py`
- `python3 polystorechain/pkg/retrievalchallenge/testdata/check_large_session_v3_vectors.py`
- `git diff --check`
- Pre-capacity-fix SSH snapshot (d6dd1818): `/home/mikers/polystore-bench-290/worktrees/pr291-primitives-d6dd1818`
- That snapshot: chain Go suite and Rust v3 vectors pass on the SSH host. The final header-capacity correction passes focused local Go/Rust tests and current-head Go/Rust CI.

Bounded SSH microbenchmark (`-benchtime=100x`) shows plan construction stays fixed at 448 B and one allocation for 1 KiB, three-blob, and 1 GiB ranges (178.2 ns, 92.7 ns, 79.1 ns). Full challenge derivation, including each sampled `z`, scales with the bounded sample count: 3.019 us (`Q=1`), 6.734 us (`Q=3`), and 262.802 us (`Q=132`). These timings cover transcript/challenge derivation only; they do not measure KZG proof generation, proof verification, or byte delivery.
