### PR TITLE
gateway: authenticate v3 generations and submit sampled provider proofs

### DIFF
--- a/.github/scripts/disable-google-chrome-apt-source.sh
+++ b/.github/scripts/disable-google-chrome-apt-source.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${GITHUB_ACTIONS:-}" != "true" || "${RUNNER_OS:-}" != "Linux" ]]; then
+  echo "This helper is only for Linux GitHub Actions runners." >&2
+  exit 1
+fi
+
+# GitHub's Ubuntu image preinstalls Google Chrome and its apt source. Playwright
+# downloads Chromium itself, and the Tauri build only needs Ubuntu packages, so
+# neither job should depend on the unrelated Chrome repository being consistent.
+sources_dir="${APT_SOURCES_DIR:-/etc/apt/sources.list.d}"
+for source in \
+  "$sources_dir/google-chrome.list" \
+  "$sources_dir/google-chrome.sources"
+do
+  if [[ -f "$source" ]]; then
+    sudo mv -- "$source" "$source.disabled"
+  fi
+done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Disable preinstalled Google Chrome apt source
+        run: .github/scripts/disable-google-chrome-apt-source.sh
+
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -312,6 +315,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+
+      - name: Disable preinstalled Google Chrome apt source
+        run: .github/scripts/disable-google-chrome-apt-source.sh
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -485,6 +491,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Disable preinstalled Google Chrome apt source
+        run: .github/scripts/disable-google-chrome-apt-source.sh
+
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -571,6 +580,9 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
+
+      - name: Disable preinstalled Google Chrome apt source
+        run: .github/scripts/disable-google-chrome-apt-source.sh
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/e2e_playwright.yml
+++ b/.github/workflows/e2e_playwright.yml
@@ -12,6 +12,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Disable preinstalled Google Chrome apt source
+        run: .github/scripts/disable-google-chrome-apt-source.sh
+
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/repro_bug.yml
+++ b/.github/workflows/repro_bug.yml
@@ -10,6 +10,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Disable preinstalled Google Chrome apt source
+        run: .github/scripts/disable-google-chrome-apt-source.sh
+
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:

--- a/docs/retrieval-v3-large-session-profile.md
+++ b/docs/retrieval-v3-large-session-profile.md
@@ -548,8 +548,11 @@ route rejects v3 before charging or consuming authority. Activation requires:
 
 Vector success establishes byte-level agreement only. It does not qualify signer
 authority, block-hash freshness, gas, crash recovery, transport delivery or safe
-network activation. Every v3 runtime path remains disabled until the complete
-qualification list above passes independent review.
+network activation. Deployed v3 runtime paths remain disabled until the complete
+qualification list above passes independent review. Isolated qualification
+networks may explicitly enable v3 through its normal activation parameter to run
+these tests under the same protocol and resource limits; this does not authorize
+deployed activation or establish delivery or throughput claims.
 
 Run the independent standard-library oracle with:
 
@@ -595,3 +598,57 @@ contains the raw committed H+1 anchor, **not** the derived sampling seed. Derive
 before anchor capture and after reference release. The CLI does not generate
 proofs, authenticate downloaded bytes, or create ACK digests; those require the
 frozen context and provider/client integration specified above.
+
+## Provider-daemon integrity artifact
+
+A generation-local `integrity_leaves_v3.bin` contains the ordered raw 32-byte
+integrity leaf hashes, with no header or per-leaf sibling paths. Entry
+`(mdu_index - metadata_mdus) * 96 + leaf_index` corresponds to that absolute
+coordinate under the frozen generation. Its exact length is
+`user_mdus * 96 * 32` bytes, bounded by 201,326,592 bytes at the protocol limit.
+This is a local ingest representation, not an additional consensus encoding.
+
+Before accepting a proposed generation, the provider-daemon authenticates the
+FAT v3 header and requires its root and leaf count to match the proposal. It
+streams the leaf vector to reconstruct the canonical duplicate-last tree root
+with logarithmic working memory, and recomputes every leaf in its assigned slot
+from the stored encoded blob while verifying its KZG commitment membership.
+This includes parity slots. A matching sidecar root alone does not establish
+that the provider stores the corresponding bytes.
+
+The vector belongs to the immutable generation artifacts. Reusing a generation
+with shifted absolute MDU coordinates requires new leaf hashes, as specified
+above. This representation does not by itself provide client integrity-path
+serving or qualify full-byte delivery.
+
+The authenticated provider-daemon action is `POST /sp/generation-v3/accept`
+with `{"deal_id":0}` and the existing `X-PolyStore-Gateway-Auth` header. An
+optional `provider` must equal the daemon's actual signing address. The action
+queries the proposed generation and derives the provider slot; callers do not
+supply acceptance roots or digests. Owner proposal/finalization remain native
+CLI actions. Acceptance uses the same signer coordination and durable pending
+transaction state as normal audits; an uncertain broadcast requires
+reconciliation before further signing.
+
+## Provider-daemon sampled proof action
+
+Use the existing authenticated `POST /sp/session-proof` action with a single
+`session_id` and, optionally, the daemon's actual `provider` address. V3 routing
+requires an explicit not-found response from the older session query; a timeout,
+malformed response, or server error does not authorize a version fallback.
+
+The daemon reconstructs the frozen context, compact provider plan, and global
+sample set from committed session state and the raw anchor. It selects only its
+assigned, unaccepted global ordinals, generates and locally verifies at most 64
+proofs, then submits one native proof message. Further calls handle any remaining
+samples. The action reads challenged blobs; it does not download the requested
+file, acknowledge delivery, or qualify client integrity verification.
+
+Normal audits, generation acceptance, and retrieval proofs share the actual
+provider's signer lock and durable pending-operation record. A recorded
+transaction hash is reconciled before fresh signing, even when its proposal or
+session is no longer current. An unknown broadcast without a recorded hash
+remains blocked unless the exact operation's accepted effects establish its
+outcome. A recovered transaction is not evidence that a different requested
+session is complete; callers must query current session state before deciding
+whether more proofs or a delivery acknowledgement are required.

