### PR TITLE
Keep verified cached downloads available during balance outages

### DIFF
--- a/polystore-website/src/components/Dashboard.tsx
+++ b/polystore-website/src/components/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
-import { RefreshCw, CheckCircle2, HardDrive, Database, ChevronDown, ChevronUp, Coins } from 'lucide-react'
+import { RefreshCw, CheckCircle2, HardDrive, Database, ChevronDown, ChevronUp } from 'lucide-react'
 import { useConnectModal } from '@rainbow-me/rainbowkit'
 import { useCreateDeal } from '../hooks/useCreateDeal'
 import { useUpdateDealContent } from '../hooks/useUpdateDealContent'
@@ -104,6 +104,7 @@ export function Dashboard() {
     isConnected,
     polystoreAddress,
     hasFunds,
+    fundingStatus,
     isWrongNetwork,
     walletChainId,
     genesisMismatch,
@@ -1000,6 +1001,13 @@ export function Dashboard() {
     if (!file || !address) {
       return
     }
+    if (!hasFunds) {
+      setStatusTone('error')
+      setStatusMsg(fundingStatus === 'unavailable'
+        ? 'Wallet balance is temporarily unavailable. Uploads remain paused until the network answers balance checks.'
+        : 'A funded wallet is required before uploading data.')
+      return
+    }
     if (!targetDealId) {
       setStatusTone('error')
       setStatusMsg('Select a target deal before uploading.')
@@ -1062,7 +1070,9 @@ export function Dashboard() {
     if (!hasFunds) {
       setStatusTone('error')
       setStatusMsg(
-        appConfig.faucetEnabled
+        fundingStatus === 'unavailable' || fundingStatus === 'checking'
+          ? 'Wallet balance is temporarily unavailable. Creating deals remains paused until the network confirms your balance.'
+          : appConfig.faucetEnabled
           ? 'You must request testnet NIL from the faucet before creating a storage deal.'
           : 'Your wallet needs funds before creating a storage deal.',
       )
@@ -1179,7 +1189,9 @@ export function Dashboard() {
 
   const handleCreateDealClick = async () => {
     if (!hasFunds) {
-      const message = appConfig.faucetEnabled
+      const message = fundingStatus === 'unavailable' || fundingStatus === 'checking'
+        ? 'Wallet balance is temporarily unavailable. Creating deals remains paused until the network confirms your balance.'
+        : appConfig.faucetEnabled
         ? 'You must request testnet NIL from the faucet before creating a storage deal.'
         : 'Your wallet needs funds before creating a storage deal.'
       setStatusTone('error')
@@ -1436,30 +1448,6 @@ export function Dashboard() {
       </div>
     )
 
-  if (!hasFunds)
-    return (
-      <div className="px-4 pb-12 pt-24">
-        <div className="container mx-auto max-w-6xl">
-          <div className="glass-panel industrial-border p-12 text-center">
-            <div className="nil-section-label">/DASHBOARD</div>
-            <h2 className="mt-2 text-xl font-semibold text-foreground">Fund your wallet to continue</h2>
-            <p className="mx-auto mt-4 max-w-2xl text-muted-foreground">
-              Your wallet is connected, but it needs testnet NIL before you can allocate deals or upload data.
-            </p>
-            <button
-              type="button"
-              onClick={() => void session.requestFunds()}
-              disabled={!address || session.faucetBusy || !session.faucetEnabled}
-              className="cta-shadow mt-6 inline-flex items-center justify-center gap-3 border border-primary bg-primary px-6 py-3 text-[10px] font-bold uppercase tracking-[0.2em] text-primary-foreground transition-all hover:translate-x-[-1px] hover:translate-y-[-1px] active:translate-x-[2px] active:translate-y-[2px] disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              {session.faucetBusy ? <RefreshCw className="h-4 w-4 animate-spin" /> : <Coins className="h-4 w-4" />}
-              {session.faucetBusy ? 'Funding' : 'Fund Wallet'}
-            </button>
-          </div>
-        </div>
-      </div>
-    )
-
   const onChainCid = String(targetDeal?.cid || '').trim()
 
   const dealExplorerTopPanel = (
@@ -1534,7 +1522,7 @@ export function Dashboard() {
                 <input
                   type="file"
                   onChange={handleFileChange}
-                  disabled={!targetDealId || uploadLoading || isTargetDealMode2 || targetDealExpired}
+                  disabled={!hasFunds || !targetDealId || uploadLoading || isTargetDealMode2 || targetDealExpired}
                   data-testid="content-file-input"
                   className="w-full recessed-input px-3 py-2 text-[11px] focus:outline-none focus:ring-1 focus:ring-primary/30 disabled:opacity-50"
                 />
@@ -1591,7 +1579,7 @@ export function Dashboard() {
                     stagedUpload.witnessMdus,
                   )
                 }}
-                disabled={updateLoading || !stagedUpload || !targetDealId || isTargetDealMode2 || targetDealExpired}
+                disabled={!hasFunds || updateLoading || !stagedUpload || !targetDealId || isTargetDealMode2 || targetDealExpired}
                 data-testid="content-commit"
                 className="px-4 py-3 bg-primary hover:bg-primary/90 text-primary-foreground text-[10px] font-bold uppercase tracking-[0.2em] font-mono-data shadow-[0_0_50px_rgba(0,0,0,0.06)] dark:shadow-[0_0_60px_rgba(0,0,0,0.8)] disabled:opacity-50 transition-all"
               >
@@ -1609,6 +1597,10 @@ export function Dashboard() {
                 {targetDealExpiryMsg}
               </div>
             </div>
+          ) : !hasFunds ? (
+            <InlineNotice tone="info" title="Uploads paused while balance is unavailable" testId="upload-balance-unavailable">
+              Existing deal files remain available. Upload controls will resume after the network confirms your wallet balance.
+            </InlineNotice>
           ) : (
             <FileSharder
               dealId={targetDealId}
@@ -1760,7 +1752,7 @@ export function Dashboard() {
 
         <button
           onClick={handleCreateDealClick}
-          disabled={dealLoading || !initialEscrow}
+          disabled={!hasFunds || dealLoading || !initialEscrow}
           data-testid="alloc-submit"
           className="w-full bg-primary py-3 text-[10px] font-bold uppercase tracking-[0.2em] text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
         >
@@ -1773,6 +1765,23 @@ export function Dashboard() {
   return (
     <div className="px-4 pb-12 pt-24">
       <div className="container mx-auto max-w-6xl space-y-6">
+      {fundingStatus !== 'funded' ? (
+        <InlineNotice
+          tone={fundingStatus === 'checking' ? 'pending' : 'info'}
+          title={fundingStatus === 'unavailable'
+            ? 'Wallet balance temporarily unavailable'
+            : fundingStatus === 'unfunded'
+              ? 'Fund your wallet to create or upload'
+              : 'Checking wallet balance'}
+          testId="wallet-balance-unavailable"
+        >
+          {fundingStatus === 'unavailable'
+            ? 'The network did not report a zero balance. Existing deals and verified cached downloads remain available; uploads and creating deals will resume after balance checks recover.'
+            : fundingStatus === 'unfunded'
+              ? 'Your wallet has no confirmed testnet NIL. Existing deals and cached files remain available; use Fund Wallet in the navigation to create or upload.'
+              : 'Existing deals remain available while the network confirms whether uploads and creating deals can continue.'}
+        </InlineNotice>
+      ) : null}
       {/* TOP HEADER PANEL */}
       <div className="glass-panel industrial-border">
         <div className="flex items-end justify-between gap-6 border-b border-border/20 p-6">

--- a/polystore-website/src/components/Dashboard.tsx
+++ b/polystore-website/src/components/Dashboard.tsx
@@ -1598,8 +1598,8 @@ export function Dashboard() {
               </div>
             </div>
           ) : !hasFunds ? (
-            <InlineNotice tone="info" title="Uploads paused while balance is unavailable" testId="upload-balance-unavailable">
-              Existing deal files remain available. Upload controls will resume after the network confirms your wallet balance.
+            <InlineNotice tone="info" title={fundingStatus === 'unfunded' ? 'Fund your wallet to upload' : 'Checking wallet balance before uploads'} testId="upload-balance-unavailable">
+              Existing deal files remain available. Uploads require a confirmed funded balance.
             </InlineNotice>
           ) : (
             <FileSharder

--- a/polystore-website/src/components/DealDetail.tsx
+++ b/polystore-website/src/components/DealDetail.tsx
@@ -20,7 +20,13 @@ import { useProofs } from '../hooks/useProofs'
 import { useTransportRouter } from '../hooks/useTransportRouter'
 import { useUpdateDealRetrievalPolicy, type RetrievalPolicyMode } from '../hooks/useUpdateDealRetrievalPolicy'
 import { evaluateCacheFreshness, normalizeManifestRoot } from '../lib/cacheFreshness'
-import { preferVerifiedCache, readVerifiedCachedDownload, verifiedCachedDownloadAvailability } from '../lib/cachedDownload'
+import {
+  cachedDownloadAuthority,
+  preferVerifiedCache,
+  readVerifiedCachedDownload,
+  verifiedCachedDownloadAvailability,
+  type CachedDownloadAuthority,
+} from '../lib/cachedDownload'
 import { buildBlake2sMerkleLayers } from '../lib/merkle'
 import { multiaddrToHttpUrl, multiaddrToP2pTarget } from '../lib/multiaddr'
 import {
@@ -146,6 +152,7 @@ interface DealIndexRequirement {
 interface FileRowProps {
   file: PolyfsFileEntry
   deal: LcdDeal
+  cacheAuthority: CachedDownloadAuthority | null
   manifestRoot: string
   owner: string
   browserCached: boolean
@@ -193,6 +200,7 @@ async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: str
 function FileRow({
   file,
   deal,
+  cacheAuthority,
   manifestRoot,
   owner,
   browserCached,
@@ -273,7 +281,11 @@ function FileRow({
       if (!manifestRoot) throw new Error('commit required (no on-chain manifest root)')
       onFileActivity?.({ dealId, filePath: file.path, sizeBytes: file.size_bytes, manifestRoot, action: 'download', status: 'pending' })
       const outcome = await preferVerifiedCache(
-        () => preferCache ? readVerifiedCachedDownload({ dealId, manifestRoot, owner: requestOwner, viewerOwners, file, rangeStart: downloadRangeStart, rangeLen: downloadRangeLen }) : Promise.resolve(null),
+        async () => {
+          if (!preferCache || !cacheAuthority) return null
+          await ensureWasmReady()
+          return readVerifiedCachedDownload({ dealId, manifestRoot, owner: requestOwner, viewerOwners, file, authority: cacheAuthority, rangeStart: downloadRangeStart, rangeLen: downloadRangeLen })
+        },
         preferCache ? retrievalUnavailableReason : undefined,
         () => fetchFile({ dealId, manifestRoot, owner: requestOwner, filePath: file.path, serviceBase: resolveProviderHttpBase(), routePreference: preference,
           rangeStart: downloadRangeStart, rangeLen: downloadRangeLen, sponsoredAuth }),
@@ -451,9 +463,14 @@ export function DealDetail({
   const fallbackOwner = dealOwner || String(polystoreAddress || '').trim()
   const [authoritativeManifestRoot, setAuthoritativeManifestRoot] = useState<string>(fallbackManifestRoot)
   const [authoritativeOwner, setAuthoritativeOwner] = useState<string>(fallbackOwner)
+  const [authoritativeCacheDeal, setAuthoritativeCacheDeal] = useState<LcdDeal>(deal)
   const [authoritativeDealLoaded, setAuthoritativeDealLoaded] = useState(false)
   const requestOwner = authoritativeOwner || fallbackOwner
   const committedManifestRoot = authoritativeManifestRoot || fallbackManifestRoot
+  const cacheAuthority = useMemo(
+    () => cachedDownloadAuthority({ ...authoritativeCacheDeal, cid: committedManifestRoot }),
+    [authoritativeCacheDeal, committedManifestRoot],
+  )
   const isMode2 = serviceHint.mode === 'mode2' || serviceHint.mode === 'auto'
   const hasCommittedContent = Boolean(committedManifestRoot)
   const dealSizeBytes = Number.parseInt(String(deal.size ?? '0'), 10)
@@ -834,20 +851,23 @@ export function DealDetail({
       const owner = String(latest?.owner || '').trim() || fallback.owner
       setAuthoritativeManifestRoot(manifestRoot)
       setAuthoritativeOwner(owner)
+      setAuthoritativeCacheDeal(latest || deal)
       return { manifestRoot, owner }
     } catch {
       setAuthoritativeManifestRoot(fallback.manifestRoot)
       setAuthoritativeOwner(fallback.owner)
+      setAuthoritativeCacheDeal(deal)
       return fallback
     } finally {
       setAuthoritativeDealLoaded(true)
     }
-  }, [deal.id, fallbackManifestRoot, fallbackOwner])
+  }, [deal, fallbackManifestRoot, fallbackOwner])
 
   useEffect(() => {
     let cancelled = false
     setAuthoritativeManifestRoot(fallbackManifestRoot)
     setAuthoritativeOwner(fallbackOwner)
+    setAuthoritativeCacheDeal(deal)
     setAuthoritativeDealLoaded(false)
     void refreshAuthoritativeDealHead().then((head) => {
       if (cancelled) return
@@ -858,7 +878,7 @@ export function DealDetail({
     return () => {
       cancelled = true
     }
-  }, [fallbackManifestRoot, fallbackOwner, refreshAuthoritativeDealHead])
+  }, [deal, fallbackManifestRoot, fallbackOwner, refreshAuthoritativeDealHead])
 
   const fetchLocalFiles = useCallback(async (dealId: string) => {
     setLoadingFiles(true)
@@ -915,6 +935,7 @@ export function DealDetail({
         owner: requestOwner,
         viewerOwners: [polystoreAddress, address || ''],
         file,
+        authority: cacheAuthority,
       })))
 
       if (canceled) return
@@ -925,7 +946,7 @@ export function DealDetail({
     return () => {
       canceled = true
     }
-  }, [address, committedManifestRoot, deal.id, files, polystoreAddress, requestOwner])
+  }, [address, cacheAuthority, committedManifestRoot, deal.id, files, polystoreAddress, requestOwner])
 
   function triggerBrowserDownload(url: string, filePath: string) {
     const a = document.createElement('a')
@@ -1949,6 +1970,7 @@ export function DealDetail({
                               key={`${f.path}:${f.start_offset}`}
                               file={f}
                               deal={deal}
+                              cacheAuthority={cacheAuthority}
                               manifestRoot={committedManifestRoot}
                               owner={requestOwner}
                               browserCached={!!browserCachedByPath[f.path]}

--- a/polystore-website/src/components/DealDetail.tsx
+++ b/polystore-website/src/components/DealDetail.tsx
@@ -20,20 +20,20 @@ import { useProofs } from '../hooks/useProofs'
 import { useTransportRouter } from '../hooks/useTransportRouter'
 import { useUpdateDealRetrievalPolicy, type RetrievalPolicyMode } from '../hooks/useUpdateDealRetrievalPolicy'
 import { evaluateCacheFreshness, normalizeManifestRoot } from '../lib/cacheFreshness'
+import { preferVerifiedCache, readVerifiedCachedDownload, verifiedCachedDownloadAvailability } from '../lib/cachedDownload'
 import { buildBlake2sMerkleLayers } from '../lib/merkle'
 import { multiaddrToHttpUrl, multiaddrToP2pTarget } from '../lib/multiaddr'
 import {
   parsePolyfsFilesFromMdu0,
   parsePolyfsRootTableFromMdu0
 } from '../lib/polyfsLocal'
-import { inferWitnessCountFromOpfs, RAW_MDU_CAPACITY } from '../lib/polyfsOpfsFetch'
+import { inferWitnessCountFromOpfs } from '../lib/polyfsOpfsFetch'
 import { fetchPinnedGeneration } from '../lib/retrieval'
 import { formatCacheSourceLabel, isGatewayModePreferred, primaryCacheIndicatorLabel } from '../lib/retrievalMode'
 import { parseServiceHint } from '../lib/serviceHint'
 import {
   deleteCachedFile,
   deleteDealDirectory,
-  hasCachedFile,
   readManifestRoot,
   readMdu,
   readSlabMetadata,
@@ -154,6 +154,8 @@ interface FileRowProps {
   isBusy: boolean
   isAnyDownloading: boolean
   retrievalUnavailable: boolean
+  retrievalUnavailableReason?: string
+  viewerOwners: readonly string[]
   isOpen: boolean
   onToggleMenu: () => void
   onCloseMenu: () => void
@@ -199,6 +201,8 @@ function FileRow({
   isBusy,
   isAnyDownloading,
   retrievalUnavailable,
+  retrievalUnavailableReason,
+  viewerOwners,
   isOpen,
   onToggleMenu,
   onCloseMenu,
@@ -262,16 +266,25 @@ function FileRow({
     }
   }, [isOpen])
 
-  const downloadVerified = async (preference?: RoutePreference) => {
+  const downloadVerified = async (preference?: RoutePreference, preferCache = false) => {
     setFileActionError(null); setBusyFilePath(file.path)
     const dealId = String(deal.id)
     try {
       if (!manifestRoot) throw new Error('commit required (no on-chain manifest root)')
       onFileActivity?.({ dealId, filePath: file.path, sizeBytes: file.size_bytes, manifestRoot, action: 'download', status: 'pending' })
-      const result = await fetchFile({ dealId, manifestRoot, owner: requestOwner, filePath: file.path, serviceBase: resolveProviderHttpBase(), routePreference: preference,
-        rangeStart: downloadRangeStart, rangeLen: downloadRangeLen, sponsoredAuth })
-      downloadBlobAsFile(result.blob, file.path)
-      markDownloadPath('Verified retrieval', result.route || 'network_fetch', 'verified_file', 'pinned_generation')
+      const outcome = await preferVerifiedCache(
+        () => preferCache ? readVerifiedCachedDownload({ dealId, manifestRoot, owner: requestOwner, viewerOwners, file, rangeStart: downloadRangeStart, rangeLen: downloadRangeLen }) : Promise.resolve(null),
+        preferCache ? retrievalUnavailableReason : undefined,
+        () => fetchFile({ dealId, manifestRoot, owner: requestOwner, filePath: file.path, serviceBase: resolveProviderHttpBase(), routePreference: preference,
+          rangeStart: downloadRangeStart, rangeLen: downloadRangeLen, sponsoredAuth }),
+      )
+      if (outcome.source === 'cache') {
+        downloadBlobAsFile(new Blob([outcome.bytes as BlobPart]), file.path)
+        markDownloadPath('Browser cache', 'opfs_generation', 'verified_file', 'pinned_generation')
+      } else {
+        downloadBlobAsFile(outcome.result.blob, file.path)
+        markDownloadPath('Verified retrieval', outcome.result.route || 'network_fetch', 'verified_file', 'pinned_generation')
+      }
       onFileActivity?.({ dealId, filePath: file.path, sizeBytes: file.size_bytes, manifestRoot, action: 'download', status: 'success' })
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
@@ -279,7 +292,7 @@ function FileRow({
       if (manifestRoot) onFileActivity?.({ dealId, filePath: file.path, sizeBytes: file.size_bytes, manifestRoot, action: 'download', status: 'failed', error: message })
     } finally { setBusyFilePath(null); onCloseMenu() }
   }
-  const handleAutoDownload = () => downloadVerified(transportPreference)
+  const handleAutoDownload = () => downloadVerified(transportPreference, true)
   const handleOnchainRetrieval = () => downloadVerified('prefer_direct_sp')
   const handleGatewayProviderRetrieval = () => downloadVerified('gateway_only')
 
@@ -321,7 +334,7 @@ function FileRow({
       <div className="flex items-center gap-2">
         <button
           onClick={handleAutoDownload}
-          disabled={retrievalUnavailable || isAnyDownloading || isBusy || !manifestRoot}
+          disabled={(retrievalUnavailable && !browserMduAvailable) || isAnyDownloading || isBusy || !manifestRoot}
           data-testid="deal-detail-download"
           data-file-path={file.path}
           className="bg-primary px-3 py-1 text-[10px] font-bold uppercase tracking-wider text-primary-foreground rounded-none shadow-[2px_2px_0px_0px_rgba(0,0,0,0.1)] transition-colors hover:bg-primary/90 active:translate-x-[1px] active:translate-y-[1px] active:shadow-none disabled:opacity-50"
@@ -896,81 +909,23 @@ export function DealDetail({
         return
       }
       const dealId = String(deal.id)
-      const entries = await Promise.all(
-        files.map(async (f) => {
-          try {
-            return [f.path, await hasCachedFile(dealId, f.path)] as const
-          } catch {
-            return [f.path, false] as const
-          }
-        }),
-      )
-
-      const nextMduAvailable: Record<string, boolean> = {}
-      const chainManifestRoot = normalizeManifestRoot(committedManifestRoot)
-      if (chainManifestRoot) {
-        try {
-          const persistedManifestRoot = normalizeManifestRoot(await readManifestRoot(dealId).catch(() => null))
-          const localMeta = await readSlabMetadata(dealId).catch(() => null)
-          const metadataManifestRoot = normalizeManifestRoot(localMeta?.manifest_root)
-          const localManifestRoot = persistedManifestRoot || metadataManifestRoot
-          const freshness = evaluateCacheFreshness(localManifestRoot, chainManifestRoot)
-          if (freshness.status === 'fresh') {
-            const mdu0 = await readMdu(dealId, 0).catch(() => null)
-            if (mdu0 && mdu0.byteLength > 0) {
-              const { slabStartIdx, maxEnd } = await inferWitnessCountFromOpfs(dealId, files)
-              const mduPresence = new Map<number, boolean>()
-              const hasMdu = async (idx: number): Promise<boolean> => {
-                if (mduPresence.has(idx)) return mduPresence.get(idx) === true
-                const present = Boolean(await readMdu(dealId, idx).catch(() => null))
-                mduPresence.set(idx, present)
-                return present
-              }
-
-              for (const fileEntry of files) {
-                const start = Math.max(0, Number(fileEntry.start_offset) || 0)
-                const size = Math.max(0, Number(fileEntry.size_bytes) || 0)
-                if (size <= 0) {
-                  nextMduAvailable[fileEntry.path] = true
-                  continue
-                }
-
-                const endExclusive = start + size
-                if (endExclusive > maxEnd) {
-                  nextMduAvailable[fileEntry.path] = false
-                  continue
-                }
-
-                const firstUserMdu = Math.floor(start / RAW_MDU_CAPACITY)
-                const lastUserMdu = Math.floor((endExclusive - 1) / RAW_MDU_CAPACITY)
-                let available = true
-                for (let userMdu = firstUserMdu; userMdu <= lastUserMdu; userMdu += 1) {
-                  const slabMdu = slabStartIdx + userMdu
-                  if (!(await hasMdu(slabMdu))) {
-                    available = false
-                    break
-                  }
-                }
-                nextMduAvailable[fileEntry.path] = available
-              }
-            }
-          }
-        } catch (error) {
-          console.warn('Failed to compute local MDU availability for cache status', { dealId, error })
-        }
-      }
+      const verified = await verifiedCachedDownloadAvailability(files.map((file) => ({
+        dealId,
+        manifestRoot: committedManifestRoot,
+        owner: requestOwner,
+        viewerOwners: [polystoreAddress, address || ''],
+        file,
+      })))
 
       if (canceled) return
-      const next: Record<string, boolean> = {}
-      for (const [path, ok] of entries) next[path] = ok
-      setBrowserCachedByPath(next)
-      setBrowserMduAvailableByPath(nextMduAvailable)
+      setBrowserCachedByPath({})
+      setBrowserMduAvailableByPath(verified)
     }
     void refreshBrowserCache()
     return () => {
       canceled = true
     }
-  }, [committedManifestRoot, deal.id, files])
+  }, [address, committedManifestRoot, deal.id, files, polystoreAddress, requestOwner])
 
   function triggerBrowserDownload(url: string, filePath: string) {
     const a = document.createElement('a')
@@ -2002,6 +1957,8 @@ export function DealDetail({
                               isBusy={busyFilePath === f.path}
                               isAnyDownloading={downloading}
                               retrievalUnavailable={Boolean(unavailableReason)}
+                              retrievalUnavailableReason={unavailableReason || undefined}
+                              viewerOwners={[polystoreAddress, address || '']}
                               isOpen={openMenuFilePath === f.path}
                               onToggleMenu={() => setOpenMenuFilePath(openMenuFilePath === f.path ? null : f.path)}
                               onCloseMenu={() => setOpenMenuFilePath(null)}

--- a/polystore-website/src/components/NavSessionStatus.tsx
+++ b/polystore-website/src/components/NavSessionStatus.tsx
@@ -8,6 +8,8 @@ const SESSION_BADGE_STYLES: Record<string, string> = {
   disconnected: 'border-border/30 bg-background/70 text-muted-foreground',
   'needs-reconnect': 'border-primary/30 bg-primary/10 text-primary',
   'wrong-network': 'border-destructive/30 bg-destructive/10 text-destructive',
+  'checking-balance': 'border-border/30 bg-background/70 text-muted-foreground',
+  'balance-unavailable': 'border-destructive/30 bg-destructive/10 text-destructive',
   'needs-funds': 'border-primary/30 bg-primary/10 text-primary',
   'ready-browser': 'border-success/30 bg-success/10 text-success',
   'ready-gateway': 'border-success/30 bg-success/10 text-success',
@@ -17,6 +19,8 @@ const SESSION_BADGE_LABELS: Record<string, string> = {
   disconnected: 'Connect Wallet',
   'needs-reconnect': 'Reconnect',
   'wrong-network': 'Wrong Network',
+  'checking-balance': 'Checking Balance',
+  'balance-unavailable': 'Balance Unavailable',
   'needs-funds': 'Needs Funds',
   'ready-browser': 'Ready',
   'ready-gateway': 'Gateway Ready',
@@ -43,7 +47,8 @@ export function NavSessionStatus({
   const session = useSessionStatus()
   const stakeBalanceLabel = session.lcdStakeBalance ? `${session.lcdStakeBalance} stake` : '—'
 
-  const shouldShowFaucet = session.faucetEnabled && session.isConnected && !session.isWrongNetwork
+  const shouldShowFaucet = session.faucetEnabled && session.isConnected && !session.isWrongNetwork &&
+    (session.fundingStatus === 'funded' || session.fundingStatus === 'unfunded')
   const faucetClassName = responsive
     ? 'px-2.5 py-2 text-[9px] 2xl:px-3 2xl:text-[10px]'
     : compact

--- a/polystore-website/src/domain/lcd.test.ts
+++ b/polystore-website/src/domain/lcd.test.ts
@@ -17,6 +17,8 @@ test('normalizeLcdDealsResponse maps manifest_root bytes to Deal.cid hex', () =>
         size: '123',
         escrow_balance: '9',
         end_block: '100',
+        redundancy_mode: 2,
+        mode2_profile: { k: 8, m: 4 },
         providers: ['nil1p1', 'nil1p2'],
       },
     ],
@@ -31,6 +33,16 @@ test('normalizeLcdDealsResponse maps manifest_root bytes to Deal.cid hex', () =>
   assert.equal(deals[0].escrow, '9')
   assert.equal(deals[0].end_block, '100')
   assert.deepEqual(deals[0].providers, ['nil1p1', 'nil1p2'])
+  assert.equal(deals[0].redundancy_mode, 2)
+  assert.deepEqual(deals[0].mode2_profile, { k: 8, m: 4 })
+})
+
+test('normalizeLcdDealsResponse does not coerce malformed Mode 2 geometry', () => {
+  const [deal] = normalizeLcdDealsResponse({ deals: [{
+    id: '9', redundancy_mode: '2', mode2_profile: { k: '8', m: null },
+  }] })
+  assert.equal(deal.redundancy_mode, undefined)
+  assert.equal(deal.mode2_profile, undefined)
 })
 
 test('normalizeLcdDealsResponse accepts PolyFS 32-byte manifest_root bytes', () => {

--- a/polystore-website/src/domain/lcd.ts
+++ b/polystore-website/src/domain/lcd.ts
@@ -7,6 +7,8 @@ export interface LcdDeal {
   total_mdus?: string
   witness_mdus?: string
   current_gen?: string
+  redundancy_mode?: number
+  mode2_profile?: { k: number; m: number }
   owner: string
   escrow: string
   end_block: string
@@ -77,6 +79,11 @@ export function normalizeLcdDeal(input: unknown): LcdDeal | null {
         voucher_signer: asString(input['retrieval_policy']['voucher_signer'] ?? ''),
       }
     : undefined
+  const mode2Profile = isRecord(input['mode2_profile']) &&
+    Number.isSafeInteger(input['mode2_profile']['k']) && Number.isSafeInteger(input['mode2_profile']['m'])
+    ? { k: Number(input['mode2_profile']['k']), m: Number(input['mode2_profile']['m']) }
+    : undefined
+  const redundancyMode = Number.isSafeInteger(input['redundancy_mode']) ? Number(input['redundancy_mode']) : undefined
 
   return {
     id: asString(input['id']),
@@ -86,6 +93,8 @@ export function normalizeLcdDeal(input: unknown): LcdDeal | null {
     total_mdus: asString(input['total_mdus']),
     witness_mdus: asString(input['witness_mdus']),
     current_gen: asString(input['current_gen']),
+    redundancy_mode: redundancyMode,
+    mode2_profile: mode2Profile,
     escrow: asString(input['escrow_balance'] ?? input['escrow'] ?? ''),
     end_block: asString(input['end_block']),
     start_block: asString(input['start_block']),

--- a/polystore-website/src/hooks/useSessionStatus.ts
+++ b/polystore-website/src/hooks/useSessionStatus.ts
@@ -4,6 +4,7 @@ import { formatUnits } from 'viem'
 
 import { ethToPolystoreAddress } from '../lib/address'
 import { appConfig } from '../config'
+import { parseStakeBalancePayload, resolveFundingStatus, type FundingStatus } from '../lib/sessionFunding'
 import { useFaucet } from './useFaucet'
 import { useLocalGateway } from './useLocalGateway'
 import { useWalletNetworkGuard } from './useWalletNetworkGuard'
@@ -12,6 +13,8 @@ export type PrimarySessionState =
   | 'disconnected'
   | 'needs-reconnect'
   | 'wrong-network'
+  | 'checking-balance'
+  | 'balance-unavailable'
   | 'needs-funds'
   | 'ready-browser'
   | 'ready-gateway'
@@ -33,6 +36,7 @@ export type SessionStatus = {
   balance: ReturnType<typeof useBalance>['data']
   balanceLabel: string
   lcdStakeBalance: string | null
+  fundingStatus: FundingStatus
   hasFunds: boolean
   isWrongNetwork: boolean
   walletChainId: number | null
@@ -86,26 +90,25 @@ function useSessionStatusValue(options?: UseSessionStatusOptions): SessionStatus
     if (!address) return ''
     return address.startsWith('0x') ? ethToPolystoreAddress(address) : address
   }, [address])
-  const [lcdStakeBalance, setLcdStakeBalance] = useState<string | null>(null)
-  const [lcdBalanceLoaded, setLcdBalanceLoaded] = useState(false)
+  const [lcdBalanceState, setLcdBalanceState] = useState<{
+    owner: string
+    amount: string | null
+    loaded: boolean
+    unavailable: boolean
+  }>({ owner: '', amount: null, loaded: false, unavailable: false })
+  const currentLcdBalance = lcdBalanceState.owner === polystoreAddress
+    ? lcdBalanceState
+    : { owner: polystoreAddress, amount: null, loaded: false, unavailable: false }
+  const lcdStakeBalance = currentLcdBalance.amount
 
   const walletAddressShort = useMemo(() => {
     if (!address) return 'Not connected'
     return `${address.slice(0, 6)}...${address.slice(-4)}`
   }, [address])
 
-  const evmHasFunds = useMemo(() => {
-    try {
-      return Boolean(balance?.value && BigInt(balance.value) > 0n)
-    } catch {
-      return Boolean(balance?.value)
-    }
-  }, [balance?.value])
-
   useEffect(() => {
     if (!polystoreAddress) {
-      setLcdStakeBalance(null)
-      setLcdBalanceLoaded(false)
+      setLcdBalanceState({ owner: '', amount: null, loaded: false, unavailable: false })
       return
     }
 
@@ -114,19 +117,23 @@ function useSessionStatusValue(options?: UseSessionStatusOptions): SessionStatus
 
     const load = async () => {
       try {
-        const res = await fetch(`${appConfig.lcdBase}/cosmos/bank/v1beta1/balances/${polystoreAddress}`)
-        const json = await res.json()
-        const balances = Array.isArray(json?.balances) ? json.balances : []
-        const match = balances.find(
-          (entry: { denom?: string; amount?: string }) => entry?.denom === 'stake' || entry?.denom === 'aatom',
-        )
+        const res = await fetch(`${appConfig.lcdBase}/cosmos/bank/v1beta1/balances/${polystoreAddress}`, {
+          signal: AbortSignal.timeout(10_000),
+        })
+        if (!res.ok) throw new Error(`balance lookup failed (HTTP ${res.status})`)
+        const amount = parseStakeBalancePayload(await res.json())
         if (cancelled) return
-        setLcdStakeBalance(match?.amount ? String(match.amount) : null)
-        setLcdBalanceLoaded(true)
+        setLcdBalanceState({
+          owner: polystoreAddress,
+          amount,
+          loaded: true,
+          unavailable: false,
+        })
       } catch {
         if (cancelled) return
-        setLcdStakeBalance(null)
-        setLcdBalanceLoaded(true)
+        setLcdBalanceState((previous) => previous.owner === polystoreAddress
+          ? { ...previous, unavailable: true }
+          : { owner: polystoreAddress, amount: null, loaded: false, unavailable: true })
       }
     }
 
@@ -151,15 +158,13 @@ function useSessionStatusValue(options?: UseSessionStatusOptions): SessionStatus
     }
   }, [polystoreAddress, faucetTxStatus, options?.lcdBalancePollMs])
 
-  const hasFunds = useMemo(() => {
-    if (!lcdBalanceLoaded) return evmHasFunds
-    if (!lcdStakeBalance) return false
-    try {
-      return BigInt(lcdStakeBalance) > 0n
-    } catch {
-      return Boolean(lcdStakeBalance)
-    }
-  }, [evmHasFunds, lcdBalanceLoaded, lcdStakeBalance])
+  const fundingStatus = useMemo(() => resolveFundingStatus({
+    lcdLoaded: currentLcdBalance.loaded,
+    lcdAmount: currentLcdBalance.amount,
+    lcdUnavailable: currentLcdBalance.unavailable,
+    evmAmount: balance?.value,
+  }), [balance?.value, currentLcdBalance.amount, currentLcdBalance.loaded, currentLcdBalance.unavailable])
+  const hasFunds = fundingStatus === 'funded'
 
   const balanceLabel = useMemo(() => {
     if (lcdStakeBalance) return `${lcdStakeBalance} NIL`
@@ -186,8 +191,12 @@ function useSessionStatusValue(options?: UseSessionStatusOptions): SessionStatus
       ? 'needs-reconnect'
       : isWrongNetwork
         ? 'wrong-network'
-        : !hasFunds
-          ? 'needs-funds'
+        : fundingStatus === 'checking'
+          ? 'checking-balance'
+          : fundingStatus === 'unavailable'
+            ? 'balance-unavailable'
+            : fundingStatus === 'unfunded'
+              ? 'needs-funds'
           : gatewayConnected
             ? 'ready-gateway'
             : 'ready-browser'
@@ -206,6 +215,7 @@ function useSessionStatusValue(options?: UseSessionStatusOptions): SessionStatus
     balance,
     balanceLabel,
     lcdStakeBalance,
+    fundingStatus,
     hasFunds,
     isWrongNetwork,
     walletChainId,

--- a/polystore-website/src/lib/cachedDownload.test.ts
+++ b/polystore-website/src/lib/cachedDownload.test.ts
@@ -1,0 +1,212 @@
+import assert from 'node:assert'
+import { test } from 'node:test'
+import { bech32 } from 'bech32'
+
+import {
+  hasVerifiedCachedDownload,
+  preferVerifiedCache,
+  readVerifiedCachedDownload,
+  type CachedDownloadInput,
+  type CachedDownloadStorage,
+  verifiedCachedDownloadAvailability,
+} from './cachedDownload'
+import { readPolyfsFileFromVerifiedLayout } from './polyfsOpfsFetch'
+import type { CompleteSlabGeneration, SlabMetadata } from './storage/OpfsAdapter'
+
+const root = `0x${'ab'.repeat(48)}`
+const otherRoot = `0x${'cd'.repeat(48)}`
+const evmOwner = `0x${'12'.repeat(20)}`
+const chainOwner = bech32.encode('nil', bech32.toWords(new Uint8Array(20).fill(0x12)))
+const file = { path: 'report.txt', start_offset: 0, size_bytes: 4, flags: 0 }
+const completeMdu = new Uint8Array(8 * 1024 * 1024)
+completeMdu.set([1, 2, 3, 4], 28)
+const input: CachedDownloadInput = {
+  dealId: '7',
+  manifestRoot: root,
+  owner: chainOwner,
+  viewerOwners: [evmOwner],
+  file,
+}
+
+function metadata(overrides: Partial<SlabMetadata> = {}): SlabMetadata {
+  return {
+    schema_version: 1,
+    generation_id: root.slice(2),
+    deal_id: '7',
+    manifest_root: root,
+    owner: evmOwner,
+    source: 'browser_mode2_commit',
+    created_at: '2026-09-09T00:00:00Z',
+    last_validated_at: null,
+    witness_mdus: 1,
+    user_mdus: 1,
+    total_mdus: 3,
+    file_records: [file],
+    ...overrides,
+  }
+}
+
+function generation(overrides: Partial<CompleteSlabGeneration> = {}): CompleteSlabGeneration {
+  return {
+    manifestRoot: root,
+    readManifestRoot: async () => root,
+    readMetadata: async () => metadata(),
+    readMdu: async (index) => index === 2 ? completeMdu : null,
+    mduSize: async (index) => index === 2 ? completeMdu.byteLength : null,
+    ...overrides,
+  }
+}
+
+function storage(candidate: CompleteSlabGeneration | null): CachedDownloadStorage {
+  return { openGeneration: async () => candidate }
+}
+
+test('verified complete current-generation cache bypasses paid network retrieval while v2 is inactive', async () => {
+  let networkCalls = 0
+  const result = await preferVerifiedCache(
+    () => readVerifiedCachedDownload(input, storage(generation())),
+    'secured retrieval inactive',
+    async () => { networkCalls++; return 'paid' },
+  )
+  assert.equal(result.source, 'cache')
+  assert.equal(networkCalls, 0)
+  if (result.source === 'cache') assert.deepEqual(result.bytes, new Uint8Array([1, 2, 3, 4]))
+})
+
+test('availability checks sizes without reading or allocating cached payloads', async () => {
+  let payloadReads = 0
+  const candidate = generation({
+    mduSize: async () => 8 * 1024 * 1024,
+    readMdu: async () => { payloadReads++; return null },
+  })
+  assert.equal(await hasVerifiedCachedDownload(input, storage(candidate)), true)
+  assert.equal(payloadReads, 0)
+})
+
+test('a file listing opens and parses one pinned generation', async () => {
+  let opens = 0
+  let metadataReads = 0
+  let sizeReads = 0
+  const second = { path: 'second.txt', start_offset: 4, size_bytes: 4, flags: 0 }
+  const candidate = generation({
+    readMetadata: async () => { metadataReads++; return metadata({ file_records: [file, second] }) },
+    mduSize: async () => { sizeReads++; return completeMdu.byteLength },
+  })
+  const availability = await verifiedCachedDownloadAvailability([
+    input,
+    { ...input, file: second },
+  ], { openGeneration: async () => { opens++; return candidate } })
+  assert.deepEqual(availability, { 'report.txt': true, 'second.txt': true })
+  assert.equal(opens, 1)
+  assert.equal(metadataReads, 1)
+  assert.equal(sizeReads, 1)
+})
+
+test('complete committed MDU bytes are decoded from the pinned generation', async () => {
+  const mdu = new Uint8Array(8 * 1024 * 1024)
+  mdu.set([1, 2, 3, 4], 28)
+  const candidate = generation({
+    mduSize: async () => mdu.byteLength,
+    readMdu: async (index) => index === 2 ? mdu : null,
+  })
+  assert.deepEqual(await readVerifiedCachedDownload(input, storage(candidate)), new Uint8Array([1, 2, 3, 4]))
+})
+
+test('partial cache falls back to the secured-network availability gate', async () => {
+  let networkCalls = 0
+  const partial = generation({
+    mduSize: async () => null,
+  })
+  await assert.rejects(
+    preferVerifiedCache(
+      () => readVerifiedCachedDownload(input, storage(partial)),
+      'secured retrieval inactive',
+      async () => { networkCalls++; return 'paid' },
+    ),
+    /secured retrieval inactive/,
+  )
+  assert.equal(networkCalls, 0)
+})
+
+test('stale root, wrong owner, wrong deal, wrong file, transformed file, and missing generation are rejected', async () => {
+  const cases: Array<CachedDownloadStorage> = [
+    storage(generation({ manifestRoot: otherRoot })),
+    storage(generation({ readManifestRoot: async () => otherRoot })),
+    storage(generation({ readMetadata: async () => metadata({ manifest_root: otherRoot }) })),
+    storage(generation({ readMetadata: async () => metadata({ owner: `0x${'34'.repeat(20)}` }) })),
+    storage(generation({ readMetadata: async () => metadata({ deal_id: '8' }) })),
+    storage(generation({ readMetadata: async () => metadata({ file_records: [{ ...file, path: 'other.txt' }] }) })),
+    storage(generation({ readMetadata: async () => metadata({ file_records: [{ ...file, flags: 2 }] }) })),
+    storage(generation({ readMetadata: async () => metadata({ witness_mdus: 1.5, total_mdus: 3.5 }) })),
+    storage(null),
+  ]
+  for (const candidate of cases) assert.equal(await readVerifiedCachedDownload(input, candidate), null)
+  const transformed = { ...file, flags: 2 }
+  assert.equal(await readVerifiedCachedDownload(
+    { ...input, file: transformed },
+    storage(generation({ readMetadata: async () => metadata({ file_records: [transformed] }) })),
+  ), null)
+})
+
+test('cache hits do not alter pending settlement state', async () => {
+  const checkpoint = { unsettled: 2, warning: 'Provider settlement pending' }
+  await preferVerifiedCache(
+    () => readVerifiedCachedDownload(input, storage(generation())),
+    undefined,
+    async () => { checkpoint.unsettled = 0; checkpoint.warning = ''; return 'network' },
+  )
+  assert.deepEqual(checkpoint, { unsettled: 2, warning: 'Provider settlement pending' })
+})
+
+test('a generation replacement during reads cannot mix the new generation into the download', async () => {
+  let active = generation({
+    manifestRoot: otherRoot,
+    readManifestRoot: async () => otherRoot,
+    readMetadata: async () => metadata({ manifest_root: otherRoot }),
+    readMdu: async () => new Uint8Array(completeMdu.byteLength).fill(9),
+  })
+  const pinned = generation({
+    readManifestRoot: async () => {
+      active = generation({ manifestRoot: otherRoot })
+      return root
+    },
+  })
+  let opens = 0
+  const replacingStorage: CachedDownloadStorage = {
+    openGeneration: async () => {
+      opens++
+      return opens === 1 ? pinned : active
+    },
+  }
+  assert.deepEqual(await readVerifiedCachedDownload(input, replacingStorage), new Uint8Array([1, 2, 3, 4]))
+  assert.equal(opens, 1)
+})
+
+test('gateway-style metadata/root rebinding over an older complete generation fails closed', async () => {
+  const rebound = generation({
+    manifestRoot: root,
+    readManifestRoot: async () => otherRoot,
+    readMetadata: async () => metadata({ manifest_root: otherRoot, generation_id: otherRoot.slice(2) }),
+  })
+  assert.equal(await hasVerifiedCachedDownload({ ...input, manifestRoot: otherRoot }, storage(rebound)), false)
+})
+
+test('cache miss uses secured network only when it is available', async () => {
+  let networkCalls = 0
+  const result = await preferVerifiedCache(
+    () => readVerifiedCachedDownload(input, storage(null)),
+    undefined,
+    async () => { networkCalls++; return 'paid' },
+  )
+  assert.deepEqual(result, { source: 'network', result: 'paid' })
+  assert.equal(networkCalls, 1)
+})
+
+test('verified-layout reader rejects a short local MDU instead of zero-padding it', async () => {
+  await assert.rejects(
+    readPolyfsFileFromVerifiedLayout({
+      dealId: '7', file, allFiles: [file], witnessMdus: 1, userMdus: 1, totalMdus: 3,
+    }, async () => new Uint8Array([0, 1, 2, 3, 4])),
+    /incomplete/,
+  )
+})

--- a/polystore-website/src/lib/cachedDownload.test.ts
+++ b/polystore-website/src/lib/cachedDownload.test.ts
@@ -3,21 +3,24 @@ import { test } from 'node:test'
 import { bech32 } from 'bech32'
 
 import {
+  cachedDownloadAuthority,
   hasVerifiedCachedDownload,
   preferVerifiedCache,
   readVerifiedCachedDownload,
   type CachedDownloadInput,
   type CachedDownloadStorage,
+  type CachedDownloadVerifier,
   verifiedCachedDownloadAvailability,
 } from './cachedDownload'
-import { readPolyfsFileFromVerifiedLayout } from './polyfsOpfsFetch'
+import { RAW_MDU_CAPACITY, readPolyfsFileFromVerifiedLayout } from './polyfsOpfsFetch'
 import type { CompleteSlabGeneration, SlabMetadata } from './storage/OpfsAdapter'
 
-const root = `0x${'ab'.repeat(48)}`
-const otherRoot = `0x${'cd'.repeat(48)}`
+const root = `0x${'ab'.repeat(32)}`
+const otherRoot = `0x${'cd'.repeat(32)}`
 const evmOwner = `0x${'12'.repeat(20)}`
 const chainOwner = bech32.encode('nil', bech32.toWords(new Uint8Array(20).fill(0x12)))
 const file = { path: 'report.txt', start_offset: 0, size_bytes: 4, flags: 0 }
+const authority = cachedDownloadAuthority({ cid: root, total_mdus: '3', witness_mdus: '1', redundancy_mode: 2, mode2_profile: { k: 8, m: 4 } })!
 const completeMdu = new Uint8Array(8 * 1024 * 1024)
 completeMdu.set([1, 2, 3, 4], 28)
 const input: CachedDownloadInput = {
@@ -26,6 +29,14 @@ const input: CachedDownloadInput = {
   owner: chainOwner,
   viewerOwners: [evmOwner],
   file,
+  authority,
+}
+
+const verifier: CachedDownloadVerifier = {
+  verifyMetadata: async () => [{ path: file.path, start_offset: BigInt(file.start_offset), size_bytes: BigInt(file.size_bytes), flags: file.flags }],
+  verifyWitness: async (bytes) => bytes,
+  readCommitments: async (pin) => new Uint8Array(pin.leafCount * 48),
+  verifyMdu: async (_pin, bytes) => bytes,
 }
 
 function metadata(overrides: Partial<SlabMetadata> = {}): SlabMetadata {
@@ -51,8 +62,8 @@ function generation(overrides: Partial<CompleteSlabGeneration> = {}): CompleteSl
     manifestRoot: root,
     readManifestRoot: async () => root,
     readMetadata: async () => metadata(),
-    readMdu: async (index) => index === 2 ? completeMdu : null,
-    mduSize: async (index) => index === 2 ? completeMdu.byteLength : null,
+    readMdu: async (index) => index >= 0 && index <= 2 ? completeMdu.slice() : null,
+    mduSize: async (index) => index >= 0 && index <= 2 ? completeMdu.byteLength : null,
     ...overrides,
   }
 }
@@ -61,10 +72,20 @@ function storage(candidate: CompleteSlabGeneration | null): CachedDownloadStorag
   return { openGeneration: async () => candidate }
 }
 
+test('cache authority accepts only exact current Mode 2 chain geometry', () => {
+  assert.deepEqual(authority, {
+    root, layout: 2, k: 8, m: 4, rows: 8, leafCount: 96,
+    metadataMdus: 2n, userMdus: 1n, totalMdus: 3n,
+  })
+  assert.equal(cachedDownloadAuthority({ cid: root, total_mdus: '3', witness_mdus: '1', redundancy_mode: 1, mode2_profile: { k: 8, m: 4 } }), null)
+  assert.equal(cachedDownloadAuthority({ cid: root, total_mdus: '3', witness_mdus: '0', redundancy_mode: 2, mode2_profile: { k: 8, m: 4 } }), null)
+  assert.equal(cachedDownloadAuthority({ cid: root, total_mdus: '3', witness_mdus: '1', redundancy_mode: 2, mode2_profile: { k: 3, m: 1 } }), null)
+})
+
 test('verified complete current-generation cache bypasses paid network retrieval while v2 is inactive', async () => {
   let networkCalls = 0
   const result = await preferVerifiedCache(
-    () => readVerifiedCachedDownload(input, storage(generation())),
+    () => readVerifiedCachedDownload(input, storage(generation()), verifier),
     'secured retrieval inactive',
     async () => { networkCalls++; return 'paid' },
   )
@@ -107,19 +128,20 @@ test('complete committed MDU bytes are decoded from the pinned generation', asyn
   mdu.set([1, 2, 3, 4], 28)
   const candidate = generation({
     mduSize: async () => mdu.byteLength,
-    readMdu: async (index) => index === 2 ? mdu : null,
+    readMdu: async (index) => index === 2 ? mdu : index < 2 ? completeMdu.slice() : null,
   })
-  assert.deepEqual(await readVerifiedCachedDownload(input, storage(candidate)), new Uint8Array([1, 2, 3, 4]))
+  assert.deepEqual(await readVerifiedCachedDownload(input, storage(candidate), verifier), new Uint8Array([1, 2, 3, 4]))
 })
 
 test('partial cache falls back to the secured-network availability gate', async () => {
   let networkCalls = 0
   const partial = generation({
     mduSize: async () => null,
+    readMdu: async (index) => index < 2 ? completeMdu.slice() : null,
   })
   await assert.rejects(
     preferVerifiedCache(
-      () => readVerifiedCachedDownload(input, storage(partial)),
+      () => readVerifiedCachedDownload(input, storage(partial), verifier),
       'secured retrieval inactive',
       async () => { networkCalls++; return 'paid' },
     ),
@@ -128,30 +150,68 @@ test('partial cache falls back to the secured-network availability gate', async 
   assert.equal(networkCalls, 0)
 })
 
-test('stale root, wrong owner, wrong deal, wrong file, transformed file, and missing generation are rejected', async () => {
+test('stale root, unauthorised viewer, wrong authenticated file, transformed file, and missing generation are rejected', async () => {
   const cases: Array<CachedDownloadStorage> = [
     storage(generation({ manifestRoot: otherRoot })),
     storage(generation({ readManifestRoot: async () => otherRoot })),
-    storage(generation({ readMetadata: async () => metadata({ manifest_root: otherRoot }) })),
-    storage(generation({ readMetadata: async () => metadata({ owner: `0x${'34'.repeat(20)}` }) })),
-    storage(generation({ readMetadata: async () => metadata({ deal_id: '8' }) })),
-    storage(generation({ readMetadata: async () => metadata({ file_records: [{ ...file, path: 'other.txt' }] }) })),
-    storage(generation({ readMetadata: async () => metadata({ file_records: [{ ...file, flags: 2 }] }) })),
-    storage(generation({ readMetadata: async () => metadata({ witness_mdus: 1.5, total_mdus: 3.5 }) })),
     storage(null),
   ]
-  for (const candidate of cases) assert.equal(await readVerifiedCachedDownload(input, candidate), null)
+  for (const candidate of cases) assert.equal(await readVerifiedCachedDownload(input, candidate, verifier), null)
+  assert.equal(await readVerifiedCachedDownload({ ...input, viewerOwners: [`0x${'34'.repeat(20)}`] }, storage(generation()), verifier), null)
+  assert.equal(await readVerifiedCachedDownload(input, storage(generation()), {
+    ...verifier,
+    verifyMetadata: async () => [{ path: 'other.txt', start_offset: 0n, size_bytes: 4n, flags: 0 }],
+  }), null)
   const transformed = { ...file, flags: 2 }
   assert.equal(await readVerifiedCachedDownload(
     { ...input, file: transformed },
-    storage(generation({ readMetadata: async () => metadata({ file_records: [transformed] }) })),
+    storage(generation()), { ...verifier, verifyMetadata: async () => [{ path: file.path, start_offset: 0n, size_bytes: 4n, flags: 2 }] },
   ), null)
+})
+
+test('same-size MDU corruption, mutated FAT, and mutated witness fall back instead of serving bytes', async () => {
+  const corrupted = completeMdu.slice()
+  corrupted[28] ^= 1
+  const cases: CachedDownloadVerifier[] = [
+    {
+      ...verifier,
+      verifyMdu: async (_pin, bytes) => {
+        if (bytes[28] !== 1) throw new Error('data commitments mismatch')
+        return bytes
+      },
+    },
+    { ...verifier, verifyMetadata: async () => { throw new Error('metadata root mismatch') } },
+    { ...verifier, verifyWitness: async () => { throw new Error('witness root mismatch') } },
+  ]
+  const generations = [
+    generation({ readMdu: async (index) => index === 2 ? corrupted : completeMdu.slice() }),
+    generation(),
+    generation(),
+  ]
+  for (let i = 0; i < cases.length; i += 1) {
+    let networkCalls = 0
+    const result = await preferVerifiedCache(
+      () => readVerifiedCachedDownload(input, storage(generations[i]), cases[i]),
+      undefined,
+      async () => { networkCalls += 1; return 'secured' },
+    )
+    assert.deepEqual(result, { source: 'network', result: 'secured' })
+    assert.equal(networkCalls, 1)
+  }
+})
+
+test('mutated advisory slab metadata cannot change authenticated downloaded bytes', async () => {
+  const candidate = generation({ readMetadata: async () => metadata({
+    owner: `0x${'34'.repeat(20)}`,
+    file_records: [{ path: file.path, start_offset: 9, size_bytes: 999, flags: 0 }],
+  }) })
+  assert.deepEqual(await readVerifiedCachedDownload(input, storage(candidate), verifier), new Uint8Array([1, 2, 3, 4]))
 })
 
 test('cache hits do not alter pending settlement state', async () => {
   const checkpoint = { unsettled: 2, warning: 'Provider settlement pending' }
   await preferVerifiedCache(
-    () => readVerifiedCachedDownload(input, storage(generation())),
+    () => readVerifiedCachedDownload(input, storage(generation()), verifier),
     undefined,
     async () => { checkpoint.unsettled = 0; checkpoint.warning = ''; return 'network' },
   )
@@ -178,7 +238,7 @@ test('a generation replacement during reads cannot mix the new generation into t
       return opens === 1 ? pinned : active
     },
   }
-  assert.deepEqual(await readVerifiedCachedDownload(input, replacingStorage), new Uint8Array([1, 2, 3, 4]))
+  assert.deepEqual(await readVerifiedCachedDownload(input, replacingStorage, verifier), new Uint8Array([1, 2, 3, 4]))
   assert.equal(opens, 1)
 })
 
@@ -209,4 +269,94 @@ test('verified-layout reader rejects a short local MDU instead of zero-padding i
     }, async () => new Uint8Array([0, 1, 2, 3, 4])),
     /incomplete/,
   )
+})
+
+test('production WASM authenticates a two-MDU cached download before returning its bytes', { timeout: 120_000 }, async () => {
+  const [{ readFile }, { default: init, PolyStoreWasm, WasmMdu0Builder }, recovery, wire] = await Promise.all([
+    import('node:fs/promises'),
+    import('./polystoreCoreRuntime.js'),
+    import('./retrievalRecovery'),
+    import('./retrievalWire'),
+  ])
+  const repoRoot = new URL('../../../', import.meta.url)
+  await init({ module_or_path: await readFile(new URL('polystore-website/public/wasm/polystore_core_bg.wasm', repoRoot)) })
+  const wasm = new PolyStoreWasm(await readFile(new URL('polystorechain/trusted_setup.txt', repoRoot)))
+  const raw = new Uint8Array(RAW_MDU_CAPACITY + 4)
+  for (let i = 0; i < raw.length; i += 1) raw[i] = (i * 17 + 3) % 251
+  const encode = (payload: Uint8Array) => {
+    const encoded = new Uint8Array(8 * 1024 * 1024)
+    for (let i = 0; i < payload.length; i += 31) {
+      const chunk = payload.subarray(i, i + 31)
+      encoded.set(chunk, Math.floor(i / 31) * 32 + 32 - chunk.length)
+    }
+    return encoded
+  }
+  const userMdus = [encode(raw.subarray(0, RAW_MDU_CAPACITY)), encode(raw.subarray(RAW_MDU_CAPACITY))]
+  const commitments = userMdus.map((encoded) => {
+    const expanded = wasm.expand_mdu_rs_flat_uncommitted(encoded, 2, 1) as { shards_flat: Uint8Array | number[] }
+    const flat = expanded.shards_flat instanceof Uint8Array ? expanded.shards_flat : Uint8Array.from(expanded.shards_flat)
+    const list = new Uint8Array(96 * 48)
+    for (let leaf = 0; leaf < 96; leaf += 1) list.set(wasm.commit_received_blob(flat.subarray(leaf * 131072, (leaf + 1) * 131072)), leaf * 48)
+    return list
+  })
+  const witness = encode(Uint8Array.from([...commitments[0], ...commitments[1]]))
+  const witnessRoot = Uint8Array.from(wasm.commit_mdu(witness).mdu_root)
+  const userRoots = commitments.map((list) => {
+    const value = wasm.compute_mdu_root(list)
+    return value instanceof Uint8Array ? value : Uint8Array.from(value as ArrayLike<number>)
+  })
+  const builder = WasmMdu0Builder.new_with_commitments(2n, 96n)
+  builder.set_root(0n, witnessRoot)
+  userRoots.forEach((value, index) => builder.set_root(BigInt(index + 1), value))
+  builder.append_file('verified.bin', BigInt(raw.length), 0n)
+  const mdu0 = builder.bytes()
+  builder.free()
+  const manifestRoot = `0x${Buffer.from(wasm.commit_mdu(mdu0).mdu_root).toString('hex')}`
+  const realAuthority = cachedDownloadAuthority({ cid: manifestRoot, total_mdus: '4', witness_mdus: '1', redundancy_mode: 2, mode2_profile: { k: 2, m: 1 } })!
+  const realFile = { path: 'verified.bin', start_offset: 0, size_bytes: raw.length, flags: 0 }
+  const phases = { metadataMs: 0, witnessMs: 0, commitmentsMs: 0, dataMs: 0 }
+  const measured = async <T>(phase: keyof typeof phases, operation: () => T | Promise<T>): Promise<T> => {
+    const started = performance.now()
+    try { return await operation() } finally { phases[phase] += performance.now() - started }
+  }
+  const realVerifier: CachedDownloadVerifier = {
+    verifyMetadata: (bytes, pin) => measured('metadataMs', () => wire.verifyRetrievalMetadata(bytes, pin, wasm)),
+    verifyWitness: (bytes, cell) => measured('witnessMs', () => { recovery.verifyWitnessMdu(bytes, cell, wasm); return bytes }),
+    readCommitments: (pin, ordinal, bytes, cell) => measured('commitmentsMs', () => recovery.readUserCommitments(pin, ordinal, bytes, cell, wasm)),
+    verifyMdu: (pin, bytes, list) => measured('dataMs', () => { recovery.verifyRecoveredMdu(pin, bytes, list, wasm); return bytes }),
+  }
+  const mutatedFat = mdu0.slice()
+  const fatPathOffset = 16 * 128 * 1024 + Math.floor(152 / 31) * 32 + 1 + 152 % 31
+  mutatedFat[fatPathOffset] ^= 1
+  assert.throws(() => wire.verifyRetrievalMetadata(mutatedFat, realAuthority, wasm), /generation/)
+  const mutatedWitness = witness.slice(); mutatedWitness[31] ^= 1
+  assert.throws(() => recovery.verifyWitnessMdu(mutatedWitness, mdu0.subarray(0, 32), wasm), /root/)
+  const mutatedUser = userMdus[0].slice(); mutatedUser[31] ^= 1
+  assert.throws(() => recovery.verifyRecoveredMdu(realAuthority, mutatedUser, commitments[0], wasm), /commitments/)
+  const realGeneration = generation({
+    manifestRoot,
+    readManifestRoot: async () => manifestRoot,
+    readMetadata: async () => metadata({
+      generation_id: manifestRoot.slice(2), manifest_root: manifestRoot,
+      witness_mdus: 1, user_mdus: 2, total_mdus: 4, file_records: [realFile],
+    }),
+    readMdu: async (index) => [mdu0, witness, ...userMdus][index]?.slice() ?? null,
+    mduSize: async (index) => index >= 0 && index < 4 ? 8 * 1024 * 1024 : null,
+  })
+  const started = performance.now()
+  try {
+    const downloaded = await readVerifiedCachedDownload({
+      dealId: '7', manifestRoot, owner: chainOwner, viewerOwners: [evmOwner], file: realFile, authority: realAuthority,
+    }, storage(realGeneration), realVerifier)
+    assert.deepEqual(downloaded, raw)
+    const measurement = {
+      physicalMibVerified: 16,
+      outputBytes: raw.length,
+      ...Object.fromEntries(Object.entries(phases).map(([key, value]) => [key, Number(value.toFixed(1))])),
+      totalMs: Number((performance.now() - started).toFixed(1)),
+    }
+    console.log(`cached-download-verification ${JSON.stringify(measurement)}`)
+  } finally {
+    wasm.free()
+  }
 })

--- a/polystore-website/src/lib/cachedDownload.ts
+++ b/polystore-website/src/lib/cachedDownload.ts
@@ -3,6 +3,8 @@ import { bech32 } from 'bech32'
 import type { PolyfsFileEntry } from '../domain/polyfs'
 import { normalizeManifestRoot } from './cacheFreshness'
 import { RAW_MDU_CAPACITY, readPolyfsFileFromVerifiedLayout } from './polyfsOpfsFetch'
+import { createRecoveryCommitmentReader, type RecoveryGeometry } from './retrievalRecovery'
+import type { RetrievalFile } from './retrieval'
 import {
   openCompleteSlabGeneration,
   type CompleteSlabGeneration,
@@ -17,8 +19,21 @@ export interface CachedDownloadInput {
   owner: string
   viewerOwners: readonly string[]
   file: PolyfsFileEntry
+  authority: CachedDownloadAuthority | null
   rangeStart?: number
   rangeLen?: number
+}
+
+export interface CachedDownloadAuthority extends RecoveryGeometry {
+  root: `0x${string}`
+  totalMdus: bigint
+}
+
+export interface CachedDownloadVerifier {
+  verifyMetadata(bytes: Uint8Array, authority: CachedDownloadAuthority): Promise<readonly RetrievalFile[]>
+  verifyWitness(bytes: Uint8Array, cell: Uint8Array): Promise<Uint8Array>
+  readCommitments(authority: CachedDownloadAuthority, ordinal: bigint, witness: { index: bigint; bytes: Uint8Array }[], cell: Uint8Array): Promise<Uint8Array>
+  verifyMdu(authority: CachedDownloadAuthority, bytes: Uint8Array, commitments: Uint8Array): Promise<Uint8Array>
 }
 
 export interface CachedDownloadStorage {
@@ -27,6 +42,41 @@ export interface CachedDownloadStorage {
 
 const browserStorage: CachedDownloadStorage = {
   openGeneration: openCompleteSlabGeneration,
+}
+
+const browserVerifier: CachedDownloadVerifier = {
+  verifyMetadata: async (bytes, authority) => (await import('./worker-client')).workerClient.verifyRetrievalMetadata(bytes, authority),
+  verifyWitness: async (bytes, cell) => (await import('./worker-client')).workerClient.verifyRetrievalWitness(bytes, cell),
+  readCommitments: async (authority, ordinal, witness, cell) => (await import('./worker-client')).workerClient.readRetrievalCommitments(authority, ordinal, witness, cell),
+  verifyMdu: async (authority, bytes, commitments) => (await import('./worker-client')).workerClient.verifyRetrievalMdu(authority, bytes, commitments),
+}
+
+export function cachedDownloadAuthority(input: {
+  cid?: string
+  total_mdus?: string
+  witness_mdus?: string
+  redundancy_mode?: number
+  mode2_profile?: { k?: number; m?: number }
+}): CachedDownloadAuthority | null {
+  const root = normalizeManifestRoot(input.cid)
+  const total = input.total_mdus
+  const witness = input.witness_mdus
+  const k = input.mode2_profile?.k
+  const m = input.mode2_profile?.m
+  if (
+    !/^0x[0-9a-f]{64}$/.test(root) || input.redundancy_mode !== 2 ||
+    typeof total !== 'string' || !/^[1-9][0-9]{0,4}$/.test(total) ||
+    typeof witness !== 'string' || !/^(0|[1-9][0-9]{0,4})$/.test(witness) ||
+    !Number.isSafeInteger(k) || !k || k < 1 || k > 64 || 64 % k !== 0 ||
+    !Number.isSafeInteger(m) || !m || m < 1 || k + m > 256
+  ) return null
+  const totalMdus = BigInt(total)
+  const metadataMdus = 1n + BigInt(witness)
+  const userMdus = totalMdus - metadataMdus
+  const rows = 64 / k
+  const leafCount = rows * (k + m)
+  if (userMdus < 0n || totalMdus > 65537n || userMdus * BigInt(leafCount * 48) > BigInt(witness) * BigInt(RAW_MDU_CAPACITY)) return null
+  return { root: root as `0x${string}`, layout: 2, k, m, rows, leafCount, metadataMdus, userMdus, totalMdus }
 }
 
 function canonicalAccount(value: string | null | undefined): string {
@@ -64,7 +114,7 @@ function validateMetadata(
   metadata: SlabMetadata,
 ): Map<string, PolyfsFileEntry> | null {
   const root = normalizeManifestRoot(input.manifestRoot)
-  if (!root || normalizeManifestRoot(generation.manifestRoot) !== root) return null
+  if (!root || !validAuthority(input) || normalizeManifestRoot(generation.manifestRoot) !== root) return null
   if (metadata.schema_version !== 1) return null
   if (String(metadata.deal_id ?? '') !== input.dealId || normalizeManifestRoot(metadata.manifest_root) !== root) return null
   if (!sameAccount(metadata.owner, input.owner)) return null
@@ -84,6 +134,20 @@ function validateMetadata(
     files.set(candidate.path, { ...candidate })
   }
   return files
+}
+
+function validAuthority(input: CachedDownloadInput): input is CachedDownloadInput & { authority: CachedDownloadAuthority } {
+  const authority = input.authority
+  return Boolean(
+    authority && authority.layout === 2 &&
+    normalizeManifestRoot(authority.root) === normalizeManifestRoot(input.manifestRoot) &&
+    Number.isSafeInteger(authority.k) && authority.k > 0 && authority.k <= 64 && 64 % authority.k === 0 &&
+    Number.isSafeInteger(authority.m) && authority.m > 0 && authority.k + authority.m <= 256 &&
+    authority.rows === 64 / authority.k && authority.leafCount === authority.rows * (authority.k + authority.m) &&
+    authority.metadataMdus >= 1n && authority.userMdus >= 0n &&
+    authority.totalMdus === authority.metadataMdus + authority.userMdus && authority.totalMdus <= 65537n &&
+    authority.userMdus * BigInt(authority.leafCount * 48) <= (authority.metadataMdus - 1n) * BigInt(RAW_MDU_CAPACITY),
+  )
 }
 
 function rangeFor(file: PolyfsFileEntry, startRaw?: number, lengthRaw?: number): { start: number; length: number } | null {
@@ -205,24 +269,56 @@ export async function verifiedCachedDownloadAvailability(
 export async function readVerifiedCachedDownload(
   input: CachedDownloadInput,
   storage: CachedDownloadStorage = browserStorage,
+  verifier: CachedDownloadVerifier = browserVerifier,
 ): Promise<Uint8Array | null> {
   try {
-    const opened = await openVerifiedFile(input, storage)
-    if (!opened) return null
-    const { generation, metadata, file, start, length } = opened
-    if (!(await hasRequiredMduSizes(generation, metadata, file, start, length))) return null
+    if (!validAuthority(input) || !input.viewerOwners.some((viewer) => sameAccount(viewer, input.owner))) return null
+    const root = normalizeManifestRoot(input.manifestRoot)
+    const generation = await storage.openGeneration(input.dealId)
+    if (!generation || normalizeManifestRoot(generation.manifestRoot) !== root || normalizeManifestRoot(await generation.readManifestRoot()) !== root) return null
 
+    const mdu0 = await generation.readMdu(0)
+    if (!mdu0 || mdu0.byteLength !== MDU_SIZE_BYTES) return null
+    const authenticatedRecords = await verifier.verifyMetadata(mdu0, input.authority)
+    const allFiles: PolyfsFileEntry[] = authenticatedRecords.filter((record) => record.path).map((record) => ({
+      path: record.path,
+      start_offset: Number(record.start_offset),
+      size_bytes: Number(record.size_bytes),
+      flags: record.flags,
+    }))
+    if (allFiles.some((record) => !safeRecord(record))) return null
+    const file = allFiles.find((record) => record.path === input.file.path)
+    if (!file || file.flags !== 0 || !sameFile(file, input.file)) return null
+    const range = rangeFor(file, input.rangeStart, input.rangeLen)
+    if (!range) return null
+
+    const readCommitments = createRecoveryCommitmentReader(input.authority, mdu0, {
+      fetch: async (index) => {
+        const bytes = await generation.readMdu(Number(index))
+        if (!bytes || bytes.byteLength !== MDU_SIZE_BYTES) throw new Error('cached witness MDU is incomplete')
+        return bytes
+      },
+      verifyWitness: verifier.verifyWitness,
+      readCommitments: verifier.readCommitments,
+    })
     const bytes = await readPolyfsFileFromVerifiedLayout({
       dealId: input.dealId,
       file,
-      allFiles: metadata.file_records,
-      witnessMdus: metadata.witness_mdus,
-      userMdus: metadata.user_mdus,
-      totalMdus: metadata.total_mdus,
-      rangeStart: start,
-      rangeLen: length,
-    }, (_dealId, mduIndex) => generation.readMdu(mduIndex))
-    return bytes.byteLength === length ? bytes : null
+      allFiles,
+      witnessMdus: Number(input.authority.metadataMdus - 1n),
+      userMdus: Number(input.authority.userMdus),
+      totalMdus: Number(input.authority.totalMdus),
+      rangeStart: range.start,
+      rangeLen: range.length,
+    }, async (_dealId, mduIndex) => {
+      const ordinal = BigInt(mduIndex) - input.authority.metadataMdus
+      const encoded = await generation.readMdu(mduIndex)
+      if (!encoded || encoded.byteLength !== MDU_SIZE_BYTES) return null
+      const commitments = await readCommitments(ordinal)
+      const verified = await verifier.verifyMdu(input.authority, encoded, commitments)
+      return verified.byteLength === MDU_SIZE_BYTES ? verified : null
+    })
+    return bytes.byteLength === range.length ? bytes : null
   } catch {
     return null
   }

--- a/polystore-website/src/lib/cachedDownload.ts
+++ b/polystore-website/src/lib/cachedDownload.ts
@@ -1,0 +1,240 @@
+import { bech32 } from 'bech32'
+
+import type { PolyfsFileEntry } from '../domain/polyfs'
+import { normalizeManifestRoot } from './cacheFreshness'
+import { RAW_MDU_CAPACITY, readPolyfsFileFromVerifiedLayout } from './polyfsOpfsFetch'
+import {
+  openCompleteSlabGeneration,
+  type CompleteSlabGeneration,
+  type SlabMetadata,
+} from './storage/OpfsAdapter'
+
+const MDU_SIZE_BYTES = 8 * 1024 * 1024
+
+export interface CachedDownloadInput {
+  dealId: string
+  manifestRoot: string
+  owner: string
+  viewerOwners: readonly string[]
+  file: PolyfsFileEntry
+  rangeStart?: number
+  rangeLen?: number
+}
+
+export interface CachedDownloadStorage {
+  openGeneration(dealId: string): Promise<CompleteSlabGeneration | null>
+}
+
+const browserStorage: CachedDownloadStorage = {
+  openGeneration: openCompleteSlabGeneration,
+}
+
+function canonicalAccount(value: string | null | undefined): string {
+  const normalized = String(value || '').trim().toLowerCase()
+  if (/^0x[0-9a-f]{40}$/.test(normalized)) return normalized.slice(2)
+  try {
+    const decoded = bech32.decode(normalized)
+    const bytes = new Uint8Array(bech32.fromWords(decoded.words))
+    if (bytes.byteLength === 20) return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')
+  } catch {
+    // Non-address owner identifiers still require exact text equality.
+  }
+  return normalized
+}
+
+function sameAccount(a: string | null | undefined, b: string | null | undefined): boolean {
+  const left = canonicalAccount(a)
+  return left !== '' && left === canonicalAccount(b)
+}
+
+function safeRecord(file: PolyfsFileEntry): boolean {
+  return Boolean(file.path) &&
+    Number.isSafeInteger(file.start_offset) && file.start_offset >= 0 &&
+    Number.isSafeInteger(file.size_bytes) && file.size_bytes >= 0 &&
+    Number.isSafeInteger(file.flags) && file.flags >= 0 && file.flags <= 0xff
+}
+
+function sameFile(a: PolyfsFileEntry, b: PolyfsFileEntry): boolean {
+  return a.path === b.path && a.start_offset === b.start_offset && a.size_bytes === b.size_bytes && a.flags === b.flags
+}
+
+function validateMetadata(
+  input: CachedDownloadInput,
+  generation: CompleteSlabGeneration,
+  metadata: SlabMetadata,
+): Map<string, PolyfsFileEntry> | null {
+  const root = normalizeManifestRoot(input.manifestRoot)
+  if (!root || normalizeManifestRoot(generation.manifestRoot) !== root) return null
+  if (metadata.schema_version !== 1) return null
+  if (String(metadata.deal_id ?? '') !== input.dealId || normalizeManifestRoot(metadata.manifest_root) !== root) return null
+  if (!sameAccount(metadata.owner, input.owner)) return null
+  if (!input.viewerOwners.some((viewer) => sameAccount(viewer, input.owner))) return null
+  if (
+    !Number.isSafeInteger(metadata.witness_mdus) || metadata.witness_mdus < 0 ||
+    !Number.isSafeInteger(metadata.user_mdus) || metadata.user_mdus < 0 ||
+    !Number.isSafeInteger(metadata.total_mdus) || metadata.total_mdus !== 1 + metadata.witness_mdus + metadata.user_mdus
+  ) return null
+
+  const capacity = metadata.user_mdus * RAW_MDU_CAPACITY
+  if (!Number.isSafeInteger(capacity)) return null
+  const files = new Map<string, PolyfsFileEntry>()
+  for (const candidate of metadata.file_records) {
+    if (!safeRecord(candidate) || candidate.start_offset + candidate.size_bytes > capacity) return null
+    if (files.has(candidate.path)) return null
+    files.set(candidate.path, { ...candidate })
+  }
+  return files
+}
+
+function rangeFor(file: PolyfsFileEntry, startRaw?: number, lengthRaw?: number): { start: number; length: number } | null {
+  const start = Number(startRaw || 0)
+  const requested = Number(lengthRaw || 0)
+  if (!Number.isSafeInteger(start) || start < 0 || !Number.isSafeInteger(requested) || requested < 0 || start > file.size_bytes) return null
+  const length = requested > 0 ? requested : file.size_bytes - start
+  if (!Number.isSafeInteger(length) || start + length > file.size_bytes) return null
+  return { start, length }
+}
+
+async function openVerifiedGeneration(
+  input: CachedDownloadInput,
+  storage: CachedDownloadStorage,
+): Promise<{ generation: CompleteSlabGeneration; metadata: SlabMetadata; files: Map<string, PolyfsFileEntry> } | null> {
+  const root = normalizeManifestRoot(input.manifestRoot)
+  if (!root || !input.owner) return null
+  const generation = await storage.openGeneration(input.dealId)
+  if (!generation) return null
+  const [localRoot, metadata] = await Promise.all([generation.readManifestRoot(), generation.readMetadata()])
+  if (!metadata || normalizeManifestRoot(localRoot) !== root) return null
+  const files = validateMetadata(input, generation, metadata)
+  return files ? { generation, metadata, files } : null
+}
+
+function selectVerifiedFile(
+  opened: Awaited<ReturnType<typeof openVerifiedGeneration>>,
+  input: CachedDownloadInput,
+): { generation: CompleteSlabGeneration; metadata: SlabMetadata; file: PolyfsFileEntry; start: number; length: number } | null {
+  if (!opened) return null
+  const candidate = opened.files.get(input.file.path)
+  // The current bounded decoder supports raw PolyFS records only.
+  const file = candidate && candidate.flags === 0 && sameFile(candidate, input.file) ? candidate : null
+  const range = file ? rangeFor(file, input.rangeStart, input.rangeLen) : null
+  return file && range ? { generation: opened.generation, metadata: opened.metadata, file, ...range } : null
+}
+
+async function openVerifiedFile(
+  input: CachedDownloadInput,
+  storage: CachedDownloadStorage,
+): Promise<ReturnType<typeof selectVerifiedFile>> {
+  return selectVerifiedFile(await openVerifiedGeneration(input, storage), input)
+}
+
+async function hasRequiredMduSizes(
+  generation: CompleteSlabGeneration,
+  metadata: SlabMetadata,
+  file: PolyfsFileEntry,
+  start: number,
+  length: number,
+  knownSizes?: Map<number, boolean>,
+): Promise<boolean> {
+  if (length === 0) return true
+  const first = Math.floor((file.start_offset + start) / RAW_MDU_CAPACITY)
+  const last = Math.floor((file.start_offset + start + length - 1) / RAW_MDU_CAPACITY)
+  if (first < 0 || last >= metadata.user_mdus) return false
+  for (let ordinal = first; ordinal <= last; ordinal += 1) {
+    const index = 1 + metadata.witness_mdus + ordinal
+    let complete = knownSizes?.get(index)
+    if (complete == null) {
+      complete = await generation.mduSize(index) === MDU_SIZE_BYTES
+      knownSizes?.set(index, complete)
+    }
+    if (!complete) return false
+  }
+  return true
+}
+
+/** Checks cache completeness without reading or allocating the file payload. */
+export async function hasVerifiedCachedDownload(
+  input: CachedDownloadInput,
+  storage: CachedDownloadStorage = browserStorage,
+): Promise<boolean> {
+  try {
+    const opened = await openVerifiedFile(input, storage)
+    if (!opened) return false
+    return hasRequiredMduSizes(opened.generation, opened.metadata, opened.file, opened.start, opened.length)
+  } catch {
+    return false
+  }
+}
+
+/** Checks a file listing through one metadata snapshot and one pinned generation. */
+export async function verifiedCachedDownloadAvailability(
+  inputs: readonly CachedDownloadInput[],
+  storage: CachedDownloadStorage = browserStorage,
+): Promise<Record<string, boolean>> {
+  const available: Record<string, boolean> = {}
+  for (const input of inputs) available[input.file.path] = false
+  if (inputs.length === 0) return available
+  try {
+    const opened = await openVerifiedGeneration(inputs[0], storage)
+    if (!opened) return available
+    const knownSizes = new Map<number, boolean>()
+    for (const input of inputs) {
+      if (
+        input.dealId !== inputs[0].dealId ||
+        normalizeManifestRoot(input.manifestRoot) !== normalizeManifestRoot(inputs[0].manifestRoot) ||
+        !sameAccount(input.owner, inputs[0].owner) ||
+        !input.viewerOwners.some((viewer) => sameAccount(viewer, input.owner))
+      ) continue
+      const selected = selectVerifiedFile(opened, input)
+      if (!selected) continue
+      available[selected.file.path] = await hasRequiredMduSizes(
+        opened.generation,
+        opened.metadata,
+        selected.file,
+        selected.start,
+        selected.length,
+        knownSizes,
+      )
+    }
+  } catch {
+    // A removed or incomplete generation remains unavailable.
+  }
+  return available
+}
+
+export async function readVerifiedCachedDownload(
+  input: CachedDownloadInput,
+  storage: CachedDownloadStorage = browserStorage,
+): Promise<Uint8Array | null> {
+  try {
+    const opened = await openVerifiedFile(input, storage)
+    if (!opened) return null
+    const { generation, metadata, file, start, length } = opened
+    if (!(await hasRequiredMduSizes(generation, metadata, file, start, length))) return null
+
+    const bytes = await readPolyfsFileFromVerifiedLayout({
+      dealId: input.dealId,
+      file,
+      allFiles: metadata.file_records,
+      witnessMdus: metadata.witness_mdus,
+      userMdus: metadata.user_mdus,
+      totalMdus: metadata.total_mdus,
+      rangeStart: start,
+      rangeLen: length,
+    }, (_dealId, mduIndex) => generation.readMdu(mduIndex))
+    return bytes.byteLength === length ? bytes : null
+  } catch {
+    return null
+  }
+}
+
+export async function preferVerifiedCache<T>(
+  readCache: () => Promise<Uint8Array | null>,
+  networkUnavailableReason: string | undefined,
+  fetchNetwork: () => Promise<T>,
+): Promise<{ source: 'cache'; bytes: Uint8Array } | { source: 'network'; result: T }> {
+  const bytes = await readCache()
+  if (bytes) return { source: 'cache', bytes }
+  if (networkUnavailableReason) throw new Error(networkUnavailableReason)
+  return { source: 'network', result: await fetchNetwork() }
+}

--- a/polystore-website/src/lib/polyfsOpfsFetch.ts
+++ b/polystore-website/src/lib/polyfsOpfsFetch.ts
@@ -130,7 +130,7 @@ function decodeRawSliceFromMdu(opts: {
     const payloadStart = scalarBase + (isPartialScalar ? (POLYFS_SCALAR_BYTES - lastPartialLen) : 1)
     const encStart = payloadStart + offsetInScalar
 
-    out.set(mdu.slice(encStart, encStart + take), outOffset)
+    out.set(mdu.subarray(encStart, encStart + take), outOffset)
     outOffset += take
     remaining -= take
     cursor += take
@@ -192,5 +192,55 @@ export async function readPolyfsFileFromOpfs(opts: {
     remaining -= take
   }
 
+  return out
+}
+
+export async function readPolyfsFileFromVerifiedLayout(opts: {
+  dealId: string
+  file: PolyfsFileEntry
+  allFiles: PolyfsFileEntry[]
+  witnessMdus: number
+  userMdus: number
+  totalMdus: number
+  rangeStart?: number
+  rangeLen?: number
+}, readLocalMdu: typeof readMdu = readMdu): Promise<Uint8Array> {
+  const { dealId, file, allFiles, witnessMdus, userMdus, totalMdus } = opts
+  if (
+    !Number.isSafeInteger(witnessMdus) || witnessMdus < 0 ||
+    !Number.isSafeInteger(userMdus) || userMdus < 0 ||
+    totalMdus !== 1 + witnessMdus + userMdus
+  ) throw new Error('invalid committed slab layout')
+
+  const maxEnd = inferMaxEnd(allFiles)
+  if (maxEnd > userMdus * RAW_MDU_CAPACITY) throw new Error('file table exceeds committed slab layout')
+  const rangeStart = Number(opts.rangeStart || 0)
+  const requestedLength = Number(opts.rangeLen || 0)
+  if (!Number.isSafeInteger(rangeStart) || rangeStart < 0 || rangeStart > file.size_bytes) throw new Error('invalid cached file range')
+  if (!Number.isSafeInteger(requestedLength) || requestedLength < 0) throw new Error('invalid cached file range')
+  const length = requestedLength > 0 ? requestedLength : file.size_bytes - rangeStart
+  if (rangeStart + length > file.size_bytes) throw new Error('cached file range exceeds EOF')
+
+  const slabStartIdx = 1 + witnessMdus
+  let remaining = length
+  let cursor = file.start_offset + rangeStart
+  let outOffset = 0
+  const out = new Uint8Array(length)
+  while (remaining > 0) {
+    const userMduIdx = Math.floor(cursor / RAW_MDU_CAPACITY)
+    if (userMduIdx >= userMdus) throw new Error('cached file exceeds committed user MDUs')
+    const offsetInMdu = cursor % RAW_MDU_CAPACITY
+    const mduBase = userMduIdx * RAW_MDU_CAPACITY
+    const rawValidLen = Math.max(0, Math.min(RAW_MDU_CAPACITY, maxEnd - mduBase))
+    const take = Math.min(remaining, rawValidLen - offsetInMdu)
+    if (take <= 0) throw new Error('cached file range is unavailable')
+
+    const mdu = await readLocalMdu(dealId, slabStartIdx + userMduIdx)
+    if (!mdu || mdu.byteLength !== MDU_SIZE_BYTES) throw new Error('cached user MDU is incomplete')
+    out.set(decodeRawSliceFromMdu({ mdu, rawStart: offsetInMdu, rawLen: take, rawValidLen }), outOffset)
+    cursor += take
+    outOffset += take
+    remaining -= take
+  }
   return out
 }

--- a/polystore-website/src/lib/retrievalRecovery.ts
+++ b/polystore-website/src/lib/retrievalRecovery.ts
@@ -5,7 +5,9 @@ import { decodeRetrievalSlice } from './retrievalFlow'
 import type { RetrievalCrypto } from './retrievalWire'
 
 const RAW_MDU = BigInt(RAW_MDU_CAPACITY_BYTES)
-export function witnessSpan(pin: PinnedGeneration, ordinal: bigint) {
+export type RecoveryGeometry = Pick<PinnedGeneration, 'layout' | 'k' | 'm' | 'rows' | 'leafCount' | 'metadataMdus' | 'userMdus'>
+
+export function witnessSpan(pin: RecoveryGeometry, ordinal: bigint) {
   if (pin.layout !== 2 || ordinal < 0n || ordinal >= pin.userMdus || pin.leafCount < 64 || pin.leafCount > 16384) throw new Error('invalid recovery geometry')
   const total = pin.userMdus * BigInt(pin.leafCount * 48), start = ordinal * BigInt(pin.leafCount * 48), end = start + BigInt(pin.leafCount * 48)
   if (total > (pin.metadataMdus - 1n) * RAW_MDU) throw new Error('insufficient frozen witness extent')
@@ -19,7 +21,7 @@ export function verifyWitnessMdu(bytes: Uint8Array, cell: Uint8Array, crypto: Re
   for (let i = 0; i < 64; i++) commitments.set(crypto.commit_received_blob(bytes.subarray(i * 131072, (i + 1) * 131072)), i * 48)
   assertPolyfsRootCell(new Uint8Array(crypto.compute_mdu_root(commitments) as ArrayLike<number>), cell)
 }
-export function readUserCommitments(pin: PinnedGeneration, ordinal: bigint, witness: readonly { index: bigint; bytes: Uint8Array }[], userCell: Uint8Array, crypto: RetrievalCrypto): Uint8Array {
+export function readUserCommitments(pin: RecoveryGeometry, ordinal: bigint, witness: readonly { index: bigint; bytes: Uint8Array }[], userCell: Uint8Array, crypto: RetrievalCrypto): Uint8Array {
   const span = witnessSpan(pin, ordinal)
   if (witness.length !== span.indices.length || witness.some((w, i) => w.index !== span.indices[i] || w.bytes.length !== 8388608)) throw new Error('wrong witness generation span')
   const out = new Uint8Array(pin.leafCount * 48)
@@ -36,7 +38,7 @@ export function readUserCommitments(pin: PinnedGeneration, ordinal: bigint, witn
   assertPolyfsRootCell(new Uint8Array(crypto.compute_mdu_root(out) as ArrayLike<number>), userCell)
   return out
 }
-export function verifyRecoveredMdu(pin: PinnedGeneration, bytes: Uint8Array, commitments: Uint8Array, crypto: RetrievalCrypto): void {
+export function verifyRecoveredMdu(pin: RecoveryGeometry, bytes: Uint8Array, commitments: Uint8Array, crypto: RetrievalCrypto): void {
   if (bytes.length !== 8388608 || commitments.length !== pin.leafCount * 48) throw new Error('incomplete recovered MDU')
   for (let blob = 0; blob < 64; blob++) {
     const leaf = (blob % pin.k) * pin.rows + Math.floor(blob / pin.k)
@@ -84,16 +86,16 @@ export async function recoverRetrievalMdu(pin: PinnedGeneration, ordinal: bigint
   return bytes
 }
 
-export interface RecoveryMetadataReader {
+export interface RecoveryMetadataReader<T extends RecoveryGeometry = RecoveryGeometry> {
   fetch(index: bigint): Promise<Uint8Array>
   verifyWitness(bytes: Uint8Array, cell: Uint8Array): Promise<Uint8Array>
-  readCommitments(pin: PinnedGeneration, ordinal: bigint, witness: { index: bigint; bytes: Uint8Array }[], cell: Uint8Array): Promise<Uint8Array>
+  readCommitments(pin: T, ordinal: bigint, witness: { index: bigint; bytes: Uint8Array }[], cell: Uint8Array): Promise<Uint8Array>
 }
 // One reader belongs to one immutable generation. Two verified witness MDUs
 // cover any legal user list; older entries are evicted before another is kept.
-export function createRecoveryCommitmentReader(pin: PinnedGeneration, mdu0: Uint8Array, reader: RecoveryMetadataReader, signal?: AbortSignal): (ordinal: bigint) => Promise<Uint8Array> {
+export function createRecoveryCommitmentReader<T extends RecoveryGeometry>(pin: T, mdu0: Uint8Array, reader: RecoveryMetadataReader<T>, signal?: AbortSignal): (ordinal: bigint) => Promise<Uint8Array> {
   if (mdu0.length !== 8388608) throw new Error('missing authenticated MDU0')
-  const frozen = { ...pin }, roots = mdu0.slice(0, 2 * 1024 * 1024)
+  const frozen = { ...pin } as T, roots = mdu0.slice(0, 2 * 1024 * 1024)
   const cache = new Map<bigint, Uint8Array>()
   const cell = (index: bigint) => roots.slice(Number(index - 1n) * 32, Number(index) * 32)
   return async (ordinal) => {

--- a/polystore-website/src/lib/retrievalWire.ts
+++ b/polystore-website/src/lib/retrievalWire.ts
@@ -129,7 +129,9 @@ export function verifyRetrievalWindow(session: FrozenSession, envelope: Retrieva
   return envelope.bytes
 }
 
-export function verifyRetrievalMetadata(bytes: Uint8Array, pin: PinnedGeneration, crypto: RetrievalCrypto) {
+export type RetrievalMetadataGeneration = Pick<PinnedGeneration, 'root' | 'userMdus'>
+
+export function verifyRetrievalMetadata(bytes: Uint8Array, pin: RetrievalMetadataGeneration, crypto: RetrievalCrypto) {
   const records = parsePolyfsRecordsFromMdu0(bytes)
   const commitments = new Uint8Array(64 * 48)
   for (let i = 0; i < 64; i++) commitments.set(crypto.commit_received_blob(bytes.subarray(i * BLOB_SIZE_BYTES, (i + 1) * BLOB_SIZE_BYTES)), i * 48)

--- a/polystore-website/src/lib/sessionFunding.test.ts
+++ b/polystore-website/src/lib/sessionFunding.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert'
+import { test } from 'node:test'
+
+import { parseStakeBalancePayload, resolveFundingStatus } from './sessionFunding'
+
+test('a confirmed funded balance remains funded through an LCD outage', () => {
+  assert.equal(resolveFundingStatus({ lcdLoaded: true, lcdAmount: '42', lcdUnavailable: true }), 'funded')
+})
+
+test('an LCD error without a confirmed balance is unavailable rather than zero', () => {
+  assert.equal(resolveFundingStatus({ lcdLoaded: false, lcdAmount: null, lcdUnavailable: true }), 'unavailable')
+})
+
+test('a failed refresh does not reuse a last-known zero as a confirmed zero', () => {
+  assert.equal(resolveFundingStatus({ lcdLoaded: true, lcdAmount: '0', lcdUnavailable: true }), 'unavailable')
+})
+
+test('only a successful zero LCD response confirms an unfunded wallet', () => {
+  assert.equal(resolveFundingStatus({ lcdLoaded: true, lcdAmount: '0', lcdUnavailable: false }), 'unfunded')
+})
+
+test('a positive EVM balance can establish funding while LCD is pending', () => {
+  assert.equal(resolveFundingStatus({ lcdLoaded: false, lcdAmount: null, lcdUnavailable: false, evmAmount: 1n }), 'funded')
+})
+
+test('an unconfirmed zero EVM balance does not replace the pending LCD result', () => {
+  assert.equal(resolveFundingStatus({ lcdLoaded: false, lcdAmount: null, lcdUnavailable: false, evmAmount: 0n }), 'checking')
+})
+
+test('only a valid LCD balance payload can confirm zero', () => {
+  assert.equal(parseStakeBalancePayload({ balances: [] }), '0')
+  assert.equal(parseStakeBalancePayload({ balances: [{ denom: 'stake', amount: '42' }] }), '42')
+  assert.throws(() => parseStakeBalancePayload({ code: 530, message: 'maintenance' }), /invalid balance response/)
+  assert.throws(() => parseStakeBalancePayload({ balances: [{ denom: 'stake', amount: null }] }), /invalid balance amount/)
+})

--- a/polystore-website/src/lib/sessionFunding.ts
+++ b/polystore-website/src/lib/sessionFunding.ts
@@ -1,0 +1,37 @@
+export type FundingStatus = 'checking' | 'funded' | 'unfunded' | 'unavailable'
+
+function positive(value: bigint | string | number | null | undefined): boolean {
+  if (value == null || value === '') return false
+  try {
+    return BigInt(value) > 0n
+  } catch {
+    return false
+  }
+}
+
+export function resolveFundingStatus(input: {
+  lcdLoaded: boolean
+  lcdAmount: string | null
+  lcdUnavailable: boolean
+  evmAmount?: bigint | null
+}): FundingStatus {
+  if (input.lcdLoaded && positive(input.lcdAmount)) return 'funded'
+  if (positive(input.evmAmount)) return 'funded'
+  if (input.lcdUnavailable) return 'unavailable'
+  if (input.lcdLoaded) return 'unfunded'
+  return 'checking'
+}
+
+export function parseStakeBalancePayload(payload: unknown): string {
+  if (!payload || typeof payload !== 'object') throw new Error('invalid balance response')
+  const balances = (payload as { balances?: unknown }).balances
+  if (!Array.isArray(balances)) throw new Error('invalid balance response')
+  const match = balances.find((entry) => {
+    if (!entry || typeof entry !== 'object') return false
+    const denom = (entry as { denom?: unknown }).denom
+    return denom === 'stake' || denom === 'aatom'
+  }) as { amount?: unknown } | undefined
+  if (!match) return '0'
+  if (typeof match.amount !== 'string' || !/^\d+$/.test(match.amount)) throw new Error('invalid balance amount')
+  return match.amount
+}

--- a/polystore-website/src/lib/storage/OpfsAdapter.test.ts
+++ b/polystore-website/src/lib/storage/OpfsAdapter.test.ts
@@ -493,6 +493,12 @@ test('OpfsAdapter: verified generation metadata rejects fractional layout counts
     const opened = await OpfsAdapter.openCompleteSlabGeneration(dealId)
     assert.ok(opened)
     assert.strictEqual(await opened?.readMetadata(), null)
+    for (const invalid of [null, false, '', [], 0.5]) {
+        const bad = { ...makeMetadata({ dealId, manifestRoot: root, generationId: root.slice(2) }),
+            file_records: [{ path: 'a', start_offset: 0, size_bytes: 1, flags: invalid }] }
+        await writeMockFile(generationDir, 'slab_meta.json', JSON.stringify(bad))
+        assert.strictEqual(await opened?.readMetadata(), null, `invalid flags: ${JSON.stringify(invalid)}`)
+    }
 })
 
 test('OpfsAdapter: atomic slab generation swap survives stale cleanup failure after activation', async () => {

--- a/polystore-website/src/lib/storage/OpfsAdapter.test.ts
+++ b/polystore-website/src/lib/storage/OpfsAdapter.test.ts
@@ -441,6 +441,60 @@ test('OpfsAdapter: atomic slab generation swap serves new generation and cleans 
     assert.ok(files.includes('manifest.bin'))
 })
 
+test('OpfsAdapter: verified generation is pinned and its completion marker is root-bound', async () => {
+    const dealId = 'test-deal-verified-generation'
+    const root = '0x' + 'de'.repeat(48)
+    await OpfsAdapter.writeSlabGenerationAtomically(dealId, {
+        manifestRoot: root,
+        manifestBlob: new Uint8Array([1]),
+        mdus: [
+            { index: 0, data: new Uint8Array([2]) },
+            { index: 1, data: new Uint8Array([3]) },
+        ],
+        metadata: makeMetadata({ dealId, manifestRoot: root, generationId: root.slice(2) }),
+    })
+
+    const dealDir = await mockRootDirectoryHandle.getDirectoryHandle(`deal-${dealId}`)
+    const pointer = await (await dealDir.getFileHandle('active_generation.txt')).getFile()
+    const generationName = (await pointer.text()).trim()
+    const generationDir = await (await dealDir.getDirectoryHandle('generations')).getDirectoryHandle(generationName)
+    const marker = await (await generationDir.getFileHandle('.generation_complete')).getFile()
+    assert.strictEqual((await marker.text()).trim(), root)
+
+    const opened = await OpfsAdapter.openCompleteSlabGeneration(dealId)
+    assert.strictEqual(opened?.manifestRoot, root)
+    assert.deepStrictEqual(await opened?.readMdu(1), new Uint8Array([3]))
+
+    await writeMockFile(generationDir, '.generation_complete', 'ok\n')
+    assert.strictEqual(await OpfsAdapter.openCompleteSlabGeneration(dealId), null)
+})
+
+test('OpfsAdapter: verified generation metadata rejects fractional layout counts', async () => {
+    const dealId = 'test-deal-strict-generation-metadata'
+    const root = '0x' + 'ef'.repeat(48)
+    await OpfsAdapter.writeSlabGenerationAtomically(dealId, {
+        manifestRoot: root,
+        manifestBlob: new Uint8Array([1]),
+        mdus: [
+            { index: 0, data: new Uint8Array([2]) },
+            { index: 1, data: new Uint8Array([3]) },
+        ],
+        metadata: makeMetadata({ dealId, manifestRoot: root, generationId: root.slice(2) }),
+    })
+    const dealDir = await mockRootDirectoryHandle.getDirectoryHandle(`deal-${dealId}`)
+    const pointer = await (await dealDir.getFileHandle('active_generation.txt')).getFile()
+    const generationName = (await pointer.text()).trim()
+    const generationDir = await (await dealDir.getDirectoryHandle('generations')).getDirectoryHandle(generationName)
+    const malformed = makeMetadata({ dealId, manifestRoot: root, generationId: root.slice(2) }) as unknown as Record<string, unknown>
+    malformed.witness_mdus = 0.5
+    malformed.total_mdus = 1.5
+    await writeMockFile(generationDir, 'slab_meta.json', JSON.stringify(malformed))
+
+    const opened = await OpfsAdapter.openCompleteSlabGeneration(dealId)
+    assert.ok(opened)
+    assert.strictEqual(await opened?.readMetadata(), null)
+})
+
 test('OpfsAdapter: atomic slab generation swap survives stale cleanup failure after activation', async () => {
     const dealId = 'test-deal-atomic-swap-cleanup-failure'
     const rootA = '0x' + '12'.repeat(48)

--- a/polystore-website/src/lib/storage/OpfsAdapter.ts
+++ b/polystore-website/src/lib/storage/OpfsAdapter.ts
@@ -62,6 +62,14 @@ export interface SlabMetadata {
     file_records: SlabMetadataFileRecord[]
 }
 
+export interface CompleteSlabGeneration {
+    manifestRoot: string
+    readManifestRoot(): Promise<string | null>
+    readMetadata(): Promise<SlabMetadata | null>
+    readMdu(mduIndex: number): Promise<Uint8Array | null>
+    mduSize(mduIndex: number): Promise<number | null>
+}
+
 /**
  * Returns a handle to the root of the origin's private file system.
  * This handle is persistent across sessions for the same origin.
@@ -125,6 +133,17 @@ async function readBlobFromDirectory(dir: FileSystemDirectoryHandle, name: strin
     throw lastRetryableError
 }
 
+async function readBlobSizeFromDirectory(dir: FileSystemDirectoryHandle, name: string): Promise<number | null> {
+    try {
+        const fileHandle = await dir.getFileHandle(name)
+        const file = await fileHandle.getFile()
+        return file.size
+    } catch (e: unknown) {
+        if (isDomErrorName(e, 'NotFoundError')) return null
+        throw e
+    }
+}
+
 async function removeEntryIfExists(dir: FileSystemDirectoryHandle, name: string, recursive = false): Promise<void> {
     try {
         await dir.removeEntry(name, recursive ? { recursive: true } : undefined)
@@ -177,12 +196,13 @@ async function writeActiveGenerationName(dealDir: FileSystemDirectoryHandle, gen
 }
 
 async function generationLooksComplete(dir: FileSystemDirectoryHandle): Promise<boolean> {
-    const marker = await readBlobFromDirectory(dir, GENERATION_COMPLETE_MARKER_FILE)
-    if (!marker) return false
-    const meta = await readBlobFromDirectory(dir, SLAB_METADATA_FILE)
-    const mdu0 = await readBlobFromDirectory(dir, 'mdu_0.bin')
-    const manifest = await readBlobFromDirectory(dir, 'manifest.bin')
-    return !!meta && !!mdu0 && !!manifest
+    const [marker, meta, mdu0, manifest] = await Promise.all([
+        readBlobSizeFromDirectory(dir, GENERATION_COMPLETE_MARKER_FILE),
+        readBlobSizeFromDirectory(dir, SLAB_METADATA_FILE),
+        readBlobSizeFromDirectory(dir, 'mdu_0.bin'),
+        readBlobSizeFromDirectory(dir, 'manifest.bin'),
+    ])
+    return marker !== null && marker > 0 && meta !== null && meta > 0 && mdu0 !== null && manifest !== null
 }
 
 async function cleanupInactiveGenerations(
@@ -464,7 +484,9 @@ export async function writeSlabGenerationAtomically(
         }
         const payload = JSON.stringify(metadata, null, 2)
         await writeBlobToDirectory(generationDir, SLAB_METADATA_FILE, new TextEncoder().encode(payload))
-        await writeBlobToDirectory(generationDir, GENERATION_COMPLETE_MARKER_FILE, new TextEncoder().encode('ok\n'))
+        // Bind the completion marker to the root written into this immutable
+        // generation. Legacy `ok` markers cannot prove which root they contain.
+        await writeBlobToDirectory(generationDir, GENERATION_COMPLETE_MARKER_FILE, new TextEncoder().encode(`${manifestRoot}\n`))
 
         await writeActiveGenerationName(dealDir, generationName)
         try {
@@ -503,13 +525,20 @@ export async function readManifestRoot(dealId: string): Promise<string | null> {
     return trimmed ? trimmed : null;
 }
 
-function coerceNumber(value: unknown): number | null {
-    const n = typeof value === 'number' ? value : Number(value)
-    if (!Number.isFinite(n) || n < 0) return null
-    return Math.floor(n)
+async function readManifestRootFromDirectory(dir: FileSystemDirectoryHandle): Promise<string | null> {
+    const bytes = await readBlobFromDirectory(dir, 'manifest_root.txt')
+    if (!bytes) return null
+    const value = new TextDecoder().decode(bytes).trim()
+    return value || null
 }
 
-function normalizeSlabMetadata(value: unknown): SlabMetadata | null {
+function coerceNumber(value: unknown): number | null {
+    const n = typeof value === 'number' ? value : Number(value)
+    if (!Number.isSafeInteger(n) || n < 0) return null
+    return n
+}
+
+function normalizeSlabMetadata(value: unknown, strictFileRecords = false): SlabMetadata | null {
     if (!value || typeof value !== 'object') return null
     const raw = value as Record<string, unknown>
 
@@ -543,15 +572,22 @@ function normalizeSlabMetadata(value: unknown): SlabMetadata | null {
     if (totalMdus !== 1 + witnessMdus + userMdus) return null
 
     const fileRecords: SlabMetadataFileRecord[] = []
+    if (strictFileRecords && !Array.isArray(raw.file_records)) return null
     if (Array.isArray(raw.file_records)) {
         for (const item of raw.file_records) {
-            if (!item || typeof item !== 'object') continue
+            if (!item || typeof item !== 'object') {
+                if (strictFileRecords) return null
+                continue
+            }
             const rec = item as Record<string, unknown>
             const path = typeof rec.path === 'string' ? rec.path.trim() : ''
             const startOffset = coerceNumber(rec.start_offset)
             const sizeBytes = coerceNumber(rec.size_bytes)
             const flags = coerceNumber(rec.flags)
-            if (!path || startOffset == null || sizeBytes == null || flags == null) continue
+            if (!path || startOffset == null || sizeBytes == null || flags == null) {
+                if (strictFileRecords) return null
+                continue
+            }
             fileRecords.push({
                 path,
                 start_offset: startOffset,
@@ -576,8 +612,8 @@ function normalizeSlabMetadata(value: unknown): SlabMetadata | null {
     const dealId =
         typeof dealIdRaw === 'string'
             ? dealIdRaw.trim() || undefined
-            : typeof dealIdRaw === 'number'
-                ? Math.floor(dealIdRaw)
+            : typeof dealIdRaw === 'number' && Number.isSafeInteger(dealIdRaw) && dealIdRaw >= 0
+                ? dealIdRaw
                 : undefined
 
     const owner = typeof raw.owner === 'string' ? raw.owner.trim() : undefined
@@ -613,6 +649,57 @@ export async function readSlabMetadata(dealId: string): Promise<SlabMetadata | n
         return normalizeSlabMetadata(parsed)
     } catch {
         return null
+    }
+}
+
+async function readSlabMetadataFromDirectory(dir: FileSystemDirectoryHandle): Promise<SlabMetadata | null> {
+    const bytes = await readBlobFromDirectory(dir, SLAB_METADATA_FILE)
+    if (!bytes) return null
+    try {
+        return normalizeSlabMetadata(JSON.parse(new TextDecoder().decode(bytes)) as unknown, true)
+    } catch {
+        return null
+    }
+}
+
+async function readArtifactSizeFromDirectory(dir: FileSystemDirectoryHandle, name: string): Promise<number | null> {
+    const physicalSize = await readBlobSizeFromDirectory(dir, name)
+    if (physicalSize == null) return null
+    const fullSize = await readArtifactMetaFullSize(dir, name)
+    if (fullSize == null) return physicalSize
+    if (physicalSize > fullSize) throw new Error(`artifact bytes exceed fullSize: ${physicalSize} > ${fullSize}`)
+    return fullSize
+}
+
+/**
+ * Pins one immutable, root-bound generation directory for a cache decision.
+ * Every subsequent read uses this handle, so an active-generation swap cannot
+ * mix metadata from one generation with bytes from another.
+ */
+export async function openCompleteSlabGeneration(dealId: string): Promise<CompleteSlabGeneration | null> {
+    try {
+        const dealDir = await getDealDirectory(dealId, false)
+        const generationName = await readActiveGenerationName(dealDir)
+        if (!generationName) return null
+        const generationsDir = await getGenerationsDirectory(dealDir, false)
+        if (!generationsDir) return null
+        const dir = await generationsDir.getDirectoryHandle(generationName)
+        if (!(await generationLooksComplete(dir))) return null
+
+        const markerBytes = await readBlobFromDirectory(dir, GENERATION_COMPLETE_MARKER_FILE)
+        const manifestRoot = normalizeManifestRootString(new TextDecoder().decode(markerBytes || new Uint8Array()))
+        if (!/^0x(?:[0-9a-f]{64}|[0-9a-f]{96})$/.test(manifestRoot)) return null
+
+        return {
+            manifestRoot,
+            readManifestRoot: () => readManifestRootFromDirectory(dir),
+            readMetadata: () => readSlabMetadataFromDirectory(dir),
+            readMdu: (mduIndex) => readArtifactFromDirectory(dir, `mdu_${mduIndex}.bin`),
+            mduSize: (mduIndex) => readArtifactSizeFromDirectory(dir, `mdu_${mduIndex}.bin`),
+        }
+    } catch (e: unknown) {
+        if (isDomErrorName(e, 'NotFoundError')) return null
+        throw e
     }
 }
 

--- a/polystore-website/src/lib/storage/OpfsAdapter.ts
+++ b/polystore-website/src/lib/storage/OpfsAdapter.ts
@@ -533,6 +533,7 @@ async function readManifestRootFromDirectory(dir: FileSystemDirectoryHandle): Pr
 }
 
 function coerceNumber(value: unknown): number | null {
+    if (typeof value !== 'number' && (typeof value !== 'string' || !/^\d+$/.test(value))) return null
     const n = typeof value === 'number' ? value : Number(value)
     if (!Number.isSafeInteger(n) || n < 0) return null
     return n

--- a/polystore-website/src/lib/worker-client.ts
+++ b/polystore-website/src/lib/worker-client.ts
@@ -4,8 +4,9 @@
 // It abstracts the message passing and Promise-based communication.
 import { DEFAULT_EXPANSION_HARDWARE_CONCURRENCY, pickExpansionWorkerCount } from './expansionWorkers'
 import type { FrozenSession, PinnedGeneration } from './retrieval'
+import type { RecoveryGeometry } from './retrievalRecovery'
 import { readBoundedResponse } from './retrieval'
-import type { RetrievalEnvelope, verifyRetrievalMetadata } from './retrievalWire'
+import type { RetrievalEnvelope, RetrievalMetadataGeneration, verifyRetrievalMetadata } from './retrievalWire'
 import type { RetrievalOutputRequest } from './storage/retrievalOutput'
 import type { UserMduBrowserKzgResult, UserMduUncommittedExpansion } from './upload/userMduBrowserKzg'
 import { recommendedUserMduKzgBatchCapForWebGpuAdapter } from './upload/userMduKzgBatch'
@@ -423,15 +424,18 @@ export const workerClient = {
     const trustedSetupBytes = await readBoundedResponse(response, 807177, signal)
     await sendMessageToWorker('initRetrievalWasm', { trustedSetupBytes }, [trustedSetupBytes.buffer])
   },
-  async verifyRetrievalMetadata(bytes: Uint8Array, pin: PinnedGeneration): Promise<ReturnType<typeof verifyRetrievalMetadata>> {
+  async verifyRetrievalMetadata(bytes: Uint8Array, pin: RetrievalMetadataGeneration): Promise<ReturnType<typeof verifyRetrievalMetadata>> {
     // Metadata remains available to the caller for generation-specific storage.
     return sendMessageToWorker('verifyRetrievalMetadata', { bytes, pin }) as Promise<ReturnType<typeof verifyRetrievalMetadata>>
   },
   async verifyRetrievalWitness(bytes: Uint8Array, cell: Uint8Array): Promise<Uint8Array> {
     return sendMessageToWorker('verifyRetrievalWitness', { bytes, cell }, [bytes.buffer]) as Promise<Uint8Array>
   },
-  async readRetrievalCommitments(pin: PinnedGeneration, ordinal: bigint, witness: { index: bigint; bytes: Uint8Array }[], cell: Uint8Array): Promise<Uint8Array> {
+  async readRetrievalCommitments(pin: RecoveryGeometry, ordinal: bigint, witness: { index: bigint; bytes: Uint8Array }[], cell: Uint8Array): Promise<Uint8Array> {
     return sendMessageToWorker('readRetrievalCommitments', { pin, ordinal, witness, cell }, witness.map((w) => w.bytes.buffer)) as Promise<Uint8Array>
+  },
+  async verifyRetrievalMdu(pin: RecoveryGeometry, bytes: Uint8Array, commitments: Uint8Array): Promise<Uint8Array> {
+    return sendMessageToWorker('verifyRetrievalMdu', { pin, bytes, commitments }, [bytes.buffer, commitments.buffer]) as Promise<Uint8Array>
   },
   async reconstructRetrievalMdu(pin: PinnedGeneration, shards: (Uint8Array | null)[], commitments: Uint8Array): Promise<Uint8Array> {
     return sendMessageToWorker('reconstructRetrievalMdu', { pin, shards, commitments }, shards.flatMap((s) => s ? [s.buffer] : [])) as Promise<Uint8Array>

--- a/polystore-website/src/workers/gateway.worker.ts
+++ b/polystore-website/src/workers/gateway.worker.ts
@@ -366,6 +366,12 @@ self.onmessage = async (event) => {
                 result = readUserCommitments(payload.pin, payload.ordinal, payload.witness, payload.cell, polyStoreWasmInstance);
                 break;
             }
+            case 'verifyRetrievalMdu': {
+                if (!polyStoreWasmInstance) throw new Error('PolyStoreWasm not initialized');
+                verifyRecoveredMdu(payload.pin, payload.bytes, payload.commitments, polyStoreWasmInstance);
+                result = payload.bytes;
+                break;
+            }
             case 'reconstructRetrievalMdu': {
                 if (!polyStoreWasmInstance) throw new Error('PolyStoreWasm not initialized');
                 result = PolyStoreWasm.reconstruct_mdu_from_shards(payload.shards, payload.pin.k, payload.pin.m);

--- a/polystore-website/tests/deal-explorer-browser-download-network.spec.ts
+++ b/polystore-website/tests/deal-explorer-browser-download-network.spec.ts
@@ -25,8 +25,8 @@ test(`Deal Explorer: ${scenario} browser cache uses the correct download gate`, 
   const polystoreAddress = ethToPolystoreAddress(account.address)
 
   const dealId = '1'
-  const manifestRoot = `0x${'bb'.repeat(48)}`
-  const staleManifestRoot = `0x${'cc'.repeat(48)}`
+  const manifestRoot = `0x${'bb'.repeat(32)}`
+  const staleManifestRoot = `0x${'cc'.repeat(32)}`
   const filePath = 'browser-network.txt'
   const fileBytes = Buffer.from('hello browser network')
   const staleCachedBytes = Buffer.from('stale browser cache bytes')
@@ -54,6 +54,10 @@ test(`Deal Explorer: ${scenario} browser cache uses the correct download gate`, 
             owner: polystoreAddress,
             cid: manifestRoot,
             size: String(24 * 1024 * 1024),
+            total_mdus: '3',
+            witness_mdus: '1',
+            redundancy_mode: 2,
+            mode2_profile: { k: 8, m: 4 },
             escrow_balance: '1000000',
             end_block: '1000',
             providers: ['nil1provider'],
@@ -73,6 +77,10 @@ test(`Deal Explorer: ${scenario} browser cache uses the correct download gate`, 
           owner: polystoreAddress,
           manifest_root: Buffer.from(manifestRoot.slice(2), 'hex').toString('base64'),
           size: String(24 * 1024 * 1024),
+          total_mdus: '3',
+          witness_mdus: '1',
+          redundancy_mode: 2,
+          mode2_profile: { k: 8, m: 4 },
           escrow_balance: '1000000',
           end_block: '1000',
           providers: ['nil1provider'],
@@ -415,6 +423,18 @@ test(`Deal Explorer: ${scenario} browser cache uses the correct download gate`, 
 
   await page.goto(path)
 
+  // This browser test covers UI routing and downloaded bytes. Its tiny OPFS
+  // fixture deliberately mocks the worker boundary; cachedDownload.test.ts
+  // separately exercises the same path with production WASM commitments.
+  await page.evaluate(async ({ filePath, fileSize }) => {
+    const { workerClient } = await import('/src/lib/worker-client.ts')
+    workerClient.initRetrievalWasm = async () => {}
+    workerClient.verifyRetrievalMetadata = async () => [{ path: filePath, start_offset: 0n, size_bytes: BigInt(fileSize), timestamp: 0n, flags: 0 }]
+    workerClient.verifyRetrievalWitness = async (bytes) => bytes
+    workerClient.readRetrievalCommitments = async (pin) => new Uint8Array(pin.leafCount * 48)
+    workerClient.verifyRetrievalMdu = async (_pin, bytes) => bytes
+  }, { filePath, fileSize: fileBytes.length })
+
   if (!(await page.locator('[data-testid="wallet-address"], [data-testid="wallet-address-full"]').first().isVisible())) {
     await page.getByTestId('connect-wallet').first().click({ force: true })
     await expect(page.locator('[data-testid="wallet-address"], [data-testid="wallet-address-full"]').first()).toBeVisible()
@@ -457,7 +477,7 @@ test(`Deal Explorer: ${scenario} browser cache uses the correct download gate`, 
       await writeFile('manifest.bin', new Uint8Array([1]))
       await writeFile('slab_meta.json', JSON.stringify({
         schema_version: 1, generation_id: manifestRoot.slice(2), manifest_root: manifestRoot,
-        deal_id: dealId, owner, source: 'browser_mode1_commit', created_at: new Date().toISOString(),
+        deal_id: dealId, owner, source: 'browser_mode2_commit', created_at: new Date().toISOString(),
         witness_mdus: 1, user_mdus: 1, total_mdus: 3,
         file_records: [{ path: filePath, start_offset: 0, size_bytes: cachedBytes.length, flags: 0 }],
       }))

--- a/polystore-website/tests/deal-explorer-browser-download-network.spec.ts
+++ b/polystore-website/tests/deal-explorer-browser-download-network.spec.ts
@@ -14,7 +14,8 @@ function ethToPolystoreAddress(ethAddress: string): string {
   return bech32.encode('nil', words)
 }
 
-test('Deal Explorer: stale browser cache does not bypass required provider sync', async ({ page }) => {
+for (const scenario of ['stale', 'cached-unfunded', 'cached-unavailable'] as const) {
+test(`Deal Explorer: ${scenario} browser cache uses the correct download gate`, async ({ page }) => {
   test.setTimeout(180_000)
 
   const randomPk = generatePrivateKey()
@@ -82,9 +83,9 @@ test('Deal Explorer: stale browser cache does not bypass required provider sync'
 
   await page.route('**/cosmos/bank/v1beta1/balances/*', async (route) => {
     await route.fulfill({
-      status: 200,
+      status: scenario === 'cached-unavailable' ? 503 : 200,
       contentType: 'application/json',
-      body: JSON.stringify({ balances: [{ denom: 'stake', amount: '1000' }], pagination: { total: '1' } }),
+      body: JSON.stringify(scenario === 'cached-unavailable' ? { error: 'RPC unavailable' } : { balances: [{ denom: 'stake', amount: scenario === 'stale' ? '1000' : '0' }] }),
     })
   })
 
@@ -371,6 +372,7 @@ test('Deal Explorer: stale browser cache does not bypass required provider sync'
     const w = window as any
     if (w.ethereum) return
     let sendCount = 0
+    w.__browserNetworkSendCount = 0
     w.ethereum = {
       isMetaMask: true,
       selectedAddress: address,
@@ -390,6 +392,7 @@ test('Deal Explorer: stale browser cache does not bypass required provider sync'
             return computeResult
           case 'eth_sendTransaction':
             sendCount += 1
+            w.__browserNetworkSendCount = sendCount
             return sendCount % 2 === 1 ? txOpen : txConfirm
           default:
             return null
@@ -419,7 +422,7 @@ test('Deal Explorer: stale browser cache does not bypass required provider sync'
 
   // Seed OPFS with a stale manifest root and stale browser file cache. The default Download
   // path must ignore this stale local cache and fetch the current bytes from the network.
-  await page.evaluate(async ({ dealId, manifestRoot, filePath, cachedBytes }) => {
+  await page.evaluate(async ({ dealId, manifestRoot, filePath, cachedBytes, scenario, owner }) => {
     async function sha256Hex(text: string): Promise<string> {
       const encoded = new TextEncoder().encode(text)
       const digest = await crypto.subtle.digest('SHA-256', encoded)
@@ -429,7 +432,12 @@ test('Deal Explorer: stale browser cache does not bypass required provider sync'
     }
 
     const root = await navigator.storage.getDirectory()
-    const dealDir = await root.getDirectoryHandle(`deal-${dealId}`, { create: true })
+    let dealDir = await root.getDirectoryHandle(`deal-${dealId}`, { create: true })
+    const outerDir = dealDir
+    if (scenario !== 'stale') {
+      const generations = await dealDir.getDirectoryHandle('generations', { create: true })
+      dealDir = await generations.getDirectoryHandle('gen-browser-test', { create: true })
+    }
     const writeFile = async (name: string, bytes: Uint8Array | string) => {
       const h = await dealDir.getFileHandle(name, { create: true })
       const w = await (h as any).createWritable()
@@ -437,13 +445,47 @@ test('Deal Explorer: stale browser cache does not bypass required provider sync'
       await w.close()
     }
     await writeFile('manifest_root.txt', manifestRoot)
-    const cacheName = `filecache_${await sha256Hex(filePath)}.bin`
-    await writeFile(cacheName, new Uint8Array(cachedBytes as number[]))
-  }, { dealId, manifestRoot: staleManifestRoot, filePath, cachedBytes: [...staleCachedBytes] })
+    if (scenario === 'stale') {
+      const cacheName = `filecache_${await sha256Hex(filePath)}.bin`
+      await writeFile(cacheName, new Uint8Array(cachedBytes))
+    } else {
+      const mdu = new Uint8Array(8 * 1024 * 1024)
+      mdu.set(cachedBytes, 32 - cachedBytes.length)
+      await writeFile('mdu_0.bin', new Uint8Array(8 * 1024 * 1024))
+      await writeFile('mdu_1.bin', new Uint8Array(8 * 1024 * 1024))
+      await writeFile('mdu_2.bin', mdu)
+      await writeFile('manifest.bin', new Uint8Array([1]))
+      await writeFile('slab_meta.json', JSON.stringify({
+        schema_version: 1, generation_id: manifestRoot.slice(2), manifest_root: manifestRoot,
+        deal_id: dealId, owner, source: 'browser_mode1_commit', created_at: new Date().toISOString(),
+        witness_mdus: 1, user_mdus: 1, total_mdus: 3,
+        file_records: [{ path: filePath, start_offset: 0, size_bytes: cachedBytes.length, flags: 0 }],
+      }))
+      await writeFile('.generation_complete', manifestRoot)
+      dealDir = outerDir
+      await writeFile('active_generation.txt', 'gen-browser-test')
+    }
+  }, { dealId, manifestRoot: scenario === 'stale' ? staleManifestRoot : manifestRoot, filePath,
+    cachedBytes: [...(scenario === 'stale' ? staleCachedBytes : fileBytes)], scenario, owner: polystoreAddress })
 
   await page.getByTestId(`deal-row-${dealId}`).click()
   await expect(page.getByTestId('deal-detail')).toBeVisible({ timeout: 60_000 })
 
+  if (scenario !== 'stale') {
+    await expect(page.getByTestId('wallet-balance-unavailable')).toContainText(scenario === 'cached-unfunded' ? 'Fund your wallet' : 'Wallet balance temporarily unavailable')
+    await expect(page.getByTestId('retrieval-availability')).toBeVisible()
+    const button = page.locator(`[data-testid="deal-detail-download"][data-file-path="${filePath}"]`)
+    await expect(button).toBeEnabled()
+    const downloaded = page.waitForEvent('download')
+    await button.click()
+    const stream = await (await downloaded).createReadStream()
+    const chunks: Buffer[] = []
+    for await (const chunk of stream!) chunks.push(Buffer.from(chunk))
+    expect(Buffer.concat(chunks)).toEqual(fileBytes)
+    expect(fetchCalls).toBe(0)
+    expect(await page.evaluate(() => (window as any).__browserNetworkSendCount)).toBe(0)
+    return
+  }
   await expect(page.getByTestId('deal-index-sync-panel')).toBeVisible({ timeout: 60_000 })
   await expect(page.getByTestId('deal-index-sync-panel')).toContainText('Deal Index Required')
   await expect(page.getByTestId('deal-index-sync-panel')).toContainText(/stale|missing/i)
@@ -451,3 +493,5 @@ test('Deal Explorer: stale browser cache does not bypass required provider sync'
   expect(listFilesCalls).toBe(0)
   expect(fetchCalls).toBe(0)
 })
+
+}


### PR DESCRIPTION
A balance RPC outage could hide the entire dashboard as if the wallet were empty, and Download stayed disabled when secured network retrieval was inactive even if the browser retained the committed file.

The dashboard now preserves access to existing files while distinguishing an unavailable balance from a confirmed zero. Download can use a complete atomic Mode 2 slab generation only when the chain supplies exact current geometry. It pins one generation directory, authenticates MDU0 and its FAT against the committed root, authenticates the required witness MDU, checks each selected user MDU against the authenticated commitments, and decodes those exact verified bytes. Any mismatch falls back to the existing secured retrieval gate. A cache hit creates no payment or ACK and preserves existing settlement checkpoints.

The listing check remains advisory and cheap: it opens and parses one metadata snapshot and checks required artifact sizes without reading payload MDUs. Mode 1, legacy completion markers, incomplete or stale generations, altered metadata, malformed geometry, unsupported file flags, and ownership mismatches fail closed.

Validation:
- 29 focused unit and production-WASM tests passed, including same-size user-MDU corruption, mutated FAT, mutated witness, generation replacement, partial/stale cache, exact ownership and layout checks, network fallback, and pending-settlement preservation.
- The production-WASM cached-download integration authenticated two 8 MiB user MDUs and returned 8,126,468 decoded bytes. The measured cache-read phase was 15,175.5 ms: 79.1 ms MDU0, 72.5 ms witness, 1.0 ms commitment extraction, and 15,008.7 ms user-MDU verification. Fixture construction and WASM startup were outside this measurement.
- The advisory availability regression performs zero payload reads and one metadata parse for a file listing.
- TypeScript, focused ESLint, and the production app build passed.
- Three Playwright cases passed in installed Chrome: stale cache rejection, a confirmed-zero wallet, and an unavailable balance RPC. The two valid cache cases intentionally mock the worker boundary for UI coverage and assert downloaded-byte equality, zero wallet transactions, and zero provider fetches; the separate unit integration uses the production WASM verifier.

This PR does not activate v3 retrieval or change on-chain proof/payment rules.
