### PR TITLE
gateway: produce native v3 generation candidates through uploads

### DIFF
--- a/docs/retrieval-v3-large-session-profile.md
+++ b/docs/retrieval-v3-large-session-profile.md
@@ -599,6 +599,72 @@ before anchor capture and after reference release. The CLI does not generate
 proofs, authenticate downloaded bytes, or create ACK digests; those require the
 frozen context and provider/client integration specified above.
 
+## Production upload of an initial v3 generation
+
+`POST /gateway/upload?deal_id=0&fat_version=3` opts into the native v3
+producer. Send one multipart `file`; optional fields are `owner`, `file_path`
+and `file_size_bytes`. Query `upload_id` enables the existing asynchronous
+upload/status flow. The `(deal_id, upload_id)` identity is atomically bound to
+FAT version, including retries and cached results. Absent `fat_version`, or
+explicit `fat_version=2`, retains the v2 response and behavior.
+
+This initial producer requires an existing, empty, unexpired generation-zero
+deal whose actual chain profile is K=8/M=4 and whose twelve distinct slots are
+active without pending replacements. It accepts nonempty plain files only;
+append, implicit deal creation, file flags, PolyCE, fake ingest and fast ingest
+are rejected. Only query parameters select the version and asynchronous identity.
+The file's contents are opaque; callers must not label externally encrypted
+bytes as a protocol encryption mode.
+
+During RS encoding, each worker hashes all 96 encoded blobs, including parity
+and padding, and writes one 3,072-byte block to its deterministic sidecar offset.
+The producer streams the completed vector to calculate its root, replaces the
+scalar-packed FAT header, and then computes the original encoded MDU0 root.
+Artifacts remain immutable and provisional until native generation admission.
+
+The producer uploads MDU0, witness/manifest metadata, the complete integrity
+sidecar and the assigned user shards to all twelve providers using the existing
+bundle transport. Even a colocated provider receives its bundle through its
+registered endpoint. Unsupported bundle endpoints and any incomplete fanout
+fail the upload; no per-artifact fallback drops the sidecar. Provider assignments
+are checked against the original snapshot before fanout and again before a
+successful response.
+
+A successful response contains `generation_candidate`, with decimal-string
+`deal_id`, `expected_current_generation`, `size_bytes`, `total_mdus`,
+`witness_mdus`, `integrity_leaf_count`; hex `polyfs_root`, `integrity_root`;
+`previous_polyfs_root`; `commit_action="propose-deal-generation-v3"` and
+`required_acceptances=12`. There is no top-level legacy `cid` or
+`manifest_root`, including asynchronous status and cached results.
+
+Save the response as `upload.json`, then use the native CLI proposal route
+with your usual owner signing/network flags:
+
+```sh
+polystorechaind tx polystorechain propose-deal-generation-v3 \
+  --deal-id "$(jq -r .generation_candidate.deal_id upload.json)" \
+  --expected-current-generation "$(jq -r .generation_candidate.expected_current_generation upload.json)" \
+  --previous-polyfs-root "$(jq -r .generation_candidate.previous_polyfs_root upload.json)" \
+  --polyfs-root "$(jq -r .generation_candidate.polyfs_root upload.json)" \
+  --integrity-root "$(jq -r .generation_candidate.integrity_root upload.json)" \
+  --size "$(jq -r .generation_candidate.size_bytes upload.json)" \
+  --total-mdus "$(jq -r .generation_candidate.total_mdus upload.json)" \
+  --witness-mdus "$(jq -r .generation_candidate.witness_mdus upload.json)" \
+  --integrity-leaf-count "$(jq -r .generation_candidate.integrity_leaf_count upload.json)"
+```
+
+For asynchronous status, the candidate is under `result.generation_candidate`.
+The size flag is `--size`, not `--size-bytes`. After proposal inclusion, invoke
+the authenticated acceptance action below on each provider. Confirm the pending
+candidate's acceptance mask is `4095` (`0xfff`), then have the owner submit
+`finalize-deal-generation-v3 --deal-id <id> --generation 1 --polyfs-root <root>`.
+The gateway does not sign proposals or finalize on the owner's behalf. Both
+legacy gateway update relays reject locally staged FAT v3 roots; a direct legacy
+chain transaction cannot inspect MDU0, so this is a local relay guard, not a new
+consensus format check. Chain activation remains disabled by default and must be
+qualified separately. Upload acceptance alone does not qualify retrieval or
+chain throughput.
+
 ## Provider-daemon integrity artifact
 
 A generation-local `integrity_leaves_v3.bin` contains the ordered raw 32-byte

--- a/docs/retrieval-v3-large-session-profile.md
+++ b/docs/retrieval-v3-large-session-profile.md
@@ -624,8 +624,10 @@ Artifacts remain immutable and provisional until native generation admission.
 
 The producer uploads MDU0, witness/manifest metadata, the complete integrity
 sidecar and the assigned user shards to all twelve providers using the existing
-bundle transport. Even a colocated provider receives its bundle through its
-registered endpoint. Unsupported bundle endpoints and any incomplete fanout
+bundle transport, in batches of at most 4,096 artifacts sent serially per
+provider. All batches must finish; file size does not increase concurrent
+requests. Even a colocated provider receives its bundles through its registered
+endpoint. Unsupported bundle endpoints and any incomplete fanout
 fail the upload; no per-artifact fallback drops the sidecar. Provider assignments
 are checked against the original snapshot before fanout and again before a
 successful response.

--- a/polystore_gateway/ingest_mode2.go
+++ b/polystore_gateway/ingest_mode2.go
@@ -23,6 +23,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	"polystorechain/pkg/retrievalchallenge"
 	"polystorechain/x/crypto_ffi"
 	"polystorechain/x/polystorechain/types"
 )