--- a/polystore_gateway/main.go
+++ b/polystore_gateway/main.go
@@ -317,6 +317,7 @@ func registerProviderDaemonRoutes(r *mux.Router) {
 	r.HandleFunc("/sp/receipts", SpSubmitReceipts).Methods("POST", "OPTIONS")
 	r.HandleFunc("/sp/session-receipt", SpSubmitSessionReceipt).Methods("POST", "OPTIONS")
 	r.HandleFunc("/sp/session-proof", SpSubmitRetrievalSessionProof).Methods("POST", "OPTIONS")
+	r.HandleFunc("/sp/generation-v3/accept", SpAcceptDealGenerationV3).Methods("POST", "OPTIONS")
 	r.HandleFunc("/sp/upload_mdu", SpUploadMdu).Methods("POST", "OPTIONS")
 	r.HandleFunc("/sp/upload_shard", SpUploadShard).Methods("POST", "OPTIONS")
 	r.HandleFunc("/sp/shard", SpFetchShard).Methods("GET", "OPTIONS")

--- a/polystore_gateway/retrieval_proof.go
+++ b/polystore_gateway/retrieval_proof.go
@@ -251,6 +251,9 @@ func validateFATV3Metadata(wire []byte, key retrievalGenerationKey, requireInteg
 // Authenticate exactly the complete ordered commitment list for this user MDU.
 // The enclosing witness packaging is not cached or claimed to be authenticated.
 func (g *authenticatedGeneration) userMDU(ctx context.Context, dir string, c retrievalchallenge.Context, mduIndex uint64) (*authenticatedUserMDU, error) {
+	if _, err := c.Bytes(); err != nil {
+		return nil, err
+	}
 	return g.userMDUFor(ctx, dir, retrievalGeneration(c), mduIndex)
 }
 

--- a/polystore_gateway/retrieval_proof.go
+++ b/polystore_gateway/retrieval_proof.go
@@ -42,14 +42,15 @@ func admitRetrievalResponse(ctx context.Context) (context.Context, func(), error
 
 type retrievalGenerationKey struct {
 	Chain                             string
-	Setup, Root                       [32]byte
+	Setup, Root, Integrity            [32]byte
 	Deal, Generation, Metadata, Users uint64
 	Layout                            uint8
 	K, M                              uint32
+	Version                           uint32
 }
 
 func retrievalGeneration(c retrievalchallenge.Context) retrievalGenerationKey {
-	return retrievalGenerationKey{c.ChainID, c.SetupDigest, c.Root, c.DealID, c.Generation, c.MetadataMDUs, c.UserMDUs, c.Layout, c.K, c.M}
+	return retrievalGenerationKey{Chain: c.ChainID, Setup: c.SetupDigest, Root: c.Root, Deal: c.DealID, Generation: c.Generation, Metadata: c.MetadataMDUs, Users: c.UserMDUs, Layout: c.Layout, K: c.K, M: c.M, Version: 2}
 }
 
 type authenticatedGeneration struct {
@@ -79,7 +80,14 @@ var retrievalMetadataCache = struct {
 }{entries: make(map[retrievalGenerationKey]generationCacheEntry)}
 
 func authenticatedRetrievalMetadata(ctx context.Context, dir string, c retrievalchallenge.Context) (*authenticatedGeneration, error) {
+	if _, err := c.Bytes(); err != nil {
+		return nil, err
+	}
 	key := retrievalGeneration(c)
+	return authenticatedRetrievalMetadataFor(ctx, dir, key)
+}
+
+func authenticatedRetrievalMetadataFor(ctx context.Context, dir string, key retrievalGenerationKey) (*authenticatedGeneration, error) {
 	retrievalMetadataCache.Lock()
 	entry, found := retrievalMetadataCache.entries[key]
 	if found {
@@ -100,7 +108,7 @@ func authenticatedRetrievalMetadata(ctx context.Context, dir string, c retrieval
 		if ok {
 			return cached.value, nil
 		}
-		prepared, err := prepareRetrievalMetadata(ctx, dir, c)
+		prepared, err := prepareRetrievalMetadata(ctx, dir, key)
 		if err != nil {
 			return nil, err
 		}
@@ -152,19 +160,28 @@ func readExactArtifactRange(path string, size, offset, length uint64) ([]byte, e
 	return data, nil
 }
 
-func prepareRetrievalMetadata(ctx context.Context, dir string, c retrievalchallenge.Context) (*authenticatedGeneration, error) {
-	if _, err := c.Bytes(); err != nil {
-		return nil, err
-	}
+func prepareRetrievalMetadata(ctx context.Context, dir string, key retrievalGenerationKey) (*authenticatedGeneration, error) {
 	wire, err := readExactArtifactRange(filepath.Join(dir, "mdu_0.bin"), types.MDU_SIZE, 0, types.MDU_SIZE)
 	if err != nil {
 		return nil, err
 	}
-	builder, err := crypto_ffi.LoadMdu0Builder(wire, c.UserMDUs)
-	if err != nil {
-		return nil, fmt.Errorf("noncanonical MDU #0: %w", err)
+	switch key.Version {
+	case 2:
+		builder, err := crypto_ffi.LoadMdu0Builder(wire, key.Users)
+		if err != nil {
+			if err := validateFATV3Metadata(wire, key, false); err != nil {
+				return nil, fmt.Errorf("noncanonical MDU #0: %w", err)
+			}
+		} else {
+			builder.Free()
+		}
+	case 3:
+		if err := validateFATV3Metadata(wire, key, true); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("unsupported retrieval generation version")
 	}
-	builder.Free()
 	commitments := make([][]byte, 64)
 	leaves := make([][32]byte, 64)
 	for i := range commitments {
@@ -178,15 +195,66 @@ func prepareRetrievalMetadata(ctx context.Context, dir string, c retrievalchalle
 		leaves[i] = blake2s.Sum256(commitments[i])
 	}
 	tree := buildProofMerkleTree(leaves)
-	if tree[len(tree)-1][0] != c.Root {
+	if tree[len(tree)-1][0] != key.Root {
 		return nil, fmt.Errorf("MDU #0 does not match frozen manifest root")
 	}
 	return &authenticatedGeneration{rootTable: bytes.Clone(wire[:16*types.BLOB_SIZE]), commitments: commitments, tree: tree}, nil
 }
 
+func fatV3HeaderFromEncodedMDU0(wire []byte) ([retrievalchallenge.FATV3HeaderBytes]byte, error) {
+	var raw [retrievalchallenge.FATV3HeaderBytes]byte
+	if len(wire) != types.MDU_SIZE {
+		return raw, fmt.Errorf("invalid MDU #0 size")
+	}
+	start := 16 * types.BLOB_SIZE
+	for i := range raw {
+		scalar := i / 31
+		if wire[start+scalar*32] != 0 {
+			return raw, fmt.Errorf("nonzero FAT scalar prefix")
+		}
+		raw[i] = wire[start+scalar*32+1+i%31]
+	}
+	return raw, nil
+}
+
+// validateFATV3Metadata uses the existing full FAT v2 validator after replacing
+// only the authenticated v3 header in a bounded copy with its canonical v2
+// equivalent. Commitments below are always computed over the original bytes.
+func validateFATV3Metadata(wire []byte, key retrievalGenerationKey, requireIntegrity bool) error {
+	raw, err := fatV3HeaderFromEncodedMDU0(wire)
+	if err != nil {
+		return err
+	}
+	header, err := retrievalchallenge.ParseFATV3Header(raw[:])
+	if err != nil || key.Users > retrievalchallenge.MaxIntegrityLeaves/retrievalchallenge.IntegrityLeavesPerUserMDU || header.LeafCount != key.Users*retrievalchallenge.IntegrityLeavesPerUserMDU || (requireIntegrity && header.IntegrityRoot != key.Integrity) {
+		return fmt.Errorf("noncanonical or mismatched FAT v3 header")
+	}
+	normalized := bytes.Clone(wire)
+	var v2 [retrievalchallenge.FATV3HeaderBytes]byte
+	copy(v2[:4], "NILF")
+	v2[4] = 2
+	v2[6] = 0
+	v2[7] = 1
+	copy(v2[8:12], raw[8:12])
+	start := 16 * types.BLOB_SIZE
+	for i, value := range v2 {
+		normalized[start+(i/31)*32+1+i%31] = value
+	}
+	builder, err := crypto_ffi.LoadMdu0Builder(normalized, key.Users)
+	if err != nil {
+		return fmt.Errorf("noncanonical FAT v3 records: %w", err)
+	}
+	builder.Free()
+	return nil
+}
+
 // Authenticate exactly the complete ordered commitment list for this user MDU.
 // The enclosing witness packaging is not cached or claimed to be authenticated.
 func (g *authenticatedGeneration) userMDU(ctx context.Context, dir string, c retrievalchallenge.Context, mduIndex uint64) (*authenticatedUserMDU, error) {
+	return g.userMDUFor(ctx, dir, retrievalGeneration(c), mduIndex)
+}
+
+func (g *authenticatedGeneration) userMDUFor(ctx context.Context, dir string, key retrievalGenerationKey, mduIndex uint64) (*authenticatedUserMDU, error) {
 	// ponytail: one prepared user MDU per generation; a measured working-set miss
 	// rate can justify a larger cache, while every caller remains memory-bounded.
 	g.mu.Lock()
@@ -194,17 +262,14 @@ func (g *authenticatedGeneration) userMDU(ctx context.Context, dir string, c ret
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	if _, err := c.Bytes(); err != nil {
-		return nil, err
-	}
-	if mduIndex < c.MetadataMDUs || mduIndex-c.MetadataMDUs >= c.UserMDUs {
+	if mduIndex < key.Metadata || mduIndex-key.Metadata >= key.Users {
 		return nil, fmt.Errorf("user MDU outside frozen allocation")
 	}
 	if g.lastProof != nil && g.lastMDU == mduIndex {
 		return g.lastProof, nil
 	}
-	leafCount := uint64(64/c.K) * uint64(c.K+c.M)
-	raw, err := readFrozenWitnessCommitments(dir, c, mduIndex, leafCount)
+	leafCount := uint64(64/key.K) * uint64(key.K+key.M)
+	raw, err := readFrozenWitnessCommitmentsFor(dir, key, mduIndex, leafCount)
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +291,7 @@ func (g *authenticatedGeneration) userMDU(ctx context.Context, dir string, c ret
 	}
 	path := proofMerklePath(g.tree, int(du))
 	flat, _ := flattenMerkleProof32(path)
-	valid, err := crypto_ffi.VerifyMdu0RootTableProof(c.Root[:], mduIndex, root[:], g.commitments[du], flat, opening)
+	valid, err := crypto_ffi.VerifyMdu0RootTableProof(key.Root[:], mduIndex, root[:], g.commitments[du], flat, opening)
 	if err != nil {
 		return nil, err
 	}
@@ -242,15 +307,19 @@ func readFrozenWitnessCommitments(dir string, c retrievalchallenge.Context, mduI
 	if _, err := c.Bytes(); err != nil {
 		return nil, err
 	}
-	if leaves == 0 || leaves > 16384 || c.MetadataMDUs < 2 || mduIndex < c.MetadataMDUs || mduIndex-c.MetadataMDUs >= c.UserMDUs {
+	return readFrozenWitnessCommitmentsFor(dir, retrievalGeneration(c), mduIndex, leaves)
+}
+
+func readFrozenWitnessCommitmentsFor(dir string, key retrievalGenerationKey, mduIndex, leaves uint64) ([]byte, error) {
+	if leaves == 0 || leaves > 16384 || key.Metadata < 2 || mduIndex < key.Metadata || mduIndex-key.Metadata >= key.Users {
 		return nil, fmt.Errorf("invalid witness geometry")
 	}
 	span := leaves * 48
-	total := c.UserMDUs * span // C2 bounds Users <= 65536 and leaves <= 16384.
-	if total > (c.MetadataMDUs-1)*RawMduCapacity {
+	total := key.Users * span // C2/v3 bounds Users <= 65536 and leaves <= 16384.
+	if total > (key.Metadata-1)*RawMduCapacity {
 		return nil, fmt.Errorf("witness allocation is too small")
 	}
-	start := (mduIndex - c.MetadataMDUs) * span
+	start := (mduIndex - key.Metadata) * span
 	out := make([]byte, 0, int(span))
 	for pos := start; pos < start+span; {
 		index, offset := pos/RawMduCapacity, pos%RawMduCapacity

--- a/polystore_gateway/retrieval_proof.go
+++ b/polystore_gateway/retrieval_proof.go
@@ -165,6 +165,27 @@ func prepareRetrievalMetadata(ctx context.Context, dir string, key retrievalGene
 	if err != nil {
 		return nil, err
 	}
+	var commitments [][]byte
+	var tree [][][32]byte
+	authenticate := func() error {
+		commitments = make([][]byte, 64)
+		leaves := make([][32]byte, 64)
+		for i := range commitments {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			commitments[i], err = crypto_ffi.CommitReceivedBlob(wire[i*types.BLOB_SIZE : (i+1)*types.BLOB_SIZE])
+			if err != nil {
+				return err
+			}
+			leaves[i] = blake2s.Sum256(commitments[i])
+		}
+		tree = buildProofMerkleTree(leaves)
+		if tree[len(tree)-1][0] != key.Root {
+			return fmt.Errorf("MDU #0 does not match frozen manifest root")
+		}
+		return nil
+	}
 	switch key.Version {
 	case 2:
 		builder, err := crypto_ffi.LoadMdu0Builder(wire, key.Users)
@@ -176,27 +197,21 @@ func prepareRetrievalMetadata(ctx context.Context, dir string, key retrievalGene
 			builder.Free()
 		}
 	case 3:
+		// V3 header fields are untrusted until the original encoded MDU #0 is
+		// authenticated against the frozen PolyFS root.
+		if err := authenticate(); err != nil {
+			return nil, err
+		}
 		if err := validateFATV3Metadata(wire, key, true); err != nil {
 			return nil, err
 		}
 	default:
 		return nil, fmt.Errorf("unsupported retrieval generation version")
 	}
-	commitments := make([][]byte, 64)
-	leaves := make([][32]byte, 64)
-	for i := range commitments {
-		if err := ctx.Err(); err != nil {
+	if commitments == nil {
+		if err := authenticate(); err != nil {
 			return nil, err
 		}
-		commitments[i], err = crypto_ffi.CommitReceivedBlob(wire[i*types.BLOB_SIZE : (i+1)*types.BLOB_SIZE])
-		if err != nil {
-			return nil, err
-		}
-		leaves[i] = blake2s.Sum256(commitments[i])
-	}
-	tree := buildProofMerkleTree(leaves)
-	if tree[len(tree)-1][0] != key.Root {
-		return nil, fmt.Errorf("MDU #0 does not match frozen manifest root")
 	}
 	return &authenticatedGeneration{rootTable: bytes.Clone(wire[:16*types.BLOB_SIZE]), commitments: commitments, tree: tree}, nil
 }
@@ -435,24 +450,28 @@ func generateFrozenSessionProof(ctx context.Context, dir string, f *frozenRetrie
 // and prepares this exact MDU. Sessions and audits share byte/proof construction,
 // while their distinct challenge and admission semantics remain with the caller.
 func buildFrozenBlobProof(ctx context.Context, ch retrievalchallenge.Challenge, user *authenticatedUserMDU, blob []byte) (types.ChainedProof, error) {
+	return buildFrozenBlobProofAt(ctx, ch.MDUIndex, ch.LeafIndex, ch.Z, user, blob)
+}
+
+func buildFrozenBlobProofAt(ctx context.Context, mduIndex uint64, leafIndex uint32, z [32]byte, user *authenticatedUserMDU, blob []byte) (types.ChainedProof, error) {
 	if err := ctx.Err(); err != nil {
 		return types.ChainedProof{}, err
 	}
-	if uint64(ch.LeafIndex) >= uint64(len(user.commitments)/48) {
+	if uint64(leafIndex) >= uint64(len(user.commitments)/48) {
 		return types.ChainedProof{}, fmt.Errorf("leaf outside authenticated MDU")
 	}
 	commitment, err := crypto_ffi.CommitReceivedBlob(blob)
 	if err != nil {
 		return types.ChainedProof{}, err
 	}
-	expected := user.commitments[int(ch.LeafIndex)*48 : (int(ch.LeafIndex)+1)*48]
+	expected := user.commitments[int(leafIndex)*48 : (int(leafIndex)+1)*48]
 	if !bytes.Equal(commitment, expected) {
 		return types.ChainedProof{}, fmt.Errorf("stored response blob does not match authenticated commitment")
 	}
-	opening, y, err := crypto_ffi.ComputeBlobProof(blob, ch.Z[:])
+	opening, y, err := crypto_ffi.ComputeBlobProof(blob, z[:])
 	if err != nil {
 		return types.ChainedProof{}, err
 	}
 	root := user.tree[len(user.tree)-1][0]
-	return types.ChainedProof{MduIndex: ch.MDUIndex, BlobIndex: ch.LeafIndex, MduRootFr: root[:], RootTableDuCommitment: user.rootCommitment, RootTableDuMerklePath: user.rootPath, ManifestOpening: user.rootOpening, BlobCommitment: commitment, MerklePath: proofMerklePath(user.tree, int(ch.LeafIndex)), ZValue: ch.Z[:], YValue: y, KzgOpeningProof: opening}, nil
+	return types.ChainedProof{MduIndex: mduIndex, BlobIndex: leafIndex, MduRootFr: root[:], RootTableDuCommitment: user.rootCommitment, RootTableDuMerklePath: user.rootPath, ManifestOpening: user.rootOpening, BlobCommitment: commitment, MerklePath: proofMerklePath(user.tree, int(leafIndex)), ZValue: z[:], YValue: y, KzgOpeningProof: opening}, nil
 }

--- a/polystore_gateway/retrieval_submission.go
+++ b/polystore_gateway/retrieval_submission.go
@@ -150,7 +150,7 @@ func decodePendingSigner(raw []byte, out *pendingSignerOperation) error {
 	if err := d.Decode(out); err != nil {
 		return err
 	}
-	if (out.Kind != "retrieval" && out.Kind != "audit") || len(out.IDs) == 0 || len(out.IDs) > 64 {
+	if (out.Kind != "retrieval" && out.Kind != "audit" && out.Kind != "generation-v3") || len(out.IDs) == 0 || len(out.IDs) > 64 {
 		return fmt.Errorf("invalid pending signer identity")
 	}
 	seen := make(map[string]bool, len(out.IDs))

--- a/polystore_gateway/retrieval_submission.go
+++ b/polystore_gateway/retrieval_submission.go
@@ -150,7 +150,7 @@ func decodePendingSigner(raw []byte, out *pendingSignerOperation) error {
 	if err := d.Decode(out); err != nil {
 		return err
 	}
-	if (out.Kind != "retrieval" && out.Kind != "audit" && out.Kind != "generation-v3") || len(out.IDs) == 0 || len(out.IDs) > 64 {
+	if (out.Kind != "retrieval" && out.Kind != "audit" && out.Kind != "generation-v3" && out.Kind != "retrieval-v3") || len(out.IDs) == 0 || len(out.IDs) > 64 {
 		return fmt.Errorf("invalid pending signer identity")
 	}
 	seen := make(map[string]bool, len(out.IDs))
@@ -487,6 +487,10 @@ func SpSubmitRetrievalSessionProof(w http.ResponseWriter, r *http.Request) {
 	for _, id := range ids {
 		response, height, err := queryRetrievalSession(r.Context(), id)
 		if err != nil {
+			if errors.Is(err, ErrSessionNotFound) && len(ids) == 1 && request.SessionIDs == nil {
+				submitRetrievalSessionProofV3(w, r.Context(), key, signer, id)
+				return
+			}
 			writeJSONError(w, http.StatusBadGateway, "session authority unavailable", err.Error())
 			return
 		}

--- a/polystore_gateway/retrieval_v3_generation.go
+++ b/polystore_gateway/retrieval_v3_generation.go
@@ -133,10 +133,6 @@ func verifyIntegrityVectorV3(ctx context.Context, dir string, key retrievalGener
 	return nil
 }
 
-func generationOperationID(a *types.DealGenerationAdmissionV3, slot uint32) string {
-	return fmt.Sprintf("%d/%d/%d/%s", a.DealId, a.Generation, slot, hex.EncodeToString(a.PolyfsRoot))
-}
-
 func updatePendingSignerV3(signer string, op pendingSignerOperation, clear bool) error {
 	if sessionDB == nil {
 		return fmt.Errorf("session DB unavailable")
@@ -169,7 +165,7 @@ func SpAcceptDealGenerationV3(w http.ResponseWriter, r *http.Request) {
 	}
 	decoder := json.NewDecoder(bytes.NewReader(body))
 	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&request); err != nil || request.DealID == 0 {
+	if err := decoder.Decode(&request); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "invalid v3 generation acceptance request", "")
 		return
 	}
@@ -216,7 +212,12 @@ func SpAcceptDealGenerationV3(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusForbidden, "provider is not assigned to the generation", "")
 		return
 	}
-	id := generationOperationID(candidate, uint32(slot))
+	digest, err := (retrievalchallenge.GenerationAcceptanceV3{ChainID: generation.Chain, SetupDigest: generation.Setup, DealID: generation.Deal, Generation: generation.Generation, PolyFSRoot: generation.Root, IntegrityRoot: generation.Integrity, MetadataMDUs: generation.Metadata, UserMDUs: generation.Users, Slot: uint32(slot), Provider: providerRaw}).Hash()
+	if err != nil {
+		writeJSONError(w, http.StatusConflict, "invalid v3 generation acceptance digest", err.Error())
+		return
+	}
+	id := hex.EncodeToString(digest[:])
 	release, err := claimRetrievalOperations([]string{id}, signer)
 	if err != nil {
 		writeJSONError(w, http.StatusTooManyRequests, "provider signer busy", err.Error())
@@ -276,11 +277,6 @@ func SpAcceptDealGenerationV3(w http.ResponseWriter, r *http.Request) {
 	}
 	if err != nil {
 		writeJSONError(w, http.StatusConflict, "v3 generation ingest verification failed", err.Error())
-		return
-	}
-	digest, err := (retrievalchallenge.GenerationAcceptanceV3{ChainID: generation.Chain, SetupDigest: generation.Setup, DealID: generation.Deal, Generation: generation.Generation, PolyFSRoot: generation.Root, IntegrityRoot: generation.Integrity, MetadataMDUs: generation.Metadata, UserMDUs: generation.Users, Slot: uint32(slot), Provider: providerRaw}).Hash()
-	if err != nil {
-		writeJSONError(w, http.StatusConflict, "invalid v3 generation acceptance digest", err.Error())
 		return
 	}
 	if err := updatePendingSignerV3(signer, op, false); err != nil {

--- a/polystore_gateway/retrieval_v3_generation.go
+++ b/polystore_gateway/retrieval_v3_generation.go
@@ -46,10 +46,10 @@ func queryDealGenerationV3(ctx context.Context, deal uint64) (*types.QueryGetDea
 	return &response, height, nil
 }
 
-func validateGenerationAdmissionV3(a *types.DealGenerationAdmissionV3) (retrievalGenerationKey, [12][20]byte, error) {
+func validateGenerationAdmissionV3(a *types.DealGenerationAdmissionV3, expectedDeal uint64) (retrievalGenerationKey, [12][20]byte, error) {
 	var providers [12][20]byte
 	setup, setupErr := hex.DecodeString(types.RetrievalSetupDigest)
-	if a == nil || a.ChainId != chainID || a.Generation == 0 || a.ProposedHeight <= 0 || len(a.PolyfsRoot) != 32 || len(a.IntegrityRoot) != 32 || len(a.SetupDigest) != 32 || setupErr != nil || !bytes.Equal(a.SetupDigest, setup) || len(a.Providers) != 12 || a.MetadataMdus < 2 || a.WitnessMdus != a.MetadataMdus-1 || a.UserMdus == 0 || a.MetadataMdus > 65536 || a.UserMdus > 65536-a.MetadataMdus || a.TotalMdus != a.MetadataMdus+a.UserMdus || a.UserMdus > retrievalchallenge.MaxIntegrityLeaves/retrievalchallenge.IntegrityLeavesPerUserMDU || a.IntegrityLeafCount != a.UserMdus*retrievalchallenge.IntegrityLeavesPerUserMDU || a.AcceptedSlotsMask&^uint32(0xfff) != 0 {
+	if a == nil || a.DealId != expectedDeal || a.ChainId != chainID || a.Generation == 0 || a.ProposedHeight <= 0 || len(a.PolyfsRoot) != 32 || len(a.IntegrityRoot) != 32 || len(a.SetupDigest) != 32 || setupErr != nil || !bytes.Equal(a.SetupDigest, setup) || len(a.Providers) != 12 || a.MetadataMdus < 2 || a.WitnessMdus != a.MetadataMdus-1 || a.UserMdus == 0 || a.MetadataMdus > 65536 || a.UserMdus > 65536-a.MetadataMdus || a.TotalMdus != a.MetadataMdus+a.UserMdus || a.UserMdus > retrievalchallenge.MaxIntegrityLeaves/retrievalchallenge.IntegrityLeavesPerUserMDU || a.IntegrityLeafCount != a.UserMdus*retrievalchallenge.IntegrityLeavesPerUserMDU || a.AcceptedSlotsMask&^uint32(0xfff) != 0 {
 		return retrievalGenerationKey{}, providers, fmt.Errorf("invalid v3 generation snapshot")
 	}
 	key := retrievalGenerationKey{Chain: a.ChainId, Deal: a.DealId, Generation: a.Generation, Metadata: a.MetadataMdus, Users: a.UserMdus, Layout: retrievalchallenge.StripeK8M4, K: 8, M: 4, Version: 3}
@@ -145,6 +145,10 @@ func updatePendingSignerV3(signer string, op pendingSignerOperation, clear bool)
 	})
 }
 
+func generationAcceptanceDigestV3(generation retrievalGenerationKey, slot uint32, provider [20]byte) ([32]byte, error) {
+	return (retrievalchallenge.GenerationAcceptanceV3{ChainID: generation.Chain, SetupDigest: generation.Setup, DealID: generation.Deal, Generation: generation.Generation, PolyFSRoot: generation.Root, IntegrityRoot: generation.Integrity, MetadataMDUs: generation.Metadata, UserMDUs: generation.Users, Slot: slot, Provider: provider}).Hash()
+}
+
 func SpAcceptDealGenerationV3(w http.ResponseWriter, r *http.Request) {
 	setCORS(w)
 	if r.Method == http.MethodOptions {
@@ -178,6 +182,42 @@ func SpAcceptDealGenerationV3(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusForbidden, "routing provider differs from actual signing key", "")
 		return
 	}
+	lockID := "generation-v3:" + strconv.FormatUint(request.DealID, 10)
+	release, err := claimRetrievalOperations([]string{lockID}, signer)
+	if err != nil {
+		writeJSONError(w, http.StatusTooManyRequests, "provider signer busy", err.Error())
+		return
+	}
+	defer release()
+	pending, err := loadPendingSigner(signer)
+	if err != nil {
+		writeJSONError(w, http.StatusConflict, "generation acceptance cleanup state unavailable", err.Error())
+		return
+	}
+	if pending != nil && pending.Kind != "generation-v3" {
+		writeJSONError(w, http.StatusConflict, "provider signer has unresolved operation", fmt.Sprintf("actual signer awaits %s reconciliation", pending.Kind))
+		return
+	}
+	if pending != nil && pending.TxHash != "" {
+		hash, waitErr := waitForCommittedTx(ctx, pending.TxHash)
+		if waitErr == nil || errors.Is(waitErr, errTxFailed) {
+			if clearErr := updatePendingSignerV3(signer, *pending, true); clearErr != nil {
+				writeJSONError(w, http.StatusConflict, "generation acceptance cleanup pending", clearErr.Error())
+				return
+			}
+		}
+		if waitErr != nil {
+			if errors.Is(waitErr, errTxFailed) {
+				writeJSONError(w, http.StatusConflict, "generation acceptance failed", waitErr.Error())
+				return
+			}
+			writeJSONError(w, http.StatusAccepted, "generation acceptance pending", waitErr.Error())
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": "reconciled", "tx_hash": hash, "cleanup_status": "complete"})
+		return
+	}
 	response, height, err := queryDealGenerationV3(ctx, request.DealID)
 	if err != nil {
 		writeJSONError(w, http.StatusConflict, "v3 generation admission unavailable", err.Error())
@@ -187,7 +227,7 @@ func SpAcceptDealGenerationV3(w http.ResponseWriter, r *http.Request) {
 	if candidate == nil {
 		candidate = response.Admitted
 	}
-	generation, providers, err := validateGenerationAdmissionV3(candidate)
+	generation, providers, err := validateGenerationAdmissionV3(candidate, request.DealID)
 	if err != nil || height == 0 || uint64(candidate.ProposedHeight) > height {
 		if err == nil {
 			err = fmt.Errorf("v3 generation query lacks a committed proposal height")
@@ -212,52 +252,34 @@ func SpAcceptDealGenerationV3(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusForbidden, "provider is not assigned to the generation", "")
 		return
 	}
-	digest, err := (retrievalchallenge.GenerationAcceptanceV3{ChainID: generation.Chain, SetupDigest: generation.Setup, DealID: generation.Deal, Generation: generation.Generation, PolyFSRoot: generation.Root, IntegrityRoot: generation.Integrity, MetadataMDUs: generation.Metadata, UserMDUs: generation.Users, Slot: uint32(slot), Provider: providerRaw}).Hash()
+	digest, err := generationAcceptanceDigestV3(generation, uint32(slot), providerRaw)
 	if err != nil {
 		writeJSONError(w, http.StatusConflict, "invalid v3 generation acceptance digest", err.Error())
 		return
 	}
 	id := hex.EncodeToString(digest[:])
-	release, err := claimRetrievalOperations([]string{id}, signer)
-	if err != nil {
-		writeJSONError(w, http.StatusTooManyRequests, "provider signer busy", err.Error())
-		return
-	}
-	defer release()
 	op := pendingSignerOperation{Kind: "generation-v3", IDs: []string{id}}
 	if candidate.AcceptedSlotsMask&(1<<uint(slot)) != 0 || response.Pending == nil {
-		if pending, err := loadPendingSigner(signer); err == nil && pending != nil && pending.Kind == op.Kind && len(pending.IDs) == 1 && pending.IDs[0] == id {
-			_ = updatePendingSignerV3(signer, op, true)
+		if pending != nil && len(pending.IDs) == 1 && pending.IDs[0] == id {
+			if err := updatePendingSignerV3(signer, op, true); err != nil {
+				writeJSONError(w, http.StatusConflict, "generation acceptance cleanup pending", err.Error())
+				return
+			}
+		}
+		if pending != nil {
+			writeJSONError(w, http.StatusConflict, "provider signer has unresolved generation acceptance", "stored acceptance identity differs from current generation")
+			return
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{"status": "already_accepted", "slot": slot})
 		return
 	}
-	if pending, err := loadPendingSigner(signer); err != nil || pending != nil {
-		if err != nil || pending.Kind != op.Kind || len(pending.IDs) != 1 || pending.IDs[0] != id {
-			if err == nil {
-				err = fmt.Errorf("actual signer awaits %s reconciliation", pending.Kind)
-			}
-			writeJSONError(w, http.StatusConflict, "provider signer has unresolved operation", err.Error())
+	if pending != nil {
+		if len(pending.IDs) != 1 || pending.IDs[0] != id {
+			writeJSONError(w, http.StatusConflict, "provider signer has unresolved generation acceptance", "stored acceptance identity differs from current generation")
 			return
 		}
-		if pending.TxHash == "" {
-			writeJSONError(w, http.StatusAccepted, "generation acceptance outcome unknown", "broadcast hash was not persisted")
-			return
-		}
-		hash, waitErr := waitForCommittedTx(ctx, pending.TxHash)
-		if waitErr == nil || errors.Is(waitErr, errTxFailed) {
-			_ = updatePendingSignerV3(signer, op, true)
-		}
-		if waitErr != nil {
-			if errors.Is(waitErr, errTxFailed) {
-				writeJSONError(w, http.StatusConflict, "generation acceptance failed", waitErr.Error())
-				return
-			}
-			writeJSONError(w, http.StatusAccepted, "generation acceptance pending", waitErr.Error())
-			return
-		}
-		_ = json.NewEncoder(w).Encode(map[string]any{"status": "reconciled", "tx_hash": hash})
+		writeJSONError(w, http.StatusAccepted, "generation acceptance outcome unknown", "broadcast hash was not persisted")
 		return
 	}
 	root, err := parseManifestRoot("0x" + hex.EncodeToString(candidate.PolyfsRoot))
@@ -287,8 +309,17 @@ func SpAcceptDealGenerationV3(w http.ResponseWriter, r *http.Request) {
 		op.TxHash = hash
 		return updatePendingSignerV3(signer, op, false)
 	}, "tx", "polystorechain", "accept-deal-generation-v3", "--deal-id", strconv.FormatUint(candidate.DealId, 10), "--slot", strconv.Itoa(slot), "--acceptance-digest", hex.EncodeToString(digest[:]), "--from", keyName, "--chain-id", chainID, "--home", homeDir, "--keyring-backend", "test", "--yes", "--gas", "auto", "--gas-adjustment", "1.6", "--gas-prices", gasPrices, "--broadcast-mode", "sync", "--output", "json")
+	cleanup := "retained"
 	if err == nil || errors.Is(err, errTxFailed) || errors.Is(err, errTxRejected) || errors.Is(err, errTxNotSubmitted) {
-		_ = updatePendingSignerV3(signer, op, true)
+		if clearErr := updatePendingSignerV3(signer, op, true); clearErr != nil {
+			if err == nil {
+				err = fmt.Errorf("transaction committed but local acceptance cleanup remains pending: %w", clearErr)
+			} else {
+				err = fmt.Errorf("%w; local acceptance cleanup remains pending: %v", err, clearErr)
+			}
+		} else {
+			cleanup = "complete"
+		}
 	}
 	status := "success"
 	if err != nil {
@@ -302,5 +333,5 @@ func SpAcceptDealGenerationV3(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		errorText = err.Error()
 	}
-	_ = json.NewEncoder(w).Encode(map[string]any{"status": status, "tx_hash": hash, "slot": slot, "error": errorText})
+	_ = json.NewEncoder(w).Encode(map[string]any{"status": status, "tx_hash": hash, "slot": slot, "cleanup_status": cleanup, "error": errorText})
 }

--- a/polystore_gateway/retrieval_v3_generation.go
+++ b/polystore_gateway/retrieval_v3_generation.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -24,6 +25,15 @@ import (
 )
 
 const integrityLeavesV3File = "integrity_leaves_v3.bin"
+
+const (
+	generationVerificationBaseTimeoutV3   = 5 * time.Minute
+	generationVerificationPerUserMDUV3    = 250 * time.Millisecond
+	generationVerificationProgressEveryV3 = 60 * time.Second
+	generationSubmissionTimeoutV3         = 2 * time.Minute
+)
+
+var errProviderNotAssignedV3 = errors.New("provider is not assigned to the generation")
 
 type generationAcceptanceV3Request struct {
 	DealID   uint64 `json:"deal_id"`
@@ -99,6 +109,8 @@ func verifyIntegrityVectorV3(ctx context.Context, dir string, key retrievalGener
 	if err != nil || root != key.Integrity {
 		return fmt.Errorf("integrity leaf vector does not match authenticated header")
 	}
+	started := time.Now()
+	nextProgress := started.Add(generationVerificationProgressEveryV3)
 	for user := uint64(0); user < key.Users; user++ {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -113,6 +125,9 @@ func verifyIntegrityVectorV3(ctx context.Context, dir string, key retrievalGener
 			return err
 		}
 		for row := uint32(0); row < 8; row++ {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
 			leaf := slot*8 + row
 			blob := shard[uint64(row)*types.BLOB_SIZE : uint64(row+1)*types.BLOB_SIZE]
 			commitment, err := crypto_ffi.CommitReceivedBlob(blob)
@@ -129,8 +144,94 @@ func verifyIntegrityVectorV3(ctx context.Context, dir string, key retrievalGener
 				return fmt.Errorf("slot blob %d/%d does not match integrity vector", mdu, leaf)
 			}
 		}
+		if now := time.Now(); !now.Before(nextProgress) {
+			log.Printf("v3 generation verification progress deal=%d generation=%d slot=%d user_mdus=%d/%d elapsed=%s", key.Deal, key.Generation, slot, user+1, key.Users, now.Sub(started).Round(time.Second))
+			nextProgress = now.Add(generationVerificationProgressEveryV3)
+		}
 	}
 	return nil
+}
+
+func generationVerificationTimeoutV3(users uint64) (time.Duration, error) {
+	maxUsers := retrievalchallenge.MaxIntegrityLeaves / retrievalchallenge.IntegrityLeavesPerUserMDU
+	if users == 0 || users > maxUsers {
+		return 0, fmt.Errorf("invalid v3 generation user MDU count")
+	}
+	return generationVerificationBaseTimeoutV3 + time.Duration(users)*generationVerificationPerUserMDUV3, nil
+}
+
+func claimGenerationVerificationV3(deal uint64, signer string) (func(), error) {
+	return claimRetrievalOperations([]string{
+		"generation-v3:" + strconv.FormatUint(deal, 10),
+		"generation-verification-v3:" + signer,
+	}, "")
+}
+
+type generationAcceptanceViewV3 struct {
+	response   *types.QueryGetDealGenerationV3Response
+	candidate  *types.DealGenerationAdmissionV3
+	generation retrievalGenerationKey
+	providers  [12][20]byte
+	provider   [20]byte
+	slot       int
+	digest     [32]byte
+	id         string
+	root       ManifestRoot
+}
+
+func queryGenerationAcceptanceViewV3(ctx context.Context, deal uint64, signer string) (*generationAcceptanceViewV3, error) {
+	response, height, err := queryDealGenerationV3(ctx, deal)
+	if err != nil {
+		return nil, err
+	}
+	candidate := response.Pending
+	if candidate == nil {
+		candidate = response.Admitted
+	}
+	generation, providers, err := validateGenerationAdmissionV3(candidate, deal)
+	if err != nil || height == 0 || candidate == nil || uint64(candidate.ProposedHeight) > height {
+		if err == nil {
+			err = fmt.Errorf("v3 generation query lacks a committed proposal height")
+		}
+		return nil, err
+	}
+	provider, err := rawProviderV3(signer)
+	if err != nil {
+		return nil, err
+	}
+	slot := -1
+	for i := range providers {
+		if providers[i] == provider {
+			if slot != -1 {
+				return nil, fmt.Errorf("provider occupies multiple frozen slots")
+			}
+			slot = i
+		}
+	}
+	if slot < 0 {
+		return nil, errProviderNotAssignedV3
+	}
+	digest, err := generationAcceptanceDigestV3(generation, uint32(slot), provider)
+	if err != nil {
+		return nil, err
+	}
+	root, err := parseManifestRoot("0x" + hex.EncodeToString(candidate.PolyfsRoot))
+	if err != nil {
+		return nil, err
+	}
+	return &generationAcceptanceViewV3{
+		response: response, candidate: candidate, generation: generation, providers: providers,
+		provider: provider, slot: slot, digest: digest, id: hex.EncodeToString(digest[:]), root: root,
+	}, nil
+}
+
+func (v *generationAcceptanceViewV3) accepted() bool {
+	return v.response.Pending == nil || v.candidate.AcceptedSlotsMask&(1<<uint(v.slot)) != 0
+}
+
+func (v *generationAcceptanceViewV3) sameFrozenCandidate(other *generationAcceptanceViewV3) bool {
+	return other != nil && v.generation == other.generation && v.providers == other.providers &&
+		v.provider == other.provider && v.slot == other.slot && v.digest == other.digest && v.root == other.root
 }
 
 func updatePendingSignerV3(signer string, op pendingSignerOperation, clear bool) error {
@@ -173,8 +274,6 @@ func SpAcceptDealGenerationV3(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusForbidden, "forbidden", "")
 		return
 	}
-	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Minute)
-	defer cancel()
 	var request generationAcceptanceV3Request
 	body, err := io.ReadAll(io.LimitReader(r.Body, maxSessionProofRequestBytes+1))
 	if err != nil || len(body) > maxSessionProofRequestBytes || validateJSONObject(body) != nil {
@@ -187,7 +286,7 @@ func SpAcceptDealGenerationV3(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, "invalid v3 generation acceptance request", "")
 		return
 	}
-	keyName, signer, err := retrievalSigner(ctx)
+	keyName, signer, err := retrievalSigner(r.Context())
 	if err != nil {
 		writeJSONError(w, http.StatusServiceUnavailable, "provider signing key unavailable", err.Error())
 		return
@@ -196,13 +295,22 @@ func SpAcceptDealGenerationV3(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusForbidden, "routing provider differs from actual signing key", "")
 		return
 	}
-	lockID := "generation-v3:" + strconv.FormatUint(request.DealID, 10)
-	release, err := claimRetrievalOperations([]string{lockID}, signer)
+	releaseDeal, err := claimGenerationVerificationV3(request.DealID, signer)
+	if err != nil {
+		writeJSONError(w, http.StatusTooManyRequests, "generation verification busy", err.Error())
+		return
+	}
+	defer releaseDeal()
+	releaseSigner, err := claimRetrievalOperations(nil, signer)
 	if err != nil {
 		writeJSONError(w, http.StatusTooManyRequests, "provider signer busy", err.Error())
 		return
 	}
-	defer release()
+	defer func() {
+		if releaseSigner != nil {
+			releaseSigner()
+		}
+	}()
 	pending, err := loadPendingSigner(signer)
 	if err != nil {
 		writeJSONError(w, http.StatusConflict, "generation acceptance cleanup state unavailable", err.Error())
@@ -213,7 +321,7 @@ func SpAcceptDealGenerationV3(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if pending != nil && pending.TxHash != "" {
-		hash, waitErr := waitForCommittedTx(ctx, pending.TxHash)
+		hash, waitErr := waitForCommittedTx(r.Context(), pending.TxHash)
 		if waitErr == nil || errors.Is(waitErr, errTxFailed) {
 			if clearErr := updatePendingSignerV3(signer, *pending, true); clearErr != nil {
 				writeJSONError(w, http.StatusConflict, "generation acceptance cleanup pending", clearErr.Error())
@@ -232,97 +340,114 @@ func SpAcceptDealGenerationV3(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"status": "reconciled", "tx_hash": hash, "cleanup_status": "complete"})
 		return
 	}
-	response, height, err := queryDealGenerationV3(ctx, request.DealID)
+	view, err := queryGenerationAcceptanceViewV3(r.Context(), request.DealID, signer)
 	if err != nil {
-		writeJSONError(w, http.StatusConflict, "v3 generation admission unavailable", err.Error())
-		return
-	}
-	candidate := response.Pending
-	if candidate == nil {
-		candidate = response.Admitted
-	}
-	generation, providers, err := validateGenerationAdmissionV3(candidate, request.DealID)
-	if err != nil || height == 0 || uint64(candidate.ProposedHeight) > height {
-		if err == nil {
-			err = fmt.Errorf("v3 generation query lacks a committed proposal height")
+		if errors.Is(err, errProviderNotAssignedV3) {
+			writeJSONError(w, http.StatusForbidden, err.Error(), "")
+			return
 		}
 		writeJSONError(w, http.StatusConflict, "invalid v3 generation admission", err.Error())
 		return
 	}
-	var providerRaw [20]byte
-	providerAddress, _ := sdk.AccAddressFromBech32(signer)
-	copy(providerRaw[:], providerAddress)
-	slot := -1
-	for i := range providers {
-		if providers[i] == providerRaw {
-			if slot != -1 {
-				writeJSONError(w, http.StatusConflict, "provider occupies multiple frozen slots", "")
-				return
-			}
-			slot = i
-		}
-	}
-	if slot < 0 {
-		writeJSONError(w, http.StatusForbidden, "provider is not assigned to the generation", "")
-		return
-	}
-	digest, err := generationAcceptanceDigestV3(generation, uint32(slot), providerRaw)
-	if err != nil {
-		writeJSONError(w, http.StatusConflict, "invalid v3 generation acceptance digest", err.Error())
-		return
-	}
-	id := hex.EncodeToString(digest[:])
-	op := pendingSignerOperation{Kind: "generation-v3", IDs: []string{id}}
-	if candidate.AcceptedSlotsMask&(1<<uint(slot)) != 0 || response.Pending == nil {
-		if pending != nil && len(pending.IDs) == 1 && pending.IDs[0] == id {
-			if err := updatePendingSignerV3(signer, op, true); err != nil {
+	op := pendingSignerOperation{Kind: "generation-v3", IDs: []string{view.id}}
+	if view.accepted() {
+		if pending != nil && len(pending.IDs) == 1 && pending.IDs[0] == view.id {
+			if err := updatePendingSignerV3(signer, *pending, true); err != nil {
 				writeJSONError(w, http.StatusConflict, "generation acceptance cleanup pending", err.Error())
 				return
 			}
+			pending = nil
 		}
 		if pending != nil {
 			writeJSONError(w, http.StatusConflict, "provider signer has unresolved generation acceptance", "stored acceptance identity differs from current generation")
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{"status": "already_accepted", "slot": slot})
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": "already_accepted", "slot": view.slot})
 		return
 	}
 	if pending != nil {
-		if len(pending.IDs) != 1 || pending.IDs[0] != id {
+		if len(pending.IDs) != 1 || pending.IDs[0] != view.id {
 			writeJSONError(w, http.StatusConflict, "provider signer has unresolved generation acceptance", "stored acceptance identity differs from current generation")
 			return
 		}
 		writeJSONError(w, http.StatusAccepted, "generation acceptance outcome unknown", "broadcast hash was not persisted")
 		return
 	}
-	root, err := parseManifestRoot("0x" + hex.EncodeToString(candidate.PolyfsRoot))
-	if err != nil {
-		writeJSONError(w, http.StatusConflict, "invalid frozen generation root", err.Error())
-		return
-	}
-	dir, releaseGeneration, err := openFrozenGeneration(candidate.DealId, root)
+	// The durable signer marker is clear. Release the shared signer while the
+	// deal-specific verification lock and immutable generation lease bound the
+	// expensive scan; audits and retrieval proofs can continue signing.
+	releaseSigner()
+	releaseSigner = nil
+	dir, releaseGeneration, err := openFrozenGeneration(view.candidate.DealId, view.root)
 	if err != nil {
 		writeJSONError(w, http.StatusConflict, "frozen generation artifacts unavailable", err.Error())
 		return
 	}
 	defer releaseGeneration()
-	metadata, err := authenticatedRetrievalMetadataFor(ctx, dir, generation)
+	verificationTimeout, err := generationVerificationTimeoutV3(view.generation.Users)
+	if err != nil {
+		writeJSONError(w, http.StatusConflict, "invalid v3 generation verification bound", err.Error())
+		return
+	}
+	verificationCtx, cancelVerification := context.WithTimeout(r.Context(), verificationTimeout)
+	defer cancelVerification()
+	metadata, err := authenticatedRetrievalMetadataFor(verificationCtx, dir, view.generation)
 	if err == nil {
-		err = verifyIntegrityVectorV3(ctx, dir, generation, uint32(slot), metadata)
+		err = verifyIntegrityVectorV3(verificationCtx, dir, view.generation, uint32(view.slot), metadata)
 	}
 	if err != nil {
 		writeJSONError(w, http.StatusConflict, "v3 generation ingest verification failed", err.Error())
 		return
 	}
+	cancelVerification()
+
+	releaseSigner, err = claimRetrievalOperations(nil, signer)
+	if err != nil {
+		writeJSONError(w, http.StatusTooManyRequests, "provider signer busy after generation verification", err.Error())
+		return
+	}
+	pending, err = loadPendingSigner(signer)
+	if err != nil {
+		writeJSONError(w, http.StatusConflict, "generation acceptance cleanup state unavailable", err.Error())
+		return
+	}
+	if pending != nil {
+		writeJSONError(w, http.StatusConflict, "provider signer has unresolved operation", fmt.Sprintf("actual signer awaits %s reconciliation", pending.Kind))
+		return
+	}
+	submissionCtx, cancelSubmission := context.WithTimeout(r.Context(), generationSubmissionTimeoutV3)
+	defer cancelSubmission()
+	fresh, err := queryGenerationAcceptanceViewV3(submissionCtx, request.DealID, signer)
+	if err != nil || !view.sameFrozenCandidate(fresh) {
+		if err == nil {
+			err = fmt.Errorf("v3 generation candidate changed during verification")
+		}
+		writeJSONError(w, http.StatusConflict, "v3 generation revalidation failed", err.Error())
+		return
+	}
+	if freshDir, lookupErr := lookupDealGeneration(fresh.candidate.DealId, fresh.root, fresh.root.Canonical); lookupErr != nil || filepath.Clean(freshDir) != filepath.Clean(dir) {
+		if lookupErr == nil {
+			lookupErr = fmt.Errorf("frozen generation artifact identity changed")
+		}
+		writeJSONError(w, http.StatusConflict, "v3 generation artifact revalidation failed", lookupErr.Error())
+		return
+	}
+	if fresh.accepted() {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": "already_accepted", "slot": fresh.slot})
+		return
+	}
+	view = fresh
+	op = pendingSignerOperation{Kind: "generation-v3", IDs: []string{view.id}}
 	if err := updatePendingSignerV3(signer, op, false); err != nil {
 		writeJSONError(w, http.StatusConflict, "cannot persist generation acceptance intent", err.Error())
 		return
 	}
-	hash, err := submitTxAndRecord(ctx, func(hash string) error {
+	hash, err := submitTxAndRecord(submissionCtx, func(hash string) error {
 		op.TxHash = hash
 		return updatePendingSignerV3(signer, op, false)
-	}, "tx", "polystorechain", "accept-deal-generation-v3", "--deal-id", strconv.FormatUint(candidate.DealId, 10), "--slot", strconv.Itoa(slot), "--acceptance-digest", hex.EncodeToString(digest[:]), "--from", keyName, "--chain-id", chainID, "--home", homeDir, "--keyring-backend", "test", "--yes", "--gas", "auto", "--gas-adjustment", "1.6", "--gas-prices", gasPrices, "--broadcast-mode", "sync", "--output", "json")
+	}, "tx", "polystorechain", "accept-deal-generation-v3", "--deal-id", strconv.FormatUint(view.candidate.DealId, 10), "--slot", strconv.Itoa(view.slot), "--acceptance-digest", hex.EncodeToString(view.digest[:]), "--from", keyName, "--chain-id", chainID, "--home", homeDir, "--keyring-backend", "test", "--yes", "--gas", "auto", "--gas-adjustment", "1.6", "--gas-prices", gasPrices, "--broadcast-mode", "sync", "--output", "json")
 	cleanup := "retained"
 	if err == nil || errors.Is(err, errTxFailed) || errors.Is(err, errTxRejected) || errors.Is(err, errTxNotSubmitted) {
 		if clearErr := updatePendingSignerV3(signer, op, true); clearErr != nil {
@@ -342,5 +467,5 @@ func SpAcceptDealGenerationV3(w http.ResponseWriter, r *http.Request) {
 			status = "failed"
 		}
 	}
-	writeGenerationAcceptanceV3Outcome(w, status, hash, slot, cleanup, err)
+	writeGenerationAcceptanceV3Outcome(w, status, hash, view.slot, cleanup, err)
 }

--- a/polystore_gateway/retrieval_v3_generation.go
+++ b/polystore_gateway/retrieval_v3_generation.go
@@ -1,0 +1,310 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/gogoproto/jsonpb"
+	bolt "go.etcd.io/bbolt"
+	"polystorechain/pkg/retrievalchallenge"
+	"polystorechain/x/crypto_ffi"
+	"polystorechain/x/polystorechain/types"
+)
+
+const integrityLeavesV3File = "integrity_leaves_v3.bin"
+
+type generationAcceptanceV3Request struct {
+	DealID   uint64 `json:"deal_id"`
+	Provider string `json:"provider,omitempty"`
+}
+
+func queryDealGenerationV3(ctx context.Context, deal uint64) (*types.QueryGetDealGenerationV3Response, uint64, error) {
+	path := "/polystorechain/polystorechain/v1/deals/" + strconv.FormatUint(deal, 10) + "/generation-v3"
+	body, height, err := readLCDJSON(ctx, path, 0, maxSessionQueryBytes)
+	if errors.Is(err, errLCDNotFound) {
+		return nil, 0, ErrSessionNotFound
+	}
+	if err != nil {
+		return nil, 0, err
+	}
+	var response types.QueryGetDealGenerationV3Response
+	if err := jsonpb.Unmarshal(bytes.NewReader(body), &response); err != nil {
+		return nil, 0, fmt.Errorf("invalid v3 generation query: %w", err)
+	}
+	return &response, height, nil
+}
+
+func validateGenerationAdmissionV3(a *types.DealGenerationAdmissionV3) (retrievalGenerationKey, [12][20]byte, error) {
+	var providers [12][20]byte
+	setup, setupErr := hex.DecodeString(types.RetrievalSetupDigest)
+	if a == nil || a.ChainId != chainID || a.Generation == 0 || a.ProposedHeight <= 0 || len(a.PolyfsRoot) != 32 || len(a.IntegrityRoot) != 32 || len(a.SetupDigest) != 32 || setupErr != nil || !bytes.Equal(a.SetupDigest, setup) || len(a.Providers) != 12 || a.MetadataMdus < 2 || a.WitnessMdus != a.MetadataMdus-1 || a.UserMdus == 0 || a.MetadataMdus > 65536 || a.UserMdus > 65536-a.MetadataMdus || a.TotalMdus != a.MetadataMdus+a.UserMdus || a.UserMdus > retrievalchallenge.MaxIntegrityLeaves/retrievalchallenge.IntegrityLeavesPerUserMDU || a.IntegrityLeafCount != a.UserMdus*retrievalchallenge.IntegrityLeavesPerUserMDU || a.AcceptedSlotsMask&^uint32(0xfff) != 0 {
+		return retrievalGenerationKey{}, providers, fmt.Errorf("invalid v3 generation snapshot")
+	}
+	key := retrievalGenerationKey{Chain: a.ChainId, Deal: a.DealId, Generation: a.Generation, Metadata: a.MetadataMdus, Users: a.UserMdus, Layout: retrievalchallenge.StripeK8M4, K: 8, M: 4, Version: 3}
+	copy(key.Root[:], a.PolyfsRoot)
+	copy(key.Integrity[:], a.IntegrityRoot)
+	copy(key.Setup[:], a.SetupDigest)
+	seen := make(map[[20]byte]struct{}, len(a.Providers))
+	for i, raw := range a.Providers {
+		address, err := sdk.AccAddressFromBech32(raw)
+		if err != nil || len(address) != 20 || address.String() != raw {
+			return retrievalGenerationKey{}, providers, fmt.Errorf("invalid v3 provider %d", i)
+		}
+		copy(providers[i][:], address)
+		if _, duplicate := seen[providers[i]]; duplicate {
+			return retrievalGenerationKey{}, providers, fmt.Errorf("duplicate v3 provider %d", i)
+		}
+		seen[providers[i]] = struct{}{}
+	}
+	return key, providers, nil
+}
+
+type contextReaderV3 struct {
+	ctx context.Context
+	r   io.Reader
+}
+
+func (r contextReaderV3) Read(p []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.r.Read(p)
+}
+
+func verifyIntegrityVectorV3(ctx context.Context, dir string, key retrievalGenerationKey, slot uint32, metadata *authenticatedGeneration) error {
+	path := filepath.Join(dir, integrityLeavesV3File)
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	wantSize := int64(key.Users * retrievalchallenge.IntegrityLeavesPerUserMDU * 32)
+	if err != nil || !info.Mode().IsRegular() || info.Size() != wantSize {
+		return fmt.Errorf("integrity leaf vector has invalid type or size")
+	}
+	root, err := retrievalchallenge.IntegrityRootV3Reader(bufio.NewReaderSize(contextReaderV3{ctx, f}, 1<<20), key.Users*retrievalchallenge.IntegrityLeavesPerUserMDU)
+	if err != nil || root != key.Integrity {
+		return fmt.Errorf("integrity leaf vector does not match authenticated header")
+	}
+	for user := uint64(0); user < key.Users; user++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		mdu := key.Metadata + user
+		authenticated, err := metadata.userMDUFor(ctx, dir, key, mdu)
+		if err != nil {
+			return err
+		}
+		shard, err := readExactArtifactRange(filepath.Join(dir, fmt.Sprintf("mdu_%d_slot_%d.bin", mdu, slot)), 8*types.BLOB_SIZE, 0, 8*types.BLOB_SIZE)
+		if err != nil {
+			return err
+		}
+		for row := uint32(0); row < 8; row++ {
+			leaf := slot*8 + row
+			blob := shard[uint64(row)*types.BLOB_SIZE : uint64(row+1)*types.BLOB_SIZE]
+			commitment, err := crypto_ffi.CommitReceivedBlob(blob)
+			if err != nil || !bytes.Equal(commitment, authenticated.commitments[uint64(leaf)*48:uint64(leaf+1)*48]) {
+				return fmt.Errorf("slot blob %d/%d does not match authenticated KZG commitment", mdu, leaf)
+			}
+			hash, err := retrievalchallenge.IntegrityLeafV3(mdu, leaf, blob)
+			if err != nil {
+				return err
+			}
+			position := user*retrievalchallenge.IntegrityLeavesPerUserMDU + uint64(leaf)
+			var expected [32]byte
+			if _, err := f.ReadAt(expected[:], int64(position*32)); err != nil || hash != expected {
+				return fmt.Errorf("slot blob %d/%d does not match integrity vector", mdu, leaf)
+			}
+		}
+	}
+	return nil
+}
+
+func generationOperationID(a *types.DealGenerationAdmissionV3, slot uint32) string {
+	return fmt.Sprintf("%d/%d/%d/%s", a.DealId, a.Generation, slot, hex.EncodeToString(a.PolyfsRoot))
+}
+
+func updatePendingSignerV3(signer string, op pendingSignerOperation, clear bool) error {
+	if sessionDB == nil {
+		return fmt.Errorf("session DB unavailable")
+	}
+	return sessionDB.Update(func(tx *bolt.Tx) error {
+		if clear {
+			return clearPendingSigner(tx, signer, op.Kind, op.IDs)
+		}
+		return claimPendingSigner(tx, signer, op)
+	})
+}
+
+func SpAcceptDealGenerationV3(w http.ResponseWriter, r *http.Request) {
+	setCORS(w)
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if !isGatewayAuthorized(r) {
+		writeJSONError(w, http.StatusForbidden, "forbidden", "")
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Minute)
+	defer cancel()
+	var request generationAcceptanceV3Request
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxSessionProofRequestBytes+1))
+	if err != nil || len(body) > maxSessionProofRequestBytes || validateJSONObject(body) != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid v3 generation acceptance request", "")
+		return
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&request); err != nil || request.DealID == 0 {
+		writeJSONError(w, http.StatusBadRequest, "invalid v3 generation acceptance request", "")
+		return
+	}
+	keyName, signer, err := retrievalSigner(ctx)
+	if err != nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "provider signing key unavailable", err.Error())
+		return
+	}
+	if request.Provider != "" && request.Provider != signer {
+		writeJSONError(w, http.StatusForbidden, "routing provider differs from actual signing key", "")
+		return
+	}
+	response, height, err := queryDealGenerationV3(ctx, request.DealID)
+	if err != nil {
+		writeJSONError(w, http.StatusConflict, "v3 generation admission unavailable", err.Error())
+		return
+	}
+	candidate := response.Pending
+	if candidate == nil {
+		candidate = response.Admitted
+	}
+	generation, providers, err := validateGenerationAdmissionV3(candidate)
+	if err != nil || height == 0 || uint64(candidate.ProposedHeight) > height {
+		if err == nil {
+			err = fmt.Errorf("v3 generation query lacks a committed proposal height")
+		}
+		writeJSONError(w, http.StatusConflict, "invalid v3 generation admission", err.Error())
+		return
+	}
+	var providerRaw [20]byte
+	providerAddress, _ := sdk.AccAddressFromBech32(signer)
+	copy(providerRaw[:], providerAddress)
+	slot := -1
+	for i := range providers {
+		if providers[i] == providerRaw {
+			if slot != -1 {
+				writeJSONError(w, http.StatusConflict, "provider occupies multiple frozen slots", "")
+				return
+			}
+			slot = i
+		}
+	}
+	if slot < 0 {
+		writeJSONError(w, http.StatusForbidden, "provider is not assigned to the generation", "")
+		return
+	}
+	id := generationOperationID(candidate, uint32(slot))
+	release, err := claimRetrievalOperations([]string{id}, signer)
+	if err != nil {
+		writeJSONError(w, http.StatusTooManyRequests, "provider signer busy", err.Error())
+		return
+	}
+	defer release()
+	op := pendingSignerOperation{Kind: "generation-v3", IDs: []string{id}}
+	if candidate.AcceptedSlotsMask&(1<<uint(slot)) != 0 || response.Pending == nil {
+		if pending, err := loadPendingSigner(signer); err == nil && pending != nil && pending.Kind == op.Kind && len(pending.IDs) == 1 && pending.IDs[0] == id {
+			_ = updatePendingSignerV3(signer, op, true)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": "already_accepted", "slot": slot})
+		return
+	}
+	if pending, err := loadPendingSigner(signer); err != nil || pending != nil {
+		if err != nil || pending.Kind != op.Kind || len(pending.IDs) != 1 || pending.IDs[0] != id {
+			if err == nil {
+				err = fmt.Errorf("actual signer awaits %s reconciliation", pending.Kind)
+			}
+			writeJSONError(w, http.StatusConflict, "provider signer has unresolved operation", err.Error())
+			return
+		}
+		if pending.TxHash == "" {
+			writeJSONError(w, http.StatusAccepted, "generation acceptance outcome unknown", "broadcast hash was not persisted")
+			return
+		}
+		hash, waitErr := waitForCommittedTx(ctx, pending.TxHash)
+		if waitErr == nil || errors.Is(waitErr, errTxFailed) {
+			_ = updatePendingSignerV3(signer, op, true)
+		}
+		if waitErr != nil {
+			if errors.Is(waitErr, errTxFailed) {
+				writeJSONError(w, http.StatusConflict, "generation acceptance failed", waitErr.Error())
+				return
+			}
+			writeJSONError(w, http.StatusAccepted, "generation acceptance pending", waitErr.Error())
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": "reconciled", "tx_hash": hash})
+		return
+	}
+	root, err := parseManifestRoot("0x" + hex.EncodeToString(candidate.PolyfsRoot))
+	if err != nil {
+		writeJSONError(w, http.StatusConflict, "invalid frozen generation root", err.Error())
+		return
+	}
+	dir, releaseGeneration, err := openFrozenGeneration(candidate.DealId, root)
+	if err != nil {
+		writeJSONError(w, http.StatusConflict, "frozen generation artifacts unavailable", err.Error())
+		return
+	}
+	defer releaseGeneration()
+	metadata, err := authenticatedRetrievalMetadataFor(ctx, dir, generation)
+	if err == nil {
+		err = verifyIntegrityVectorV3(ctx, dir, generation, uint32(slot), metadata)
+	}
+	if err != nil {
+		writeJSONError(w, http.StatusConflict, "v3 generation ingest verification failed", err.Error())
+		return
+	}
+	digest, err := (retrievalchallenge.GenerationAcceptanceV3{ChainID: generation.Chain, SetupDigest: generation.Setup, DealID: generation.Deal, Generation: generation.Generation, PolyFSRoot: generation.Root, IntegrityRoot: generation.Integrity, MetadataMDUs: generation.Metadata, UserMDUs: generation.Users, Slot: uint32(slot), Provider: providerRaw}).Hash()
+	if err != nil {
+		writeJSONError(w, http.StatusConflict, "invalid v3 generation acceptance digest", err.Error())
+		return
+	}
+	if err := updatePendingSignerV3(signer, op, false); err != nil {
+		writeJSONError(w, http.StatusConflict, "cannot persist generation acceptance intent", err.Error())
+		return
+	}
+	hash, err := submitTxAndRecord(ctx, func(hash string) error {
+		op.TxHash = hash
+		return updatePendingSignerV3(signer, op, false)
+	}, "tx", "polystorechain", "accept-deal-generation-v3", "--deal-id", strconv.FormatUint(candidate.DealId, 10), "--slot", strconv.Itoa(slot), "--acceptance-digest", hex.EncodeToString(digest[:]), "--from", keyName, "--chain-id", chainID, "--home", homeDir, "--keyring-backend", "test", "--yes", "--gas", "auto", "--gas-adjustment", "1.6", "--gas-prices", gasPrices, "--broadcast-mode", "sync", "--output", "json")
+	if err == nil || errors.Is(err, errTxFailed) || errors.Is(err, errTxRejected) || errors.Is(err, errTxNotSubmitted) {
+		_ = updatePendingSignerV3(signer, op, true)
+	}
+	status := "success"
+	if err != nil {
+		status = "pending"
+		if errors.Is(err, errTxFailed) || errors.Is(err, errTxRejected) || errors.Is(err, errTxNotSubmitted) {
+			status = "failed"
+		}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	errorText := ""
+	if err != nil {
+		errorText = err.Error()
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{"status": status, "tx_hash": hash, "slot": slot, "error": errorText})
+}

--- a/polystore_gateway/retrieval_v3_generation.go
+++ b/polystore_gateway/retrieval_v3_generation.go
@@ -149,6 +149,20 @@ func generationAcceptanceDigestV3(generation retrievalGenerationKey, slot uint32
 	return (retrievalchallenge.GenerationAcceptanceV3{ChainID: generation.Chain, SetupDigest: generation.Setup, DealID: generation.Deal, Generation: generation.Generation, PolyFSRoot: generation.Root, IntegrityRoot: generation.Integrity, MetadataMDUs: generation.Metadata, UserMDUs: generation.Users, Slot: slot, Provider: provider}).Hash()
 }
 
+func writeGenerationAcceptanceV3Outcome(w http.ResponseWriter, status, hash string, slot int, cleanup string, err error) {
+	w.Header().Set("Content-Type", "application/json")
+	if status == "pending" {
+		w.WriteHeader(http.StatusAccepted)
+	} else if status == "failed" {
+		w.WriteHeader(http.StatusConflict)
+	}
+	errorText := ""
+	if err != nil {
+		errorText = err.Error()
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{"status": status, "tx_hash": hash, "slot": slot, "cleanup_status": cleanup, "error": errorText})
+}
+
 func SpAcceptDealGenerationV3(w http.ResponseWriter, r *http.Request) {
 	setCORS(w)
 	if r.Method == http.MethodOptions {
@@ -328,10 +342,5 @@ func SpAcceptDealGenerationV3(w http.ResponseWriter, r *http.Request) {
 			status = "failed"
 		}
 	}
-	w.Header().Set("Content-Type", "application/json")
-	errorText := ""
-	if err != nil {
-		errorText = err.Error()
-	}
-	_ = json.NewEncoder(w).Encode(map[string]any{"status": status, "tx_hash": hash, "slot": slot, "cleanup_status": cleanup, "error": errorText})
+	writeGenerationAcceptanceV3Outcome(w, status, hash, slot, cleanup, err)
 }

--- a/polystore_gateway/retrieval_v3_generation_test.go
+++ b/polystore_gateway/retrieval_v3_generation_test.go
@@ -2,7 +2,11 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -129,5 +133,50 @@ func TestValidateGenerationAdmissionV3BoundsAndProviderIdentity(t *testing.T) {
 	a.SetupDigest[0] ^= 1
 	if _, _, err := validateGenerationAdmissionV3(a, 0); err == nil {
 		t.Fatal("accepted mismatched setup digest")
+	}
+}
+
+func TestGenerationAcceptanceV3ReconcilesPersistedHashBeforeReplacementQuery(t *testing.T) {
+	path := submissionTestDB(t)
+	signer := sdk.AccAddress(bytes.Repeat([]byte{9}, 20)).String()
+	hash := strings.Repeat("A", 64)
+	op := pendingSignerOperation{Kind: "generation-v3", IDs: []string{strings.Repeat("b", 64)}, TxHash: hash}
+	if err := updatePendingSignerV3(signer, op, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := closeSessionDB(); err != nil {
+		t.Fatal(err)
+	}
+	if err := initSessionDB(path); err != nil {
+		t.Fatal(err)
+	}
+	queriedCandidate := false
+	lcd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/cosmos/tx/v1beta1/txs/") {
+			fmt.Fprintf(w, `{"tx_response":{"txhash":%q,"height":"12","code":0}}`, hash)
+			return
+		}
+		queriedCandidate = true
+		http.Error(w, "replacement proposal must not affect old reconciliation", http.StatusInternalServerError)
+	}))
+	defer lcd.Close()
+	oldLCD := lcdBase
+	lcdBase = lcd.URL
+	defer func() { lcdBase = oldLCD }()
+	setupMockCombinedOutput(t, func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "keys" {
+			return []byte(signer), nil
+		}
+		return nil, fmt.Errorf("unexpected command")
+	})
+	req := httptest.NewRequest(http.MethodPost, "/sp/generation-v3/accept", strings.NewReader(`{"deal_id":99,"provider":`+fmt.Sprintf("%q", signer)+`}`))
+	req.Header.Set(gatewayAuthHeader, gatewayToProviderAuthToken())
+	w := httptest.NewRecorder()
+	SpAcceptDealGenerationV3(w, req)
+	if w.Code != http.StatusOK || queriedCandidate || !strings.Contains(w.Body.String(), `"status":"reconciled"`) {
+		t.Fatalf("persisted acceptance was not reconciled independently: code=%d query=%t body=%s", w.Code, queriedCandidate, w.Body.String())
+	}
+	if marker, err := loadPendingSigner(signer); err != nil || marker != nil {
+		t.Fatalf("committed acceptance retained signer quarantine: %+v %v", marker, err)
 	}
 }

--- a/polystore_gateway/retrieval_v3_generation_test.go
+++ b/polystore_gateway/retrieval_v3_generation_test.go
@@ -9,10 +9,13 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/gogoproto/jsonpb"
 	"polystorechain/pkg/retrievalchallenge"
 	"polystorechain/x/crypto_ffi"
 	"polystorechain/x/polystorechain/types"
@@ -178,5 +181,157 @@ func TestGenerationAcceptanceV3ReconcilesPersistedHashBeforeReplacementQuery(t *
 	}
 	if marker, err := loadPendingSigner(signer); err != nil || marker != nil {
 		t.Fatalf("committed acceptance retained signer quarantine: %+v %v", marker, err)
+	}
+}
+
+func TestGenerationAcceptanceV3OutcomeStatusCodes(t *testing.T) {
+	for _, tc := range []struct {
+		status string
+		code   int
+	}{
+		{status: "success", code: http.StatusOK},
+		{status: "pending", code: http.StatusAccepted},
+		{status: "failed", code: http.StatusConflict},
+	} {
+		t.Run(tc.status, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			writeGenerationAcceptanceV3Outcome(w, tc.status, strings.Repeat("A", 64), 0, "complete", nil)
+			if w.Code != tc.code || !strings.Contains(w.Body.String(), `"status":"`+tc.status+`"`) {
+				t.Fatalf("unexpected outcome code=%d body=%s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestProviderV3FreshHandlersSubmitTrackedNativeTransactions(t *testing.T) {
+	submissionTestDB(t)
+	frozen, key, _ := buildProviderV3ArtifactFixture(t)
+	signer := frozen.Session.Obligations[0].AssignedProvider
+	t.Setenv("POLYSTORE_PROVIDER_KEY", "faucet")
+	t.Setenv("POLYSTORE_PROVIDER_ADDRESS", "")
+
+	providers := make([]string, 12)
+	for i := range providers {
+		raw := make([]byte, 20)
+		raw[19] = byte(i + 1)
+		providers[i] = sdk.AccAddress(raw).String()
+	}
+	candidate := &types.DealGenerationAdmissionV3{
+		DealId: key.Deal, Generation: key.Generation, PolyfsRoot: bytes.Clone(key.Root[:]), IntegrityRoot: bytes.Clone(key.Integrity[:]),
+		SetupDigest: bytes.Clone(key.Setup[:]), WitnessMdus: key.Metadata - 1, MetadataMdus: key.Metadata, UserMdus: key.Users,
+		TotalMdus: key.Metadata + key.Users, IntegrityLeafCount: key.Users * retrievalchallenge.IntegrityLeavesPerUserMDU,
+		Providers: providers, ProposedHeight: 10, ChainId: key.Chain,
+	}
+	generationBody, err := (&jsonpb.Marshaler{OrigName: true}).MarshalToString(&types.QueryGetDealGenerationV3Response{Pending: candidate})
+	if err != nil {
+		t.Fatal(err)
+	}
+	anchor := make([]byte, 32)
+	anchor[0] = 42
+	sessionBody, err := (&jsonpb.Marshaler{OrigName: true}).MarshalToString(&types.QueryGetRetrievalSessionV3Response{Session: frozen.Session, AnchorSeed: anchor})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const generationHash = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+	const proofHash = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+	lcd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/deals/0/generation-v3"):
+			w.Header().Set(committedHeightHeader, "13")
+			_, _ = w.Write([]byte(generationBody))
+		case strings.Contains(r.URL.Path, "/retrieval-sessions-v3/"):
+			w.Header().Set(committedHeightHeader, strconv.FormatUint(frozen.Height, 10))
+			_, _ = w.Write([]byte(sessionBody))
+		case strings.Contains(r.URL.Path, "/retrieval-sessions/"):
+			http.NotFound(w, r)
+		case strings.Contains(r.URL.Path, "/cosmos/tx/v1beta1/txs/"):
+			hash := generationHash
+			if strings.HasSuffix(r.URL.Path, proofHash) {
+				hash = proofHash
+			}
+			fmt.Fprintf(w, `{"tx_response":{"txhash":%q,"height":"13","code":0}}`, hash)
+		default:
+			t.Fatalf("unexpected LCD request %s", r.URL.Path)
+		}
+	}))
+	defer lcd.Close()
+	oldLCD := lcdBase
+	lcdBase = lcd.URL
+	t.Cleanup(func() { lcdBase = oldLCD })
+
+	providerRaw, err := rawProviderV3(signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest, err := generationAcceptanceDigestV3(key, 0, providerRaw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantGeneration := []string{"tx", "polystorechain", "accept-deal-generation-v3", "--deal-id", "0", "--slot", "0", "--acceptance-digest", hex.EncodeToString(digest[:]), "--from", "faucet", "--chain-id", chainID, "--home", homeDir, "--keyring-backend", "test", "--yes", "--gas", "auto", "--gas-adjustment", "1.6", "--gas-prices", gasPrices, "--broadcast-mode", "sync", "--output", "json"}
+	_, proofs, _, err := buildProviderProofBatchV3(t.Context(), frozen, signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantProof := &types.MsgSubmitRetrievalSessionProofV3{Creator: signer, SessionId: bytes.Clone(frozen.Session.SessionId), Slot: 0, Proofs: proofs}
+	wantProofJSON, err := (&jsonpb.Marshaler{OrigName: true}).MarshalToString(wantProof)
+	if err != nil {
+		t.Fatal(err)
+	}
+	txCalls := 0
+	setupMockCombinedOutput(t, func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "keys" {
+			return []byte(signer), nil
+		}
+		txCalls++
+		if len(args) < 4 || args[len(args)-4] != "--submission-phase-file" || args[len(args)-2] != "--node" || args[len(args)-1] != nodeAddr {
+			t.Fatalf("submission phase flag missing from %q", args)
+		}
+		phase, err := os.ReadFile(args[len(args)-3])
+		if err != nil || len(phase) != 0 {
+			t.Fatalf("invalid fresh submission phase file: %q %v", phase, err)
+		}
+		switch txCalls {
+		case 1:
+			if !reflect.DeepEqual(args[:len(args)-4], wantGeneration) {
+				t.Fatalf("generation CLI args mismatch\n got: %q\nwant: %q", args[:len(args)-4], wantGeneration)
+			}
+			return []byte(`{"txhash":"` + generationHash + `","code":0}`), nil
+		case 2:
+			got := args[:len(args)-4]
+			if len(got) < 5 || !reflect.DeepEqual(got[:4], []string{"tx", "polystorechain", "retrieval-session-v3", "prove"}) || !reflect.DeepEqual(got[5:], []string{"--from", "faucet", "--chain-id", chainID, "--home", homeDir, "--keyring-backend", "test", "--yes", "--gas", "auto", "--gas-adjustment", "1.6", "--gas-prices", gasPrices, "--broadcast-mode", "sync", "--output", "json"}) {
+				t.Fatalf("proof CLI args mismatch: %q", got)
+			}
+			proofJSON, err := os.ReadFile(got[4])
+			if err != nil || strings.TrimSpace(string(proofJSON)) != strings.TrimSpace(wantProofJSON) {
+				t.Fatalf("proof input mismatch\n got: %s\nwant: %s\nerr: %v", proofJSON, wantProofJSON, err)
+			}
+			return []byte(`{"txhash":"` + proofHash + `","code":0}`), nil
+		default:
+			t.Fatalf("unexpected tx call %d: %q", txCalls, args)
+			return nil, nil
+		}
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/sp/generation-v3/accept", strings.NewReader(`{"deal_id":0,"provider":`+fmt.Sprintf("%q", signer)+`}`))
+	req.Header.Set(gatewayAuthHeader, gatewayToProviderAuthToken())
+	generationResult := httptest.NewRecorder()
+	SpAcceptDealGenerationV3(generationResult, req)
+	if generationResult.Code != http.StatusOK || !strings.Contains(generationResult.Body.String(), `"status":"success"`) {
+		t.Fatalf("fresh generation acceptance failed: code=%d body=%s", generationResult.Code, generationResult.Body.String())
+	}
+	if marker, err := loadPendingSigner(signer); err != nil || marker != nil {
+		t.Fatalf("generation acceptance retained marker: %+v %v", marker, err)
+	}
+
+	proofResult := invokeSubmission(`{"session_id":"0x` + hex.EncodeToString(frozen.Session.SessionId) + `"}`)
+	if proofResult.Code != http.StatusOK || !strings.Contains(proofResult.Body.String(), `"status":"success"`) {
+		t.Fatalf("fresh proof submission failed: code=%d body=%s", proofResult.Code, proofResult.Body.String())
+	}
+	if marker, err := loadPendingSigner(signer); err != nil || marker != nil {
+		t.Fatalf("proof submission retained marker: %+v %v", marker, err)
+	}
+	if txCalls != 2 {
+		t.Fatalf("submitted %d transactions, want 2", txCalls)
 	}
 }

--- a/polystore_gateway/retrieval_v3_generation_test.go
+++ b/polystore_gateway/retrieval_v3_generation_test.go
@@ -3,6 +3,9 @@ package main
 import (
 	"bytes"
 	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -59,6 +62,39 @@ func TestValidateFATV3MetadataUsesPackedAuthenticatedBytes(t *testing.T) {
 	if err := validateFATV3Metadata(malformed, key, true); err == nil {
 		t.Fatal("accepted nonzero FAT header reserved byte")
 	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "mdu_0.bin"), malformed, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	key.Version = 3
+	if _, err := prepareRetrievalMetadata(t.Context(), dir, key); err == nil || !strings.Contains(err.Error(), "frozen manifest root") {
+		t.Fatalf("parsed unauthenticated v3 header before rejecting root: %v", err)
+	}
+}
+
+func TestGenerationAcceptanceOperationIdentityBindsTranscript(t *testing.T) {
+	g := retrievalGenerationKey{Chain: "polystore-test-1", Deal: 0, Generation: 1, Metadata: 2, Users: 1}
+	g.Setup[0], g.Root[0], g.Integrity[0] = 1, 2, 3
+	provider := [20]byte{19: 4}
+	want, err := generationAcceptanceDigestV3(g, 0, provider)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutations := []func(){
+		func() { g.Chain = "polystore-test-2" },
+		func() { g.Setup[0] ^= 1 },
+		func() { g.Root[0] ^= 1 },
+		func() { provider[0] ^= 1 },
+	}
+	for i, mutate := range mutations {
+		originalG, originalProvider := g, provider
+		mutate()
+		got, err := generationAcceptanceDigestV3(g, 0, provider)
+		if err != nil || got == want {
+			t.Fatalf("mutation %d did not change durable acceptance identity: %x %v", i, got, err)
+		}
+		g, provider = originalG, originalProvider
+	}
 }
 
 func TestValidateGenerationAdmissionV3BoundsAndProviderIdentity(t *testing.T) {
@@ -79,16 +115,19 @@ func TestValidateGenerationAdmissionV3BoundsAndProviderIdentity(t *testing.T) {
 		raw[19] = byte(i + 1)
 		a.Providers = append(a.Providers, sdk.AccAddress(raw).String())
 	}
-	if _, _, err := validateGenerationAdmissionV3(a); err != nil {
+	if _, _, err := validateGenerationAdmissionV3(a, 0); err != nil {
 		t.Fatalf("first deal rejected: %v", err)
 	}
+	if _, _, err := validateGenerationAdmissionV3(a, 1); err == nil {
+		t.Fatal("accepted generation for a different requested deal")
+	}
 	a.Providers[11] = a.Providers[10]
-	if _, _, err := validateGenerationAdmissionV3(a); err == nil {
+	if _, _, err := validateGenerationAdmissionV3(a, 0); err == nil {
 		t.Fatal("accepted duplicate provider assignment")
 	}
 	a.Providers[11] = sdk.AccAddress(append(make([]byte, 19), 12)).String()
 	a.SetupDigest[0] ^= 1
-	if _, _, err := validateGenerationAdmissionV3(a); err == nil {
+	if _, _, err := validateGenerationAdmissionV3(a, 0); err == nil {
 		t.Fatal("accepted mismatched setup digest")
 	}
 }

--- a/polystore_gateway/retrieval_v3_generation_test.go
+++ b/polystore_gateway/retrieval_v3_generation_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"polystorechain/pkg/retrievalchallenge"
+	"polystorechain/x/crypto_ffi"
+	"polystorechain/x/polystorechain/types"
+)
+
+func writePackedFATHeaderV3(t *testing.T, wire []byte, header retrievalchallenge.FATV3Header) {
+	t.Helper()
+	raw, err := header.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	start := 16 * types.BLOB_SIZE
+	for i, value := range raw {
+		wire[start+(i/31)*32] = 0
+		wire[start+(i/31)*32+1+i%31] = value
+	}
+}
+
+func TestValidateFATV3MetadataUsesPackedAuthenticatedBytes(t *testing.T) {
+	initCryptoForTest(t)
+	builder := crypto_ffi.NewMdu0Builder(1)
+	if builder == nil {
+		t.Fatal("builder unavailable")
+	}
+	defer builder.Free()
+	wire, err := builder.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	integrity := [32]byte{1, 2, 3}
+	writePackedFATHeaderV3(t, wire, retrievalchallenge.FATV3Header{LeafCount: 96, IntegrityRoot: integrity})
+	key := retrievalGenerationKey{Users: 1, Integrity: integrity}
+	if err := validateFATV3Metadata(wire, key, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateFATV3Metadata(wire, key, false); err != nil {
+		t.Fatalf("legacy audit rejected authenticated FAT v3 generation: %v", err)
+	}
+	badRoot := key
+	badRoot.Integrity[0] ^= 1
+	if err := validateFATV3Metadata(wire, badRoot, true); err == nil {
+		t.Fatal("accepted mismatched integrity root")
+	}
+	malformed := bytes.Clone(wire)
+	malformed[16*types.BLOB_SIZE] = 1
+	if err := validateFATV3Metadata(malformed, key, true); err == nil {
+		t.Fatal("accepted nonzero FAT scalar prefix")
+	}
+	malformed = bytes.Clone(wire)
+	malformed[16*types.BLOB_SIZE+5*32+1] = 1
+	if err := validateFATV3Metadata(malformed, key, true); err == nil {
+		t.Fatal("accepted nonzero FAT header reserved byte")
+	}
+}
+
+func TestValidateGenerationAdmissionV3BoundsAndProviderIdentity(t *testing.T) {
+	oldChain := chainID
+	chainID = "polystore-test-1"
+	t.Cleanup(func() { chainID = oldChain })
+	setup, err := hex.DecodeString(types.RetrievalSetupDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := &types.DealGenerationAdmissionV3{
+		DealId: 0, Generation: 1, PolyfsRoot: make([]byte, 32), IntegrityRoot: make([]byte, 32),
+		SetupDigest: setup, WitnessMdus: 1, MetadataMdus: 2, UserMdus: 1, TotalMdus: 3,
+		IntegrityLeafCount: 96, ProposedHeight: 1, ChainId: chainID,
+	}
+	for i := 0; i < 12; i++ {
+		raw := make([]byte, 20)
+		raw[19] = byte(i + 1)
+		a.Providers = append(a.Providers, sdk.AccAddress(raw).String())
+	}
+	if _, _, err := validateGenerationAdmissionV3(a); err != nil {
+		t.Fatalf("first deal rejected: %v", err)
+	}
+	a.Providers[11] = a.Providers[10]
+	if _, _, err := validateGenerationAdmissionV3(a); err == nil {
+		t.Fatal("accepted duplicate provider assignment")
+	}
+	a.Providers[11] = sdk.AccAddress(append(make([]byte, 19), 12)).String()
+	a.SetupDigest[0] ^= 1
+	if _, _, err := validateGenerationAdmissionV3(a); err == nil {
+		t.Fatal("accepted mismatched setup digest")
+	}
+}

--- a/polystore_gateway/retrieval_v3_generation_test.go
+++ b/polystore_gateway/retrieval_v3_generation_test.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/gogoproto/jsonpb"
@@ -20,6 +21,50 @@ import (
 	"polystorechain/x/crypto_ffi"
 	"polystorechain/x/polystorechain/types"
 )
+
+func TestGenerationVerificationV3UsesBoundedWorkScaledDeadline(t *testing.T) {
+	maxUsers := retrievalchallenge.MaxIntegrityLeaves / retrievalchallenge.IntegrityLeavesPerUserMDU
+	for _, tc := range []struct {
+		users uint64
+		want  time.Duration
+	}{
+		{1, generationVerificationBaseTimeoutV3 + generationVerificationPerUserMDUV3},
+		{maxUsers, generationVerificationBaseTimeoutV3 + time.Duration(maxUsers)*generationVerificationPerUserMDUV3},
+	} {
+		got, err := generationVerificationTimeoutV3(tc.users)
+		if err != nil || got != tc.want {
+			t.Fatalf("timeout(%d)=%s,%v want %s", tc.users, got, err, tc.want)
+		}
+	}
+	for _, users := range []uint64{0, maxUsers + 1} {
+		if _, err := generationVerificationTimeoutV3(users); err == nil {
+			t.Fatalf("accepted invalid user MDU count %d", users)
+		}
+	}
+}
+
+func TestGenerationVerificationV3BoundsScansWithoutHoldingSigner(t *testing.T) {
+	signer := sdk.AccAddress(bytes.Repeat([]byte{7}, 20)).String()
+	release, err := claimGenerationVerificationV3(701, signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+	if other, err := claimGenerationVerificationV3(702, signer); err == nil {
+		other()
+		t.Fatal("same provider started a second generation scan")
+	}
+	otherSigner := sdk.AccAddress(bytes.Repeat([]byte{8}, 20)).String()
+	if other, err := claimGenerationVerificationV3(701, otherSigner); err == nil {
+		other()
+		t.Fatal("same generation started a second scan")
+	}
+	sign, err := claimRetrievalOperations(nil, signer)
+	if err != nil {
+		t.Fatalf("generation scan held shared signer lock: %v", err)
+	}
+	sign()
+}
 
 func writePackedFATHeaderV3(t *testing.T, wire []byte, header retrievalchallenge.FATV3Header) {
 	t.Helper()
@@ -31,6 +76,23 @@ func writePackedFATHeaderV3(t *testing.T, wire []byte, header retrievalchallenge
 	for i, value := range raw {
 		wire[start+(i/31)*32] = 0
 		wire[start+(i/31)*32+1+i%31] = value
+	}
+}
+
+func providerGenerationCandidateV3(t *testing.T, key retrievalGenerationKey, signer string) *types.DealGenerationAdmissionV3 {
+	t.Helper()
+	providers := make([]string, 12)
+	providers[0] = signer
+	for i := 1; i < 12; i++ {
+		raw := make([]byte, 20)
+		raw[19] = byte(i + 1)
+		providers[i] = sdk.AccAddress(raw).String()
+	}
+	return &types.DealGenerationAdmissionV3{
+		DealId: key.Deal, Generation: key.Generation, PolyfsRoot: bytes.Clone(key.Root[:]), IntegrityRoot: bytes.Clone(key.Integrity[:]),
+		SetupDigest: bytes.Clone(key.Setup[:]), WitnessMdus: key.Metadata - 1, MetadataMdus: key.Metadata, UserMdus: key.Users,
+		TotalMdus: key.Metadata + key.Users, IntegrityLeafCount: key.Users * retrievalchallenge.IntegrityLeavesPerUserMDU,
+		Providers: providers, ProposedHeight: 10, ChainId: key.Chain,
 	}
 }
 
@@ -181,6 +243,173 @@ func TestGenerationAcceptanceV3ReconcilesPersistedHashBeforeReplacementQuery(t *
 	}
 	if marker, err := loadPendingSigner(signer); err != nil || marker != nil {
 		t.Fatalf("committed acceptance retained signer quarantine: %+v %v", marker, err)
+	}
+}
+
+func TestGenerationAcceptanceV3ClearsMatchingAcceptedNoHashMarker(t *testing.T) {
+	submissionTestDB(t)
+	oldChain := chainID
+	chainID = "polystore-test-1"
+	t.Cleanup(func() { chainID = oldChain })
+	signerRaw := bytes.Repeat([]byte{9}, 20)
+	signer := sdk.AccAddress(signerRaw).String()
+	setup, err := hex.DecodeString(types.RetrievalSetupDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	providers := make([]string, 12)
+	providers[0] = signer
+	for i := 1; i < 12; i++ {
+		raw := make([]byte, 20)
+		raw[19] = byte(i + 1)
+		providers[i] = sdk.AccAddress(raw).String()
+	}
+	candidate := &types.DealGenerationAdmissionV3{
+		DealId: 77, Generation: 3, PolyfsRoot: bytes.Repeat([]byte{1}, 32), IntegrityRoot: bytes.Repeat([]byte{2}, 32),
+		SetupDigest: setup, WitnessMdus: 1, MetadataMdus: 2, UserMdus: 1, TotalMdus: 3,
+		IntegrityLeafCount: 96, Providers: providers, ProposedHeight: 10, ChainId: chainID, AcceptedSlotsMask: 1,
+	}
+	body, err := (&jsonpb.Marshaler{OrigName: true}).MarshalToString(&types.QueryGetDealGenerationV3Response{Pending: candidate})
+	if err != nil {
+		t.Fatal(err)
+	}
+	generation, _, err := validateGenerationAdmissionV3(candidate, candidate.DealId)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var provider [20]byte
+	copy(provider[:], signerRaw)
+	digest, err := generationAcceptanceDigestV3(generation, 0, provider)
+	if err != nil {
+		t.Fatal(err)
+	}
+	op := pendingSignerOperation{Kind: "generation-v3", IDs: []string{hex.EncodeToString(digest[:])}}
+	if err := updatePendingSignerV3(signer, op, false); err != nil {
+		t.Fatal(err)
+	}
+	lcd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/deals/77/generation-v3") {
+			t.Fatalf("unexpected LCD request %s", r.URL.Path)
+		}
+		w.Header().Set(committedHeightHeader, "12")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer lcd.Close()
+	oldLCD := lcdBase
+	lcdBase = lcd.URL
+	t.Cleanup(func() { lcdBase = oldLCD })
+	setupMockCombinedOutput(t, func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "keys" {
+			return []byte(signer), nil
+		}
+		return nil, fmt.Errorf("unexpected command")
+	})
+	req := httptest.NewRequest(http.MethodPost, "/sp/generation-v3/accept", strings.NewReader(`{"deal_id":77,"provider":`+fmt.Sprintf("%q", signer)+`}`))
+	req.Header.Set(gatewayAuthHeader, gatewayToProviderAuthToken())
+	w := httptest.NewRecorder()
+	SpAcceptDealGenerationV3(w, req)
+	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), `"status":"already_accepted"`) {
+		t.Fatalf("matching accepted marker did not reconcile: code=%d body=%s", w.Code, w.Body.String())
+	}
+	if marker, err := loadPendingSigner(signer); err != nil || marker != nil {
+		t.Fatalf("matching accepted marker remained: %+v %v", marker, err)
+	}
+	mismatch := pendingSignerOperation{Kind: "generation-v3", IDs: []string{strings.Repeat("f", 64)}}
+	if err := updatePendingSignerV3(signer, mismatch, false); err != nil {
+		t.Fatal(err)
+	}
+	req = httptest.NewRequest(http.MethodPost, "/sp/generation-v3/accept", strings.NewReader(`{"deal_id":77,"provider":`+fmt.Sprintf("%q", signer)+`}`))
+	req.Header.Set(gatewayAuthHeader, gatewayToProviderAuthToken())
+	w = httptest.NewRecorder()
+	SpAcceptDealGenerationV3(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("mismatched accepted marker was not quarantined: code=%d body=%s", w.Code, w.Body.String())
+	}
+	if marker, err := loadPendingSigner(signer); err != nil || marker == nil || !reflect.DeepEqual(marker.IDs, mismatch.IDs) {
+		t.Fatalf("mismatched accepted marker changed: %+v %v", marker, err)
+	}
+}
+
+func TestGenerationAcceptanceV3RevalidatesAfterScanBeforeSigning(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		injectMarker bool
+	}{
+		{name: "candidate_changed"},
+		{name: "pending_signer_appeared", injectMarker: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			submissionTestDB(t)
+			frozen, key, _ := buildProviderV3ArtifactFixture(t)
+			signer := frozen.Session.Obligations[0].AssignedProvider
+			t.Setenv("POLYSTORE_PROVIDER_KEY", "faucet")
+			t.Setenv("POLYSTORE_PROVIDER_ADDRESS", "")
+			candidate := providerGenerationCandidateV3(t, key, signer)
+			changed := *candidate
+			changed.Generation++
+			firstBody, err := (&jsonpb.Marshaler{OrigName: true}).MarshalToString(&types.QueryGetDealGenerationV3Response{Pending: candidate})
+			if err != nil {
+				t.Fatal(err)
+			}
+			changedBody, err := (&jsonpb.Marshaler{OrigName: true}).MarshalToString(&types.QueryGetDealGenerationV3Response{Pending: &changed})
+			if err != nil {
+				t.Fatal(err)
+			}
+			injected := pendingSignerOperation{Kind: "audit", IDs: []string{"epoch:77"}}
+			queries := 0
+			lcd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !strings.Contains(r.URL.Path, "/generation-v3") {
+					t.Fatalf("unexpected LCD request %s", r.URL.Path)
+				}
+				queries++
+				w.Header().Set(committedHeightHeader, "13")
+				if queries == 1 {
+					_, _ = w.Write([]byte(firstBody))
+					if tc.injectMarker {
+						if err := updatePendingSignerV3(signer, injected, false); err != nil {
+							t.Errorf("inject pending signer marker: %v", err)
+						}
+					}
+					return
+				}
+				_, _ = w.Write([]byte(changedBody))
+			}))
+			defer lcd.Close()
+			oldLCD := lcdBase
+			lcdBase = lcd.URL
+			t.Cleanup(func() { lcdBase = oldLCD })
+			txCalls := 0
+			setupMockCombinedOutput(t, func(_ context.Context, _ string, args ...string) ([]byte, error) {
+				if len(args) > 0 && args[0] == "keys" {
+					return []byte(signer), nil
+				}
+				txCalls++
+				return nil, fmt.Errorf("unexpected transaction")
+			})
+			req := httptest.NewRequest(http.MethodPost, "/sp/generation-v3/accept", strings.NewReader(`{"deal_id":0,"provider":`+fmt.Sprintf("%q", signer)+`}`))
+			req.Header.Set(gatewayAuthHeader, gatewayToProviderAuthToken())
+			w := httptest.NewRecorder()
+			SpAcceptDealGenerationV3(w, req)
+			if w.Code != http.StatusConflict || txCalls != 0 {
+				t.Fatalf("changed state reached signing: code=%d tx=%d body=%s", w.Code, txCalls, w.Body.String())
+			}
+			marker, err := loadPendingSigner(signer)
+			if tc.injectMarker {
+				if queries != 1 || !strings.Contains(w.Body.String(), "provider signer has unresolved operation") {
+					t.Fatalf("concurrent marker did not stop before fresh query: queries=%d body=%s", queries, w.Body.String())
+				}
+				if err != nil || marker == nil || marker.Kind != injected.Kind || !reflect.DeepEqual(marker.IDs, injected.IDs) {
+					t.Fatalf("concurrent marker changed: %+v %v", marker, err)
+				}
+			} else {
+				if queries != 2 || !strings.Contains(w.Body.String(), "candidate changed during verification") {
+					t.Fatalf("candidate change did not reach fresh revalidation: queries=%d body=%s", queries, w.Body.String())
+				}
+				if err != nil || marker != nil {
+					t.Fatalf("candidate change created marker: %+v %v", marker, err)
+				}
+			}
+		})
 	}
 }
 

--- a/polystore_gateway/retrieval_v3_session.go
+++ b/polystore_gateway/retrieval_v3_session.go
@@ -1,0 +1,300 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+	"path/filepath"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/gogoproto/jsonpb"
+	"polystorechain/pkg/retrievalchallenge"
+	"polystorechain/x/crypto_ffi"
+	"polystorechain/x/polystorechain/types"
+)
+
+const v3SampleBitmapBytes = int((retrievalchallenge.MaxLargeSessionSamples + 7) / 8)
+
+type frozenRetrievalSessionV3 struct {
+	Session    types.RetrievalSessionV3
+	Height     uint64
+	Context    retrievalchallenge.ContextV3
+	Hash       [32]byte
+	Seed       [32]byte
+	Challenges []retrievalchallenge.ChallengeV3
+	Plan       retrievalchallenge.PlanV3
+}
+
+func queryRetrievalSessionV3(ctx context.Context, sessionID string) (*types.QueryGetRetrievalSessionV3Response, uint64, error) {
+	_, id, err := parseSessionIDHex(sessionID)
+	if err != nil {
+		return nil, 0, err
+	}
+	path := "/polystorechain/polystorechain/v1/retrieval-sessions-v3/" + base64.URLEncoding.EncodeToString(id)
+	body, height, err := readLCDJSON(ctx, path, 0, maxSessionQueryBytes)
+	if errors.Is(err, errLCDNotFound) {
+		return nil, 0, ErrSessionNotFound
+	}
+	if err != nil {
+		return nil, 0, err
+	}
+	var response types.QueryGetRetrievalSessionV3Response
+	if err := jsonpb.Unmarshal(bytes.NewReader(body), &response); err != nil {
+		return nil, 0, fmt.Errorf("invalid v3 session query: %w", err)
+	}
+	if !bytes.Equal(response.Session.SessionId, id) {
+		return nil, 0, fmt.Errorf("v3 session query returned a different identity")
+	}
+	return &response, height, nil
+}
+
+func rawProviderV3(address string) ([20]byte, error) {
+	var out [20]byte
+	raw, err := sdk.AccAddressFromBech32(address)
+	if err != nil || len(raw) != len(out) || raw.String() != address {
+		return out, fmt.Errorf("invalid canonical v3 address")
+	}
+	copy(out[:], raw)
+	return out, nil
+}
+
+func contextV3FromSession(s types.RetrievalSessionV3) (retrievalchallenge.ContextV3, error) {
+	var setup, id, root, integrity, plan [32]byte
+	if len(s.SetupDigest) != 32 || len(s.SessionId) != 32 || len(s.PolyfsRoot) != 32 || len(s.IntegrityRoot) != 32 || len(s.PlanHash) != 32 {
+		return retrievalchallenge.ContextV3{}, fmt.Errorf("invalid v3 session hashes")
+	}
+	copy(setup[:], s.SetupDigest)
+	copy(id[:], s.SessionId)
+	copy(root[:], s.PolyfsRoot)
+	copy(integrity[:], s.IntegrityRoot)
+	copy(plan[:], s.PlanHash)
+	owner, err := rawProviderV3(s.Owner)
+	if err != nil {
+		return retrievalchallenge.ContextV3{}, err
+	}
+	payer, err := rawProviderV3(s.Payer)
+	if err != nil {
+		return retrievalchallenge.ContextV3{}, err
+	}
+	c := retrievalchallenge.ContextV3{
+		ChainID: s.ChainId, SetupDigest: setup, SessionID: id, SessionOwner: owner,
+		DealID: s.DealId, Generation: s.Generation, PolyFSRoot: root, IntegrityRoot: integrity,
+		FileRecordIndex: s.FileRecordIndex, FileStartOffset: s.FileStartOffset, FileLength: s.FileLength,
+		RangeStart: s.RangeStart, RangeLength: s.RangeLength, MetadataMDUs: s.MetadataMdus, UserMDUs: s.UserMdus,
+		PlanHash: plan, Population: s.Population, SampleCount: s.SampleCount, Nonce: s.Nonce,
+		PriceDenom: s.PriceDenom, PricePerBlob: s.PricePerBlob.String(), BaseFee: s.BaseFee.String(),
+		CompletionBurnBPS: s.CompletionBurnBps, FundingKind: uint8(s.Funding), FundingPayer: payer,
+		Window:  retrievalchallenge.Window{Snapshot: s.SnapshotHeight, Anchor: s.AnchorHeight, First: s.FirstResponseHeight, Deadline: s.DeadlineHeight},
+		DealEnd: s.DealEndHeight,
+	}
+	if _, err := c.Bytes(); err != nil {
+		return retrievalchallenge.ContextV3{}, err
+	}
+	return c, nil
+}
+
+func v3BitmapSet(bitmap []byte, ordinal uint64) bool {
+	return bitmap[ordinal/8]&(byte(1)<<uint(ordinal%8)) != 0
+}
+
+func freezeRetrievalSessionV3Response(r *types.QueryGetRetrievalSessionV3Response, height uint64) (*frozenRetrievalSessionV3, error) {
+	if r == nil || height == 0 {
+		return nil, fmt.Errorf("v3 session query lacks committed state")
+	}
+	s := r.Session
+	if s.OpenedHeight < 1 || s.SnapshotHeight != uint64(s.OpenedHeight) || s.UpdatedHeight < s.OpenedHeight || uint64(s.UpdatedHeight) > height || s.Expired || height < s.FirstResponseHeight || height > s.DeadlineHeight {
+		return nil, fmt.Errorf("v3 session is malformed, terminal, or outside its response window")
+	}
+	if s.PricePerBlob.IsNil() || s.PricePerBlob.IsNegative() || s.BaseFee.IsNil() || s.BaseFee.IsNegative() || s.LockedFee.IsNil() || s.LockedFee.IsNegative() || s.Funding != types.RetrievalSessionFunding_RETRIEVAL_SESSION_FUNDING_DEAL_ESCROW && s.Funding != types.RetrievalSessionFunding_RETRIEVAL_SESSION_FUNDING_REQUESTER {
+		return nil, fmt.Errorf("invalid v3 session economics")
+	}
+	if len(s.ContextHash) != 32 || len(s.AcceptedSampleBitmap) != v3SampleBitmapBytes || s.AcceptedSampleBitmap[v3SampleBitmapBytes-1]&0xf0 != 0 || len(s.Obligations) == 0 || len(s.Obligations) > 8 {
+		return nil, fmt.Errorf("invalid v3 session bounds")
+	}
+	c, err := contextV3FromSession(s)
+	if err != nil {
+		return nil, fmt.Errorf("invalid v3 session context: %w", err)
+	}
+	setup, setupErr := hex.DecodeString(types.RetrievalSetupDigest)
+	if c.ChainID != chainID || setupErr != nil || !bytes.Equal(c.SetupDigest[:], setup) {
+		return nil, fmt.Errorf("v3 session chain or setup mismatch")
+	}
+	hash, err := c.Hash()
+	if err != nil || !bytes.Equal(hash[:], s.ContextHash) {
+		return nil, fmt.Errorf("v3 session context hash mismatch")
+	}
+	rng, err := retrievalchallenge.CheckedRangeV3(s.FileStartOffset, s.FileLength, s.RangeStart, s.RangeLength, s.UserMdus)
+	if err != nil || rng.First != s.FirstBlob || rng.Last != s.LastBlob || rng.Population != s.Population {
+		return nil, fmt.Errorf("v3 session range mismatch")
+	}
+	var providers [8][20]byte
+	var represented uint32
+	remaining := new(big.Int)
+	for i := range s.Obligations {
+		o := s.Obligations[i]
+		if o.Slot >= 8 || (i > 0 && s.Obligations[i-1].Slot >= o.Slot) || o.AssignedProvider != o.Payee || o.BlobCount == 0 || o.LockedFee.IsNil() || o.LockedFee.IsNegative() {
+			return nil, fmt.Errorf("invalid v3 obligation")
+		}
+		expected := new(big.Int).Mul(s.PricePerBlob.BigInt(), new(big.Int).SetUint64(o.BlobCount))
+		if expected.BitLen() > 256 || expected.Cmp(o.LockedFee.BigInt()) != 0 {
+			return nil, fmt.Errorf("invalid v3 obligation fee")
+		}
+		provider, err := rawProviderV3(o.AssignedProvider)
+		if err != nil {
+			return nil, err
+		}
+		providers[o.Slot] = provider
+		represented |= uint32(1) << o.Slot
+		bit := uint32(1) << o.Slot
+		if s.SettledSlotsMask&bit == 0 && s.RefundedSlotsMask&bit == 0 {
+			remaining.Add(remaining, o.LockedFee.BigInt())
+			if remaining.BitLen() > 256 {
+				return nil, fmt.Errorf("v3 remaining fee exceeds uint256")
+			}
+		}
+	}
+	if masks := s.AckedSlotsMask | s.SettledSlotsMask | s.RefundedSlotsMask; masks&^represented != 0 || s.SettledSlotsMask&s.RefundedSlotsMask != 0 || s.SettledSlotsMask&^s.AckedSlotsMask != 0 {
+		return nil, fmt.Errorf("invalid v3 settlement masks")
+	}
+	if remaining.Cmp(s.LockedFee.BigInt()) != 0 {
+		return nil, fmt.Errorf("v3 locked fee does not match unsettled obligations")
+	}
+	plan, err := retrievalchallenge.BuildPlanV3(rng, providers)
+	if err != nil || len(plan.Obligations) != len(s.Obligations) {
+		return nil, fmt.Errorf("invalid v3 session plan")
+	}
+	for i, want := range plan.Obligations {
+		got := s.Obligations[i]
+		if got.Slot != want.Slot || got.BlobCount != want.BlobCount {
+			return nil, fmt.Errorf("v3 obligation does not match compact plan")
+		}
+	}
+	planHash, err := plan.Hash()
+	if err != nil || !bytes.Equal(planHash[:], s.PlanHash) {
+		return nil, fmt.Errorf("v3 plan hash mismatch")
+	}
+	if len(r.AnchorSeed) != 32 {
+		return nil, fmt.Errorf("v3 session anchor is unavailable or malformed")
+	}
+	seed, err := c.Seed(r.AnchorSeed)
+	if err != nil {
+		return nil, err
+	}
+	challenges, err := c.Challenges(seed[:])
+	if err != nil {
+		return nil, err
+	}
+	counts := make(map[uint32]uint64, len(s.Obligations))
+	for _, challenge := range challenges {
+		counts[challenge.Slot]++
+	}
+	var storedSamples uint64
+	for _, obligation := range s.Obligations {
+		storedSamples += obligation.SampleCount
+		if obligation.SampleCount != 0 && obligation.SampleCount != counts[obligation.Slot] {
+			return nil, fmt.Errorf("v3 sample partition mismatch")
+		}
+	}
+	if storedSamples != 0 && storedSamples != s.SampleCount {
+		return nil, fmt.Errorf("v3 stored sample count mismatch")
+	}
+	return &frozenRetrievalSessionV3{Session: s, Height: height, Context: c, Hash: hash, Seed: seed, Challenges: challenges, Plan: plan}, nil
+}
+
+func providerChallengesV3(f *frozenRetrievalSessionV3, signer string, limit int) (uint32, []retrievalchallenge.ChallengeV3, int, error) {
+	if f == nil || limit < 1 || limit > 64 {
+		return 0, nil, 0, fmt.Errorf("invalid v3 proof selection bounds")
+	}
+	slot := uint32(math.MaxUint32)
+	for _, obligation := range f.Session.Obligations {
+		if obligation.AssignedProvider == signer {
+			if slot != math.MaxUint32 {
+				return 0, nil, 0, fmt.Errorf("signer occupies multiple v3 obligations")
+			}
+			slot = obligation.Slot
+		}
+	}
+	if slot == math.MaxUint32 {
+		return 0, nil, 0, fmt.Errorf("signer is not a frozen v3 provider")
+	}
+	bit := uint32(1) << slot
+	if f.Session.SettledSlotsMask&bit != 0 || f.Session.RefundedSlotsMask&bit != 0 {
+		return slot, nil, 0, nil
+	}
+	selected := make([]retrievalchallenge.ChallengeV3, 0, limit)
+	remaining := 0
+	for _, challenge := range f.Challenges {
+		if challenge.Slot != slot || v3BitmapSet(f.Session.AcceptedSampleBitmap, challenge.Ordinal) {
+			continue
+		}
+		remaining++
+		if len(selected) < limit {
+			selected = append(selected, challenge)
+		}
+	}
+	return slot, selected, remaining - len(selected), nil
+}
+
+func buildProviderProofBatchV3(ctx context.Context, f *frozenRetrievalSessionV3, signer string) (uint32, []types.RetrievalSampleProofV3, int, error) {
+	slot, challenges, remaining, err := providerChallengesV3(f, signer, 64)
+	if err != nil || len(challenges) == 0 {
+		return slot, nil, remaining, err
+	}
+	root, err := parseManifestRoot("0x" + hex.EncodeToString(f.Context.PolyFSRoot[:]))
+	if err != nil {
+		return 0, nil, 0, err
+	}
+	dir, release, err := openFrozenGeneration(f.Context.DealID, root)
+	if err != nil {
+		return 0, nil, 0, err
+	}
+	defer release()
+	key := retrievalGenerationKey{Chain: f.Context.ChainID, Setup: f.Context.SetupDigest, Root: f.Context.PolyFSRoot, Integrity: f.Context.IntegrityRoot, Deal: f.Context.DealID, Generation: f.Context.Generation, Metadata: f.Context.MetadataMDUs, Users: f.Context.UserMDUs, Layout: retrievalchallenge.StripeK8M4, K: 8, M: 4, Version: 3}
+	metadata, err := authenticatedRetrievalMetadataFor(ctx, dir, key)
+	if err != nil {
+		return 0, nil, 0, err
+	}
+	proofs := make([]types.RetrievalSampleProofV3, len(challenges))
+	for i, challenge := range challenges {
+		if err := ctx.Err(); err != nil {
+			return 0, nil, 0, err
+		}
+		user, err := metadata.userMDUFor(ctx, dir, key, challenge.MDUIndex)
+		if err != nil {
+			return 0, nil, 0, err
+		}
+		row := uint64(challenge.LeafIndex % 8)
+		path := filepath.Join(dir, fmt.Sprintf("mdu_%d_slot_%d.bin", challenge.MDUIndex, slot))
+		blob, err := readExactArtifactRange(path, 8*types.BLOB_SIZE, row*types.BLOB_SIZE, types.BLOB_SIZE)
+		if err != nil {
+			return 0, nil, 0, err
+		}
+		proof, err := buildFrozenBlobProofAt(ctx, challenge.MDUIndex, challenge.LeafIndex, challenge.Z, user, blob)
+		if err != nil {
+			return 0, nil, 0, err
+		}
+		flat, err := flattenMerkleProof32(proof.MerklePath)
+		if err != nil {
+			return 0, nil, 0, err
+		}
+		valid, err := crypto_ffi.VerifyMduProof(proof.MduRootFr, proof.BlobCommitment, flat, proof.BlobIndex, retrievalchallenge.IntegrityLeavesPerUserMDU, proof.ZValue, proof.YValue, proof.KzgOpeningProof)
+		if err != nil || !valid {
+			return 0, nil, 0, fmt.Errorf("generated v3 proof failed native verification")
+		}
+		proofs[i] = types.RetrievalSampleProofV3{Ordinal: challenge.Ordinal, Proof: proof}
+	}
+	return slot, proofs, remaining, nil
+}
+
+func fetchFrozenRetrievalSessionV3(ctx context.Context, sessionID string) (*frozenRetrievalSessionV3, error) {
+	r, height, err := queryRetrievalSessionV3(ctx, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	return freezeRetrievalSessionV3Response(r, height)
+}

--- a/polystore_gateway/retrieval_v3_session_test.go
+++ b/polystore_gateway/retrieval_v3_session_test.go
@@ -1,0 +1,463 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	cosmosmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	bolt "go.etcd.io/bbolt"
+	"golang.org/x/crypto/blake2s"
+	"polystorechain/pkg/retrievalchallenge"
+	"polystorechain/x/crypto_ffi"
+	"polystorechain/x/polystorechain/types"
+)
+
+func frozenSessionV3Fixture(t *testing.T, rangeLength, userMDUs uint64) (*types.QueryGetRetrievalSessionV3Response, uint64) {
+	t.Helper()
+	oldChain := chainID
+	chainID = "polystore-test-1"
+	t.Cleanup(func() { chainID = oldChain })
+	setup, err := hex.DecodeString(types.RetrievalSetupDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ownerRaw := [20]byte{19: 99}
+	owner := sdk.AccAddress(ownerRaw[:]).String()
+	var providers [8][20]byte
+	for i := range providers {
+		providers[i][19] = byte(i + 1)
+	}
+	rng, err := retrievalchallenge.CheckedRangeV3(0, rangeLength, 0, rangeLength, userMDUs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := retrievalchallenge.BuildPlanV3(rng, providers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	planHash, err := plan.Hash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, err := (retrievalchallenge.SessionBindingV3{ChainID: chainID, Owner: ownerRaw, DealID: 0, Generation: 1, FileRecordIndex: 3, RangeStart: 0, RangeLength: rangeLength, PlanHash: planHash, Nonce: 7}).ID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	window, err := retrievalchallenge.SessionWindow(10, 20, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var setup32 [32]byte
+	copy(setup32[:], setup)
+	c := retrievalchallenge.ContextV3{
+		ChainID: chainID, SetupDigest: setup32, SessionID: id, SessionOwner: ownerRaw,
+		DealID: 0, Generation: 1, FileRecordIndex: 3, FileLength: rangeLength, RangeLength: rangeLength,
+		MetadataMDUs: 4, UserMDUs: userMDUs, PlanHash: planHash, Population: rng.Population,
+		SampleCount: min(rng.Population, retrievalchallenge.MaxLargeSessionSamples), Nonce: 7,
+		PriceDenom: "stake", PricePerBlob: "1", BaseFee: "0",
+		FundingKind: retrievalchallenge.FundingRequester, FundingPayer: ownerRaw, Window: window, DealEnd: 100,
+	}
+	hash, err := c.Hash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := types.RetrievalSessionV3{
+		SessionId: id[:], ContextHash: hash[:], DealId: 0, Generation: 1, Owner: owner, Payer: owner,
+		PolyfsRoot: c.PolyFSRoot[:], IntegrityRoot: c.IntegrityRoot[:], SetupDigest: setup,
+		FileRecordIndex: 3, FileLength: rangeLength, RangeLength: rangeLength, MetadataMdus: 4, UserMdus: userMDUs,
+		PlanHash: planHash[:], FirstBlob: rng.First, LastBlob: rng.Last, Population: rng.Population,
+		SampleCount: c.SampleCount, Nonce: 7, PriceDenom: "stake", PricePerBlob: cosmosmath.OneInt(), BaseFee: cosmosmath.ZeroInt(),
+		Funding:        types.RetrievalSessionFunding_RETRIEVAL_SESSION_FUNDING_REQUESTER,
+		SnapshotHeight: window.Snapshot, AnchorHeight: window.Anchor, FirstResponseHeight: window.First, DeadlineHeight: window.Deadline, DealEndHeight: 100,
+		AcceptedSampleBitmap: make([]byte, v3SampleBitmapBytes), LockedFee: cosmosmath.NewIntFromUint64(rng.Population),
+		OpenedHeight: 10, UpdatedHeight: 10, ChainId: chainID,
+	}
+	for _, o := range plan.Obligations {
+		address := sdk.AccAddress(o.Assigned[:]).String()
+		s.Obligations = append(s.Obligations, types.RetrievalObligationV3{Slot: o.Slot, AssignedProvider: address, Payee: address, BlobCount: o.BlobCount, LockedFee: cosmosmath.NewIntFromUint64(o.BlobCount)})
+	}
+	anchor := make([]byte, 32)
+	anchor[0] = 42
+	return &types.QueryGetRetrievalSessionV3Response{Session: s, AnchorSeed: anchor}, window.First
+}
+
+func TestFreezeRetrievalSessionV3ResponseDerivesGlobalPartition(t *testing.T) {
+	r, height := frozenSessionV3Fixture(t, 1<<30, 133)
+	frozen, err := freezeRetrievalSessionV3Response(r, height)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(frozen.Challenges) != int(retrievalchallenge.MaxLargeSessionSamples) {
+		t.Fatalf("challenge count %d", len(frozen.Challenges))
+	}
+	counts := map[uint32]uint64{}
+	rng, err := retrievalchallenge.CheckedRangeV3(frozen.Context.FileStartOffset, frozen.Context.FileLength, frozen.Context.RangeStart, frozen.Context.RangeLength, frozen.Context.UserMDUs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for ordinal, challenge := range frozen.Challenges {
+		if challenge.Ordinal != uint64(ordinal) || challenge.T != rng.First+challenge.Position {
+			t.Fatalf("challenge %d ordinal or population mapping mismatch", ordinal)
+		}
+		mdu, leaf, slot, err := retrievalchallenge.SystematicCoordinateV3(challenge.T, frozen.Context.MetadataMDUs, frozen.Context.UserMDUs)
+		if err != nil || challenge.MDUIndex != mdu || challenge.LeafIndex != leaf || challenge.Slot != slot {
+			t.Fatalf("challenge %d coordinate mismatch", ordinal)
+		}
+		counts[slot]++
+	}
+	for _, obligation := range frozen.Session.Obligations {
+		if counts[obligation.Slot] == 0 {
+			t.Fatalf("fixture unexpectedly omitted represented slot %d", obligation.Slot)
+		}
+	}
+	r.Session.ContextHash[0] ^= 1
+	if _, err := freezeRetrievalSessionV3Response(r, height); err == nil {
+		t.Fatal("accepted rebound v3 context hash")
+	}
+}
+
+func TestProviderChallengesV3PreservesGlobalOrdinalsAndBoundsEnvelope(t *testing.T) {
+	r, height := frozenSessionV3Fixture(t, 1<<30, 133)
+	frozen, err := freezeRetrievalSessionV3Response(r, height)
+	if err != nil {
+		t.Fatal(err)
+	}
+	obligation := frozen.Session.Obligations[0]
+	frozen.Challenges = make([]retrievalchallenge.ChallengeV3, 66)
+	for i := range frozen.Challenges {
+		frozen.Challenges[i] = retrievalchallenge.ChallengeV3{Ordinal: uint64(i), Slot: obligation.Slot}
+	}
+	// Accepted samples remain keyed by their global ordinal across envelopes.
+	frozen.Session.AcceptedSampleBitmap[3/8] |= 1 << (3 % 8)
+	slot, selected, remaining, err := providerChallengesV3(frozen, obligation.AssignedProvider, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slot != obligation.Slot || len(selected) != 64 || remaining != 1 {
+		t.Fatalf("unexpected partition slot=%d selected=%d remaining=%d", slot, len(selected), remaining)
+	}
+	for _, challenge := range selected {
+		if challenge.Ordinal == 3 {
+			t.Fatal("reselected accepted global ordinal")
+		}
+	}
+	outsider := sdk.AccAddress(bytes.Repeat([]byte{99}, 20)).String()
+	if _, _, _, err := providerChallengesV3(frozen, outsider, 64); err == nil {
+		t.Fatal("accepted a signer outside the frozen provider vector")
+	}
+}
+
+func TestFreezeRetrievalSessionV3ResponseRejectsMalformedEconomics(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		mutate func(*types.QueryGetRetrievalSessionV3Response)
+	}{
+		{"funding aliases after uint8 conversion", func(r *types.QueryGetRetrievalSessionV3Response) {
+			r.Session.Funding = types.RetrievalSessionFunding(257)
+		}},
+		{"obligation fee mismatch", func(r *types.QueryGetRetrievalSessionV3Response) {
+			r.Session.Obligations[0].LockedFee = r.Session.Obligations[0].LockedFee.AddRaw(1)
+		}},
+		{"remaining lock mismatch", func(r *types.QueryGetRetrievalSessionV3Response) { r.Session.LockedFee = r.Session.LockedFee.AddRaw(1) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r, height := frozenSessionV3Fixture(t, 1<<20, 1)
+			tc.mutate(r)
+			if _, err := freezeRetrievalSessionV3Response(r, height); err == nil || !strings.Contains(err.Error(), "v3") {
+				t.Fatalf("accepted malformed economics: %v", err)
+			}
+		})
+	}
+}
+
+func TestRetrievalProofOperationV3TracksExactGlobalOrdinals(t *testing.T) {
+	id := bytes.Repeat([]byte{7}, 32)
+	idHex := hex.EncodeToString(id)
+	proofs := []types.RetrievalSampleProofV3{{Ordinal: 4}, {Ordinal: 129}}
+	op := retrievalProofOperationV3(id, proofs)
+	if op.Kind != "retrieval-v3" || len(op.IDs) != 2 || !strings.HasSuffix(op.IDs[0], ":4") || !strings.HasSuffix(op.IDs[1], ":129") {
+		t.Fatalf("unexpected durable proof identity: %+v", op)
+	}
+	s := types.RetrievalSessionV3{SessionId: bytes.Clone(id), SampleCount: 132, AcceptedSampleBitmap: make([]byte, v3SampleBitmapBytes)}
+	for _, ordinal := range []uint64{4, 129} {
+		s.AcceptedSampleBitmap[ordinal/8] |= 1 << (ordinal % 8)
+	}
+	if !pendingRetrievalProofsAcceptedV3(&op, s) {
+		t.Fatal("exact accepted proof ordinals did not reconcile")
+	}
+	s.SessionId[0] ^= 1
+	if pendingRetrievalProofsAcceptedV3(&op, s) {
+		t.Fatal("reconciled proof marker against another session")
+	}
+	bad := pendingSignerOperation{Kind: "retrieval-v3", IDs: []string{idHex + ":132"}}
+	s.SessionId = bytes.Clone(id)
+	s.SampleCount = ^uint64(0)
+	if pendingRetrievalProofsAcceptedV3(&bad, s) {
+		t.Fatal("accepted proof ordinal outside the canonical v3 bitmap")
+	}
+	recorded, ordinals, ok := parseRetrievalProofOperationV3(&op)
+	if !ok || recorded != idHex {
+		t.Fatalf("lost recorded session identity: %q %t", recorded, ok)
+	}
+	if len(ordinals) != 2 || ordinals[0] != 4 || ordinals[1] != 129 {
+		t.Fatalf("lost recorded ordinals: %v", ordinals)
+	}
+	for _, malformed := range []string{idHex + ":junk", strings.ToUpper(strings.Repeat("ab", 32)) + ":4", idHex + ":04", idHex + ":132", idHex + ":4:5"} {
+		bad := pendingSignerOperation{Kind: "retrieval-v3", IDs: []string{malformed}, TxHash: strings.Repeat("A", 64)}
+		if _, _, ok := parseRetrievalProofOperationV3(&bad); ok {
+			t.Fatalf("accepted malformed committed proof marker %q", malformed)
+		}
+	}
+}
+
+func TestRetrievalV3RecoveryOutcomeDoesNotAttributeRequestedSession(t *testing.T) {
+	w := httptest.NewRecorder()
+	recorded := strings.Repeat("ab", 32)
+	writeRetrievalV3RecoveryOutcome(w, "reconciled", recorded, strings.Repeat("C", 64), 2, "complete", nil)
+	body := w.Body.String()
+	for _, want := range []string{`"recorded_session_id":"` + recorded + `"`, `"retry_required":true`} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("missing %s in %s", want, body)
+		}
+	}
+	if strings.Contains(body, `"session_id"`) || strings.Contains(body, `"remaining"`) || strings.Contains(body, `"slot"`) {
+		t.Fatalf("recovery response claimed unqueried current-session state: %s", body)
+	}
+}
+
+func buildProviderV3ArtifactFixture(t *testing.T) (*frozenRetrievalSessionV3, retrievalGenerationKey, string) {
+	t.Helper()
+	useTempUploadDir(t)
+	initCryptoForTest(t)
+	const dealID = uint64(0)
+	payload := filepath.Join(t.TempDir(), "payload.bin")
+	if err := os.WriteFile(payload, bytes.Repeat([]byte{0x5a}, 1024), 0600); err != nil {
+		t.Fatal(err)
+	}
+	result, oldDir, err := mode2BuildArtifacts(context.Background(), payload, dealID, "General:rs=8+4", "payload.bin", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	metadataMDUs := uint64(1 + result.witnessMdus)
+	leaves := make([][32]byte, result.userMdus*retrievalchallenge.IntegrityLeavesPerUserMDU)
+	for user := uint64(0); user < result.userMdus; user++ {
+		mdu := metadataMDUs + user
+		for slot := uint32(0); slot < 12; slot++ {
+			shard, err := os.ReadFile(filepath.Join(oldDir, fmt.Sprintf("mdu_%d_slot_%d.bin", mdu, slot)))
+			if err != nil || len(shard) != 8*types.BLOB_SIZE {
+				t.Fatalf("read slot artifact %d/%d: %v size=%d", mdu, slot, err, len(shard))
+			}
+			for row := uint32(0); row < 8; row++ {
+				leaf := slot*8 + row
+				hash, err := retrievalchallenge.IntegrityLeafV3(mdu, leaf, shard[int(row)*types.BLOB_SIZE:int(row+1)*types.BLOB_SIZE])
+				if err != nil {
+					t.Fatal(err)
+				}
+				leaves[user*retrievalchallenge.IntegrityLeavesPerUserMDU+uint64(leaf)] = hash
+			}
+		}
+	}
+	integrity, err := retrievalchallenge.IntegrityRootV3(leaves)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vector := make([]byte, 0, len(leaves)*32)
+	for _, leaf := range leaves {
+		vector = append(vector, leaf[:]...)
+	}
+	if err := os.WriteFile(filepath.Join(oldDir, integrityLeavesV3File), vector, 0600); err != nil {
+		t.Fatal(err)
+	}
+	mdu0, err := os.ReadFile(filepath.Join(oldDir, "mdu_0.bin"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	builder, err := crypto_ffi.LoadMdu0Builder(mdu0, result.userMdus)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recordCount := builder.GetRecordCount()
+	builder.Free()
+	writePackedFATHeaderV3(t, mdu0, retrievalchallenge.FATV3Header{RecordCount: recordCount, LeafCount: uint64(len(leaves)), IntegrityRoot: integrity})
+	if err := os.WriteFile(filepath.Join(oldDir, "mdu_0.bin"), mdu0, 0600); err != nil {
+		t.Fatal(err)
+	}
+	polyfsLeaves := make([][32]byte, 64)
+	for i := range polyfsLeaves {
+		commitment, err := crypto_ffi.CommitReceivedBlob(mdu0[i*types.BLOB_SIZE : (i+1)*types.BLOB_SIZE])
+		if err != nil {
+			t.Fatal(err)
+		}
+		polyfsLeaves[i] = blake2s.Sum256(commitment)
+	}
+	tree := buildProofMerkleTree(polyfsLeaves)
+	root, err := parseManifestRoot("0x" + hex.EncodeToString(tree[len(tree)-1][0][:]))
+	if err != nil {
+		t.Fatal(err)
+	}
+	newDir := dealScopedDir(dealID, root)
+	if err := os.MkdirAll(filepath.Dir(newDir), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(oldDir, newDir); err != nil {
+		t.Fatal(err)
+	}
+	r, height := frozenSessionV3Fixture(t, 1024, result.userMdus)
+	r.Session.PolyfsRoot = bytes.Clone(root.Bytes[:])
+	r.Session.IntegrityRoot = integrity[:]
+	r.Session.MetadataMdus = metadataMDUs
+	c, err := contextV3FromSession(r.Session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hash, err := c.Hash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.Session.ContextHash = hash[:]
+	frozen, err := freezeRetrievalSessionV3Response(r, height)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := retrievalGenerationKey{Chain: c.ChainID, Setup: c.SetupDigest, Root: c.PolyFSRoot, Integrity: c.IntegrityRoot, Deal: c.DealID, Generation: c.Generation, Metadata: c.MetadataMDUs, Users: c.UserMDUs, Layout: retrievalchallenge.StripeK8M4, K: 8, M: 4, Version: 3}
+	return frozen, key, newDir
+}
+
+func TestBuildProviderProofBatchV3UsesAuthenticatedArtifactsAndRealKZG(t *testing.T) {
+	frozen, key, dir := buildProviderV3ArtifactFixture(t)
+	signer := frozen.Session.Obligations[0].AssignedProvider
+	metadata, err := authenticatedRetrievalMetadataFor(t.Context(), dir, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := verifyIntegrityVectorV3(t.Context(), dir, key, 0, metadata); err != nil {
+		t.Fatalf("generation ingest verification failed: %v", err)
+	}
+	slot, proofs, remaining, err := buildProviderProofBatchV3(t.Context(), frozen, signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slot != 0 || len(proofs) != 1 || proofs[0].Ordinal != 0 || remaining != 0 {
+		t.Fatalf("unexpected real proof batch slot=%d proofs=%d ordinal=%d remaining=%d", slot, len(proofs), proofs[0].Ordinal, remaining)
+	}
+	if _, _, _, err := buildProviderProofBatchV3(t.Context(), frozen, sdk.AccAddress(bytes.Repeat([]byte{99}, 20)).String()); err == nil {
+		t.Fatal("generated proof for the wrong provider")
+	}
+	shardPath := filepath.Join(dir, fmt.Sprintf("mdu_%d_slot_0.bin", key.Metadata))
+	shard, err := os.OpenFile(shardPath, os.O_RDWR, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := shard.WriteAt([]byte{0xff}, 17); err != nil {
+		t.Fatal(err)
+	}
+	if err := shard.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := buildProviderProofBatchV3(t.Context(), frozen, signer); err == nil {
+		t.Fatal("accepted a proof from corrupted frozen bytes")
+	}
+}
+
+func TestGenerationAcceptanceV3RejectsUnsampledIntegrityLeaf(t *testing.T) {
+	_, key, dir := buildProviderV3ArtifactFixture(t)
+	metadata, err := authenticatedRetrievalMetadataFor(t.Context(), dir, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, integrityLeavesV3File)
+	f, err := os.OpenFile(path, os.O_RDWR, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Corrupt another slot's leaf. Own-slot verification still authenticates the
+	// complete vector root before checking this provider's eight stored blobs.
+	if _, err := f.WriteAt([]byte{0xff}, int64(8*32+7)); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := verifyIntegrityVectorV3(t.Context(), dir, key, 0, metadata); err == nil {
+		t.Fatal("accepted an altered unsampled integrity leaf")
+	}
+}
+
+func TestRetrievalV3PendingSignerSurvivesRestartAndSharesAuditLock(t *testing.T) {
+	path := submissionTestDB(t)
+	signer := sdk.AccAddress(bytes.Repeat([]byte{9}, 20)).String()
+	audit := pendingSignerOperation{Kind: "audit", IDs: []string{"audit-context:4"}}
+	if err := sessionDB.Update(func(tx *bolt.Tx) error { return claimPendingSigner(tx, signer, audit) }); err != nil {
+		t.Fatal(err)
+	}
+	id := bytes.Repeat([]byte{7}, 32)
+	op := retrievalProofOperationV3(id, []types.RetrievalSampleProofV3{{Ordinal: 4}})
+	if err := updatePendingSignerV3(signer, op, false); err == nil {
+		t.Fatal("v3 retrieval bypassed unresolved audit signer operation")
+	}
+	got, err := loadPendingSigner(signer)
+	if err != nil || got == nil || got.Kind != "audit" {
+		t.Fatalf("failed v3 claim altered audit marker: %+v %v", got, err)
+	}
+	if err := sessionDB.Update(func(tx *bolt.Tx) error { return clearPendingSigner(tx, signer, audit.Kind, audit.IDs) }); err != nil {
+		t.Fatal(err)
+	}
+	op.TxHash = strings.Repeat("A", 64)
+	if err := updatePendingSignerV3(signer, op, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := closeSessionDB(); err != nil {
+		t.Fatal(err)
+	}
+	if err := initSessionDB(path); err != nil {
+		t.Fatal(err)
+	}
+	got, err = loadPendingSigner(signer)
+	if err != nil || got == nil || got.Kind != op.Kind || got.TxHash != op.TxHash || len(got.IDs) != 1 || got.IDs[0] != op.IDs[0] {
+		t.Fatalf("restart lost exact v3 proof quarantine: %+v %v", got, err)
+	}
+}
+
+func TestRetrievalV3MalformedCommittedMarkerRemainsQuarantined(t *testing.T) {
+	submissionTestDB(t)
+	lcd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/retrieval-sessions/") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		t.Fatalf("unexpected LCD query after malformed v3 marker: %s", r.URL.Path)
+	}))
+	t.Cleanup(lcd.Close)
+	oldLCD := lcdBase
+	lcdBase = lcd.URL
+	t.Cleanup(func() { lcdBase = oldLCD })
+	signer := sdk.AccAddress(bytes.Repeat([]byte{9}, 20)).String()
+	id := strings.Repeat("ab", 32)
+	op := pendingSignerOperation{Kind: "retrieval-v3", IDs: []string{id + ":junk"}, TxHash: strings.Repeat("A", 64)}
+	if err := updatePendingSignerV3(signer, op, false); err != nil {
+		t.Fatal(err)
+	}
+	setupMockCombinedOutput(t, func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "keys" {
+			return []byte(signer), nil
+		}
+		return nil, fmt.Errorf("unexpected command")
+	})
+	w := invokeSubmission(`{"session_id":"0x` + id + `"}`)
+	if w.Code != http.StatusConflict || !strings.Contains(w.Body.String(), "invalid v3 proof reconciliation identity") {
+		t.Fatalf("malformed marker was not rejected: %d %s", w.Code, w.Body.String())
+	}
+	got, err := loadPendingSigner(signer)
+	if err != nil || got == nil || got.TxHash != op.TxHash || got.IDs[0] != op.IDs[0] {
+		t.Fatalf("malformed committed marker was cleared: %+v %v", got, err)
+	}
+}

--- a/polystore_gateway/retrieval_v3_submission.go
+++ b/polystore_gateway/retrieval_v3_submission.go
@@ -1,0 +1,219 @@
+package main
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/cosmos/gogoproto/jsonpb"
+	"polystorechain/pkg/retrievalchallenge"
+	"polystorechain/x/polystorechain/types"
+)
+
+func retrievalProofOperationV3(sessionID []byte, proofs []types.RetrievalSampleProofV3) pendingSignerOperation {
+	prefix := hex.EncodeToString(sessionID) + ":"
+	ids := make([]string, len(proofs))
+	for i := range proofs {
+		ids[i] = prefix + strconv.FormatUint(proofs[i].Ordinal, 10)
+	}
+	return pendingSignerOperation{Kind: "retrieval-v3", IDs: ids}
+}
+
+func parseRetrievalProofOperationV3(op *pendingSignerOperation) (string, []uint64, bool) {
+	if op == nil || op.Kind != "retrieval-v3" || len(op.IDs) == 0 {
+		return "", nil, false
+	}
+	prefix, _, ok := strings.Cut(op.IDs[0], ":")
+	if !ok || len(prefix) != 64 {
+		return "", nil, false
+	}
+	decoded, err := hex.DecodeString(prefix)
+	if err != nil || hex.EncodeToString(decoded) != prefix {
+		return "", nil, false
+	}
+	ordinals := make([]uint64, len(op.IDs))
+	seen := make(map[uint64]struct{}, len(op.IDs))
+	for i, id := range op.IDs {
+		gotPrefix, rawOrdinal, ok := strings.Cut(id, ":")
+		ordinal, err := strconv.ParseUint(rawOrdinal, 10, 64)
+		if !ok || strings.Contains(rawOrdinal, ":") || gotPrefix != prefix || err != nil || strconv.FormatUint(ordinal, 10) != rawOrdinal || ordinal >= retrievalchallenge.MaxLargeSessionSamples {
+			return "", nil, false
+		}
+		if _, duplicate := seen[ordinal]; duplicate {
+			return "", nil, false
+		}
+		seen[ordinal] = struct{}{}
+		ordinals[i] = ordinal
+	}
+	return prefix, ordinals, true
+}
+
+func pendingRetrievalProofsAcceptedV3(op *pendingSignerOperation, session types.RetrievalSessionV3) bool {
+	if op == nil || op.Kind != "retrieval-v3" || len(session.SessionId) != 32 || len(session.AcceptedSampleBitmap) != v3SampleBitmapBytes {
+		return false
+	}
+	prefix, ordinals, ok := parseRetrievalProofOperationV3(op)
+	if !ok || prefix != hex.EncodeToString(session.SessionId) {
+		return false
+	}
+	for _, ordinal := range ordinals {
+		if ordinal >= session.SampleCount || !v3BitmapSet(session.AcceptedSampleBitmap, ordinal) {
+			return false
+		}
+	}
+	return true
+}
+
+func writeRetrievalV3RecoveryOutcome(w http.ResponseWriter, status, recordedSessionID, hash string, proofs int, cleanup string, err error) {
+	result := map[string]any{"status": status, "recorded_session_id": recordedSessionID, "tx_hash": hash, "proof_count": proofs, "cleanup_status": cleanup, "retry_required": true}
+	if err != nil {
+		result["error"] = err.Error()
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if status == "pending" {
+		w.WriteHeader(http.StatusAccepted)
+	} else if status == "failed" {
+		w.WriteHeader(http.StatusConflict)
+	}
+	_ = json.NewEncoder(w).Encode(result)
+}
+
+func writeRetrievalV3Outcome(w http.ResponseWriter, status, sessionID, hash string, slot uint32, proofs, remaining int, cleanup string, err error) {
+	result := map[string]any{"status": status, "session_id": sessionID, "tx_hash": hash, "slot": slot, "proof_count": proofs, "remaining": remaining, "cleanup_status": cleanup}
+	if err != nil {
+		result["error"] = err.Error()
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if status == "pending" {
+		w.WriteHeader(http.StatusAccepted)
+	} else if status == "failed" {
+		w.WriteHeader(http.StatusConflict)
+	}
+	_ = json.NewEncoder(w).Encode(result)
+}
+
+// submitRetrievalSessionProofV3 runs under the existing per-session and signer
+// in-memory locks held by SpSubmitRetrievalSessionProof.
+func submitRetrievalSessionProofV3(w http.ResponseWriter, ctx context.Context, keyName, signer, sessionID string) {
+	pending, err := loadPendingSigner(signer)
+	if err != nil {
+		writeJSONError(w, http.StatusConflict, "v3 proof reconciliation state unavailable", err.Error())
+		return
+	}
+	if pending != nil && pending.Kind != "retrieval-v3" {
+		writeJSONError(w, http.StatusConflict, "provider signer has unresolved operation", fmt.Sprintf("actual signer awaits %s reconciliation", pending.Kind))
+		return
+	}
+	recordedSessionID := ""
+	if pending != nil {
+		var ok bool
+		recordedSessionID, _, ok = parseRetrievalProofOperationV3(pending)
+		if !ok {
+			writeJSONError(w, http.StatusConflict, "invalid v3 proof reconciliation identity", "stored proof ordinals do not bind one canonical session")
+			return
+		}
+	}
+	if pending != nil && pending.TxHash != "" {
+		hash, waitErr := waitForCommittedTx(ctx, pending.TxHash)
+		if waitErr == nil || errors.Is(waitErr, errTxFailed) {
+			if clearErr := updatePendingSignerV3(signer, *pending, true); clearErr != nil {
+				writeJSONError(w, http.StatusConflict, "v3 proof cleanup pending", clearErr.Error())
+				return
+			}
+		}
+		if waitErr != nil {
+			if errors.Is(waitErr, errTxFailed) {
+				writeRetrievalV3RecoveryOutcome(w, "failed", recordedSessionID, pending.TxHash, len(pending.IDs), "complete", waitErr)
+				return
+			}
+			writeRetrievalV3RecoveryOutcome(w, "pending", recordedSessionID, pending.TxHash, len(pending.IDs), "retained", waitErr)
+			return
+		}
+		writeRetrievalV3RecoveryOutcome(w, "reconciled", recordedSessionID, hash, len(pending.IDs), "complete", nil)
+		return
+	}
+	querySessionID := sessionID
+	if pending != nil {
+		querySessionID = recordedSessionID
+	}
+	response, height, err := queryRetrievalSessionV3(ctx, querySessionID)
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, "v3 session authority unavailable", err.Error())
+		return
+	}
+	if pending != nil && pendingRetrievalProofsAcceptedV3(pending, response.Session) {
+		if err := updatePendingSignerV3(signer, *pending, true); err != nil {
+			writeJSONError(w, http.StatusConflict, "v3 proof cleanup pending", err.Error())
+			return
+		}
+		writeRetrievalV3RecoveryOutcome(w, "reconciled", recordedSessionID, "", len(pending.IDs), "complete", nil)
+		return
+	}
+	if pending != nil {
+		writeRetrievalV3RecoveryOutcome(w, "pending", recordedSessionID, "", len(pending.IDs), "retained", fmt.Errorf("broadcast hash was not persisted and exact samples are not accepted"))
+		return
+	}
+	frozen, err := freezeRetrievalSessionV3Response(response, height)
+	if err != nil {
+		writeJSONError(w, http.StatusConflict, "invalid frozen v3 session", err.Error())
+		return
+	}
+	slot, proofs, remaining, err := buildProviderProofBatchV3(ctx, frozen, signer)
+	if err != nil {
+		writeJSONError(w, http.StatusConflict, "v3 session proof unavailable", err.Error())
+		return
+	}
+	if len(proofs) == 0 {
+		writeRetrievalV3Outcome(w, "reconciled", sessionID, "", slot, 0, remaining, "complete", nil)
+		return
+	}
+	msg := &types.MsgSubmitRetrievalSessionProofV3{Creator: signer, SessionId: frozen.Session.SessionId, Slot: slot, Proofs: proofs}
+	file, err := os.CreateTemp(uploadDir, "session-proof-v3-*.json")
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "cannot create v3 proof input", err.Error())
+		return
+	}
+	defer os.Remove(file.Name())
+	marshaler := &jsonpb.Marshaler{OrigName: true}
+	writeErr := marshaler.Marshal(file, msg)
+	closeErr := file.Close()
+	if writeErr != nil || closeErr != nil {
+		writeJSONError(w, http.StatusInternalServerError, "cannot write v3 proof input", "")
+		return
+	}
+	op := retrievalProofOperationV3(frozen.Session.SessionId, proofs)
+	if err := updatePendingSignerV3(signer, op, false); err != nil {
+		writeJSONError(w, http.StatusConflict, "cannot persist v3 proof intent", err.Error())
+		return
+	}
+	hash, err := submitTxAndRecord(ctx, func(hash string) error {
+		op.TxHash = hash
+		return updatePendingSignerV3(signer, op, false)
+	}, "tx", "polystorechain", "retrieval-session-v3", "prove", file.Name(), "--from", keyName, "--chain-id", chainID, "--home", homeDir, "--keyring-backend", "test", "--yes", "--gas", "auto", "--gas-adjustment", "1.6", "--gas-prices", gasPrices, "--broadcast-mode", "sync", "--output", "json")
+	cleanup := "retained"
+	if err == nil || errors.Is(err, errTxFailed) || errors.Is(err, errTxRejected) || errors.Is(err, errTxNotSubmitted) {
+		if clearErr := updatePendingSignerV3(signer, op, true); clearErr != nil {
+			if err == nil {
+				err = fmt.Errorf("transaction committed but local v3 proof cleanup remains pending: %w", clearErr)
+			} else {
+				err = fmt.Errorf("%w; local v3 proof cleanup remains pending: %v", err, clearErr)
+			}
+		} else {
+			cleanup = "complete"
+		}
+	}
+	status := "success"
+	if err != nil {
+		status = "pending"
+		if errors.Is(err, errTxFailed) || errors.Is(err, errTxRejected) || errors.Is(err, errTxNotSubmitted) {
+			status = "failed"
+		}
+	}
+	writeRetrievalV3Outcome(w, status, sessionID, hash, slot, len(proofs), remaining, cleanup, err)
+}

--- a/polystore_gateway/sp_upload_bundle.go
+++ b/polystore_gateway/sp_upload_bundle.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"polystorechain/pkg/retrievalchallenge"
 	"polystorechain/x/polystorechain/types"
 )
 
@@ -20,6 +21,7 @@ const (
 	spUploadBundleKindMDU       = "mdu"
 	spUploadBundleKindShard     = "shard"
 	spUploadBundleKindManifest  = "manifest"
+	spUploadBundleKindIntegrity = "integrity_leaves_v3"
 	spUploadBundleV2Magic       = "NLB2"
 	spUploadBundleV2MediaType   = "application/x.polystore-bundle-v2"
 	spUploadBundleMaxArtifacts  = 4096
@@ -135,6 +137,14 @@ func (a spUploadBundleArtifact) resolve() (spUploadBundleResolvedArtifact, error
 			return spUploadBundleResolvedArtifact{}, fmt.Errorf("manifest artifact full_size must be %d", types.BLOB_SIZE)
 		}
 		resolved.filename = "manifest.bin"
+		resolved.fullSize = a.FullSize
+		resolved.maxBodyLen = a.FullSize
+	case spUploadBundleKindIntegrity:
+		maxBytes := int64(retrievalchallenge.MaxIntegrityLeaves * 32)
+		if a.MduIndex != nil || a.Slot != nil || a.FullSize <= 0 || a.FullSize > maxBytes || a.FullSize%32 != 0 {
+			return spUploadBundleResolvedArtifact{}, fmt.Errorf("integrity leaf vector has invalid coordinates or size")
+		}
+		resolved.filename = "integrity_leaves_v3.bin"
 		resolved.fullSize = a.FullSize
 		resolved.maxBodyLen = a.FullSize
 	default:

--- a/polystore_gateway/tx_submit.go
+++ b/polystore_gateway/tx_submit.go
@@ -28,7 +28,7 @@ const maxCommittedTxResponseBytes = 4 << 20
 // Only these CLI commands implement the explicit phase contract. Each attempt
 // gets its own empty private file, so retry can never reuse an earlier marker.
 func execTrackedSubmission(ctx context.Context, args ...string) ([]byte, error) {
-	if len(args) < 3 || args[0] != "tx" || (args[2] != "submit-retrieval-proof" && args[2] != "prove-liveness-system") {
+	if len(args) < 3 || args[0] != "tx" || (args[2] != "submit-retrieval-proof" && args[2] != "prove-liveness-system" && args[2] != "accept-deal-generation-v3") {
 		return execPolystorechaind(ctx, args...)
 	}
 	file, err := os.CreateTemp("", "polystore-submission-phase-*")

--- a/polystore_gateway/tx_submit.go
+++ b/polystore_gateway/tx_submit.go
@@ -28,7 +28,7 @@ const maxCommittedTxResponseBytes = 4 << 20
 // Only these CLI commands implement the explicit phase contract. Each attempt
 // gets its own empty private file, so retry can never reuse an earlier marker.
 func execTrackedSubmission(ctx context.Context, args ...string) ([]byte, error) {
-	if len(args) < 3 || args[0] != "tx" || (args[2] != "submit-retrieval-proof" && args[2] != "prove-liveness-system" && args[2] != "accept-deal-generation-v3") {
+	if len(args) < 3 || args[0] != "tx" || (args[2] != "submit-retrieval-proof" && args[2] != "prove-liveness-system" && args[2] != "accept-deal-generation-v3" && args[2] != "retrieval-session-v3") {
 		return execPolystorechaind(ctx, args...)
 	}
 	file, err := os.CreateTemp("", "polystore-submission-phase-*")

--- a/polystorechain/pkg/retrievalchallenge/v3_integrity.go
+++ b/polystorechain/pkg/retrievalchallenge/v3_integrity.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"hash"
+	"io"
 )
 
 const (
@@ -106,6 +107,58 @@ func IntegrityRootV3(leaves [][32]byte) ([32]byte, error) {
 		level = level[:write]
 	}
 	return level[0], nil
+}
+
+// IntegrityRootV3Reader verifies the canonical raw leaf-vector sidecar without
+// retaining it in memory. The reader must contain exactly leafCount consecutive
+// 32-byte hashes. Odd rightmost subtrees are duplicated at every missing level.
+func IntegrityRootV3Reader(r io.Reader, leafCount uint64) ([32]byte, error) {
+	if leafCount == 0 || leafCount > MaxIntegrityLeaves {
+		return [32]byte{}, errors.New("invalid integrity leaf count")
+	}
+	var peaks [24][32]byte
+	var occupied [24]bool
+	for i := uint64(0); i < leafCount; i++ {
+		var node [32]byte
+		if _, err := io.ReadFull(r, node[:]); err != nil {
+			return [32]byte{}, errors.New("truncated integrity leaf vector")
+		}
+		for level := 0; ; level++ {
+			if !occupied[level] {
+				peaks[level], occupied[level] = node, true
+				break
+			}
+			node = integrityParentV3(peaks[level], node)
+			occupied[level] = false
+		}
+	}
+	var extra [1]byte
+	if n, err := r.Read(extra[:]); n != 0 || err != io.EOF {
+		return [32]byte{}, errors.New("extended integrity leaf vector")
+	}
+	highest := len(peaks) - 1
+	for !occupied[highest] {
+		highest--
+	}
+	lowest := 0
+	for !occupied[lowest] {
+		lowest++
+	}
+	root, rootLevel := peaks[lowest], lowest
+	for level := lowest + 1; level <= highest; level++ {
+		if !occupied[level] {
+			root = integrityParentV3(root, root)
+			rootLevel++
+			continue
+		}
+		for rootLevel < level {
+			root = integrityParentV3(root, root)
+			rootLevel++
+		}
+		root = integrityParentV3(peaks[level], root)
+		rootLevel++
+	}
+	return root, nil
 }
 
 func VerifyIntegrityPathV3(value [32]byte, position, leafCount uint64, siblings [][32]byte, expected [32]byte) bool {

--- a/polystorechain/pkg/retrievalchallenge/v3_test.go
+++ b/polystorechain/pkg/retrievalchallenge/v3_test.go
@@ -372,6 +372,24 @@ func TestIntegrityRootV3Reader(t *testing.T) {
 	}
 }
 
+func BenchmarkIntegrityRootV3Reader(b *testing.B) {
+	for _, leafCount := range []int{96, 288, 133 * 96} {
+		wire := make([]byte, leafCount*sha256.Size)
+		for i := 0; i < leafCount; i++ {
+			leaf := sha256.Sum256([]byte(fmt.Sprintf("leaf-%d", i)))
+			copy(wire[i*sha256.Size:], leaf[:])
+		}
+		b.Run(fmt.Sprintf("leaves_%d", leafCount), func(b *testing.B) {
+			b.SetBytes(int64(len(wire)))
+			for i := 0; i < b.N; i++ {
+				if _, err := IntegrityRootV3Reader(bytes.NewReader(wire), uint64(leafCount)); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
 func TestSystematicCoordinateV3Bounds(t *testing.T) {
 	mdu, leaf, slot, err := SystematicCoordinateV3(63, 2, 1)
 	if err != nil || mdu != 2 || leaf != 63 || slot != 7 {

--- a/polystorechain/pkg/retrievalchallenge/v3_test.go
+++ b/polystorechain/pkg/retrievalchallenge/v3_test.go
@@ -1,10 +1,12 @@
 package retrievalchallenge
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"math"
 	"os"
 	"strconv"
@@ -337,6 +339,36 @@ func TestV3FATAndIntegrityGolden(t *testing.T) {
 	}
 	if _, e := IntegrityLeafV3(10, 0, pattern("zero")[:1]); e == nil {
 		t.Fatal("truncated blob")
+	}
+}
+
+func TestIntegrityRootV3Reader(t *testing.T) {
+	counts := make([]int, 0, 259)
+	for count := 1; count <= 257; count++ {
+		counts = append(counts, count)
+	}
+	counts = append(counts, 288, 133*96)
+	for _, count := range counts {
+		leaves := make([][32]byte, count)
+		var wire bytes.Buffer
+		for i := range leaves {
+			leaves[i] = sha256.Sum256([]byte(fmt.Sprintf("leaf-%d", i)))
+			wire.Write(leaves[i][:])
+		}
+		want, err := IntegrityRootV3(leaves)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, err := IntegrityRootV3Reader(bytes.NewReader(wire.Bytes()), uint64(count))
+		if err != nil || got != want {
+			t.Fatalf("count %d: got %x, %v; want %x", count, got, err, want)
+		}
+		if _, err := IntegrityRootV3Reader(bytes.NewReader(wire.Bytes()[:wire.Len()-1]), uint64(count)); err == nil {
+			t.Fatalf("count %d: accepted truncated vector", count)
+		}
+		if _, err := IntegrityRootV3Reader(bytes.NewReader(append(wire.Bytes(), 0)), uint64(count)); err == nil {
+			t.Fatalf("count %d: accepted extended vector", count)
+		}
 	}
 }
 

--- a/polystorechain/x/polystorechain/client/cli/tx_generation_v3.go
+++ b/polystorechain/x/polystorechain/client/cli/tx_generation_v3.go
@@ -76,7 +76,9 @@ func CmdAcceptDealGenerationV3() *cobra.Command {
 		Use:   "accept-deal-generation-v3",
 		Short: "Accept one frozen FAT v3 slot assignment",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) (err error) {
+			phase := beginSubmissionPhase(cmd)
+			defer phase.finish(&err)
 			clientCtx, err := getClientTxContextFn(cmd)
 			if err != nil {
 				return err
@@ -87,6 +89,10 @@ func CmdAcceptDealGenerationV3() *cobra.Command {
 			}
 			dealID, _ := cmd.Flags().GetUint64("deal-id")
 			slot, _ := cmd.Flags().GetUint32("slot")
+			clientCtx, err = phase.track(clientCtx)
+			if err != nil {
+				return err
+			}
 			return generateOrBroadcastTxCLIFn(clientCtx, cmd.Flags(), &types.MsgAcceptDealGenerationV3{Creator: clientCtx.GetFromAddress().String(), DealId: dealID, Slot: slot, AcceptanceDigest: digest})
 		},
 	}
@@ -97,6 +103,7 @@ func CmdAcceptDealGenerationV3() *cobra.Command {
 		_ = cmd.MarkFlagRequired(name)
 	}
 	flags.AddTxFlagsToCmd(cmd)
+	cmd.Flags().String(submissionPhaseFlag, "", "Write a final pre-broadcast failure marker for the invoking gateway")
 	return cmd
 }
 

--- a/polystorechain/x/polystorechain/client/cli/tx_generation_v3_test.go
+++ b/polystorechain/x/polystorechain/client/cli/tx_generation_v3_test.go
@@ -1,0 +1,61 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	clienttx "github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/cosmos/cosmos-sdk/crypto/hd"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAcceptDealGenerationV3SubmissionPhase(t *testing.T) {
+	cdc, config := retrievalTestEncoding()
+	keys := keyring.NewInMemory(cdc)
+	record, _, err := keys.NewMnemonic("provider", keyring.English, "m/44'/118'/0'/0/0", "", hd.Secp256k1)
+	require.NoError(t, err)
+	signer, err := record.GetAddress()
+	require.NoError(t, err)
+	rpc := &retrievalTestRPC{simulatedGas: 100_000}
+	ctx := client.Context{}.WithCodec(cdc).WithTxConfig(config).WithFromAddress(signer).WithFromName("provider").WithKeyring(keys).
+		WithChainID("cli-test").WithClient(&phaseFailureRPC{rpc}).WithAccountRetriever(client.MockAccountRetriever{ReturnAccNum: 2, ReturnAccSeq: 7}).
+		WithSkipConfirmation(true).WithBroadcastMode(flags.BroadcastSync).WithOutput(&bytes.Buffer{}).WithCmdContext(context.Background())
+	oldGet, oldBroadcast := getClientTxContextFn, generateOrBroadcastTxCLIFn
+	t.Cleanup(func() { getClientTxContextFn, generateOrBroadcastTxCLIFn = oldGet, oldBroadcast })
+	getClientTxContextFn = func(*cobra.Command) (client.Context, error) { return ctx, nil }
+	generateOrBroadcastTxCLIFn = clienttx.GenerateOrBroadcastTxCLI
+
+	for _, tc := range []struct {
+		name, digest string
+		broadcast    bool
+	}{
+		{name: "local", digest: "zz"},
+		{name: "broadcast", digest: strings.Repeat("ab", 32), broadcast: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			phase := filepath.Join(t.TempDir(), "phase")
+			require.NoError(t, os.WriteFile(phase, nil, 0600))
+			cmd := CmdAcceptDealGenerationV3()
+			cmd.SetContext(context.Background())
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+			cmd.SetArgs([]string{"--deal-id", "0", "--slot", "0", "--acceptance-digest", tc.digest, "--gas", "1000000", "--" + submissionPhaseFlag, phase})
+			require.Error(t, cmd.Execute())
+			marker, err := os.ReadFile(phase)
+			require.NoError(t, err)
+			if tc.broadcast {
+				require.Empty(t, marker)
+			} else {
+				require.Equal(t, submissionNotBroadcast, string(marker))
+			}
+		})
+	}
+}

--- a/polystorechain/x/polystorechain/client/cli/tx_retrieval_v3.go
+++ b/polystorechain/x/polystorechain/client/cli/tx_retrieval_v3.go
@@ -31,7 +31,9 @@ The v3 protocol must be activated on the chain. Proofs and ACK digests must
 match the frozen session and its committed anchor; this command does not
 generate proofs or acknowledge downloaded bytes automatically.`,
 		Args: cobra.ExactArgs(2),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			phase := beginSubmissionPhase(cmd)
+			defer phase.finish(&err)
 			var msg sdk.Msg
 			switch args[0] {
 			case "open":
@@ -62,9 +64,14 @@ generate proofs or acknowledge downloaded bytes automatically.`,
 			if creator == "" || creator != clientCtx.GetFromAddress().String() {
 				return fmt.Errorf("message creator must equal --from")
 			}
+			clientCtx, err = phase.track(clientCtx)
+			if err != nil {
+				return err
+			}
 			return generateOrBroadcastTxCLIFn(clientCtx, cmd.Flags(), msg)
 		},
 	}
 	flags.AddTxFlagsToCmd(cmd)
+	cmd.Flags().String(submissionPhaseFlag, "", "Write a final pre-broadcast failure marker for the invoking gateway")
 	return cmd
 }

--- a/polystorechain/x/polystorechain/client/cli/tx_retrieval_v3_test.go
+++ b/polystorechain/x/polystorechain/client/cli/tx_retrieval_v3_test.go
@@ -74,3 +74,23 @@ func TestRetrievalSessionV3CLI(t *testing.T) {
 		})
 	}
 }
+
+func TestRetrievalSessionV3CLIClassifiesPreBroadcastFailure(t *testing.T) {
+	cdc, config := retrievalTestEncoding()
+	signer := sdk.AccAddress(bytes20(7))
+	message := filepath.Join(t.TempDir(), "message.json")
+	require.NoError(t, os.WriteFile(message, []byte("{"), 0600))
+	phase := filepath.Join(t.TempDir(), "phase")
+	require.NoError(t, os.WriteFile(phase, nil, 0600))
+	ctx := client.Context{}.WithCodec(cdc).WithTxConfig(config).WithFromAddress(signer).WithChainID("cli-test").WithGenerateOnly(true).WithOutput(&bytes.Buffer{})
+	cmd := CmdRetrievalSessionV3()
+	cmd.SetContext(context.Background())
+	require.NoError(t, client.SetCmdClientContext(cmd, ctx))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"refund", message, "--from", signer.String(), "--" + submissionPhaseFlag, phase})
+	require.Error(t, cmd.Execute())
+	marker, err := os.ReadFile(phase)
+	require.NoError(t, err)
+	require.Equal(t, submissionNotBroadcast, string(marker))
+}


### PR DESCRIPTION
## Problem and behavior

Native v3 sessions need the actual provider-daemon to authenticate admitted generation artifacts and submit its sampled proofs while sharing its signer with normal audits. Previously the provider route only supported older session formats.

This adds authenticated generation acceptance and extends the existing single-session `/sp/session-proof` action to v3. The daemon reconstructs the frozen context and global sample set, reads only its challenged blobs, verifies the generated four-hop proofs locally, and submits at most 64 samples per message. Both actions reuse the existing signer lock and durable pending-transaction record; recovery reconciles recorded transactions before fresh signing and preserves uncertain outcomes.

Generation acceptance authenticates the original MDU0 commitment before parsing FAT v3, reconstructs the integrity root from a bounded streaming leaf vector, and checks every encoded blob in the provider's own slot against both integrity and KZG commitments, including parity slots. The v2 retrieval and normal-audit paths retain their existing validation.

Full-generation verification uses separate per-deal and per-provider scan guards while leaving the shared signer available to audits. It retains the immutable artifact lease and rechecks the exact candidate and pending transaction state after reacquiring the signer. The cancellable scan allowance is five minutes plus 250 ms per user MDU, with progress logs roughly every minute; transaction waits have separate short bounds. This is an operational allowance, not a completion SLA or resumable verification. A late signer collision returns an explicit retry.

Part of #291. V3 stays disabled by default. This does not implement client integrity-path delivery, ACK generation, EVM adapters, or establish retrieval/chain throughput. The subsequent chain benchmark must use these actual provider signers with normal audits active.

## Validation

On `mikers@192.168.0.111`, the final candidate passes the retrievalchallenge package (0.053s), native CLI package (0.090s), and full gateway suite (22.209s). Focused real-KZG and recovery checks cover wrong-signer/corrupted-shard rejection, unsampled integrity data, malformed durable records, and shared signer coordination. The independent Python contract-vector oracle passes.

Independent review is clean for the current candidate `82f2335407e556ec640f7f047ab00fc797a4104f`. Fresh public-handler tests cover exact CLI arguments, phase tracking, protobuf proof JSON, committed success, durable-marker cleanup, changed-candidate rejection, and preservation of a concurrent pending operation. All 28 current-head CI checks pass; hosted Codex review is clean with both findings resolved. The leaf-vector microbenchmark is diagnostic only, not a chain or retrieval throughput result.

The six affected Ubuntu PR jobs disable the unused preinstalled Google Chrome apt source before installing dependencies. This prevents unrelated Chrome repository checksum mismatches from blocking their Ubuntu packages; package integrity checks remain enabled. Shell syntax, workflow YAML, invocation ordering, and a Chrome-only source/runner-guard fixture pass.