@@ -35,6 +36,12 @@ type mode2IngestResult struct {
 	sizeBytes       uint64
 	witnessMdus     uint64
 	userMdus        uint64
+	integrityRoot   [32]byte
+	integrityLeaves uint64
+}
+
+type mode2BuildOptions struct {
+	fatVersion uint16
 }
 
 type providerUploadHTTPError struct {
@@ -120,6 +127,10 @@ func mode2EnsureCompleteMarker(dir string) {
 }
 
 func mode2BuildArtifacts(ctx context.Context, filePath string, dealID uint64, hint string, fileRecordPath string, fileFlags uint8) (*mode2IngestResult, string, error) {
+	return mode2BuildArtifactsWithOptions(ctx, filePath, dealID, hint, fileRecordPath, fileFlags, mode2BuildOptions{})
+}
+
+func mode2BuildArtifactsWithOptions(ctx context.Context, filePath string, dealID uint64, hint string, fileRecordPath string, fileFlags uint8, opts mode2BuildOptions) (*mode2IngestResult, string, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -131,6 +142,17 @@ func mode2BuildArtifacts(ctx context.Context, filePath string, dealID uint64, hi
 	if stripe.mode != 2 || stripe.k == 0 || stripe.m == 0 || stripe.rows == 0 {
 		return nil, "", fmt.Errorf("deal is not Mode 2")
 	}
+	if opts.fatVersion != 0 && opts.fatVersion != 2 && opts.fatVersion != 3 {
+		return nil, "", fmt.Errorf("unsupported FAT version %d", opts.fatVersion)
+	}
+	if opts.fatVersion == 3 {
+		if stripe.k != 8 || stripe.m != 4 || stripe.rows != 8 || stripe.slotCount != 12 || stripe.leafCount != retrievalchallenge.IntegrityLeavesPerUserMDU {
+			return nil, "", fmt.Errorf("FAT v3 requires Mode 2 K=8 M=4 with 96 leaves per user MDU")
+		}
+		if fileFlags != 0 {
+			return nil, "", fmt.Errorf("FAT v3 does not support file flags")
+		}
+	}
 
 	fi, err := os.Stat(filePath)
 	if err != nil {
@@ -139,10 +161,10 @@ func mode2BuildArtifacts(ctx context.Context, filePath string, dealID uint64, hi
 	fileSize := uint64(fi.Size())
 	userMdus := uint64(1)
 	if fileSize > 0 {
-		userMdus = (fileSize + RawMduCapacity - 1) / RawMduCapacity
-		if userMdus == 0 {
-			userMdus = 1
-		}
+		userMdus = 1 + (fileSize-1)/RawMduCapacity
+	}
+	if opts.fatVersion == 3 && userMdus > retrievalchallenge.MaxIntegrityLeaves/retrievalchallenge.IntegrityLeavesPerUserMDU {
+		return nil, "", fmt.Errorf("FAT v3 user MDU count exceeds integrity capacity")
 	}
 
 	fileRecordPath, err = normalizePolyfsRecordBasename(fileRecordPath, filePath)
@@ -157,6 +179,9 @@ func mode2BuildArtifacts(ctx context.Context, filePath string, dealID uint64, hi
 	}
 	defer builder.Free()
 	witnessCount := builder.GetWitnessCount()
+	if opts.fatVersion == 3 && (witnessCount > 65536 || userMdus > 65536-witnessCount) {
+		return nil, "", fmt.Errorf("FAT v3 generation exceeds root-table capacity")
+	}
 	totalSteps := userMdus + witnessCount + 2
 	job := uploadJobFromContext(ctx)
 	if job != nil {
@@ -189,6 +214,19 @@ func mode2BuildArtifacts(ctx context.Context, filePath string, dealID uint64, hi
 			_ = os.RemoveAll(stagingDir)
 		}
 	}()
+
+	var integrityFile *os.File
+	if opts.fatVersion == 3 {
+		integrityFile, err = os.OpenFile(filepath.Join(stagingDir, integrityLeavesV3File), os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+		if err != nil {
+			return nil, "", err
+		}
+		defer func() {
+			if integrityFile != nil {
+				_ = integrityFile.Close()
+			}
+		}()
+	}
 
 	userRoots := make([][]byte, userMdus)
 	witnessFlats := make([][]byte, userMdus)
@@ -258,6 +296,10 @@ func mode2BuildArtifacts(ctx context.Context, filePath string, dealID uint64, hi
 					witnessFlats[i] = witnessFlat
 
 					slabIndex := uint64(1) + witnessCount + i
+					var integrityBlock []byte
+					if integrityFile != nil {
+						integrityBlock = make([]byte, retrievalchallenge.IntegrityLeavesPerUserMDU*32)
+					}
 					for slot := uint64(0); slot < stripe.slotCount; slot++ {
 						if int(slot) >= len(shards) {
 							err := fmt.Errorf("missing shard for slot %d", slot)
@@ -268,6 +310,28 @@ func mode2BuildArtifacts(ctx context.Context, filePath string, dealID uint64, hi
 						if err := writeSparseArtifactFile(filepath.Join(stagingDir, name), shards[slot], int64(len(shards[slot])), 0o644); err != nil {
 							captureFirstNonContextError(err, &firstEncodeErr, &firstEncodeErrMu)
 							return err
+						}
+						if integrityFile != nil {
+							if len(shards[slot]) != 8*types.BLOB_SIZE {
+								return fmt.Errorf("invalid shard size for integrity leaves: slot %d has %d bytes", slot, len(shards[slot]))
+							}
+							for row := uint64(0); row < 8; row++ {
+								leaf := slot*8 + row
+								hash, err := retrievalchallenge.IntegrityLeafV3(slabIndex, uint32(leaf), shards[slot][row*types.BLOB_SIZE:(row+1)*types.BLOB_SIZE])
+								if err != nil {
+									return err
+								}
+								copy(integrityBlock[leaf*32:(leaf+1)*32], hash[:])
+							}
+						}
+					}
+					if integrityFile != nil {
+						offset := int64(i * retrievalchallenge.IntegrityLeavesPerUserMDU * 32)
+						if n, err := integrityFile.WriteAt(integrityBlock, offset); err != nil || n != len(integrityBlock) {
+							if err == nil {
+								err = io.ErrShortWrite
+							}
+							return fmt.Errorf("write integrity leaves for user MDU %d: %w", i, err)
 						}
 					}
 
@@ -292,6 +356,27 @@ func mode2BuildArtifacts(ctx context.Context, filePath string, dealID uint64, hi
 				return nil, "", fmt.Errorf("mode2 encoding canceled: %w", err)
 			}
 			return nil, "", fmt.Errorf("mode2 encoding failed: %w", err)
+		}
+	}
+	var integrityRoot [32]byte
+	integrityLeafCount := uint64(0)
+	if integrityFile != nil {
+		if err := integrityFile.Close(); err != nil {
+			return nil, "", fmt.Errorf("close integrity leaf vector: %w", err)
+		}
+		integrityFile = nil
+		integrityLeafCount = userMdus * retrievalchallenge.IntegrityLeavesPerUserMDU
+		leafFile, err := os.Open(filepath.Join(stagingDir, integrityLeavesV3File))
+		if err != nil {
+			return nil, "", err
+		}
+		integrityRoot, err = retrievalchallenge.IntegrityRootV3Reader(leafFile, integrityLeafCount)
+		closeErr := leafFile.Close()
+		if err != nil {
+			return nil, "", fmt.Errorf("compute integrity root: %w", err)
+		}
+		if closeErr != nil {
+			return nil, "", fmt.Errorf("close integrity leaf reader: %w", closeErr)
 		}
 	}
 	if profile != nil {
@@ -378,6 +463,16 @@ func mode2BuildArtifacts(ctx context.Context, filePath string, dealID uint64, hi
 	if err != nil {
 		return nil, "", err
 	}
+	if opts.fatVersion == 3 {
+		header := retrievalchallenge.FATV3Header{
+			RecordCount:   builder.GetRecordCount(),
+			LeafCount:     integrityLeafCount,
+			IntegrityRoot: integrityRoot,
+		}
+		if err := replacePackedFATHeaderV3(mdu0Bytes, header); err != nil {
+			return nil, "", err
+		}
+	}
 	if err := writeSparseArtifactFile(filepath.Join(stagingDir, "mdu_0.bin"), mdu0Bytes, int64(len(mdu0Bytes)), 0o644); err != nil {
 		return nil, "", err
 	}
@@ -462,6 +557,8 @@ func mode2BuildArtifacts(ctx context.Context, filePath string, dealID uint64, hi
 		sizeBytes:       sizeBytes,
 		witnessMdus:     witnessCount,
 		userMdus:        userMdus,
+		integrityRoot:   integrityRoot,
+		integrityLeaves: integrityLeafCount,
 	}, finalDir, nil
 }
 
@@ -1138,6 +1235,24 @@ func mode2UploadArtifactsToProviders(
 	witnessCount uint64,
 	userMdus uint64,
 ) error {
+	return mode2UploadArtifactsToProvidersWithOptions(ctx, dealID, manifestRoot, previousManifestRoot, hint, finalDir, witnessCount, userMdus, mode2UploadOptions{})
+}
+
+type mode2UploadOptions struct {
+	strictV3 bool
+}
+
+func mode2UploadArtifactsToProvidersWithOptions(
+	ctx context.Context,
+	dealID uint64,
+	manifestRoot ManifestRoot,
+	previousManifestRoot string,
+	hint string,
+	finalDir string,
+	witnessCount uint64,
+	userMdus uint64,
+	opts mode2UploadOptions,
+) error {
 	releaseGeneration, leaseErr := leaseGenerationPaths(finalDir)
 	if leaseErr != nil {
 		return leaseErr
@@ -1161,12 +1276,33 @@ func mode2UploadArtifactsToProviders(
 
 	// Upload to assigned providers as a dumb pipe: bytes-in/bytes-out.
 	resolveSlotsStarted := time.Now()
-	slots, err := resolveDealMode2Slots(ctx, dealID)
+	var slots []mode2SlotAssignment
+	if opts.strictV3 {
+		slots, err = fetchDealMode2SlotsFromLCD(ctx, dealID)
+	} else {
+		slots, err = resolveDealMode2Slots(ctx, dealID)
+	}
 	if err != nil {
 		return err
 	}
 	if len(slots) < int(stripe.slotCount) {
 		return fmt.Errorf("not enough slot assignments for Mode 2 (need %d, got %d)", stripe.slotCount, len(slots))
+	}
+	if opts.strictV3 {
+		if stripe.k != 8 || stripe.m != 4 || stripe.rows != 8 || stripe.slotCount != 12 || len(slots) != 12 {
+			return fmt.Errorf("FAT v3 requires the fixed Mode 2 K=8,M=4 profile with 12 slots")
+		}
+		seen := make(map[string]struct{}, len(slots))
+		for slot, assignment := range slots {
+			provider := strings.TrimSpace(assignment.Provider)
+			if assignment.Status != 1 || strings.TrimSpace(assignment.PendingProvider) != "" || provider == "" {
+				return fmt.Errorf("FAT v3 slot %d must be active, stable, and assigned", slot)
+			}
+			if _, exists := seen[provider]; exists {
+				return fmt.Errorf("FAT v3 slot providers must be distinct")
+			}
+			seen[provider] = struct{}{}
+		}
 	}
 	if profile != nil {
 		profile.addDuration("mode2_resolve_slots_ms", time.Since(resolveSlotsStarted))
@@ -1213,8 +1349,12 @@ func mode2UploadArtifactsToProviders(
 	}
 
 	job := uploadJobFromContext(ctx)
-	metadataUploads := uint64(len(metadataProviders)) * (witnessCount + 2) // mdu_0..mdu_witness + manifest.bin
-	shardUploads := uint64(len(targets)) * userMdus                        // slot-local user shards only
+	metadataArtifacts := witnessCount + 2 // mdu_0..mdu_witness + manifest.bin
+	if opts.strictV3 {
+		metadataArtifacts++ // integrity leaf vector
+	}
+	metadataUploads := uint64(len(metadataProviders)) * metadataArtifacts
+	shardUploads := uint64(len(targets)) * userMdus // slot-local user shards only
 	totalUploads := metadataUploads + shardUploads
 	if job != nil {
 		job.setPhase(uploadJobPhaseUploading, "Gateway Mode 2: uploading to providers...")
@@ -1639,6 +1779,34 @@ func mode2UploadArtifactsToProviders(
 	if len(manifestGroup) > 0 {
 		metadataTaskGroups = append(metadataTaskGroups, manifestGroup)
 	}
+	if opts.strictV3 {
+		integrityPath := filepath.Join(finalDir, integrityLeavesV3File)
+		integritySizes, err := statSizes(integrityPath, int64(retrievalchallenge.MaxIntegrityLeaves*32))
+		if err != nil {
+			return err
+		}
+		if integritySizes.full != int64(userMdus*retrievalchallenge.IntegrityLeavesPerUserMDU*32) || integritySizes.send != integritySizes.full {
+			return fmt.Errorf("FAT v3 integrity leaf vector has invalid size or sparse encoding")
+		}
+		group := make([]uploadTask, 0, len(metadataProviders))
+		for _, provider := range metadataProviders {
+			base := providerBases[provider]
+			if base == "" {
+				continue
+			}
+			group = append(group, uploadTask{
+				kind:         spUploadBundleKindIntegrity,
+				providerBase: base,
+				path:         integrityPath,
+				sizeBytes:    integritySizes.full,
+				sendBytes:    integritySizes.full,
+				maxBytes:     int64(retrievalchallenge.MaxIntegrityLeaves * 32),
+			})
+		}
+		if len(group) > 0 {
+			metadataTaskGroups = append(metadataTaskGroups, group)
+		}
+	}
 
 	shardTaskGroups := make([][]uploadTask, 0, userMdus)
 	// Upload striped user shards interleaved across providers per slab index.
@@ -1696,7 +1864,7 @@ func mode2UploadArtifactsToProviders(
 	}
 
 	uploadParallelism := mode2UploadParallelism(stripe.slotCount)
-	bundleUploadsEnabled := mode2BundleUploadsEnabled()
+	bundleUploadsEnabled := opts.strictV3 || mode2BundleUploadsEnabled()
 	log.Printf(
 		"GatewayUpload mode2 upload plan: deal_id=%d providers=%d targets=%d user_mdus=%d witness_mdus=%d total_tasks=%d parallelism=%d timeout=%s sparse=%t bundle=%t",
 		dealID,
@@ -2037,7 +2205,7 @@ func mode2UploadArtifactsToProviders(
 				inFlight.Add(1)
 				defer inFlight.Add(-1)
 				err := uploadBundle(egctx, bundle)
-				if err != nil && isBundleUnsupportedErr(err) {
+				if err != nil && !opts.strictV3 && isBundleUnsupportedErr(err) {
 					if profile != nil {
 						profile.addCount("mode2_bundle_fallback_providers", 1)
 					}

--- a/polystore_gateway/ingest_mode2.go
+++ b/polystore_gateway/ingest_mode2.go
@@ -45,6 +45,46 @@ type mode2BuildOptions struct {
 	fatVersion uint16
 }
 
+type uploadTask struct {
+	kind                 string
+	providerBase         string
+	url                  string
+	path                 string
+	sizeBytes            int64
+	sendBytes            int64
+	maxBytes             int64
+	dealID               string
+	manifestRoot         string
+	previousManifestRoot string
+	mduIndex             string
+	slot                 string
+}
+
+type providerBundleUpload struct {
+	providerBase string
+	url          string
+	tasks        []uploadTask
+	sizeBytes    int64
+}
+
+// splitProviderBundleUpload respects the receiver's artifact limit. Callers run
+// these batches serially per provider so larger generations add no concurrency.
+func splitProviderBundleUpload(bundle providerBundleUpload) []providerBundleUpload {
+	var batches []providerBundleUpload
+	for tasks := range slices.Chunk(bundle.tasks, spUploadBundleMaxArtifacts) {
+		batch := bundle
+		batch.tasks = tasks
+		batch.sizeBytes = 0
+		for _, task := range tasks {
+			if task.sizeBytes > 0 {
+				batch.sizeBytes += task.sizeBytes
+			}
+		}
+		batches = append(batches, batch)
+	}
+	return batches
+}
+
 type providerUploadHTTPError struct {
 	statusCode int
 	status     string
@@ -1469,21 +1509,6 @@ func mode2UploadArtifactsToProvidersWithOptions(
 	dealIDStr := strconv.FormatUint(dealID, 10)
 	sparseUploads := mode2SparseUploadEnabled()
 
-	type uploadTask struct {
-		kind                 string
-		providerBase         string
-		url                  string
-		path                 string
-		sizeBytes            int64
-		sendBytes            int64
-		maxBytes             int64
-		dealID               string
-		manifestRoot         string
-		previousManifestRoot string
-		mduIndex             string
-		slot                 string
-	}
-
 	isRetryableUploadErr := func(err error) bool {
 		if err == nil {
 			return false
@@ -1932,13 +1957,6 @@ func mode2UploadArtifactsToProvidersWithOptions(
 		}
 	}()
 
-	type providerBundleUpload struct {
-		providerBase string
-		url          string
-		tasks        []uploadTask
-		sizeBytes    int64
-	}
-
 	uploadBundle := func(ctx context.Context, bundle providerBundleUpload) error {
 		const maxAttempts = 3
 		targetKey := mode2UploadTargetMetricKey(bundle.providerBase)
@@ -2209,26 +2227,32 @@ func mode2UploadArtifactsToProvidersWithOptions(
 			eg.Go(func() error {
 				inFlight.Add(1)
 				defer inFlight.Add(-1)
-				err := uploadBundle(egctx, bundle)
-				if err != nil && !opts.strictV3 && isBundleUnsupportedErr(err) {
-					if profile != nil {
-						profile.addCount("mode2_bundle_fallback_providers", 1)
+				batches := []providerBundleUpload{bundle}
+				if opts.strictV3 {
+					batches = splitProviderBundleUpload(bundle)
+				}
+				for _, bundle := range batches {
+					err := uploadBundle(egctx, bundle)
+					if err != nil && !opts.strictV3 && isBundleUnsupportedErr(err) {
+						if profile != nil {
+							profile.addCount("mode2_bundle_fallback_providers", 1)
+						}
+						for _, task := range bundle.tasks {
+							if err := uploadBlob(egctx, task); err != nil {
+								captureFirstNonContextError(err, &firstUploadErr, &firstUploadErrMu)
+								return err
+							}
+							bump(task.sizeBytes)
+						}
+						return nil
+					}
+					if err != nil {
+						captureFirstNonContextError(err, &firstUploadErr, &firstUploadErrMu)
+						return err
 					}
 					for _, task := range bundle.tasks {
-						if err := uploadBlob(egctx, task); err != nil {
-							captureFirstNonContextError(err, &firstUploadErr, &firstUploadErrMu)
-							return err
-						}
 						bump(task.sizeBytes)
 					}
-					return nil
-				}
-				if err != nil {
-					captureFirstNonContextError(err, &firstUploadErr, &firstUploadErrMu)
-					return err
-				}
-				for _, task := range bundle.tasks {
-					bump(task.sizeBytes)
 				}
 				return nil
 			})

--- a/polystore_gateway/ingest_mode2.go
+++ b/polystore_gateway/ingest_mode2.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -159,6 +160,9 @@ func mode2BuildArtifactsWithOptions(ctx context.Context, filePath string, dealID
 		return nil, "", err
 	}
 	fileSize := uint64(fi.Size())
+	if opts.fatVersion == 3 && (!fi.Mode().IsRegular() || fileSize == 0 || fileSize > types.MAX_DEAL_BYTES) {
+		return nil, "", fmt.Errorf("invalid FAT v3 file size or type")
+	}
 	userMdus := uint64(1)
 	if fileSize > 0 {
 		userMdus = 1 + (fileSize-1)/RawMduCapacity
@@ -179,7 +183,7 @@ func mode2BuildArtifactsWithOptions(ctx context.Context, filePath string, dealID
 	}
 	defer builder.Free()
 	witnessCount := builder.GetWitnessCount()
-	if opts.fatVersion == 3 && (witnessCount > 65536 || userMdus > 65536-witnessCount) {
+	if opts.fatVersion == 3 && (witnessCount >= 65536 || userMdus > 65535-witnessCount) {
 		return nil, "", fmt.Errorf("FAT v3 generation exceeds root-table capacity")
 	}
 	totalSteps := userMdus + witnessCount + 2
@@ -516,8 +520,14 @@ func mode2BuildArtifactsWithOptions(ctx context.Context, filePath string, dealID
 		UserMdus:    &userMdus,
 	})
 	if err != nil {
+		if opts.fatVersion == 3 {
+			return nil, "", err
+		}
 		log.Printf("mode2BuildArtifacts: warning: failed to build slab metadata deal_id=%d manifest_root=%s: %v", dealID, parsedRoot.Canonical, err)
 	} else if err := writeSlabMetadataFile(stagingDir, meta); err != nil {
+		if opts.fatVersion == 3 {
+			return nil, "", err
+		}
 		log.Printf("mode2BuildArtifacts: warning: failed to write slab metadata deal_id=%d manifest_root=%s: %v", dealID, parsedRoot.Canonical, err)
 	}
 	if err := os.WriteFile(filepath.Join(stagingDir, mode2SlabCompleteMarker), []byte("ok\n"), 0o644); err != nil {
@@ -1239,7 +1249,8 @@ func mode2UploadArtifactsToProviders(
 }
 
 type mode2UploadOptions struct {
-	strictV3 bool
+	strictV3        bool
+	expectedV3Slots []mode2SlotAssignment
 }
 
 func mode2UploadArtifactsToProvidersWithOptions(
@@ -1278,7 +1289,14 @@ func mode2UploadArtifactsToProvidersWithOptions(
 	resolveSlotsStarted := time.Now()
 	var slots []mode2SlotAssignment
 	if opts.strictV3 {
-		slots, err = fetchDealMode2SlotsFromLCD(ctx, dealID)
+		deal, height, queryErr := queryRetrievalDeal(ctx, dealID, 0)
+		if queryErr != nil {
+			return queryErr
+		}
+		slots, err = validateUploadDealV3(deal, height)
+		if err == nil && !slices.Equal(slots, opts.expectedV3Slots) {
+			return fmt.Errorf("provider assignments changed before FAT v3 fanout")
+		}
 	} else {
 		slots, err = resolveDealMode2Slots(ctx, dealID)
 	}
@@ -1286,23 +1304,10 @@ func mode2UploadArtifactsToProvidersWithOptions(
 		return err
 	}
 	if len(slots) < int(stripe.slotCount) {
-		return fmt.Errorf("not enough slot assignments for Mode 2 (need %d, got %d)", stripe.slotCount, len(slots))
+		return fmt.Errorf("not enough Mode 2 slots")
 	}
-	if opts.strictV3 {
-		if stripe.k != 8 || stripe.m != 4 || stripe.rows != 8 || stripe.slotCount != 12 || len(slots) != 12 {
-			return fmt.Errorf("FAT v3 requires the fixed Mode 2 K=8,M=4 profile with 12 slots")
-		}
-		seen := make(map[string]struct{}, len(slots))
-		for slot, assignment := range slots {
-			provider := strings.TrimSpace(assignment.Provider)
-			if assignment.Status != 1 || strings.TrimSpace(assignment.PendingProvider) != "" || provider == "" {
-				return fmt.Errorf("FAT v3 slot %d must be active, stable, and assigned", slot)
-			}
-			if _, exists := seen[provider]; exists {
-				return fmt.Errorf("FAT v3 slot providers must be distinct")
-			}
-			seen[provider] = struct{}{}
-		}
+	if opts.strictV3 && (stripe.k != 8 || stripe.m != 4 || stripe.slotCount != 12) {
+		return fmt.Errorf("invalid FAT v3 stripe profile")
 	}
 	if profile != nil {
 		profile.addDuration("mode2_resolve_slots_ms", time.Since(resolveSlotsStarted))
@@ -1334,7 +1339,7 @@ func mode2UploadArtifactsToProvidersWithOptions(
 			// unavailable for uploads (reads should route around repairing slots).
 			continue
 		}
-		if localProviderAddr != "" && provider == localProviderAddr {
+		if !opts.strictV3 && localProviderAddr != "" && provider == localProviderAddr {
 			continue
 		}
 		targets = append(targets, slotTarget{slot: slot, provider: provider})
@@ -1781,11 +1786,11 @@ func mode2UploadArtifactsToProvidersWithOptions(
 	}
 	if opts.strictV3 {
 		integrityPath := filepath.Join(finalDir, integrityLeavesV3File)
-		integritySizes, err := statSizes(integrityPath, int64(retrievalchallenge.MaxIntegrityLeaves*32))
+		integrityInfo, err := os.Stat(integrityPath)
 		if err != nil {
 			return err
 		}
-		if integritySizes.full != int64(userMdus*retrievalchallenge.IntegrityLeavesPerUserMDU*32) || integritySizes.send != integritySizes.full {
+		if !integrityInfo.Mode().IsRegular() || integrityInfo.Size() != int64(userMdus*retrievalchallenge.IntegrityLeavesPerUserMDU*32) {
 			return fmt.Errorf("FAT v3 integrity leaf vector has invalid size or sparse encoding")
 		}
 		group := make([]uploadTask, 0, len(metadataProviders))
@@ -1798,8 +1803,8 @@ func mode2UploadArtifactsToProvidersWithOptions(
 				kind:         spUploadBundleKindIntegrity,
 				providerBase: base,
 				path:         integrityPath,
-				sizeBytes:    integritySizes.full,
-				sendBytes:    integritySizes.full,
+				sizeBytes:    integrityInfo.Size(),
+				sendBytes:    integrityInfo.Size(),
 				maxBytes:     int64(retrievalchallenge.MaxIntegrityLeaves * 32),
 			})
 		}

--- a/polystore_gateway/ingest_v3.go
+++ b/polystore_gateway/ingest_v3.go
@@ -1,7 +1,15 @@
 package main
 
 import (
+	"context"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
 	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"slices"
 
 	"polystorechain/pkg/retrievalchallenge"
 	"polystorechain/x/polystorechain/types"
@@ -20,6 +28,133 @@ func replacePackedFATHeaderV3(wire []byte, header retrievalchallenge.FATV3Header
 		scalar := i / 31
 		wire[start+scalar*32] = 0
 		wire[start+scalar*32+1+i%31] = value
+	}
+	return nil
+}
+
+// The upload result is a proposal input, never a legacy update-deal-content input.
+type generationCandidateV3 struct {
+	DealID                    uint64 `json:"deal_id,string"`
+	ExpectedCurrentGeneration uint64 `json:"expected_current_generation,string"`
+	PreviousPolyfsRoot        string `json:"previous_polyfs_root"`
+	PolyfsRoot                string `json:"polyfs_root"`
+	IntegrityRoot             string `json:"integrity_root"`
+	SizeBytes                 uint64 `json:"size_bytes,string"`
+	TotalMDUs                 uint64 `json:"total_mdus,string"`
+	WitnessMDUs               uint64 `json:"witness_mdus,string"`
+	IntegrityLeafCount        uint64 `json:"integrity_leaf_count,string"`
+	CommitAction              string `json:"commit_action"`
+	RequiredAcceptances       uint32 `json:"required_acceptances"`
+}
+
+func uploadFATVersion(r *http.Request) (uint16, error) {
+	values, present := r.URL.Query()["fat_version"]
+	if !present {
+		return 2, nil
+	}
+	if len(values) != 1 || (values[0] != "2" && values[0] != "3") {
+		return 0, fmt.Errorf("fat_version must be 2 or 3")
+	}
+	if values[0] == "3" {
+		return 3, nil
+	}
+	return 2, nil
+}
+
+func validateUploadDealV3(deal *types.Deal, height uint64) ([]mode2SlotAssignment, error) {
+	if deal == nil || height == 0 || deal.EndBlock <= height || len(deal.ManifestRoot) != 0 || deal.Size_ != 0 || deal.TotalMdus != 0 || deal.WitnessMdus != 0 || deal.CurrentGen != 0 {
+		return nil, fmt.Errorf("FAT v3 ingest requires an existing empty, unexpired generation-zero deal")
+	}
+	if _, err := rawProviderV3(deal.Owner); err != nil {
+		return nil, err
+	}
+	if deal.RedundancyMode != 2 || deal.Mode2Profile == nil || deal.Mode2Profile.K != 8 || deal.Mode2Profile.M != 4 || len(deal.Mode2Slots) != 12 {
+		return nil, fmt.Errorf("FAT v3 requires the fixed Mode 2 K=8,M=4 profile with 12 slots")
+	}
+	slots := make([]mode2SlotAssignment, 12)
+	seen := make(map[string]bool, 12)
+	for i, slot := range deal.Mode2Slots {
+		if slot == nil || slot.Slot != uint32(i) || slot.Status != types.SlotStatus_SLOT_STATUS_ACTIVE || slot.PendingProvider != "" || seen[slot.Provider] {
+			return nil, fmt.Errorf("FAT v3 requires twelve ordered, distinct, active providers without pending replacements")
+		}
+		if _, err := rawProviderV3(slot.Provider); err != nil {
+			return nil, err
+		}
+		seen[slot.Provider] = true
+		slots[i] = mode2SlotAssignment{Provider: slot.Provider, Status: 1}
+	}
+	return slots, nil
+}
+
+func ingestGenerationV3(ctx context.Context, path, recordPath, owner string, dealID uint64) (*generationCandidateV3, error) {
+	deal, height, err := queryRetrievalDeal(ctx, dealID, 0)
+	if err != nil {
+		return nil, err
+	}
+	slots, err := validateUploadDealV3(deal, height)
+	if err != nil {
+		return nil, err
+	}
+	if owner != "" && owner != deal.Owner {
+		return nil, uploadFailure{status: http.StatusForbidden, message: "owner does not match deal"}
+	}
+	var releasePublished func()
+	ctx = context.WithValue(ctx, generationPublicationLeaseKey{}, &releasePublished)
+	defer func() {
+		if releasePublished != nil {
+			releasePublished()
+		}
+	}()
+	const hint = "General:rs=8+4"
+	res, dir, err := mode2BuildArtifactsWithOptions(ctx, path, dealID, hint, recordPath, 0, mode2BuildOptions{fatVersion: 3})
+	if err != nil {
+		return nil, err
+	}
+	if err := mode2UploadArtifactsToProvidersWithOptions(ctx, dealID, res.manifestRoot, "", hint, dir, res.witnessMdus, res.userMdus, mode2UploadOptions{strictV3: true, expectedV3Slots: slots}); err != nil {
+		return nil, err
+	}
+	fresh, freshHeight, err := queryRetrievalDeal(ctx, dealID, 0)
+	if err != nil {
+		return nil, err
+	}
+	freshSlots, err := validateUploadDealV3(fresh, freshHeight)
+	if err != nil {
+		return nil, err
+	}
+	if fresh.Owner != deal.Owner || fresh.CurrentGen != deal.CurrentGen || !slices.Equal(slots, freshSlots) {
+		return nil, fmt.Errorf("deal changed during FAT v3 upload; retry against current assignments")
+	}
+	return &generationCandidateV3{DealID: dealID, ExpectedCurrentGeneration: deal.CurrentGen,
+		PolyfsRoot: res.manifestRoot.Canonical, IntegrityRoot: "0x" + hex.EncodeToString(res.integrityRoot[:]),
+		SizeBytes: res.sizeBytes, TotalMDUs: res.allocatedLength, WitnessMDUs: res.witnessMdus,
+		IntegrityLeafCount: res.integrityLeaves, CommitAction: "propose-deal-generation-v3", RequiredAcceptances: 12}, nil
+}
+
+// This guard covers local gateway relays. The legacy chain cannot inspect MDU0.
+func rejectLegacyV3Commit(dealID uint64, rootString string) error {
+	root, err := parseManifestRoot(rootString)
+	if err != nil {
+		return err
+	}
+	dir := dealScopedDir(dealID, root)
+	release, err := leaseGenerationPaths(dir)
+	if err != nil {
+		return err
+	}
+	defer release()
+	wire, err := os.ReadFile(filepath.Join(dir, "mdu_0.bin"))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	header, err := fatV3HeaderFromEncodedMDU0(wire)
+	if err != nil {
+		return nil
+	} // Legacy layouts retain their existing validation.
+	if binary.LittleEndian.Uint16(header[4:6]) == 3 {
+		return fmt.Errorf("FAT v3 requires propose-deal-generation-v3, all twelve provider acceptances, then finalize-deal-generation-v3")
 	}
 	return nil
 }

--- a/polystore_gateway/ingest_v3.go
+++ b/polystore_gateway/ingest_v3.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+
+	"polystorechain/pkg/retrievalchallenge"
+	"polystorechain/x/polystorechain/types"
+)
+
+func replacePackedFATHeaderV3(wire []byte, header retrievalchallenge.FATV3Header) error {
+	if len(wire) != types.MDU_SIZE {
+		return fmt.Errorf("invalid MDU #0 size")
+	}
+	raw, err := header.Bytes()
+	if err != nil {
+		return err
+	}
+	start := 16 * types.BLOB_SIZE
+	for i, value := range raw {
+		scalar := i / 31
+		wire[start+scalar*32] = 0
+		wire[start+scalar*32+1+i%31] = value
+	}
+	return nil
+}

--- a/polystore_gateway/ingest_v3_test.go
+++ b/polystore_gateway/ingest_v3_test.go
@@ -3,10 +3,22 @@ package main
 import (
 	"bytes"
 	"encoding/hex"
+	"encoding/json"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/gogoproto/jsonpb"
+	"io"
+	"math/rand"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"polystorechain/pkg/retrievalchallenge"
 	"polystorechain/x/crypto_ffi"
@@ -84,5 +96,217 @@ func TestMode2BuildArtifactsV3ProducesCanonicalIntegrityMetadata(t *testing.T) {
 	}
 	if got, err := retrievalchallenge.IntegrityRootV3Reader(bytes.NewReader(vector), 192); err != nil || got != header.IntegrityRoot {
 		t.Fatalf("integrity root mismatch: got=%x err=%v", got, err)
+	}
+}
+
+func emptyUploadDealV3() *types.Deal {
+	d := &types.Deal{EndBlock: 10000, RedundancyMode: 2, Mode2Profile: &types.StripeReplicaProfile{K: 8, M: 4}}
+	for i := 0; i < 12; i++ {
+		raw := make([]byte, 20)
+		raw[19] = byte(i + 1)
+		d.Mode2Slots = append(d.Mode2Slots, &types.DealSlot{Slot: uint32(i), Provider: sdk.AccAddress(raw).String(), Status: types.SlotStatus_SLOT_STATUS_ACTIVE})
+	}
+	d.Owner = d.Mode2Slots[0].Provider
+	return d
+}
+
+func TestV3UploadRejectsInvalidAdmissionAndConcurrentVersionReuse(t *testing.T) {
+	for _, mutate := range []func(*types.Deal){
+		func(d *types.Deal) { d.CurrentGen = 1 },
+		func(d *types.Deal) { d.ManifestRoot = make([]byte, 32) },
+		func(d *types.Deal) { d.Mode2Profile.K = 4 },
+		func(d *types.Deal) { d.Mode2Slots[0].Status = types.SlotStatus_SLOT_STATUS_REPAIRING },
+		func(d *types.Deal) { d.Mode2Slots[0].PendingProvider = d.Owner },
+		func(d *types.Deal) { d.Mode2Slots[1].Provider = d.Owner },
+		func(d *types.Deal) { d.Mode2Slots[0].Slot = 1 },
+	} {
+		d := emptyUploadDealV3()
+		mutate(d)
+		if _, err := validateUploadDealV3(d, 5); err == nil {
+			t.Fatal("accepted invalid admission")
+		}
+	}
+	for _, query := range []string{"fat_version=", "fat_version=03", "fat_version=4", "fat_version=2&fat_version=3", "fat_version=3"} {
+		w := httptest.NewRecorder()
+		GatewayUpload(w, httptest.NewRequest(http.MethodPost, "/gateway/upload?"+query, nil))
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("query %q: status=%d", query, w.Code)
+		}
+	}
+	const id = "v3-version-race"
+	uploadJobsMu.Lock()
+	delete(uploadJobs, uploadJobKey{0, id})
+	uploadJobsMu.Unlock()
+	t.Cleanup(func() { uploadJobsMu.Lock(); delete(uploadJobs, uploadJobKey{0, id}); uploadJobsMu.Unlock() })
+	var wg sync.WaitGroup
+	var winners atomic.Int32
+	start := make(chan struct{})
+	for _, version := range []uint16{2, 3} {
+		wg.Add(1)
+		go func(v uint16) {
+			defer wg.Done()
+			<-start
+			if _, _, err := claimUploadJob(0, id, v); err == nil {
+				winners.Add(1)
+			}
+		}(version)
+	}
+	close(start)
+	wg.Wait()
+	if winners.Load() != 1 {
+		t.Fatalf("version claims=%d", winners.Load())
+	}
+}
+
+func TestGatewayUploadV3UsesRealBundlesAndCandidateOnlyResponse(t *testing.T) {
+	useTempUploadDir(t)
+	initCryptoForTest(t)
+	oldPolyce := polyceEnabled
+	polyceEnabled = false
+	t.Cleanup(func() { polyceEnabled = oldPolyce })
+	t.Setenv("POLYSTORE_FAKE_INGEST", "0")
+	t.Setenv("POLYSTORE_FAST_INGEST", "0")
+	clearDealMetaCache()
+	resetPolyfsUploadRootPreflightCacheForTest()
+	t.Cleanup(clearDealMetaCache)
+	t.Cleanup(resetPolyfsUploadRootPreflightCacheForTest)
+	d := emptyUploadDealV3()
+	body, err := (&jsonpb.Marshaler{OrigName: true}).MarshalToString(&types.QueryGetDealResponse{Deal: d})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lcd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(committedHeightHeader, "5")
+		_, _ = io.WriteString(w, body)
+	}))
+	defer lcd.Close()
+	oldLCD := lcdBase
+	lcdBase = lcd.URL
+	t.Cleanup(func() { lcdBase = oldLCD })
+	var fail atomic.Bool
+	var mu sync.Mutex
+	seen := make(map[string]bool)
+	sp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		provider := strings.Split(strings.TrimPrefix(r.URL.Path, "/"), "/")[0]
+		if fail.Load() && provider == "11" {
+			http.Error(w, "unsupported", http.StatusNotFound)
+			return
+		}
+		if !strings.HasSuffix(r.URL.Path, "/sp/upload_bundle") {
+			http.Error(w, "unexpected fallback", http.StatusBadRequest)
+			return
+		}
+		rec := httptest.NewRecorder()
+		SpUploadBundle(rec, r)
+		if rec.Code == http.StatusOK {
+			mu.Lock()
+			seen[provider] = true
+			mu.Unlock()
+		}
+		w.WriteHeader(rec.Code)
+		_, _ = w.Write(rec.Body.Bytes())
+	}))
+	defer sp.Close()
+	for i, slot := range d.Mode2Slots {
+		providerBaseCache.Store(slot.Provider, &providerBaseCacheEntry{baseURL: sp.URL + "/" + strconv.Itoa(i), expires: time.Now().Add(time.Minute)})
+		address := slot.Provider
+		t.Cleanup(func() { providerBaseCache.Delete(address) })
+	}
+	request := func(query string) *httptest.ResponseRecorder {
+		var buf bytes.Buffer
+		mw := multipart.NewWriter(&buf)
+		part, err := mw.CreateFormFile("file", "payload.bin")
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _ = part.Write(bytes.Repeat([]byte{0x5a}, 1024))
+		_ = mw.Close()
+		r := httptest.NewRequest(http.MethodPost, "/gateway/upload?deal_id=0&fat_version=3"+query, &buf)
+		r.Header.Set("Content-Type", mw.FormDataContentType())
+		w := httptest.NewRecorder()
+		GatewayUpload(w, r)
+		return w
+	}
+	w := request("")
+	if w.Code != http.StatusOK {
+		t.Fatalf("upload status=%d: %s", w.Code, w.Body.String())
+	}
+	var result struct {
+		Candidate *generationCandidateV3 `json:"generation_candidate"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil || result.Candidate == nil {
+		t.Fatalf("invalid result: %s (%v)", w.Body.String(), err)
+	}
+	if strings.Contains(w.Body.String(), `"manifest_root"`) || strings.Contains(w.Body.String(), `"cid"`) {
+		t.Fatal("legacy commit shape exposed")
+	}
+	mu.Lock()
+	count := len(seen)
+	mu.Unlock()
+	if count != 12 {
+		t.Fatalf("successful providers=%d", count)
+	}
+	c := result.Candidate
+	if c.DealID != 0 || c.ExpectedCurrentGeneration != d.CurrentGen || c.SizeBytes != 1024 || c.IntegrityLeafCount != 96 || c.RequiredAcceptances != 12 || c.CommitAction != "propose-deal-generation-v3" {
+		t.Fatalf("wrong candidate: %+v", c)
+	}
+	if err := rejectLegacyV3Commit(0, c.PolyfsRoot); err == nil {
+		t.Fatal("legacy relay accepted v3 root")
+	}
+	// Asynchronous status and replay must retain the same safe proposal shape.
+	job, _, err := claimUploadJob(0, "v3-cached-candidate", 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	job.setResult(uploadJobResult{GenerationCandidate: c})
+	t.Cleanup(func() {
+		uploadJobsMu.Lock()
+		delete(uploadJobs, uploadJobKey{0, "v3-cached-candidate"})
+		uploadJobsMu.Unlock()
+	})
+	encoded, err := json.Marshal(job.snapshot())
+	if err != nil || strings.Contains(string(encoded), `"manifest_root"`) || !strings.Contains(string(encoded), `"generation_candidate"`) {
+		t.Fatalf("bad status: %s %v", encoded, err)
+	}
+	w = request("&upload_id=v3-cached-candidate")
+	if w.Code != http.StatusOK || strings.Contains(w.Body.String(), `"manifest_root"`) || !strings.Contains(w.Body.String(), `"generation_candidate"`) {
+		t.Fatalf("bad replay: %d %s", w.Code, w.Body.String())
+	}
+	fail.Store(true)
+	w = request("")
+	if w.Code == http.StatusOK || strings.Contains(w.Body.String(), `"generation_candidate"`) {
+		t.Fatalf("partial fanout returned candidate: %d %s", w.Code, w.Body.String())
+	}
+}
+
+func BenchmarkMode2BuildArtifactsFATVersion(b *testing.B) {
+	if err := crypto_ffi.Init(trustedSetup); err != nil {
+		b.Fatal(err)
+	}
+	old := uploadDir
+	uploadDir = b.TempDir()
+	b.Cleanup(func() { uploadDir = old })
+	data := make([]byte, 16<<20)
+	_, _ = rand.New(rand.NewSource(291)).Read(data)
+	path := filepath.Join(b.TempDir(), "dense.bin")
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		b.Fatal(err)
+	}
+	for _, version := range []uint16{2, 3} {
+		b.Run(strconv.Itoa(int(version)), func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, dir, err := mode2BuildArtifactsWithOptions(b.Context(), path, uint64(i), "General:rs=8+4", "dense.bin", 0, mode2BuildOptions{fatVersion: version})
+				if err != nil {
+					b.Fatal(err)
+				}
+				b.StopTimer()
+				if err := os.RemoveAll(dir); err != nil {
+					b.Fatal(err)
+				}
+				b.StartTimer()
+			}
+		})
 	}
 }

--- a/polystore_gateway/ingest_v3_test.go
+++ b/polystore_gateway/ingest_v3_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"polystorechain/pkg/retrievalchallenge"
+	"polystorechain/x/crypto_ffi"
+	"polystorechain/x/polystorechain/types"
+)
+
+func TestMode2BuildArtifactsV3ProducesCanonicalIntegrityMetadata(t *testing.T) {
+	useTempUploadDir(t)
+	initCryptoForTest(t)
+	payload := filepath.Join(t.TempDir(), "payload.bin")
+	if err := os.WriteFile(payload, bytes.Repeat([]byte{0x5a}, RawMduCapacity+4097), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result, dir, err := mode2BuildArtifactsWithOptions(t.Context(), payload, 0, "General:rs=8+4", "payload.bin", 0, mode2BuildOptions{fatVersion: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.userMdus != 2 || result.integrityLeaves != 192 {
+		t.Fatalf("unexpected v3 geometry: users=%d leaves=%d", result.userMdus, result.integrityLeaves)
+	}
+
+	mdu0, err := os.ReadFile(filepath.Join(dir, "mdu_0.bin"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := fatV3HeaderFromEncodedMDU0(mdu0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	header, err := retrievalchallenge.ParseFATV3Header(raw[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if header.RecordCount != 1 || header.LeafCount != 192 || header.IntegrityRoot != result.integrityRoot {
+		t.Fatalf("unexpected FAT v3 header: %+v", header)
+	}
+	root, err := crypto_ffi.ComputeMduMerkleRoot(mdu0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := "0x" + hex.EncodeToString(root); got != result.manifestRoot.Canonical {
+		t.Fatalf("MDU0 root mismatch: got %s want %s", got, result.manifestRoot.Canonical)
+	}
+
+	vector, err := os.ReadFile(filepath.Join(dir, integrityLeavesV3File))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vector) != 192*32 {
+		t.Fatalf("integrity vector length=%d", len(vector))
+	}
+	for user := uint64(0); user < result.userMdus; user++ {
+		slabIndex := uint64(1) + result.witnessMdus + user
+		for slot := uint64(0); slot < 12; slot++ {
+			shard, err := os.ReadFile(filepath.Join(dir, "mdu_"+strconv.FormatUint(slabIndex, 10)+"_slot_"+strconv.FormatUint(slot, 10)+".bin"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(shard) != 8*types.BLOB_SIZE {
+				t.Fatalf("user %d slot %d shard length=%d", user, slot, len(shard))
+			}
+			for row := uint64(0); row < 8; row++ {
+				leaf := slot*8 + row
+				want, err := retrievalchallenge.IntegrityLeafV3(slabIndex, uint32(leaf), shard[row*types.BLOB_SIZE:(row+1)*types.BLOB_SIZE])
+				if err != nil {
+					t.Fatal(err)
+				}
+				position := user*retrievalchallenge.IntegrityLeavesPerUserMDU + leaf
+				if !bytes.Equal(vector[position*32:(position+1)*32], want[:]) {
+					t.Fatalf("integrity leaf mismatch at %d", position)
+				}
+			}
+		}
+	}
+	if got, err := retrievalchallenge.IntegrityRootV3Reader(bytes.NewReader(vector), 192); err != nil || got != header.IntegrityRoot {
+		t.Fatalf("integrity root mismatch: got=%x err=%v", got, err)
+	}
+}

--- a/polystore_gateway/ingest_v3_test.go
+++ b/polystore_gateway/ingest_v3_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -308,5 +309,39 @@ func BenchmarkMode2BuildArtifactsFATVersion(b *testing.B) {
 				b.StartTimer()
 			}
 		})
+	}
+}
+
+func TestProviderBundleUploadBatchesRespectReceiverLimit(t *testing.T) {
+	for _, count := range []int{4096, 4097, 8193} {
+		bundle := providerBundleUpload{providerBase: "http://provider", url: "http://provider/sp/upload_bundle"}
+		for i := 0; i < count; i++ {
+			task := uploadTask{mduIndex: strconv.Itoa(i), sizeBytes: int64(i + 1)}
+			bundle.tasks = append(bundle.tasks, task)
+			bundle.sizeBytes += task.sizeBytes
+		}
+		batches := splitProviderBundleUpload(bundle)
+		var got []uploadTask
+		var totalBytes int64
+		for _, batch := range batches {
+			if len(batch.tasks) == 0 || len(batch.tasks) > spUploadBundleMaxArtifacts {
+				t.Fatalf("%d artifacts: invalid batch size %d", count, len(batch.tasks))
+			}
+			if batch.providerBase != bundle.providerBase || batch.url != bundle.url {
+				t.Fatal("batch changed provider destination")
+			}
+			var batchBytes int64
+			for _, task := range batch.tasks {
+				batchBytes += task.sizeBytes
+			}
+			if batch.sizeBytes != batchBytes {
+				t.Fatalf("incorrect batch byte accounting: %d != %d", batch.sizeBytes, batchBytes)
+			}
+			totalBytes += batch.sizeBytes
+			got = append(got, batch.tasks...)
+		}
+		if !slices.Equal(got, bundle.tasks) || totalBytes != bundle.sizeBytes {
+			t.Fatalf("%d artifacts: batches lost, reordered or duplicated payloads", count)
+		}
 	}
 }

--- a/polystore_gateway/main.go
+++ b/polystore_gateway/main.go
@@ -1046,6 +1046,22 @@ func GatewayUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	fatVersion, versionErr := uploadFATVersion(r)
+	if versionErr != nil {
+		http.Error(w, versionErr.Error(), http.StatusBadRequest)
+		return
+	}
+	if fatVersion == 3 {
+		if r.Method != http.MethodPost || len(r.URL.Query()["deal_id"]) != 1 || r.URL.Query().Get("deal_id") == "" || len(r.URL.Query()["upload_id"]) > 1 {
+			http.Error(w, "FAT v3 requires POST with one explicit deal_id", http.StatusBadRequest)
+			return
+		}
+		if polyceEnabled || os.Getenv("POLYSTORE_FAKE_INGEST") == "1" || os.Getenv("POLYSTORE_FAST_INGEST") == "1" {
+			http.Error(w, "FAT v3 requires canonical plain ingest; disable PolyCE, fake and fast ingest", http.StatusBadRequest)
+			return
+		}
+	}
+
 	rawDealID := strings.TrimSpace(r.URL.Query().Get("deal_id"))
 	var dealIDQuery uint64
 	dealIDQueryOK := false
@@ -1069,38 +1085,17 @@ func GatewayUpload(w http.ResponseWriter, r *http.Request) {
 	skipExistingAsyncRun := false
 	ownsAsyncUploadJob := false
 	if dealIDQueryOK && uploadID != "" {
-		existing := lookupUploadJob(dealIDQuery, uploadID)
-		if existing != nil {
-			snapshot := existing.snapshot()
-			switch snapshot.Status {
-			case string(uploadJobRunning):
-				job = existing
-				asyncUpload = true
-				skipExistingAsyncRun = true
-				log.Printf("GatewayUpload: deduped async upload (running) deal_id=%d upload_id=%s phase=%s", dealIDQuery, uploadID, snapshot.Phase)
-			case string(uploadJobSuccess):
-				job = existing
-				asyncUpload = true
-				skipExistingAsyncRun = true
-				log.Printf("GatewayUpload: deduped async upload (success) deal_id=%d upload_id=%s manifest_root=%s", dealIDQuery, uploadID, snapshot.Result.ManifestRoot)
-			default:
-				job = newUploadJob(dealIDQuery, uploadID)
-				asyncUpload = true
-				ownsAsyncUploadJob = true
-				job.setPhase(uploadJobPhaseReceiving, "Starting upload...")
-				storeUploadJob(job)
-				log.Printf("GatewayUpload: replacing terminal async job deal_id=%d upload_id=%s status=%s", dealIDQuery, uploadID, snapshot.Status)
-			}
-		} else {
-			job = newUploadJob(dealIDQuery, uploadID)
-			asyncUpload = true
-			ownsAsyncUploadJob = true
-			job.setPhase(uploadJobPhaseReceiving, "Starting upload...")
-			storeUploadJob(job)
-			log.Printf("GatewayUpload: created async job deal_id=%d upload_id=%s", dealIDQuery, uploadID)
+		var err error
+		job, skipExistingAsyncRun, err = claimUploadJob(dealIDQuery, uploadID, fatVersion)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusConflict)
+			return
 		}
-	} else if uploadID != "" {
-		log.Printf("GatewayUpload: upload_id provided but async job disabled (deal_id missing/invalid), processing synchronously upload_id=%s", uploadID)
+		asyncUpload = true
+		ownsAsyncUploadJob = !skipExistingAsyncRun
+		if ownsAsyncUploadJob {
+			job.setPhase(uploadJobPhaseReceiving, "Starting upload...")
+		}
 	}
 
 	cleanupTmpFiles := []string{}
@@ -1139,7 +1134,7 @@ func GatewayUpload(w http.ResponseWriter, r *http.Request) {
 		job.setError(fmt.Sprintf("upload failed (HTTP %d)", code))
 	}()
 	defer func() {
-		if !asyncUpload {
+		if releaseProfile {
 			cleanupRun()
 		}
 	}()
@@ -1189,6 +1184,11 @@ func GatewayUpload(w http.ResponseWriter, r *http.Request) {
 		reuseSnap := reuse.snapshot()
 		if reuseSnap.Status != string(uploadJobSuccess) || reuseSnap.Result == nil {
 			writeUploadError(uploadFailure{status: http.StatusTooManyRequests, message: "upload job has not completed"})
+			return
+		}
+		if reuseSnap.Result.GenerationCandidate != nil {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "success", "generation_candidate": reuseSnap.Result.GenerationCandidate, "deal_id": reuseSnap.DealID, "upload_id": uploadID, "status_url": buildStatusURL(r, dealIDQuery, uploadID)})
 			return
 		}
 		log.Printf("GatewayUpload: replaying cached result for upload_id=%s deal_id=%d", uploadID, dealIDQuery)
@@ -1273,6 +1273,25 @@ func GatewayUpload(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			val := strings.TrimSpace(string(b))
+			if fatVersion == 3 {
+				switch formName {
+				case "owner", "file_path", "file_size_bytes":
+				case "deal_id":
+					if val != dealIDStr {
+						writeUploadError(uploadFailure{status: http.StatusBadRequest, message: "multipart deal_id conflicts with query"})
+						return
+					}
+				case "upload_id":
+					if val != uploadID {
+						writeUploadError(uploadFailure{status: http.StatusBadRequest, message: "multipart upload_id conflicts with query"})
+						return
+					}
+				default:
+					writeUploadError(uploadFailure{status: http.StatusBadRequest, message: "unsupported FAT v3 field: " + formName})
+					return
+				}
+			}
+
 			switch formName {
 			case "owner":
 				owner = val
@@ -1427,6 +1446,12 @@ func GatewayUpload(w http.ResponseWriter, r *http.Request) {
 	}
 	contentEncoding := "none"
 	fileFlags := uint8(0)
+	if fatVersion == 3 {
+		if _, ok, err := detectPolyceHeaderFromFile(rawPath); err != nil || ok {
+			writeUploadError(uploadFailure{status: http.StatusBadRequest, message: "FAT v3 requires plain file bytes without a PolyCE envelope"})
+			return
+		}
+	}
 	prepareStarted := time.Now()
 	if polyceEnabled {
 		wrapped, err := maybeWrapPolyceZstd(receiveCtx, rawPath, polyceMinSavingsBps, polyceSampleBytes)
@@ -1455,6 +1480,7 @@ func GatewayUpload(w http.ResponseWriter, r *http.Request) {
 	profile.addDuration("gateway_prepare_ms", time.Since(prepareStarted))
 
 	type gatewayUploadResult struct {
+		candidate       *generationCandidateV3
 		cid             string
 		size            uint64
 		fileSize        uint64
@@ -1467,6 +1493,17 @@ func GatewayUpload(w http.ResponseWriter, r *http.Request) {
 		ctx = withMode2UploadProfile(ctx, profile)
 		if ctx == nil {
 			return nil, uploadFailure{status: http.StatusInternalServerError, message: "missing ingest context"}
+		}
+
+		if fatVersion == 3 {
+			candidate, err := ingestGenerationV3(withUploadJob(ctx, job), ingestPath, fileRecordPath, owner, dealIDQuery)
+			if err != nil {
+				return nil, err
+			}
+			if job != nil {
+				job.setResult(uploadJobResult{GenerationCandidate: candidate})
+			}
+			return &gatewayUploadResult{candidate: candidate}, nil
 		}
 
 		var (
@@ -1736,13 +1773,9 @@ func GatewayUpload(w http.ResponseWriter, r *http.Request) {
 			writeUploadAcceptedResponse("accepted")
 			return
 		}
-		if current.Status != string(uploadJobRunning) && skipExistingAsyncRun {
-			log.Printf("GatewayUpload: duplicate async upload status changed; re-starting async ingest deal_id=%d upload_id=%s status=%s", dealIDQuery, uploadID, current.Status)
-			skipExistingAsyncRun = false
-			job = newUploadJob(dealIDQuery, uploadID)
-			ownsAsyncUploadJob = true
-			job.setPhase(uploadJobPhaseReceiving, "Starting upload...")
-			storeUploadJob(job)
+		if skipExistingAsyncRun {
+			writeUploadError(uploadFailure{status: http.StatusConflict, message: "upload job changed; retry request"})
+			return
 		}
 
 		log.Printf("GatewayUpload async accepted: file=%s deal_id=%s upload_id=%s", filename, dealIDStr, uploadID)
@@ -1800,6 +1833,12 @@ func GatewayUpload(w http.ResponseWriter, r *http.Request) {
 	result, runErr := runIngest(receiveCtx, filename, maxUserMdusStr, dealIDStr)
 	if runErr != nil {
 		writeUploadError(runErr)
+		return
+	}
+
+	if result.candidate != nil {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"generation_candidate": result.candidate})
 		return
 	}
 
@@ -1998,6 +2037,10 @@ func GatewayUpdateDealContent(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.TotalMdus <= 1+req.WitnessMdus {
 		http.Error(w, "total_mdus must be > 1 + witness_mdus", http.StatusBadRequest)
+		return
+	}
+	if err := rejectLegacyV3Commit(req.DealID, req.Cid); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	meta, err := fetchDealMetaFresh(req.DealID)
@@ -2341,6 +2384,10 @@ func GatewayUpdateDealContentFromEvm(w http.ResponseWriter, r *http.Request) {
 	dealID, ok := parseUintFromJSON(rawDealID)
 	if !ok {
 		http.Error(w, "deal_id must be a valid integer", http.StatusBadRequest)
+		return
+	}
+	if err := rejectLegacyV3Commit(dealID, rawCid); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	meta, err := fetchDealMetaFresh(dealID)

--- a/polystore_gateway/retrieval_v3_session_test.go
+++ b/polystore_gateway/retrieval_v3_session_test.go
@@ -15,9 +15,7 @@ import (
 	cosmosmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	bolt "go.etcd.io/bbolt"
-	"golang.org/x/crypto/blake2s"
 	"polystorechain/pkg/retrievalchallenge"
-	"polystorechain/x/crypto_ffi"
 	"polystorechain/x/polystorechain/types"
 )
 
@@ -243,74 +241,13 @@ func buildProviderV3ArtifactFixture(t *testing.T) (*frozenRetrievalSessionV3, re
 	if err := os.WriteFile(payload, bytes.Repeat([]byte{0x5a}, 1024), 0600); err != nil {
 		t.Fatal(err)
 	}
-	result, oldDir, err := mode2BuildArtifacts(context.Background(), payload, dealID, "General:rs=8+4", "payload.bin", 0)
+	result, newDir, err := mode2BuildArtifactsWithOptions(context.Background(), payload, dealID, "General:rs=8+4", "payload.bin", 0, mode2BuildOptions{fatVersion: 3})
 	if err != nil {
 		t.Fatal(err)
 	}
 	metadataMDUs := uint64(1 + result.witnessMdus)
-	leaves := make([][32]byte, result.userMdus*retrievalchallenge.IntegrityLeavesPerUserMDU)
-	for user := uint64(0); user < result.userMdus; user++ {
-		mdu := metadataMDUs + user
-		for slot := uint32(0); slot < 12; slot++ {
-			shard, err := os.ReadFile(filepath.Join(oldDir, fmt.Sprintf("mdu_%d_slot_%d.bin", mdu, slot)))
-			if err != nil || len(shard) != 8*types.BLOB_SIZE {
-				t.Fatalf("read slot artifact %d/%d: %v size=%d", mdu, slot, err, len(shard))
-			}
-			for row := uint32(0); row < 8; row++ {
-				leaf := slot*8 + row
-				hash, err := retrievalchallenge.IntegrityLeafV3(mdu, leaf, shard[int(row)*types.BLOB_SIZE:int(row+1)*types.BLOB_SIZE])
-				if err != nil {
-					t.Fatal(err)
-				}
-				leaves[user*retrievalchallenge.IntegrityLeavesPerUserMDU+uint64(leaf)] = hash
-			}
-		}
-	}
-	integrity, err := retrievalchallenge.IntegrityRootV3(leaves)
-	if err != nil {
-		t.Fatal(err)
-	}
-	vector := make([]byte, 0, len(leaves)*32)
-	for _, leaf := range leaves {
-		vector = append(vector, leaf[:]...)
-	}
-	if err := os.WriteFile(filepath.Join(oldDir, integrityLeavesV3File), vector, 0600); err != nil {
-		t.Fatal(err)
-	}
-	mdu0, err := os.ReadFile(filepath.Join(oldDir, "mdu_0.bin"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	builder, err := crypto_ffi.LoadMdu0Builder(mdu0, result.userMdus)
-	if err != nil {
-		t.Fatal(err)
-	}
-	recordCount := builder.GetRecordCount()
-	builder.Free()
-	writePackedFATHeaderV3(t, mdu0, retrievalchallenge.FATV3Header{RecordCount: recordCount, LeafCount: uint64(len(leaves)), IntegrityRoot: integrity})
-	if err := os.WriteFile(filepath.Join(oldDir, "mdu_0.bin"), mdu0, 0600); err != nil {
-		t.Fatal(err)
-	}
-	polyfsLeaves := make([][32]byte, 64)
-	for i := range polyfsLeaves {
-		commitment, err := crypto_ffi.CommitReceivedBlob(mdu0[i*types.BLOB_SIZE : (i+1)*types.BLOB_SIZE])
-		if err != nil {
-			t.Fatal(err)
-		}
-		polyfsLeaves[i] = blake2s.Sum256(commitment)
-	}
-	tree := buildProofMerkleTree(polyfsLeaves)
-	root, err := parseManifestRoot("0x" + hex.EncodeToString(tree[len(tree)-1][0][:]))
-	if err != nil {
-		t.Fatal(err)
-	}
-	newDir := dealScopedDir(dealID, root)
-	if err := os.MkdirAll(filepath.Dir(newDir), 0700); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Rename(oldDir, newDir); err != nil {
-		t.Fatal(err)
-	}
+	root := result.manifestRoot
+	integrity := result.integrityRoot
 	r, height := frozenSessionV3Fixture(t, 1024, result.userMdus)
 	r.Session.PolyfsRoot = bytes.Clone(root.Bytes[:])
 	r.Session.IntegrityRoot = integrity[:]

--- a/polystore_gateway/upload_jobs.go
+++ b/polystore_gateway/upload_jobs.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"strconv"
@@ -34,12 +35,13 @@ type uploadJobKey struct {
 }
 
 type uploadJobResult struct {
-	ManifestRoot    string `json:"manifest_root"`
-	SizeBytes       uint64 `json:"size_bytes"`
-	FileSizeBytes   uint64 `json:"file_size_bytes"`
-	AllocatedLength uint64 `json:"allocated_length"`
-	TotalMdus       uint64 `json:"total_mdus"`
-	WitnessMdus     uint64 `json:"witness_mdus"`
+	GenerationCandidate *generationCandidateV3 `json:"-"`
+	ManifestRoot        string                 `json:"manifest_root"`
+	SizeBytes           uint64                 `json:"size_bytes"`
+	FileSizeBytes       uint64                 `json:"file_size_bytes"`
+	AllocatedLength     uint64                 `json:"allocated_length"`
+	TotalMdus           uint64                 `json:"total_mdus"`
+	WitnessMdus         uint64                 `json:"witness_mdus"`
 }
 
 type uploadJob struct {
@@ -48,7 +50,8 @@ type uploadJob struct {
 	dealID   uint64
 	uploadID string
 
-	fileName string
+	fatVersion uint16 // Immutable once stored. Zero is the legacy v2 default.
+	fileName   string
 
 	status  uploadJobStatus
 	phase   uploadJobPhase
@@ -96,6 +99,43 @@ type uploadJobResponse struct {
 
 var uploadJobsMu sync.RWMutex
 var uploadJobs = map[uploadJobKey]*uploadJob{}
+
+// MarshalJSON preserves the v2 wire shape while v3 exposes only proposal input.
+func (r uploadJobResult) MarshalJSON() ([]byte, error) {
+	if r.GenerationCandidate != nil {
+		return json.Marshal(struct {
+			Candidate *generationCandidateV3 `json:"generation_candidate"`
+		}{r.GenerationCandidate})
+	}
+	type legacy uploadJobResult
+	return json.Marshal(legacy(r))
+}
+
+// Lookup, version binding, and replacement must be one operation: otherwise two
+// simultaneous v2/v3 requests can both claim the same upload ID.
+func claimUploadJob(dealID uint64, uploadID string, version uint16) (*uploadJob, bool, error) {
+	pruneUploadJobs(time.Now())
+	uploadJobsMu.Lock()
+	defer uploadJobsMu.Unlock()
+	key := uploadJobKey{dealID, strings.TrimSpace(uploadID)}
+	if existing := uploadJobs[key]; existing != nil {
+		v := existing.fatVersion
+		if v == 0 {
+			v = 2
+		}
+		if v != version {
+			return nil, false, fmt.Errorf("upload_id is already bound to FAT version %d", v)
+		}
+		snapshot := existing.snapshot()
+		if snapshot.Status == string(uploadJobRunning) || snapshot.Status == string(uploadJobSuccess) {
+			return existing, true, nil
+		}
+	}
+	job := newUploadJob(dealID, uploadID)
+	job.fatVersion = version
+	uploadJobs[key] = job
+	return job, false, nil
+}
 
 func pruneUploadJobs(now time.Time) {
 	uploadJobsMu.Lock()


### PR DESCRIPTION
Existing uploads could not produce the FAT v3 integrity artifacts required by native generation admission. `POST /gateway/upload?deal_id=<id>&fat_version=3` now builds and distributes a canonical initial K8/M4 generation, then returns proposal inputs under `generation_candidate`. This advances #291 without activating v3 on the deployed chain.

- Hash all 96 encoded data/parity/padding blobs during each RS worker, write deterministic sidecar offsets, stream the integrity root, then commit the original packed FAT v3 MDU0. Reuse immutable provisional generation publication.
- Require a fresh, empty, unexpired generation-zero deal with twelve distinct active providers. Bind fanout to that provider snapshot, send complete sidecars and own-slot artifacts through bundles of at most 4,096 artifacts, serially per provider, to all twelve endpoints, and fail on partial delivery or unsupported bundle transport.
- Atomically bind upload IDs to FAT version. Synchronous, cached and asynchronous v3 results expose only the generation candidate; locally staged v3 roots reject both legacy gateway update relays. The native proposal flag is `--size`.
- Replace the handcrafted provider proof fixture with production v3 artifacts. Default/explicit v2 stays compatible.

Validation on `ssh mikers@192.168.0.111` (Ryzen 7 9700X, Go 1.25.5, unchanged cached native crypto build):

- Final `go test ./... -count=1` in `polystore_gateway`: PASS, 22.664s. Log `/tmp/provider-v3-ingest-batches-full.log`.
- Public upload through real provider bundle handlers, all twelve endpoints, failed one-provider fanout, candidate-only status/replay, concurrent v2/v3 ID conflict, invalid admission, two-user-MDU leaf ordering/parity, and production real-KZG acceptance/proof tests: PASS. Final focused run plus benchmark: 6.708s, `/tmp/provider-v3-ingest-benchmark.log`.
- `go test . -run '<focused tests>' -bench BenchmarkMode2BuildArtifactsFATVersion -benchtime=3x -benchmem`: seeded dense 16 MiB artifact build, v2 703,248,207 ns/op, 79,152,354 B/op, 809 allocs/op; v3 702,560,254 ns/op, 79,280,008 B/op, 3,428 allocs/op. The small run establishes no material observed time regression; it is not a statistically established speedup, a download benchmark or chain-capacity evidence. V3 adds about 128 KiB allocation for the integrity metadata in this case.
- Bundle boundary tests at 4,096 / 4,097 / 8,193 artifacts preserve payload order, destination and byte accounting. Independent review found the previous oversized-request failure; the correction retains one in-flight request per provider and requires every batch to succeed.
- `gofmt` and `git diff --check`: PASS. Independent review ACCEPT and hosted Codex review clean at `73804717d976c32a80e012dcf20ca89738c46f02`; current-head CI is completing.

Scope limits: initial plain nonempty files only; no append, implicit deal creation, compression/encryption mode, client delivery/ACK, EVM v3 adapter or activation qualification. Provider consent and owner finalization still occur through existing native routes. A direct legacy chain transaction cannot inspect MDU0; the local relay guard is not a consensus format detector. Native v3 throughput qualification remains in #290/#291 after this prerequisite lands.
