### PR TITLE
Fix FATv3 audits and add a native chain proof diagnostic

### DIFF
--- a/bench/retrieval_session_capacity/native-k8-290/README.md
+++ b/bench/retrieval_session_capacity/native-k8-290/README.md
@@ -140,3 +140,36 @@ proof-submission transactions (6,736 openings) with normal audits. At the final
 16/s offered step, 88 offers hit the bounded queue; its consensus-header-time
 window recorded 8.8 bundles/s. This is a single-host, 30-second-per-step result,
 not a production-capacity or byte-delivery qualification.
+
+## Native v3 production-route pilot
+
+The fixed `native-v3-providers` mode is a finite same-path diagnostic for the
+sampled large-session protocol. It uploads exactly 16 MiB through FAT v3,
+admits the generation through all twelve provider HTTP routes, opens two native
+sessions with U=133 and Q=132, and asks the eight systematic providers to submit
+one provider-batched proof transaction for each session. It records the sixteen
+committed transaction messages and gas, 264 newly accepted bitmap ordinals,
+normal audits, and expiry/refund cleanup. It never sends an owner ACK because it
+does not download and verify the file bytes. HTTP duration combines proof
+generation, local verification, gas simulation, signing, broadcast, and commit
+observation; it is neither pure proof-generation time nor chain capacity.
+
+Run only from reviewed, landed source with separately frozen Linux runtime
+hashes and a new private home:
+
+```sh
+python3 scripts/retrieval_four_validator_workload.py \
+  --mode native-v3-providers --audit-profile normal --timeout 600 \
+  --binary "$RETRIEVAL_BIN/polystorechaind" \
+  --library "$RETRIEVAL_LIBRARY" \
+  --gateway-binary "$RETRIEVAL_BIN/polystore_gateway" \
+  --cli-binary "$RETRIEVAL_BIN/polystore_cli" \
+  --product-source "$RETRIEVAL_REPO" \
+  --home "$RETRIEVAL_RUNS/native-v3-16m-pilot-001"
+```
+
+The pilot keeps v3 disabled by default and enables it only in its isolated test
+genesis. A retained result can establish production-route correctness and a
+bounded offered/committed diagnostic. A longer reviewed profile is required
+before quoting stable throughput, and delivered-file performance remains a
+separate measurement.

--- a/bench/retrieval_session_capacity/native-k8-290/README.md
+++ b/bench/retrieval_session_capacity/native-k8-290/README.md
@@ -154,8 +154,10 @@ does not download and verify the file bytes. HTTP duration combines proof
 generation, local verification, gas simulation, signing, broadcast, and commit
 observation; it is neither pure proof-generation time nor chain capacity.
 
-Run only from reviewed, landed source with separately frozen Linux runtime
-hashes and a new private home:
+A bounded pre-merge correctness smoke may run from an exact independently
+reviewed head with separately frozen Linux runtime hashes and a new private
+home. It is not retained performance evidence. Retained performance collection
+requires the harness to be reviewed and landed:
 
 ```sh
 python3 scripts/retrieval_four_validator_workload.py \

--- a/polystore_gateway/system_audit_v2.go
+++ b/polystore_gateway/system_audit_v2.go
@@ -502,7 +502,11 @@ func runFrozenSystemLiveness(ctx context.Context, height uint64, snapshot *syste
 		if err != nil {
 			return err
 		}
-		dir, err := resolveDealDirForDeal(c.DealID, root, root.Canonical)
+		// Frozen proof generation leases the selected generation and authenticates
+		// its root table, witness commitments, and selected shard. Avoid the legacy
+		// slab-metadata fallback here: a sparse FAT v3 provider has those exact
+		// artifacts but intentionally has no gateway-authored slab sidecar.
+		dir, err := lookupDealGeneration(c.DealID, root, root.Canonical)
 		if err != nil {
 			snapshot.MissingDataSkips++
 			snapshot.LastError = err.Error()

--- a/polystore_gateway/system_audit_v2_test.go
+++ b/polystore_gateway/system_audit_v2_test.go
@@ -341,6 +341,144 @@ func TestFrozenSystemProofNativeGenerationAndDomains(t *testing.T) {
 	}
 }
 
+func TestSystemAuditFATV3SparseProviderArtifacts(t *testing.T) {
+	for caseIndex, name := range []string{"valid", "corrupt_metadata", "corrupt_witness", "corrupt_shard"} {
+		t.Run(name, func(t *testing.T) {
+			submissionTestDB(t)
+			initCryptoForTest(t)
+			dealID := uint64(1200 + caseIndex)
+			payloadPath := filepath.Join(t.TempDir(), "payload.bin")
+			if err := os.WriteFile(payloadPath, bytes.Repeat([]byte{byte(0x50 + caseIndex)}, 4096), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			result, dir, err := mode2BuildArtifactsWithOptions(t.Context(), payloadPath, dealID, "General:rs=8+4", "payload.bin", 0, mode2BuildOptions{fatVersion: 3})
+			if err != nil {
+				t.Fatal(err)
+			}
+			// A provider bundle carries authenticated metadata and its assigned
+			// shards, without the uploader's local slab sidecar or publication marker.
+			for _, path := range []string{slabMetadataPathForDealDir(dir), filepath.Join(dir, mode2SlabCompleteMarker), activeDealGenerationPointerPath(dealID)} {
+				if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+					t.Fatal(err)
+				}
+			}
+			shards, err := filepath.Glob(filepath.Join(dir, "mdu_*_slot_*.bin"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, path := range shards {
+				if !strings.HasSuffix(path, "_slot_0.bin") {
+					if err := os.Remove(path); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+
+			view, _, signer := systemAuditFixture(t, retrievalchallenge.Audit)
+			view.EpochLength = 2
+			view.Audit.EpochId = 6
+			view.Audit.Assignment.DealId = dealID
+			view.Audit.Assignment.ManifestRoot = bytes.Clone(result.manifestRoot.Bytes[:])
+			view.Audit.Assignment.Snapshot.MetadataMdus = 1 + result.witnessMdus
+			view.Audit.Assignment.Snapshot.UserMdus = result.userMdus
+			c, err := types.StorageAuditContext(*view.Audit, view.EpochLength)
+			if err != nil {
+				t.Fatal(err)
+			}
+			view.CanonicalContext, _ = c.Bytes()
+			challenges, err := c.Challenges(view.Seed)
+			if err != nil {
+				t.Fatal(err)
+			}
+			flip := func(path string, offset int64) {
+				t.Helper()
+				f, err := os.OpenFile(path, os.O_RDWR, 0)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer f.Close()
+				var original [1]byte
+				if _, err := f.ReadAt(original[:], offset); err != nil {
+					t.Fatal(err)
+				}
+				original[0] ^= 0xff
+				if _, err := f.WriteAt(original[:], offset); err != nil {
+					t.Fatal(err)
+				}
+			}
+			switch name {
+			case "corrupt_metadata":
+				flip(filepath.Join(dir, "mdu_0.bin"), 17)
+			case "corrupt_witness":
+				flip(filepath.Join(dir, "mdu_1.bin"), 1)
+			case "corrupt_shard":
+				challenge := challenges[0]
+				offset := int64(uint64(challenge.LeafIndex)%uint64(64/c.K)*types.BLOB_SIZE + 17)
+				flip(filepath.Join(dir, fmt.Sprintf("mdu_%d_slot_0.bin", challenge.MDUIndex)), offset)
+			}
+
+			t.Setenv("POLYSTORE_PROVIDER_ADDRESS", "")
+			committed, commands := false, 0
+			hash := strings.Repeat("F", 64)
+			setupMockCombinedOutput(t, func(_ context.Context, _ string, args ...string) ([]byte, error) {
+				if args[0] == "keys" {
+					return []byte(signer), nil
+				}
+				commands++
+				if name != "valid" {
+					t.Fatal("corrupted provider artifact reached broadcast", args)
+				}
+				raw, err := os.ReadFile(args[5])
+				if err != nil {
+					t.Fatal(err)
+				}
+				var proof types.ChainedProof
+				if err := json.Unmarshal(raw, &proof); err != nil {
+					t.Fatal(err)
+				}
+				expected, err := c.ChallengeForPosition(view.Seed, proof.MduIndex, proof.BlobIndex)
+				if err != nil || !bytes.Equal(expected.Z[:], proof.ZValue) {
+					t.Fatal("producer sent wrong fresh challenge", err)
+				}
+				view.Audit.Coverage[expected.Ordinal/8] |= 1 << (expected.Ordinal % 8)
+				view.Audit.AcceptedCount++
+				committed = true
+				return []byte(fmt.Sprintf(`{"code":0,"txhash":%q}`, hash)), nil
+			})
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				height := "11"
+				if committed {
+					height = "12"
+				}
+				w.Header().Set(committedHeightHeader, height)
+				if strings.Contains(r.URL.Path, "/txs/") {
+					fmt.Fprintf(w, `{"tx_response":{"txhash":%q,"height":"12","code":0}}`, hash)
+					return
+				}
+				response := types.QueryListStorageAuditsByProviderResponse{Audits: []types.StorageAuditView{view}}
+				if err := (&jsonpb.Marshaler{OrigName: true, EmitDefaults: true}).Marshal(w, &response); err != nil {
+					t.Error(err)
+				}
+			}))
+			defer srv.Close()
+			oldLCD := lcdBase
+			lcdBase = srv.URL
+			t.Cleanup(func() { lcdBase = oldLCD })
+			var snapshot systemLivenessSnapshot
+			if err := runFrozenSystemLiveness(context.Background(), 11, &snapshot); err != nil {
+				t.Fatal(err)
+			}
+			if name == "valid" {
+				if commands != 1 || snapshot.ProofsSubmitted != 1 || snapshot.ProofGenFailures != 0 {
+					t.Fatal(commands, snapshot)
+				}
+			} else if commands != 0 || snapshot.ProofGenFailures != 1 || snapshot.LastError == "" {
+				t.Fatal(commands, snapshot)
+			}
+		})
+	}
+}
+
 func TestSystemAuditActivatedDispatchUsesOnlyFrozenInventory(t *testing.T) {
 	submissionTestDB(t)
 	_, _, signer := systemAuditFixture(t, retrievalchallenge.Audit)

--- a/scripts/retrieval_bench_artifact.py
+++ b/scripts/retrieval_bench_artifact.py
@@ -1327,7 +1327,7 @@ class FourValidatorLifecycle:
                 reservation.bind(("127.0.0.1", node[name]))
                 reservation.listen(1)
 
-    def prepare(self, *, audit_profile="normal", provider_count=12):
+    def prepare(self, *, audit_profile="normal", provider_count=12, enable_retrieval_v3=False):
         if audit_profile not in ("normal", "c6"):
             raise ValueError("unknown benchmark audit profile")
         provider_count = integer(provider_count, "provider signer count", 12, 44)
@@ -1357,6 +1357,10 @@ class FourValidatorLifecycle:
         if "retrieval_v2_activation_height" not in params:
             raise ValueError("binary genesis does not expose v2 activation")
         params["retrieval_v2_activation_height"] = "1"
+        if enable_retrieval_v3:
+            if "retrieval_v3_activation_height" not in params:
+                raise ValueError("binary genesis does not expose v3 activation")
+            params["retrieval_v3_activation_height"] = "1"
         if audit_profile == "c6":
             params.update(quota_min_blobs="132", quota_max_blobs="132")
         metadata = genesis["app_state"]["bank"].setdefault("denom_metadata", [])
@@ -1425,7 +1429,9 @@ class FourValidatorLifecycle:
                                            start_new_session=True)
             self.processes.append(process)
             self.doc["validator_resources"].append({"pid": process.pid, "node_id": node["node_id"],
-                "phase": phase, "peak_rss_bytes": None, "source": "wait4 ru_maxrss"})
+                "phase": phase, "peak_rss_bytes": None, "user_cpu_seconds": None,
+                "system_cpu_seconds": None, "measurement_scope": "whole validator process lifetime",
+                "source": "wait4 rusage"})
 
     def poll_validator(self, process):
         # wait4 is the sole reaper: Popen.poll/wait would discard per-child peak
@@ -1441,6 +1447,9 @@ class FourValidatorLifecycle:
                 return process.returncode
             if pid:
                 process.returncode = os.waitstatus_to_exitcode(status)
+                record["measurement_scope"] = "whole validator process lifetime"
+                record["user_cpu_seconds"] = usage.ru_utime
+                record["system_cpu_seconds"] = usage.ru_stime
                 system = platform.system()
                 if system in ("Darwin", "Linux") and usage.ru_maxrss > 0:
                     record["peak_rss_bytes"] = int(usage.ru_maxrss) * (1 if system == "Darwin" else 1024)

--- a/scripts/retrieval_four_validator_workload.py
+++ b/scripts/retrieval_four_validator_workload.py
@@ -44,6 +44,7 @@ V3_PILOT_SESSIONS = 2
 V3_MAX_SAMPLES = 132
 V3_BITMAP_BYTES = (V3_MAX_SAMPLES + 7) // 8
 V3_SYSTEMATIC_PROVIDERS = 8
+V3_PROVIDER_AUTH_TOKEN = "healthy-diagnostic-owned-local-stack"
 V3_PREFLIGHT_FREE_BYTES = 2 * 1024**3
 V3_ABORT_FREE_BYTES = 768 * 1024**2
 
@@ -154,7 +155,7 @@ def validate_v3_provider_outcomes(rows, providers, *, session_id):
         count = producer.uint(row.get("proof_count", 0))
         txhash = row.get("tx_hash", "")
         if (row.get("status") != "success" or row.get("http_status") != 200 or
-                row.get("session_id") != session_id or
+                row.get("session_id") != "0x" + session_id or
                 row.get("cleanup_status") != "complete" or slot >= V3_SYSTEMATIC_PROVIDERS or
                 providers.get(slot) != row.get("provider") or not 1 <= count <= 64 or
                 not isinstance(txhash, str) or not re.fullmatch(r"[0-9a-fA-F]{64}", txhash) or
@@ -224,7 +225,7 @@ def run_v3_http_phase(lifecycle, curl, requests, phase, *, max_in_flight):
         result = artifact.run_bounded_command([
             curl, "--silent", "--show-error", "--max-time", str(request.get("timeout_seconds", 180)),
             "--request", "POST", "--header", "Content-Type: application/json",
-            "--header", "Authorization: Bearer healthy-diagnostic-owned-local-stack",
+            "--header", "X-PolyStore-Gateway-Auth: " + V3_PROVIDER_AUTH_TOKEN,
             "--data", json.dumps(request["body"], separators=(",", ":")),
             "--max-filesize", str(1024 * 1024), "--output", str(path),
             "--write-out", "%{http_code}", request["url"],
@@ -1925,7 +1926,7 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
                 POLYSTORE_FAST_INGEST="0", POLYSTORE_FAST_SHARD="0", POLYSTORE_MODE2_ENCODE_PARALLELISM="1", POLYSTORE_MODE2_UPLOAD_PARALLELISM="2",
                 POLYSTORE_GATEWAY_UPLOAD_TIMEOUT_SECONDS="180", POLYSTORE_CMD_TIMEOUT_SECONDS="30",
                 POLYSTORE_SHARD_TIMEOUT_SECONDS="180", POLYSTORE_MODE2_UPLOAD_TASK_TIMEOUT_SECONDS="60",
-                POLYSTORE_GATEWAY_SP_AUTH="healthy-diagnostic-owned-local-stack")
+                POLYSTORE_GATEWAY_SP_AUTH=V3_PROVIDER_AUTH_TOKEN)
             reservations[i].close()
             if (artifact.sha256(gateway) != doc["provenance"]["gateway_sha256"] or
                     artifact.sha256(cli) != doc["provenance"]["cli_sha256"]):

--- a/scripts/retrieval_four_validator_workload.py
+++ b/scripts/retrieval_four_validator_workload.py
@@ -44,6 +44,25 @@ V3_PILOT_SESSIONS = 2
 V3_MAX_SAMPLES = 132
 V3_BITMAP_BYTES = (V3_MAX_SAMPLES + 7) // 8
 V3_SYSTEMATIC_PROVIDERS = 8
+V3_PREFLIGHT_FREE_BYTES = 2 * 1024**3
+V3_ABORT_FREE_BYTES = 768 * 1024**2
+
+
+def require_free_disk(path, minimum, phase):
+    free = shutil.disk_usage(path).free
+    if free < minimum:
+        raise ValueError(f"{phase} requires {minimum} free bytes; found {free}")
+    return free
+
+
+def provider_http_url(lifecycle, address, route):
+    matches = [row for row in lifecycle.doc.get("providers", []) if row.get("address") == address]
+    if len(matches) != 1:
+        raise ValueError("provider address does not identify exactly one owned daemon")
+    port = producer.uint(matches[0].get("port", 0))
+    if not 1 <= port <= 65535 or not route.startswith("/"):
+        raise ValueError("owned provider daemon has an invalid HTTP endpoint")
+    return f"http://127.0.0.1:{port}{route}"
 
 
 def v3_bitmap_ordinals(session):
@@ -94,7 +113,7 @@ def validate_v3_session(response, *, session_id, deal_id, owner, providers, nonc
             session.get("chain_id") != chain_id or
             producer.b64(session.get("polyfs_root", ""), 32).hex() != polyfs_root or
             producer.b64(session.get("integrity_root", ""), 32).hex() != integrity_root or
-            not any(producer.b64(session.get("setup_digest", ""), 32)) or
+            producer.b64(session.get("setup_digest", ""), 32).hex() != producer.SETUP_DIGEST or
             not any(producer.b64(session.get("plan_hash", ""), 32)) or
             bool(session.get("expired", False)) is not expired):
         raise ValueError("v3 session differs from the fixed pilot authority")
@@ -189,6 +208,7 @@ def run_v3_http_phase(lifecycle, curl, requests, phase, *, max_in_flight):
     if (not requests or not 1 <= max_in_flight <= 12 or
             len({row["provider"] for row in requests}) != len(requests)):
         raise ValueError("v3 HTTP phase requires distinct provider signers")
+    require_free_disk(lifecycle.home, V3_ABORT_FREE_BYTES, phase)
     directory = lifecycle.home / "v3-http"
     directory.mkdir(mode=0o700, exist_ok=True)
     started = artifact.monotonic_ns()
@@ -227,25 +247,30 @@ def run_v3_http_phase(lifecycle, curl, requests, phase, *, max_in_flight):
                     request_started_ns=began, request_finished_ns=artifact.monotonic_ns(),
                     stderr=result.stderr[-8192:], curl_returncode=result.returncode)
 
+    errors = []
     with ThreadPoolExecutor(max_workers=max_in_flight) as executor:
-        pending = {executor.submit(execute, index, request) for index, request in enumerate(requests)}
+        pending = {executor.submit(execute, index, request): request
+                   for index, request in enumerate(requests)}
         while pending:
-            done, pending = wait_futures(pending, timeout=1, return_when=FIRST_COMPLETED)
+            done, _ = wait_futures(pending, timeout=1, return_when=FIRST_COMPLETED)
             now = artifact.monotonic_ns()
             for future in done:
+                request = pending.pop(future)
                 try:
                     row = future.result()
                 except BaseException as error:
-                    retained.append(dict(status="driver_error", error=str(error)[-8192:],
-                                         request_finished_ns=now))
+                    row = dict(status="driver_error", provider=request["provider"],
+                               error=str(error)[-8192:], request_finished_ns=now)
+                    retained.append(row)
+                    errors.append(error)
                     lifecycle.save()
-                    raise
+                    continue
                 completed.append(row)
                 retained.append(row)
                 lifecycle.save()
                 last_progress = now
-            if now - last_progress >= 600 * 10**9:
-                raise TimeoutError(f"{phase} made no progress for 600 seconds")
+            if not errors and now - last_progress >= 600 * 10**9:
+                errors.append(TimeoutError(f"{phase} made no progress for 600 seconds"))
             if now - last_heartbeat >= 60 * 10**9:
                 heartbeat = dict(
                     phase=phase, completed=len(completed), total=len(requests),
@@ -254,7 +279,14 @@ def run_v3_http_phase(lifecycle, curl, requests, phase, *, max_in_flight):
                 lifecycle.save()
                 print(json.dumps(heartbeat, sort_keys=True), flush=True)
                 last_heartbeat = now
-            lifecycle.remaining()
+            if not errors:
+                try:
+                    lifecycle.remaining()
+                    require_free_disk(lifecycle.home, V3_ABORT_FREE_BYTES, phase)
+                except BaseException as error:
+                    errors.append(error)
+    if errors:
+        raise errors[0]
     heartbeat = dict(
         phase=phase, completed=len(completed), total=len(requests),
         elapsed_ns=artifact.monotonic_ns() - started, seconds_since_progress=0)
@@ -265,6 +297,8 @@ def run_v3_http_phase(lifecycle, curl, requests, phase, *, max_in_flight):
 
 
 def v3_session_query(lifecycle, session_id, height=None):
+    if height is None:
+        height = lifecycle.wait_height(1)
     encoded = base64.urlsafe_b64encode(bytes.fromhex(session_id)).decode()
     route = API + "/retrieval-sessions-v3/" + encoded
     rows = [lifecycle.query(node, route, height) for node in lifecycle.nodes]
@@ -275,6 +309,8 @@ def v3_session_query(lifecycle, session_id, height=None):
 
 def v3_retained_generations(lifecycle, *, deal_id, root, height=None):
     """Record the all-validator retention union without attributing its source."""
+    if height is None:
+        height = lifecycle.wait_height(1)
     rows = [lifecycle.query(node, API + "/retained-generations", height) for node in lifecycle.nodes]
     if any(row != rows[0] for row in rows[1:]):
         raise ValueError("four validators disagree on retained generations")
@@ -383,6 +419,8 @@ def run_native_v3_sessions(lifecycle, *, deal, providers, send, wait, curl):
     doc["retained_generations_before_sessions"] = v3_retained_generations(
         lifecycle, deal_id=deal["id"], root=polyfs_root)
     sessions = []
+    doc["sessions"] = sessions
+    lifecycle.save()
     for nonce in range(1, V3_PILOT_SESSIONS + 1):
         path = lifecycle.home / f"v3-open-{nonce}.json"
         message = dict(creator=owner, deal_id=str(deal["id"]), generation="1",
@@ -407,7 +445,8 @@ def run_native_v3_sessions(lifecycle, *, deal, providers, send, wait, curl):
         row["before_proofs"] = before
     capture_workload_metrics(lifecycle, "native_v3_before_proofs", fenced=True)
     for row in sessions:
-        requests = [dict(provider=providers[slot], url=f"http://127.0.0.1:{19091 + slot}/sp/session-proof",
+        requests = [dict(provider=providers[slot],
+                         url=provider_http_url(lifecycle, providers[slot], "/sp/session-proof"),
                          body=dict(session_id=row["session_id"]))
                     for slot in range(V3_SYSTEMATIC_PROVIDERS)]
         outcomes = run_v3_http_phase(lifecycle, curl, requests,
@@ -457,7 +496,7 @@ def run_native_v3_sessions(lifecycle, *, deal, providers, send, wait, curl):
         lifecycle.save()
     doc["retained_generations_after_refund"] = v3_retained_generations(
         lifecycle, deal_id=deal["id"], root=polyfs_root)
-    doc.update(sessions=sessions, offered_proof_transactions=16,
+    doc.update(offered_proof_transactions=16,
                committed_valid_proof_transactions=sum(len(row["proof_transactions"]) for row in sessions),
                authoritative_new_sample_ordinals=sum(len(row["accepted_sample_ordinals"]) for row in sessions),
                logical_bytes_per_session=V3_PILOT_BYTES, sample_population=133,
@@ -489,7 +528,7 @@ def admit_native_v3_generation(lifecycle, *, uploaded, deal_id, providers, send,
     proposed["validators"] = verify_transaction_nodes(lifecycle, proposed)
     lifecycle.wait_height(proposed["height"] + 1)
     requests = [dict(provider=providers[slot],
-                     url=f"http://127.0.0.1:{19091 + slot}/sp/generation-v3/accept",
+                     url=provider_http_url(lifecycle, providers[slot], "/sp/generation-v3/accept"),
                      body=dict(deal_id=producer.uint(deal_id), provider=providers[slot]))
                 for slot in range(12)]
     outcomes = run_v3_http_phase(lifecycle, curl, requests, "generation-acceptance", max_in_flight=12)
@@ -1744,6 +1783,10 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
     curl = shutil.which("curl")
     if not curl:
         raise ValueError("curl is required for bounded multipart upload")
+    preflight_free = None
+    if native_v3:
+        preflight_free = require_free_disk(lifecycle.home.parent, V3_PREFLIGHT_FREE_BYTES,
+                                           "native v3 preflight")
     lifecycle.home.mkdir(mode=0o700)
     processes, reservations = [], []
     previous = {sig: signal.getsignal(sig) for sig in (signal.SIGTERM, signal.SIGINT)}
@@ -1753,6 +1796,10 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
         signal.signal(sig, interrupted)
     doc = lifecycle.doc
     doc.pop("transactions_submitted", None)
+    if native_v3:
+        doc["disk_guard"] = dict(preflight_free_bytes=preflight_free,
+                                 preflight_minimum_bytes=V3_PREFLIGHT_FREE_BYTES,
+                                 runtime_minimum_bytes=V3_ABORT_FREE_BYTES)
     doc.update(mode="four-validator-native-v3-provider-diagnostic" if native_v3 else "four-validator-healthy-provider-diagnostic",
         setup_transactions=[], providers=[],
         workload=("one 16 MiB FAT v3 K8 deal; twelve production provider-daemons; two preopened native sessions"
@@ -1761,13 +1808,21 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
             ("Provider HTTP durations combine proof generation, gas simulation, signing, broadcast, and commit observation"
              if native_v3 else "No deputy retrieval yet"),
             "Normal mint and audit parameters retained; no economic conservation assertion", "No restart qualification"])
+    def check_disk(phase):
+        if native_v3:
+            free = require_free_disk(lifecycle.home, V3_ABORT_FREE_BYTES, phase)
+            doc["disk_guard"]["last_checked_free_bytes"] = free
+            doc["disk_guard"]["last_checked_phase"] = phase
+        return None
     def command(args, timeout=60):
         lifecycle.remaining()
+        check_disk("command")
         result = artifact.run_bounded_command(args, min(lifecycle.deadline, artifact.monotonic_ns() + timeout * 10**9), env=lifecycle.env)
         if result.returncode:
             raise ValueError("owned diagnostic command failed: " + (result.stderr + result.stdout)[-8192:])
         return result.stdout
     def send(name, args):
+        check_disk("transaction")
         job = transaction_job(lifecycle, lifecycle.signers[name], args)
         result = artifact.scheduled_transaction(job)
         doc["setup_transactions"].append(dict(result, signer=job["signer"], submit=job["submit"]))
@@ -1783,9 +1838,24 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
             os.kill(process.pid, 0)
     def wait(height):
         # Keep provider failures visible while the validators advance.
+        started = last_heartbeat = last_progress = artifact.monotonic_ns()
+        previous_height = 0
         while True:
             check_providers()
+            check_disk("height wait")
             current = lifecycle.wait_height(1)
+            now = artifact.monotonic_ns()
+            if current > previous_height:
+                previous_height = current
+                last_progress = now
+            if now - last_heartbeat >= 60 * 10**9:
+                heartbeat = dict(phase="height-wait", current_height=current,
+                    target_height=height, elapsed_ns=now - started,
+                    seconds_since_progress=(now - last_progress) / 1e9)
+                doc.setdefault("progress", []).append(heartbeat)
+                lifecycle.save()
+                print(json.dumps(heartbeat, sort_keys=True), flush=True)
+                last_heartbeat = now
             if current >= height:
                 return current
             time.sleep(min(0.2, lifecycle.remaining()))

--- a/scripts/retrieval_four_validator_workload.py
+++ b/scripts/retrieval_four_validator_workload.py
@@ -2024,9 +2024,12 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
         epoch = (height - 1) // epoch_length + 2
         def audits(at, finalized, observed_epoch=None):
             selected_epoch = epoch if observed_epoch is None else observed_epoch
+            observation = dict(height=at, epoch=selected_epoch, finalized=finalized, nodes=[])
+            doc["current_audit_observation"] = observation
             rows = []
-            for node in lifecycle.nodes:
+            for node_index, node in enumerate(lifecycle.nodes):
                 values = []
+                observation["nodes"].append(dict(node_index=node_index, audits=values))
                 for address in providers.values():
                     values.extend(lifecycle.query(node, API + "/storage-audits/by-provider/" + address, at)["audits"])
                 checked = healthy_audit_views(values, deal, providers, selected_epoch, epoch_length, lifecycle.chain,

--- a/scripts/retrieval_four_validator_workload.py
+++ b/scripts/retrieval_four_validator_workload.py
@@ -1081,15 +1081,21 @@ def verify_transaction_nodes(lifecycle, result):
     if len(lifecycle.nodes) != 4 or len({node["node_id"] for node in lifecycle.nodes}) != 4:
         raise ValueError("four distinct validators required")
     expected = artifact.committed_tx(result, result["txhash"])
+    height = producer.uint(expected["height"])
+    # A node can report the committed transaction before its peers' transaction
+    # indexes expose it. Fence every validator, then read the authoritative block
+    # bytes/results rather than polling eventually consistent secondary indexes.
+    lifecycle.wait_height(height + 1)
     observed = []
     for node in lifecycle.nodes:
-        response = lifecycle.query(node, "/tx?hash=0x" + expected["txhash"])
-        raw = base64.b64decode(response["tx"], validate=True)
-        if not raw or len(raw) > 1048576 or hashlib.sha256(raw).hexdigest().upper() != expected["txhash"].upper():
-            raise ValueError("validator returned different committed transaction bytes")
-        row = dict(txhash=response["hash"], height=response["height"], **{
-            key: response["tx_result"].get(key, 0) if key == "code" else response["tx_result"][key]
-            for key in ("code", "gas_wanted", "gas_used")})
+        summary = artifact.committed_block_summary(
+            lifecycle.query(node, f"/block?height={height}"),
+            lifecycle.query(node, f"/block_results?height={height}"), height, lifecycle.chain)
+        matches = [tx for tx in summary["transactions"]
+                   if tx["txhash"].upper() == expected["txhash"].upper()]
+        if len(matches) != 1:
+            raise ValueError("validator block does not contain the exact committed transaction")
+        row = dict(matches[0], height=height)
         artifact.committed_tx(row, expected["txhash"])
         if any(producer.uint(row[key]) != producer.uint(expected[key]) for key in ("height", "code", "gas_wanted", "gas_used")):
             raise ValueError("validators disagree on committed transaction outcome/gas")

--- a/scripts/retrieval_four_validator_workload.py
+++ b/scripts/retrieval_four_validator_workload.py
@@ -45,6 +45,8 @@ V3_MAX_SAMPLES = 132
 V3_BITMAP_BYTES = (V3_MAX_SAMPLES + 7) // 8
 V3_SYSTEMATIC_PROVIDERS = 8
 V3_PROVIDER_AUTH_TOKEN = "healthy-diagnostic-owned-local-stack"
+V3_BUSY_MAX_ATTEMPTS = 4
+V3_BUSY_RETRY_SECONDS = 2
 V3_PREFLIGHT_FREE_BYTES = 2 * 1024**3
 V3_ABORT_FREE_BYTES = 768 * 1024**2
 
@@ -155,12 +157,16 @@ def validate_v3_provider_outcomes(rows, providers, *, session_id):
         count = producer.uint(row.get("proof_count", 0))
         txhash = row.get("tx_hash", "")
         if (row.get("status") != "success" or row.get("http_status") != 200 or
+                row.get("curl_returncode") != 0 or
                 row.get("session_id") != "0x" + session_id or
                 row.get("cleanup_status") != "complete" or slot >= V3_SYSTEMATIC_PROVIDERS or
                 providers.get(slot) != row.get("provider") or not 1 <= count <= 64 or
                 not isinstance(txhash, str) or not re.fullmatch(r"[0-9a-fA-F]{64}", txhash) or
                 slot in slots or txhash.upper() in hashes):
-            raise ValueError("v3 provider response is not a unique committed proof claim")
+            error = str(row.get("error", ""))[-512:]
+            raise ValueError(
+                f"v3 provider {row.get('provider')!r} response rejected: "
+                f"http_status={row.get('http_status')!r} status={row.get('status')!r} error={error!r}")
         slots.add(slot)
         hashes.add(txhash.upper())
         proofs += count
@@ -204,7 +210,8 @@ def opened_v3_session(result, *, logical_bytes=V3_PILOT_BYTES):
     return raw[sid_offset:sid_offset + 32].hex()
 
 
-def run_v3_http_phase(lifecycle, curl, requests, phase, *, max_in_flight):
+def run_v3_http_phase(lifecycle, curl, requests, phase, *, max_in_flight,
+                      retry_pre_admission_busy=False):
     """Run one bounded disjoint-signer HTTP phase and retain every outcome."""
     if (not requests or not 1 <= max_in_flight <= 12 or
             len({row["provider"] for row in requests}) != len(requests)):
@@ -213,40 +220,64 @@ def run_v3_http_phase(lifecycle, curl, requests, phase, *, max_in_flight):
     directory = lifecycle.home / "v3-http"
     directory.mkdir(mode=0o700, exist_ok=True)
     started = artifact.monotonic_ns()
+    phase_deadline = min(lifecycle.deadline,
+                         started + max(row.get("timeout_seconds", 180) for row in requests) * 10**9)
     last_heartbeat = started
     last_progress = started
     completed = []
     retained = lifecycle.doc.setdefault("v3_http_phases", {}).setdefault(phase, [])
 
     def execute(index, request):
-        path = directory / f"{phase}-{index}.json"
-        deadline = min(lifecycle.deadline, artifact.monotonic_ns() + request.get("timeout_seconds", 180) * 10**9)
-        began = artifact.monotonic_ns()
-        result = artifact.run_bounded_command([
-            curl, "--silent", "--show-error", "--max-time", str(request.get("timeout_seconds", 180)),
-            "--request", "POST", "--header", "Content-Type: application/json",
-            "--header", "X-PolyStore-Gateway-Auth: " + V3_PROVIDER_AUTH_TOKEN,
-            "--data", json.dumps(request["body"], separators=(",", ":")),
-            "--max-filesize", str(1024 * 1024), "--output", str(path),
-            "--write-out", "%{http_code}", request["url"],
-        ], deadline, env=lifecycle.env)
-        try:
-            with path.open("rb") as source:
-                raw = source.read(1024 * 1024 + 1)
-            if len(raw) > 1024 * 1024:
-                raise ValueError("v3 HTTP response exceeds 1 MiB")
-            body = json.loads(raw)
-            if not isinstance(body, dict):
-                raise ValueError("v3 HTTP response must be a JSON object")
-        finally:
-            path.unlink(missing_ok=True)
-        try:
-            code = producer.uint(result.stdout.strip())
-        except ValueError as error:
-            raise ValueError("v3 HTTP request did not return a status code") from error
-        return dict(body, http_status=code, provider=request["provider"],
-                    request_started_ns=began, request_finished_ns=artifact.monotonic_ns(),
-                    stderr=result.stderr[-8192:], curl_returncode=result.returncode)
+        attempts = []
+        limit = V3_BUSY_MAX_ATTEMPTS if retry_pre_admission_busy else 1
+        request_deadline = min(phase_deadline,
+                               started + request.get("timeout_seconds", 180) * 10**9)
+        for attempt in range(1, limit + 1):
+            if attempt > 1:
+                if artifact.monotonic_ns() + V3_BUSY_RETRY_SECONDS * 10**9 >= request_deadline:
+                    break
+                time.sleep(V3_BUSY_RETRY_SECONDS)
+            path = directory / f"{phase}-{index}-{attempt}.json"
+            began = artifact.monotonic_ns()
+            try:
+                result = artifact.run_bounded_command([
+                    curl, "--silent", "--show-error", "--max-time", str(request.get("timeout_seconds", 180)),
+                    "--request", "POST", "--header", "Content-Type: application/json",
+                    "--header", "X-PolyStore-Gateway-Auth: " + V3_PROVIDER_AUTH_TOKEN,
+                    "--data", json.dumps(request["body"], separators=(",", ":")),
+                    "--max-filesize", str(1024 * 1024), "--output", str(path),
+                    "--write-out", "%{http_code}", request["url"],
+                ], request_deadline, env=lifecycle.env)
+                with path.open("rb") as source:
+                    raw = source.read(1024 * 1024 + 1)
+                if len(raw) > 1024 * 1024:
+                    raise ValueError("v3 HTTP response exceeds 1 MiB")
+                body = json.loads(raw)
+                if not isinstance(body, dict):
+                    raise ValueError("v3 HTTP response must be a JSON object")
+                try:
+                    code = producer.uint(result.stdout.strip())
+                except ValueError as error:
+                    raise ValueError("v3 HTTP request did not return a status code") from error
+                row = dict(body, http_status=code, provider=request["provider"], attempt=attempt,
+                           request_started_ns=began, request_finished_ns=artifact.monotonic_ns(),
+                           stderr=result.stderr[-8192:], curl_returncode=result.returncode)
+                attempts.append(row)
+                if result.returncode != 0:
+                    return attempts, ValueError(
+                        f"v3 HTTP request for provider {request['provider']!r} exited {result.returncode}")
+                busy = (code == 429 and set(body) == {"error", "hint"} and
+                        body.get("error") == "retrieval submission busy" and
+                        body.get("hint") == "retrieval submission capacity or signer busy")
+                if not retry_pre_admission_busy or not busy:
+                    return attempts, None
+            except BaseException as error:
+                attempts.append(dict(status="driver_error", provider=request["provider"], attempt=attempt,
+                                     error=str(error)[-8192:], request_finished_ns=artifact.monotonic_ns()))
+                return attempts, error
+            finally:
+                path.unlink(missing_ok=True)
+        return attempts, None
 
     errors = []
     with ThreadPoolExecutor(max_workers=max_in_flight) as executor:
@@ -257,17 +288,21 @@ def run_v3_http_phase(lifecycle, curl, requests, phase, *, max_in_flight):
             now = artifact.monotonic_ns()
             for future in done:
                 request = pending.pop(future)
+                future_error = None
                 try:
-                    row = future.result()
+                    attempts, future_error = future.result()
                 except BaseException as error:
-                    row = dict(status="driver_error", provider=request["provider"],
+                    attempts = [dict(status="driver_error", provider=request["provider"],
                                error=str(error)[-8192:], request_finished_ns=now)
-                    retained.append(row)
-                    errors.append(error)
+                    ]
+                    future_error = error
+                retained.extend(attempts)
+                if future_error is not None:
+                    errors.append(future_error)
                     lifecycle.save()
                     continue
+                row = attempts[-1]
                 completed.append(row)
-                retained.append(row)
                 lifecycle.save()
                 last_progress = now
             if not errors and now - last_progress >= 600 * 10**9:
@@ -451,7 +486,8 @@ def run_native_v3_sessions(lifecycle, *, deal, providers, send, wait, curl):
                          body=dict(session_id=row["session_id"]))
                     for slot in range(V3_SYSTEMATIC_PROVIDERS)]
         outcomes = run_v3_http_phase(lifecycle, curl, requests,
-                                     f"session-{row['nonce']}-proofs", max_in_flight=8)
+                                     f"session-{row['nonce']}-proofs", max_in_flight=8,
+                                     retry_pre_admission_busy=True)
         summary = validate_v3_provider_outcomes(outcomes, providers, session_id=row["session_id"])
         transactions = []
         for outcome in outcomes:
@@ -538,7 +574,8 @@ def admit_native_v3_generation(lifecycle, *, uploaded, deal_id, providers, send,
         slot = producer.uint(outcome.get("slot", 99))
         txhash = outcome.get("tx_hash", "")
         if (outcome.get("status") != "success" or outcome.get("cleanup_status") != "complete" or
-                outcome.get("http_status") != 200 or slot >= 12 or providers.get(slot) != outcome["provider"] or
+                outcome.get("http_status") != 200 or outcome.get("curl_returncode") != 0 or
+                slot >= 12 or providers.get(slot) != outcome["provider"] or
                 slot in seen or not re.fullmatch(r"[0-9a-fA-F]{64}", txhash)):
             raise ValueError("provider generation acceptance was not a unique committed success")
         seen.add(slot)

--- a/scripts/retrieval_four_validator_workload.py
+++ b/scripts/retrieval_four_validator_workload.py
@@ -23,6 +23,7 @@ import subprocess
 import sys
 import time
 import urllib.parse
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait as wait_futures
 
 import retrieval_bench_artifact as artifact
 import retrieval_commit_metrics as commit_metrics
@@ -38,6 +39,491 @@ OPEN_SESSION_PREPARATION_GAS = 400_000
 OPEN_SESSION_BATCH_BASE_GAS = 100_000
 OPEN_SESSION_BATCH_MAX = 64
 OPEN_SESSION_BATCH_GAS_CAP = OPEN_SESSION_BATCH_BASE_GAS + OPEN_SESSION_PREPARATION_GAS * OPEN_SESSION_BATCH_MAX
+V3_PILOT_BYTES = 16 * 1024 * 1024
+V3_PILOT_SESSIONS = 2
+V3_MAX_SAMPLES = 132
+V3_BITMAP_BYTES = (V3_MAX_SAMPLES + 7) // 8
+V3_SYSTEMATIC_PROVIDERS = 8
+
+
+def v3_bitmap_ordinals(session):
+    """Return authoritative accepted sample ordinals from one v3 query."""
+    count = producer.uint(session.get("sample_count", 0))
+    if not 1 <= count <= V3_MAX_SAMPLES:
+        raise ValueError("v3 session sample count is outside the protocol bound")
+    try:
+        bitmap = base64.b64decode(session["accepted_sample_bitmap"], validate=True)
+    except (KeyError, ValueError) as error:
+        raise ValueError("v3 session has invalid accepted sample bitmap") from error
+    if len(bitmap) != V3_BITMAP_BYTES or bitmap[-1] & 0xf0:
+        raise ValueError("v3 session has noncanonical accepted sample bitmap")
+    ordinals = [ordinal for ordinal in range(V3_MAX_SAMPLES)
+                if bitmap[ordinal // 8] & (1 << (ordinal % 8))]
+    if any(ordinal >= count for ordinal in ordinals):
+        raise ValueError("v3 bitmap accepts an ordinal beyond the frozen sample count")
+    return ordinals
+
+
+def validate_v3_session(response, *, session_id, deal_id, owner, providers, nonce,
+                        polyfs_root, integrity_root, chain_id, deadline_height,
+                        file_bytes=V3_PILOT_BYTES, expired=False, refunded=False):
+    """Fail closed on the v3 fields that define pilot claims and liabilities."""
+    session = response.get("session")
+    if not isinstance(session, dict):
+        raise ValueError("v3 session query is missing session state")
+    try:
+        got_id = base64.b64decode(session["session_id"], validate=True).hex()
+    except (KeyError, ValueError) as error:
+        raise ValueError("v3 session query has an invalid identity") from error
+    if (got_id != session_id or producer.uint(session.get("deal_id", 0)) != producer.uint(deal_id) or
+            session.get("owner") != owner or session.get("payer") != owner or
+            producer.uint(session.get("nonce", 0)) != nonce or
+            producer.uint(session.get("file_record_index", 1)) != 0 or
+            producer.uint(session.get("file_start_offset", 1)) != 0 or
+            producer.uint(session.get("file_length", 0)) != file_bytes or
+            producer.uint(session.get("range_start", 1)) != 0 or
+            producer.uint(session.get("range_length", 0)) != file_bytes or
+            producer.uint(session.get("generation", 0)) != 1 or
+            producer.uint(session.get("metadata_mdus", 0)) != 2 or
+            producer.uint(session.get("user_mdus", 0)) != 3 or
+            producer.uint(session.get("first_blob", 1)) != 0 or
+            producer.uint(session.get("last_blob", 0)) != 132 or
+            producer.uint(session.get("population", 0)) != 133 or
+            producer.uint(session.get("sample_count", 0)) != V3_MAX_SAMPLES or
+            producer.uint(session.get("deadline_height", 0)) != deadline_height or
+            session.get("chain_id") != chain_id or
+            producer.b64(session.get("polyfs_root", ""), 32).hex() != polyfs_root or
+            producer.b64(session.get("integrity_root", ""), 32).hex() != integrity_root or
+            not any(producer.b64(session.get("setup_digest", ""), 32)) or
+            not any(producer.b64(session.get("plan_hash", ""), 32)) or
+            bool(session.get("expired", False)) is not expired):
+        raise ValueError("v3 session differs from the fixed pilot authority")
+    obligations = session.get("obligations")
+    if not isinstance(obligations, list) or len(obligations) != V3_SYSTEMATIC_PROVIDERS:
+        raise ValueError("v3 session must bind all eight systematic providers")
+    slots = []
+    for obligation in obligations:
+        slot = producer.uint(obligation.get("slot", 99))
+        if (slot >= V3_SYSTEMATIC_PROVIDERS or obligation.get("assigned_provider") != providers.get(slot) or
+                obligation.get("payee") != providers.get(slot) or
+                producer.uint(obligation.get("blob_count", 0)) == 0):
+            raise ValueError("v3 session obligation differs from the finalized assignment")
+        slots.append(slot)
+    if (slots != list(range(V3_SYSTEMATIC_PROVIDERS)) or
+            sum(producer.uint(row["blob_count"]) for row in obligations) != 133):
+        raise ValueError("v3 systematic obligations must be ordered and unique")
+    ordinals = v3_bitmap_ordinals(session)
+    if refunded and not expired:
+        raise ValueError("v3 session cannot be refunded before expiry")
+    expected_mask = (1 << V3_SYSTEMATIC_PROVIDERS) - 1
+    if (producer.uint(session.get("refunded_slots_mask", 0)) != (expected_mask if refunded else 0) or
+            producer.uint(session.get("settled_slots_mask", 0)) != 0 or
+            producer.uint(session.get("acked_slots_mask", 0)) != 0 or
+            (producer.uint(session.get("locked_fee", 0), 256) == 0) is not refunded):
+        raise ValueError("unacknowledged v3 session has inconsistent settlement liabilities")
+    return session, ordinals
+
+
+def validate_v3_provider_outcomes(rows, providers, *, session_id):
+    """Validate one production proof wave without treating HTTP as chain authority."""
+    if len(rows) != V3_SYSTEMATIC_PROVIDERS:
+        raise ValueError("v3 proof wave must contact all eight systematic providers")
+    slots, hashes = set(), set()
+    proofs = 0
+    for row in rows:
+        slot = producer.uint(row.get("slot", 99))
+        count = producer.uint(row.get("proof_count", 0))
+        txhash = row.get("tx_hash", "")
+        if (row.get("status") != "success" or row.get("http_status") != 200 or
+                row.get("session_id") != session_id or
+                row.get("cleanup_status") != "complete" or slot >= V3_SYSTEMATIC_PROVIDERS or
+                providers.get(slot) != row.get("provider") or not 1 <= count <= 64 or
+                not isinstance(txhash, str) or not re.fullmatch(r"[0-9a-fA-F]{64}", txhash) or
+                slot in slots or txhash.upper() in hashes):
+            raise ValueError("v3 provider response is not a unique committed proof claim")
+        slots.add(slot)
+        hashes.add(txhash.upper())
+        proofs += count
+    if slots != set(range(V3_SYSTEMATIC_PROVIDERS)):
+        raise ValueError("v3 proof wave omitted a systematic provider")
+    return dict(unique_tx_hashes=sorted(hashes), proof_count=proofs,
+                slot_count=len(slots), payees=[providers[slot] for slot in sorted(slots)])
+
+
+def _encode_varint(value):
+    if type(value) is not int or value < 0 or value > (1 << 64) - 1:
+        raise ValueError("protobuf integer outside uint64")
+    out = bytearray()
+    while value >= 128:
+        out.append((value & 0x7f) | 0x80)
+        value >>= 7
+    out.append(value)
+    return bytes(out)
+
+
+def opened_v3_session(result, *, logical_bytes=V3_PILOT_BYTES):
+    """Decode the exact native v3 open response retained in a committed tx."""
+    data = result.get("data", "")
+    if (result.get("outcome") != "committed_success" or not isinstance(data, str) or
+            len(data) > 2048 or len(data) % 2 or not re.fullmatch(r"[0-9a-fA-F]+", data)):
+        raise ValueError("invalid committed v3 open response")
+    raw = bytes.fromhex(data)
+    expected_type = b"/polystorechain.polystorechain.v1.MsgOpenRetrievalSessionV3Response"
+    suffix = (b"\x10" + _encode_varint(logical_bytes) +
+              b"\x18" + _encode_varint(133 * artifact.ENCODED_BLOB_BYTES) +
+              b"\x20" + _encode_varint(V3_MAX_SAMPLES))
+    response = b"\x0a\x20" + bytes(32) + suffix
+    any_value = (b"\x0a" + _encode_varint(len(expected_type)) + expected_type +
+                 b"\x12" + _encode_varint(len(response)) + response)
+    expected = b"\x12" + _encode_varint(len(any_value)) + any_value
+    sid_offset = len(expected) - len(suffix) - 32
+    if (len(raw) != len(expected) or raw[:sid_offset] != expected[:sid_offset] or
+            raw[sid_offset + 32:] != expected[sid_offset + 32:] or
+            not any(raw[sid_offset:sid_offset + 32])):
+        raise ValueError("v3 open response differs from the fixed pilot geometry")
+    return raw[sid_offset:sid_offset + 32].hex()
+
+
+def run_v3_http_phase(lifecycle, curl, requests, phase, *, max_in_flight):
+    """Run one bounded disjoint-signer HTTP phase and retain every outcome."""
+    if (not requests or not 1 <= max_in_flight <= 12 or
+            len({row["provider"] for row in requests}) != len(requests)):
+        raise ValueError("v3 HTTP phase requires distinct provider signers")
+    directory = lifecycle.home / "v3-http"
+    directory.mkdir(mode=0o700, exist_ok=True)
+    started = artifact.monotonic_ns()
+    last_heartbeat = started
+    last_progress = started
+    completed = []
+    retained = lifecycle.doc.setdefault("v3_http_phases", {}).setdefault(phase, [])
+
+    def execute(index, request):
+        path = directory / f"{phase}-{index}.json"
+        deadline = min(lifecycle.deadline, artifact.monotonic_ns() + request.get("timeout_seconds", 180) * 10**9)
+        began = artifact.monotonic_ns()
+        result = artifact.run_bounded_command([
+            curl, "--silent", "--show-error", "--max-time", str(request.get("timeout_seconds", 180)),
+            "--request", "POST", "--header", "Content-Type: application/json",
+            "--header", "Authorization: Bearer healthy-diagnostic-owned-local-stack",
+            "--data", json.dumps(request["body"], separators=(",", ":")),
+            "--max-filesize", str(1024 * 1024), "--output", str(path),
+            "--write-out", "%{http_code}", request["url"],
+        ], deadline, env=lifecycle.env)
+        try:
+            with path.open("rb") as source:
+                raw = source.read(1024 * 1024 + 1)
+            if len(raw) > 1024 * 1024:
+                raise ValueError("v3 HTTP response exceeds 1 MiB")
+            body = json.loads(raw)
+            if not isinstance(body, dict):
+                raise ValueError("v3 HTTP response must be a JSON object")
+        finally:
+            path.unlink(missing_ok=True)
+        try:
+            code = producer.uint(result.stdout.strip())
+        except ValueError as error:
+            raise ValueError("v3 HTTP request did not return a status code") from error
+        return dict(body, http_status=code, provider=request["provider"],
+                    request_started_ns=began, request_finished_ns=artifact.monotonic_ns(),
+                    stderr=result.stderr[-8192:], curl_returncode=result.returncode)
+
+    with ThreadPoolExecutor(max_workers=max_in_flight) as executor:
+        pending = {executor.submit(execute, index, request) for index, request in enumerate(requests)}
+        while pending:
+            done, pending = wait_futures(pending, timeout=1, return_when=FIRST_COMPLETED)
+            now = artifact.monotonic_ns()
+            for future in done:
+                try:
+                    row = future.result()
+                except BaseException as error:
+                    retained.append(dict(status="driver_error", error=str(error)[-8192:],
+                                         request_finished_ns=now))
+                    lifecycle.save()
+                    raise
+                completed.append(row)
+                retained.append(row)
+                lifecycle.save()
+                last_progress = now
+            if now - last_progress >= 600 * 10**9:
+                raise TimeoutError(f"{phase} made no progress for 600 seconds")
+            if now - last_heartbeat >= 60 * 10**9:
+                heartbeat = dict(
+                    phase=phase, completed=len(completed), total=len(requests),
+                    elapsed_ns=now - started, seconds_since_progress=(now - last_progress) / 1e9)
+                lifecycle.doc.setdefault("progress", []).append(heartbeat)
+                lifecycle.save()
+                print(json.dumps(heartbeat, sort_keys=True), flush=True)
+                last_heartbeat = now
+            lifecycle.remaining()
+    heartbeat = dict(
+        phase=phase, completed=len(completed), total=len(requests),
+        elapsed_ns=artifact.monotonic_ns() - started, seconds_since_progress=0)
+    lifecycle.doc.setdefault("progress", []).append(heartbeat)
+    lifecycle.save()
+    print(json.dumps(heartbeat, sort_keys=True), flush=True)
+    return sorted(completed, key=lambda row: row["provider"])
+
+
+def v3_session_query(lifecycle, session_id, height=None):
+    encoded = base64.urlsafe_b64encode(bytes.fromhex(session_id)).decode()
+    route = API + "/retrieval-sessions-v3/" + encoded
+    rows = [lifecycle.query(node, route, height) for node in lifecycle.nodes]
+    if any(row != rows[0] for row in rows[1:]):
+        raise ValueError("four validators disagree on v3 session state")
+    return rows[0]
+
+
+def v3_retained_generations(lifecycle, *, deal_id, root, height=None):
+    """Record the all-validator retention union without attributing its source."""
+    rows = [lifecycle.query(node, API + "/retained-generations", height) for node in lifecycle.nodes]
+    if any(row != rows[0] for row in rows[1:]):
+        raise ValueError("four validators disagree on retained generations")
+    expected = dict(deal_id=str(deal_id), generation="1",
+                    manifest_root=base64.b64encode(bytes.fromhex(root)).decode())
+    if expected not in rows[0].get("generations", []):
+        raise ValueError("active v3 generation is absent from the retention union")
+    return rows[0]
+
+
+def validate_v3_committed_message(message, *, kind, creator, slot, deal_id=None,
+                                  session_id=None, proof_count=None):
+    """Bind a committed hash to the one native message the HTTP route intended."""
+    expected_type = {
+        "generation-acceptance": "/polystorechain.polystorechain.v1.MsgAcceptDealGenerationV3",
+        "session-proof": "/polystorechain.polystorechain.v1.MsgSubmitRetrievalSessionProofV3",
+    }.get(kind)
+    if expected_type is None or message.get("@type") != expected_type or message.get("creator") != creator or producer.uint(message.get("slot", 99)) != slot:
+        raise ValueError("committed HTTP transaction message differs from route intent")
+    if kind == "generation-acceptance":
+        if producer.uint(message.get("deal_id", 0)) != producer.uint(deal_id) or not any(producer.b64(message.get("acceptance_digest", ""), 32)):
+            raise ValueError("committed generation acceptance differs from frozen intent")
+        return []
+    if producer.b64(message.get("session_id", ""), 32).hex() != session_id:
+        raise ValueError("committed proof transaction targets the wrong session")
+    proofs = message.get("proofs")
+    if not isinstance(proofs, list) or len(proofs) != proof_count or not 1 <= len(proofs) <= 64:
+        raise ValueError("committed proof count differs from provider response")
+    ordinals = [producer.uint(proof.get("ordinal", V3_MAX_SAMPLES)) for proof in proofs]
+    if len(set(ordinals)) != len(ordinals) or any(value >= V3_MAX_SAMPLES for value in ordinals):
+        raise ValueError("committed proof transaction has duplicate or out-of-range ordinals")
+    return ordinals
+
+
+def committed_v3_http_tx(lifecycle, row, *, kind, creator, slot, deal_id=None,
+                         session_id=None, proof_count=None):
+    """Bind an HTTP result to exact committed bytes and all four validators."""
+    txhash = row["tx_hash"].upper()
+    response = lifecycle.query(lifecycle.nodes[0], "/tx?hash=0x" + txhash)
+    result = dict(txhash=response["hash"], height=response["height"],
+                  code=response["tx_result"].get("code", 0),
+                  gas_wanted=response["tx_result"]["gas_wanted"],
+                  gas_used=response["tx_result"]["gas_used"],
+                  raw_log=response["tx_result"].get("log", ""),
+                  outcome="committed_success" if not response["tx_result"].get("code", 0) else "committed_failure")
+    artifact.committed_tx(result, txhash)
+    result["validators"] = verify_transaction_nodes(lifecycle, result)
+    decoded = json.loads(lifecycle.cli(lifecycle.nodes[0]["home"], "query", "tx", txhash, "--output", "json"))
+    messages = decoded.get("tx", {}).get("body", {}).get("messages", [])
+    if len(messages) != 1:
+        raise ValueError("committed HTTP transaction must contain exactly one message")
+    result["ordinals"] = validate_v3_committed_message(messages[0], kind=kind, creator=creator,
+        slot=slot, deal_id=deal_id, session_id=session_id, proof_count=proof_count)
+    return result
+
+
+def validate_v3_candidate(value, *, deal_id):
+    candidate = value.get("generation_candidate")
+    if not isinstance(candidate, dict):
+        raise ValueError("FAT v3 upload omitted the generation candidate")
+    roots = []
+    for name in ("polyfs_root", "integrity_root"):
+        raw = candidate.get(name, "")
+        if not isinstance(raw, str) or len(raw) != 66 or not raw.startswith("0x"):
+            raise ValueError("FAT v3 candidate has an invalid root")
+        roots.append(bytes.fromhex(raw[2:]))
+    if (not all(any(root) for root in roots) or
+            [producer.uint(candidate.get(name, 0)) for name in (
+                "deal_id", "expected_current_generation", "size_bytes", "total_mdus",
+                "witness_mdus", "integrity_leaf_count")] !=
+            [producer.uint(deal_id), 0, V3_PILOT_BYTES, 5, 1, 288] or
+            candidate.get("previous_polyfs_root", "") not in ("", "0x") or
+            candidate.get("commit_action") != "propose-deal-generation-v3" or
+            producer.uint(candidate.get("required_acceptances", 0)) != 12):
+        raise ValueError("FAT v3 candidate differs from the fixed pilot geometry")
+    return candidate
+
+
+def validate_v3_generation(response, candidate, providers, *, owner, admitted):
+    value = response.get("admitted" if admitted else "pending")
+    if not isinstance(value, dict) or response.get("pending" if admitted else "admitted"):
+        raise ValueError("v3 generation query has the wrong admission state")
+    if ([producer.uint(value.get(name, 0)) for name in (
+            "deal_id", "generation", "size", "total_mdus", "witness_mdus",
+            "metadata_mdus", "user_mdus", "integrity_leaf_count", "accepted_slots_mask")] !=
+            [producer.uint(candidate["deal_id"]), 1, V3_PILOT_BYTES, 5, 1, 2, 3, 288,
+             4095] or
+            value.get("owner") != owner or
+            producer.b64(value.get("polyfs_root", ""), 32).hex() != candidate["polyfs_root"][2:] or
+            producer.b64(value.get("integrity_root", ""), 32).hex() != candidate["integrity_root"][2:] or
+            value.get("providers") != [providers[index] for index in range(12)]):
+        raise ValueError("v3 generation authority differs from the accepted candidate")
+    return value
+
+
+def run_native_v3_sessions(lifecycle, *, deal, providers, send, wait, curl):
+    """Two real preopened sessions; production providers generate and submit proofs."""
+    doc = lifecycle.doc.setdefault("native_v3", {})
+    owner = lifecycle.signers["owner0"]
+    opened_at = lifecycle.wait_height(3)
+    deadline_height = opened_at + 180
+    if deadline_height >= producer.uint(deal["end_block"]):
+        raise ValueError("v3 pilot session deadline reaches the deal end")
+    polyfs_root = producer.b64(deal["manifest_root"], 32).hex()
+    integrity_root = lifecycle.doc["native_v3_generation"]["candidate"]["integrity_root"][2:]
+    doc["retained_generations_before_sessions"] = v3_retained_generations(
+        lifecycle, deal_id=deal["id"], root=polyfs_root)
+    sessions = []
+    for nonce in range(1, V3_PILOT_SESSIONS + 1):
+        path = lifecycle.home / f"v3-open-{nonce}.json"
+        message = dict(creator=owner, deal_id=str(deal["id"]), generation="1",
+            range=dict(file_record_index=0, file_start_offset="0", file_length=str(V3_PILOT_BYTES),
+                       range_start="0", range_length=str(V3_PILOT_BYTES)),
+            nonce=str(nonce), deadline_height=str(deadline_height))
+        with path.open("x") as output:
+            json.dump(message, output, separators=(",", ":"))
+        result = send("owner0", ["retrieval-session-v3", "open", str(path)])
+        result["validators"] = verify_transaction_nodes(lifecycle, result)
+        sid = opened_v3_session(result)
+        sessions.append(dict(session_id=sid, nonce=nonce, open_transaction=result))
+        lifecycle.save()
+    wait(max(row["open_transaction"]["height"] for row in sessions) + 2)
+    for row in sessions:
+        before = v3_session_query(lifecycle, row["session_id"])
+        _, ordinals = validate_v3_session(before, session_id=row["session_id"], deal_id=deal["id"],
+            owner=owner, providers=providers, nonce=row["nonce"], polyfs_root=polyfs_root,
+            integrity_root=integrity_root, chain_id=lifecycle.chain, deadline_height=deadline_height)
+        if ordinals or before.get("anchor_seed", "") in ("", None):
+            raise ValueError("preopened v3 session lacks an anchor or starts with accepted samples")
+        row["before_proofs"] = before
+    capture_workload_metrics(lifecycle, "native_v3_before_proofs", fenced=True)
+    for row in sessions:
+        requests = [dict(provider=providers[slot], url=f"http://127.0.0.1:{19091 + slot}/sp/session-proof",
+                         body=dict(session_id=row["session_id"]))
+                    for slot in range(V3_SYSTEMATIC_PROVIDERS)]
+        outcomes = run_v3_http_phase(lifecycle, curl, requests,
+                                     f"session-{row['nonce']}-proofs", max_in_flight=8)
+        summary = validate_v3_provider_outcomes(outcomes, providers, session_id=row["session_id"])
+        transactions = []
+        for outcome in outcomes:
+            transaction = committed_v3_http_tx(lifecycle, outcome, kind="session-proof",
+                creator=outcome["provider"], slot=producer.uint(outcome["slot"]),
+                session_id=row["session_id"], proof_count=producer.uint(outcome["proof_count"]))
+            if transaction["outcome"] != "committed_success":
+                raise ValueError("provider reported success for a failed v3 proof transaction")
+            transactions.append(transaction)
+        at = max(producer.uint(tx["height"]) for tx in transactions)
+        wait(at + 1)
+        after = v3_session_query(lifecycle, row["session_id"], at)
+        _, accepted = validate_v3_session(after, session_id=row["session_id"], deal_id=deal["id"],
+            owner=owner, providers=providers, nonce=row["nonce"], polyfs_root=polyfs_root,
+            integrity_root=integrity_root, chain_id=lifecycle.chain, deadline_height=deadline_height)
+        tx_ordinals = sorted(ordinal for tx in transactions for ordinal in tx["ordinals"])
+        if accepted != tx_ordinals or len(accepted) != V3_MAX_SAMPLES or summary["proof_count"] != V3_MAX_SAMPLES:
+            raise ValueError("committed v3 proof messages do not equal authoritative bitmap deltas")
+        row.update(provider_outcomes=outcomes, outcome_summary=summary,
+                   proof_transactions=transactions, committed_height=at,
+                   accepted_sample_ordinals=accepted)
+        lifecycle.save()
+    capture_workload_metrics(lifecycle, "native_v3_after_proofs", fenced=True)
+    wait(deadline_height + 2)
+    for row in sessions:
+        expired = v3_session_query(lifecycle, row["session_id"])
+        validate_v3_session(expired, session_id=row["session_id"], deal_id=deal["id"], owner=owner,
+                            providers=providers, nonce=row["nonce"], polyfs_root=polyfs_root,
+                            integrity_root=integrity_root, chain_id=lifecycle.chain,
+                            deadline_height=deadline_height, expired=True)
+        if expired.get("anchor_seed", "") not in ("", None):
+            raise ValueError("expired v3 session retained its anchor")
+        row["expired_before_refund"] = expired
+        refunded = send("owner0", ["retrieval-session-v3", "refund", str(_write_v3_refund(lifecycle, owner, row["session_id"]))])
+        refunded["validators"] = verify_transaction_nodes(lifecycle, refunded)
+        wait(refunded["height"] + 1)
+        after = v3_session_query(lifecycle, row["session_id"], refunded["height"])
+        validate_v3_session(after, session_id=row["session_id"], deal_id=deal["id"], owner=owner,
+                            providers=providers, nonce=row["nonce"], polyfs_root=polyfs_root,
+                            integrity_root=integrity_root, chain_id=lifecycle.chain,
+                            deadline_height=deadline_height, expired=True, refunded=True)
+        row.update(refund_transaction=refunded, after_refund=after)
+        lifecycle.save()
+    doc["retained_generations_after_refund"] = v3_retained_generations(
+        lifecycle, deal_id=deal["id"], root=polyfs_root)
+    doc.update(sessions=sessions, offered_proof_transactions=16,
+               committed_valid_proof_transactions=sum(len(row["proof_transactions"]) for row in sessions),
+               authoritative_new_sample_ordinals=sum(len(row["accepted_sample_ordinals"]) for row in sessions),
+               logical_bytes_per_session=V3_PILOT_BYTES, sample_population=133,
+               samples_per_session=V3_MAX_SAMPLES, delivery_verified=False, owner_acknowledged=False,
+               qualification=False, timing_scope="provider HTTP includes proof generation, local verification, gas simulation, signing, broadcast and commit observation",
+               retention_limit="normal audits retain the same generation, so retained-generation union cannot independently attribute session reference release")
+    lifecycle.save()
+
+
+def _write_v3_refund(lifecycle, owner, session_id):
+    path = lifecycle.home / ("v3-refund-" + session_id + ".json")
+    with path.open("x") as output:
+        json.dump(dict(creator=owner, session_id=base64.b64encode(bytes.fromhex(session_id)).decode()),
+                  output, separators=(",", ":"))
+    return path
+
+
+def admit_native_v3_generation(lifecycle, *, uploaded, deal_id, providers, send, curl):
+    """Use only the owner CLI and production provider admission routes."""
+    candidate = validate_v3_candidate(uploaded, deal_id=deal_id)
+    owner = lifecycle.signers["owner0"]
+    proposed = send("owner0", ["propose-deal-generation-v3", "--deal-id", deal_id,
+        "--expected-current-generation", candidate["expected_current_generation"],
+        "--previous-polyfs-root", candidate["previous_polyfs_root"],
+        "--polyfs-root", candidate["polyfs_root"], "--integrity-root", candidate["integrity_root"],
+        "--size", candidate["size_bytes"], "--total-mdus", candidate["total_mdus"],
+        "--witness-mdus", candidate["witness_mdus"],
+        "--integrity-leaf-count", candidate["integrity_leaf_count"]])
+    proposed["validators"] = verify_transaction_nodes(lifecycle, proposed)
+    lifecycle.wait_height(proposed["height"] + 1)
+    requests = [dict(provider=providers[slot],
+                     url=f"http://127.0.0.1:{19091 + slot}/sp/generation-v3/accept",
+                     body=dict(deal_id=producer.uint(deal_id), provider=providers[slot]))
+                for slot in range(12)]
+    outcomes = run_v3_http_phase(lifecycle, curl, requests, "generation-acceptance", max_in_flight=12)
+    seen, transactions = set(), []
+    for outcome in outcomes:
+        slot = producer.uint(outcome.get("slot", 99))
+        txhash = outcome.get("tx_hash", "")
+        if (outcome.get("status") != "success" or outcome.get("cleanup_status") != "complete" or
+                outcome.get("http_status") != 200 or slot >= 12 or providers.get(slot) != outcome["provider"] or
+                slot in seen or not re.fullmatch(r"[0-9a-fA-F]{64}", txhash)):
+            raise ValueError("provider generation acceptance was not a unique committed success")
+        seen.add(slot)
+        tx = committed_v3_http_tx(lifecycle, outcome, kind="generation-acceptance",
+                                  creator=outcome["provider"], slot=slot, deal_id=deal_id)
+        if tx["outcome"] != "committed_success":
+            raise ValueError("provider reported success for failed generation acceptance")
+        transactions.append(tx)
+    if seen != set(range(12)):
+        raise ValueError("generation admission omitted a provider")
+    height = max(producer.uint(tx["height"]) for tx in transactions)
+    lifecycle.wait_height(height + 1)
+    pending = lifecycle.query(lifecycle.nodes[0], API + f"/deals/{deal_id}/generation-v3", height)
+    validate_v3_generation(pending, candidate, providers, owner=owner, admitted=False)
+    finalized = send("owner0", ["finalize-deal-generation-v3", "--deal-id", deal_id,
+                                "--generation", "1", "--polyfs-root", candidate["polyfs_root"]])
+    finalized["validators"] = verify_transaction_nodes(lifecycle, finalized)
+    lifecycle.wait_height(finalized["height"] + 1)
+    admitted = lifecycle.query(lifecycle.nodes[0], API + f"/deals/{deal_id}/generation-v3", finalized["height"])
+    validate_v3_generation(admitted, candidate, providers, owner=owner, admitted=True)
+    lifecycle.doc["native_v3_generation"] = dict(candidate=candidate, proposal_transaction=proposed,
+        provider_outcomes=outcomes, acceptance_transactions=transactions,
+        finalize_transaction=finalized, admitted=admitted)
+    lifecycle.save()
+    return candidate, finalized["height"]
 
 
 def mode2_layout(k, deputy_count=8):
@@ -149,6 +635,19 @@ def require_retrieval_cli(lifecycle):
         except (ValueError, OSError) as error:
             raise ValueError(f"#257 compatible CLI required: {command}: {error}") from error
     lifecycle.doc["retrieval_cli_capabilities"] = required
+
+
+def require_v3_cli(lifecycle):
+    required = {
+        "retrieval-session-v3": ("open", "prove", "refund"),
+        "propose-deal-generation-v3": ("--integrity-root", "--integrity-leaf-count"),
+        "finalize-deal-generation-v3": ("--generation", "--polyfs-root"),
+    }
+    for command, tokens in required.items():
+        help_text = lifecycle.cli(lifecycle.home, "tx", "nilchain", command, "--help")
+        if any(token not in help_text for token in (command, *tokens)):
+            raise ValueError("native v3 compatible CLI required: " + command)
+    lifecycle.doc["retrieval_v3_cli_capabilities"] = required
 
 
 def smoke_genesis(lifecycle):
@@ -779,7 +1278,8 @@ def run(lifecycle, fixture_k8, fixture_k2, *, proof_only=False):
     return lifecycle.home / "evidence.json"
 
 
-def healthy_audit_views(value, deal, providers, epoch, epoch_length, chain, *, finalized, expected_samples=None, k=2):
+def healthy_audit_views(value, deal, providers, epoch, epoch_length, chain, *, finalized,
+                        expected_samples=None, k=2, user_mdus=1):
     """Check committed inventory/coverage without treating absent audits as success."""
     layout = mode2_layout(k)
     found = {}
@@ -795,12 +1295,12 @@ def healthy_audit_views(value, deal, providers, epoch, epoch_length, chain, *, f
                 producer.uint(assignment.get("deal_start", 0)) != producer.uint(deal.get("start_block", 0)) or
                 assignment["manifest_root"] != deal["manifest_root"] or producer.uint(assignment["kind"]) != 2 or
                 snapshot["chain_id"] != chain or producer.uint(snapshot["generation"]) != producer.uint(deal["current_gen"]) or
-                [producer.uint(snapshot[n]) for n in ("layout", "k", "m", "metadata_mdus", "user_mdus")] != [2, k, layout["m"], 2, 1] or
+                [producer.uint(snapshot[n]) for n in ("layout", "k", "m", "metadata_mdus", "user_mdus")] != [2, k, layout["m"], 2, user_mdus] or
                 snapshot["setup_digest"] != base64.b64encode(bytes.fromhex(producer.SETUP_DIGEST)).decode() or
                 producer.uint(snapshot["deal_end"]) != producer.uint(deal["end_block"])):
             raise ValueError(f"audit differs from the committed K{k} assignment")
         count = producer.uint(audit["sample_count"])
-        if not 1 <= count <= layout["openings_per_bundle"] or (expected_samples is not None and count != expected_samples):
+        if not 1 <= count <= user_mdus * layout["openings_per_bundle"] or (expected_samples is not None and count != expected_samples):
             raise ValueError("invalid audit sample count")
         coverage = producer.b64(audit["coverage"], (count + 7) // 8)
         accepted = producer.uint(audit.get("accepted_count", 0))
@@ -813,7 +1313,7 @@ def healthy_audit_views(value, deal, providers, epoch, epoch_length, chain, *, f
             context_id="00" * 32, deal_id=producer.uint(deal["id"]), generation=producer.uint(deal["current_gen"]),
             root=producer.b64(deal["manifest_root"], 32).hex(), assigned=producer.account(providers[slot]).hex(),
             payee=producer.account(providers[slot]).hex(), layout=2, k=k, m=layout["m"], slot=slot, metadata_mdus=2,
-            user_mdus=1, start_mdu=0, start_leaf=0, blob_count=0, epoch_id=epoch, epoch_length=epoch_length,
+            user_mdus=user_mdus, start_mdu=0, start_leaf=0, blob_count=0, epoch_id=epoch, epoch_length=epoch_length,
             sample_count=count, snapshot_height=snapshot_height, anchor_height=snapshot_height + 1,
             first_response_height=snapshot_height + 2, deadline_height=min(epoch * epoch_length, producer.uint(deal["end_block"]) - 1),
             deal_end=producer.uint(deal["end_block"]))
@@ -1218,9 +1718,12 @@ def run_sustained(lifecycle, deal, providers, send, command, audits, wait, expor
                 raise ValueError("audit monitor failed: " + str(failures[0]))
 
 
-def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustained=None, audit_profile="normal"):
+def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustained=None,
+                native_v3=False, audit_profile="normal"):
     """Real canonical ingest and normal audits; optional bounded retrieval workload."""
-    k = sustained.get("k", 2) if sustained is not None else 2
+    if native_v3 and sustained is not None:
+        raise ValueError("native v3 diagnostic and sustained v2 workload are distinct modes")
+    k = 8 if native_v3 else sustained.get("k", 2) if sustained is not None else 2
     deputy_count = sustained.get("deputy_count", 8) if sustained is not None else 8
     rate_scale = sustained.get("rate_scale", 1) if sustained is not None else 1
     layout = mode2_layout(k, deputy_count)
@@ -1250,9 +1753,13 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
         signal.signal(sig, interrupted)
     doc = lifecycle.doc
     doc.pop("transactions_submitted", None)
-    doc.update(mode="four-validator-healthy-provider-diagnostic", setup_transactions=[], providers=[],
-        workload=f"one real K{k} deal; {layout['assignments']} assigned provider-daemons; one normal audit epoch",
-        qualification=False, limits=["No capacity or delivered retrieval qualification", "No deputy retrieval yet",
+    doc.update(mode="four-validator-native-v3-provider-diagnostic" if native_v3 else "four-validator-healthy-provider-diagnostic",
+        setup_transactions=[], providers=[],
+        workload=("one 16 MiB FAT v3 K8 deal; twelve production provider-daemons; two preopened native sessions"
+                  if native_v3 else f"one real K{k} deal; {layout['assignments']} assigned provider-daemons; one normal audit epoch"),
+        qualification=False, limits=["No capacity or delivered retrieval qualification",
+            ("Provider HTTP durations combine proof generation, gas simulation, signing, broadcast, and commit observation"
+             if native_v3 else "No deputy retrieval yet"),
             "Normal mint and audit parameters retained; no economic conservation assertion", "No restart qualification"])
     def command(args, timeout=60):
         lifecycle.remaining()
@@ -1284,6 +1791,8 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
             time.sleep(min(0.2, lifecycle.remaining()))
     try:
         require_retrieval_cli(lifecycle)
+        if native_v3:
+            require_v3_cli(lifecycle)
         if sustained is not None and "--append" not in lifecycle.cli(lifecycle.home, "tx", "sign-batch", "--help").split():
             raise ValueError("sustained workload requires SDK sign-batch --append")
         lifecycle.reserve_ports()
@@ -1306,9 +1815,10 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
             artifact_source_match="supplied binaries/library; build correspondence not attested")
         if doc["provenance"]["trusted_setup_sha256"] != producer.SETUP_DIGEST:
             raise ValueError("diagnostic requires the maintained trusted setup")
-        lifecycle.prepare(audit_profile=audit_profile, provider_count=layout["provisioned_provider_signers"])
+        lifecycle.prepare(audit_profile=audit_profile, provider_count=layout["provisioned_provider_signers"],
+                          enable_retrieval_v3=native_v3)
         # Normal mint is retained for both explicit audit profiles.
-        population = layout["openings_per_bundle"]
+        population = layout["openings_per_bundle"] * (3 if native_v3 else 1)
         quotas = {min(population, producer.uint(doc["frozen_module_params"]["quota_max_blobs"]),
                       max(producer.uint(doc["frozen_module_params"]["quota_min_blobs"]),
                           (population * producer.uint(doc["frozen_module_params"][key]) + 9999) // 10000))
@@ -1372,31 +1882,9 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
         if len(owned) != 1:
             raise ValueError("expected exactly one owner deal")
         identity = str(owned[0].get("id", "0"))
-        payload = lifecycle.home / "payload.bin"
-        block = bytes((i * 37 + i // 97) % 256 for i in range(4096))
-        with payload.open("xb") as output:
-            for _ in range(8126464 // len(block)):
-                output.write(block)
-        doc["payload"] = dict(path=str(payload), bytes=payload.stat().st_size, sha256=artifact.sha256(payload))
-        uploaded = json.loads(command([curl, "--silent", "--show-error", "--fail", "--max-time", "180",
-            "--form-string", "owner=" + lifecycle.signers["owner0"], "--form-string", "file_path=payload.bin",
-            "--form", "file=@" + str(payload), f"http://127.0.0.1:19091/sp/retrieval/upload?deal_id={identity}"], 185))
-        root = uploaded["manifest_root"]
-        if (not isinstance(root, str) or len(root) != 66 or root != "0x" + bytes.fromhex(root[2:]).hex() or
-                [producer.uint(uploaded[n]) for n in ("size_bytes", "file_size_bytes", "logical_size_bytes", "total_mdus", "witness_mdus")] != [8126464, 8126464, 8126464, 3, 1] or
-                uploaded.get("content_encoding") != "none"):
-            raise ValueError(f"canonical K{k} ingest returned unexpected content")
-        doc["ingest"] = uploaded
-        updated = send("owner0", ["update-deal-content", "--deal-id", identity, "--cid", root,
-            "--size", "8126464", "--total-mdus", "3", "--witness-mdus", "1"])
-        height = updated["height"]
-        wait(height + 1)
-        deal = lifecycle.query(lifecycle.nodes[0], API + "/deals/" + identity, height)["deal"]
-        deal["id"] = identity
-        if producer.b64(deal["manifest_root"], 32).hex() != root[2:]:
-            raise ValueError("committed root differs from ingest")
+        initial_deal = lifecycle.query(lifecycle.nodes[0], API + "/deals/" + identity, created["height"])["deal"]
         providers = {}
-        for slot in deal["mode2_slots"]:
+        for slot in initial_deal["mode2_slots"]:
             index = producer.uint(slot.get("slot", 0))
             if index in providers or slot["status"] != "SLOT_STATUS_ACTIVE" or slot.get("pending_provider"):
                 raise ValueError(f"K{k} slots must be distinct and ACTIVE")
@@ -1404,13 +1892,53 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
         if (set(providers) != set(range(layout["assignments"])) or
                 set(providers.values()) != {lifecycle.signers[f"provider{i}"] for i in range(layout["assignments"])}):
             raise ValueError(f"K{k} placement differs from the owned providers")
+        payload = lifecycle.home / "payload.bin"
+        block = bytes((i * 37 + i // 97) % 256 for i in range(4096))
+        payload_bytes = V3_PILOT_BYTES if native_v3 else 8126464
+        with payload.open("xb") as output:
+            for _ in range(payload_bytes // len(block)):
+                output.write(block)
+        doc["payload"] = dict(path=str(payload), bytes=payload.stat().st_size, sha256=artifact.sha256(payload))
+        uploaded = json.loads(command([curl, "--silent", "--show-error", "--fail", "--max-time", "180",
+            "--form-string", "owner=" + lifecycle.signers["owner0"], "--form-string", "file_path=payload.bin",
+            "--form", "file=@" + str(payload),
+            f"http://127.0.0.1:19091/sp/retrieval/upload?deal_id={identity}" + ("&fat_version=3" if native_v3 else "")], 185))
+        doc["ingest"] = uploaded
+        if native_v3:
+            candidate, height = admit_native_v3_generation(lifecycle, uploaded=uploaded, deal_id=identity,
+                                                            providers=providers, send=send, curl=curl)
+            root = candidate["polyfs_root"]
+        else:
+            root = uploaded["manifest_root"]
+            if (not isinstance(root, str) or len(root) != 66 or root != "0x" + bytes.fromhex(root[2:]).hex() or
+                    [producer.uint(uploaded[n]) for n in ("size_bytes", "file_size_bytes", "logical_size_bytes", "total_mdus", "witness_mdus")] != [8126464, 8126464, 8126464, 3, 1] or
+                    uploaded.get("content_encoding") != "none"):
+                raise ValueError(f"canonical K{k} ingest returned unexpected content")
+            updated = send("owner0", ["update-deal-content", "--deal-id", identity, "--cid", root,
+                "--size", "8126464", "--total-mdus", "3", "--witness-mdus", "1"])
+            height = updated["height"]
+        wait(height + 1)
+        deal = lifecycle.query(lifecycle.nodes[0], API + "/deals/" + identity, height)["deal"]
+        deal["id"] = identity
+        if producer.b64(deal["manifest_root"], 32).hex() != root[2:]:
+            raise ValueError("committed root differs from ingest")
+        if native_v3 and [producer.uint(deal.get(name, 0)) for name in
+                          ("size", "total_mdus", "witness_mdus", "current_gen")] != [V3_PILOT_BYTES, 5, 1, 1]:
+            raise ValueError("finalized FAT v3 deal differs from fixed pilot geometry")
+        if deal["mode2_slots"] != initial_deal["mode2_slots"]:
+            raise ValueError("content admission changed frozen provider assignments")
         doc["deal"] = deal
         doc["canonical_artifacts"] = []
+        user_mdus = 3 if native_v3 else 1
         for slot, address in providers.items():
             provider = next(row for row in doc["providers"] if row["address"] == address)
             directory = Path(provider["directory"]) / "deals" / identity / root[2:]
-            for filename, size in (("mdu_0.bin", 8388608), ("mdu_1.bin", 8388608),
-                                   (f"mdu_2_slot_{slot}.bin", layout["bytes_per_bundle"])):
+            expected_artifacts = [("mdu_0.bin", 8388608), ("mdu_1.bin", 8388608)]
+            expected_artifacts += [(f"mdu_{mdu}_slot_{slot}.bin", layout["bytes_per_bundle"])
+                                   for mdu in range(2, 2 + user_mdus)]
+            if native_v3:
+                expected_artifacts.append(("integrity_leaves_v3.bin", user_mdus * 96 * 32))
+            for filename, size in expected_artifacts:
                 path = directory / filename
                 if path.stat().st_size != size:
                     raise ValueError("provider canonical artifact has wrong size")
@@ -1425,7 +1953,8 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
                 for address in providers.values():
                     values.extend(lifecycle.query(node, API + "/storage-audits/by-provider/" + address, at)["audits"])
                 checked = healthy_audit_views(values, deal, providers, selected_epoch, epoch_length, lifecycle.chain,
-                                              finalized=finalized, expected_samples=expected_samples, k=k)
+                                              finalized=finalized, expected_samples=expected_samples, k=k,
+                                              user_mdus=user_mdus)
                 anchor_height = (selected_epoch - 1) * epoch_length + 1
                 anchor = lifecycle.query(node, f"/block?height={anchor_height}")
                 if (producer.uint(anchor["block"]["header"]["height"]) != anchor_height or
@@ -1457,7 +1986,10 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
                 raise ValueError("healthy audit changed active placement/content")
         check_providers()
         doc.update(status="healthy_provider_audit_diagnostic_passed", audit_coverage_verified=True)
-        if sustained is not None:
+        if native_v3:
+            run_native_v3_sessions(lifecycle, deal=deal, providers=providers, send=send, wait=wait, curl=curl)
+            doc["status"] = "native_v3_provider_diagnostic_passed"
+        elif sustained is not None:
             run_sustained(lifecycle, deal, providers, send, command, audits, wait, **sustained)
     except BaseException as error:
         doc.update(status="failed", error=str(error)[-8192:])
@@ -1490,7 +2022,8 @@ def main():
         parser.add_argument("--" + flag, required=True)
     for flag in ("fixture-k8", "fixture-k2", "gateway-binary", "cli-binary", "product-source", "proof-exporter"):
         parser.add_argument("--" + flag)
-    parser.add_argument("--mode", choices=("settlement-smoke", "healthy-providers", "sustained-providers"), default="settlement-smoke")
+    parser.add_argument("--mode", choices=("settlement-smoke", "healthy-providers", "sustained-providers",
+                                           "native-v3-providers"), default="settlement-smoke")
     parser.add_argument("--timeout", type=int, default=600)
     parser.add_argument("--audit-profile", choices=("normal", "c6"), default="normal")
     parser.add_argument("--step-seconds", type=int, default=180, help="Each of five offered-rate steps; 4 is a same-path pilot")
@@ -1522,6 +2055,12 @@ def main():
     elif (exporter or proof_gas is not None or step_seconds != 180 or sustained_k != 2 or
           sustained_rate_scale != 1 or sustained_deputies != 8):
         parser.error("exporter, proof gas, sustained K and pilot duration require sustained-providers")
+    elif mode == "native-v3-providers":
+        if (not gateway or not cli or not source or k8 or k2 or proof_only or
+                options["timeout"] > 600 or audit_profile != "normal"):
+            parser.error("native-v3-providers requires product binaries/source, normal audits, timeout <= 600, and excludes fixtures/--proof-only")
+        print(run_healthy(artifact.FourValidatorLifecycle(**options), gateway, cli, source,
+                          native_v3=True, audit_profile="normal"))
     elif mode == "healthy-providers":
         if not gateway or not cli or not source or k8 or k2 or proof_only or options["timeout"] > 600:
             parser.error("healthy-providers requires --gateway-binary/--cli-binary/--product-source, timeout <= 600, and excludes fixtures/--proof-only")

--- a/scripts/retrieval_four_validator_workload.py
+++ b/scripts/retrieval_four_validator_workload.py
@@ -520,7 +520,7 @@ def admit_native_v3_generation(lifecycle, *, uploaded, deal_id, providers, send,
     owner = lifecycle.signers["owner0"]
     proposed = send("owner0", ["propose-deal-generation-v3", "--deal-id", deal_id,
         "--expected-current-generation", candidate["expected_current_generation"],
-        "--previous-polyfs-root", candidate["previous_polyfs_root"],
+        "--previous-polyfs-root", candidate["previous_polyfs_root"] or "0x",
         "--polyfs-root", candidate["polyfs_root"], "--integrity-root", candidate["integrity_root"],
         "--size", candidate["size_bytes"], "--total-mdus", candidate["total_mdus"],
         "--witness-mdus", candidate["witness_mdus"],

--- a/scripts/test_bench_retrieval_sessions.py
+++ b/scripts/test_bench_retrieval_sessions.py
@@ -1303,7 +1303,8 @@ class FourValidatorLifecycleTest(unittest.TestCase):
                     config.mkdir(parents=True)
                     genesis = {"consensus": {"params": {"block": {}}}, "app_state": {
                         "bank": {"denom_metadata": []}, "nilchain": {"params": {
-                            "retrieval_v2_activation_height": "0", "unchanged_fee": "17"}}}}
+                            "retrieval_v2_activation_height": "0", "retrieval_v3_activation_height": "0",
+                            "unchanged_fee": "17"}}}}
                     (config / "genesis.json").write_text(json.dumps(genesis))
                     (config / "config.toml").write_text('[consensus]\\ntimeout_commit = "5s"\\n[p2p]\\naddr_book_strict = true\\n[instrumentation]\\nprometheus = false\\nprometheus_listen_addr = ":26660"\\n')
                     (config / "app.toml").write_text('[grpc]\\naddress = "localhost:9090"\\n[api]\\naddress = "tcp://localhost:1317"\\n')
@@ -1448,6 +1449,16 @@ class FourValidatorLifecycleTest(unittest.TestCase):
             self.assertEqual((params["quota_min_blobs"], params["quota_max_blobs"]), ("132", "132"))
             self.assertEqual(artifact.sha256(Path(node["home"]) / "config/genesis.json"), self.runner.doc["genesis_sha256"])
 
+    def test_v3_activation_is_explicit_and_default_remains_off(self):
+        for enabled in (False, True):
+            with self.subTest(enabled=enabled):
+                runner = artifact.FourValidatorLifecycle(self.binary, self.library, self.root / ("v3" if enabled else "default"))
+                runner.home.mkdir(mode=0o700)
+                runner.prepare(enable_retrieval_v3=enabled)
+                genesis = json.loads((Path(runner.nodes[0]["home"]) / "config/genesis.json").read_text())
+                self.assertEqual(genesis["app_state"]["nilchain"]["params"]["retrieval_v3_activation_height"],
+                                 "1" if enabled else "0")
+
     def test_prepare_provisions_bounded_high_load_signer_population(self):
         self.runner.home.mkdir(mode=0o700)
         self.runner.prepare(provider_count=44)
@@ -1476,6 +1487,9 @@ class FourValidatorLifecycleTest(unittest.TestCase):
                         os.kill(process.pid, signal.SIGKILL)
                     self.runner.stop()
                     self.assertGreater(record["peak_rss_bytes"], 32 * 1024 * 1024)
+                    self.assertIsNotNone(record["user_cpu_seconds"])
+                    self.assertIsNotNone(record["system_cpu_seconds"])
+                    self.assertEqual(record["measurement_scope"], "whole validator process lifetime")
                     self.assertIn(record["raw_unit"], ("bytes", "KiB"))
                     self.assertIsNotNone(process.returncode)
                     with self.assertRaises(ChildProcessError):

--- a/scripts/test_retrieval_four_validator_workload.py
+++ b/scripts/test_retrieval_four_validator_workload.py
@@ -71,6 +71,36 @@ def settlement_fixture():
 
 
 class FourValidatorWorkloadTest(unittest.TestCase):
+    def test_transaction_verification_uses_fenced_blocks_not_tx_indexes(self):
+        raw = b"signed transaction"
+        txhash = hashlib.sha256(raw).hexdigest().upper()
+        fenced = [False]
+        lifecycle = SimpleNamespace(
+            chain="polystore_291-1", nodes=[{"node_id": str(i)} for i in range(4)])
+        def wait_height(height):
+            self.assertEqual(height, 20)
+            fenced[0] = True
+            return height
+        def query(node, route):
+            self.assertTrue(fenced[0])
+            self.assertNotIn("/tx?hash", route)
+            if route == "/block?height=19":
+                return {"block_id": {"hash": "11" * 32}, "block": {
+                    "header": {"height": "19", "chain_id": lifecycle.chain,
+                               "app_hash": "22" * 32, "time": "2026-01-01T00:00:00Z"},
+                    "data": {"txs": [base64.b64encode(raw).decode()]}}}
+            if route == "/block_results?height=19":
+                return {"height": "19", "txs_results": [
+                    {"code": 0, "gas_wanted": "500000", "gas_used": "400000"}]}
+            self.fail("unexpected query " + route)
+        lifecycle.wait_height = Mock(side_effect=wait_height)
+        lifecycle.query = Mock(side_effect=query)
+        rows = workload.verify_transaction_nodes(lifecycle, dict(
+            txhash=txhash, height=19, code=0, gas_wanted=500000, gas_used=400000))
+        self.assertEqual(len(rows), 4)
+        self.assertEqual(lifecycle.query.call_count, 8)
+        lifecycle.wait_height.assert_called_once_with(20)
+
     def test_commit_captures_share_phase_deadline_and_never_qualify(self):
         sample = dict(chain_id="polystore_260-1", count=12, sum_seconds="0.15",
                       wall_time_ns=123, monotonic_start_ns=456, monotonic_end_ns=789)

--- a/scripts/test_retrieval_four_validator_workload.py
+++ b/scripts/test_retrieval_four_validator_workload.py
@@ -380,11 +380,13 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
 
     def test_provider_wave_and_committed_message_are_exact(self):
         providers = dict(enumerate(AUDIT_ADDRESSES[:8]))
-        rows = [dict(status="success", http_status=200, session_id=self.SESSION, cleanup_status="complete",
+        rows = [dict(status="success", http_status=200, session_id="0x" + self.SESSION, cleanup_status="complete",
                      slot=i, provider=providers[i], proof_count=17 if i < 7 else 13,
                      tx_hash=f"{i + 1:064x}") for i in range(8)]
         self.assertEqual(workload.validate_v3_provider_outcomes(rows, providers, session_id=self.SESSION)["proof_count"], 132)
-        for field, bad in (("http_status", 202), ("cleanup_status", "pending"), ("tx_hash", rows[1]["tx_hash"])):
+        for field, bad in (("http_status", 202), ("cleanup_status", "pending"),
+                           ("tx_hash", rows[1]["tx_hash"]), ("session_id", self.SESSION),
+                           ("session_id", "0x" + "00" * 32)):
             changed = copy.deepcopy(rows)
             changed[0][field] = bad
             with self.subTest(field=field), self.assertRaises(ValueError):
@@ -447,6 +449,34 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
             retained = lifecycle.doc["v3_http_phases"]["proofs"]
             self.assertEqual({row["provider"] for row in retained}, {"provider-a", "provider-b"})
             self.assertEqual({row["status"] for row in retained}, {"success", "driver_error"})
+
+    def test_native_v3_provider_routes_use_gateway_auth_contract(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            lifecycle = SimpleNamespace(home=Path(tmp), doc={}, env={},
+                deadline=artifact.monotonic_ns() + 10**9, save=Mock(), remaining=Mock(return_value=1))
+            captured = []
+            def run(argv, deadline, env):
+                captured.append(argv)
+                Path(argv[argv.index("--output") + 1]).write_text('{"status":"success"}')
+                return SimpleNamespace(stdout="200", stderr="", returncode=0)
+            requests = [
+                ("generation-acceptance", "/sp/generation-v3/accept", {"deal_id": 7, "provider": "provider-a"}),
+                ("session-proof", "/sp/session-proof", {"session_id": self.SESSION}),
+            ]
+            with patch.object(artifact, "run_bounded_command", side_effect=run), \
+                 patch.object(workload, "require_free_disk", return_value=workload.V3_ABORT_FREE_BYTES):
+                for phase, route, body in requests:
+                    workload.run_v3_http_phase(lifecycle, "/curl", [dict(
+                        provider="provider-a", url="http://provider" + route, body=body,
+                    )], phase, max_in_flight=1)
+            expected = "X-PolyStore-Gateway-Auth: " + workload.V3_PROVIDER_AUTH_TOKEN
+            self.assertEqual(len(captured), 2)
+            for argv, (_, route, body) in zip(captured, requests):
+                headers = [argv[index + 1] for index, value in enumerate(argv[:-1]) if value == "--header"]
+                self.assertIn(expected, headers)
+                self.assertFalse(any(value.startswith("Authorization:") for value in headers))
+                self.assertEqual(json.loads(argv[argv.index("--data") + 1]), body)
+                self.assertTrue(argv[-1].endswith(route))
 
     def test_disk_threshold_fails_closed(self):
         with patch.object(workload.shutil, "disk_usage", return_value=SimpleNamespace(free=99)):

--- a/scripts/test_retrieval_four_validator_workload.py
+++ b/scripts/test_retrieval_four_validator_workload.py
@@ -308,7 +308,120 @@ class FourValidatorWorkloadTest(unittest.TestCase):
                 workload.journal_results(path, [operation])
 
 
+class NativeV3PilotHelpersTest(unittest.TestCase):
+    ROOT = "11" * 32
+    INTEGRITY = "22" * 32
+    SESSION = "33" * 32
+
+    def session(self, *, expired=False, refunded=False):
+        bitmap = bytearray(17)
+        for ordinal in range(132):
+            if ordinal != 17:
+                bitmap[ordinal // 8] |= 1 << (ordinal % 8)
+        counts = [17] * 7 + [14]
+        return dict(session=dict(
+            session_id=base64.b64encode(bytes.fromhex(self.SESSION)).decode(), deal_id="7",
+            generation="1", owner=AUDIT_ADDRESSES[8], payer=AUDIT_ADDRESSES[8], nonce="1",
+            polyfs_root=base64.b64encode(bytes.fromhex(self.ROOT)).decode(),
+            integrity_root=base64.b64encode(bytes.fromhex(self.INTEGRITY)).decode(),
+            setup_digest=base64.b64encode(bytes([9]) * 32).decode(), plan_hash=base64.b64encode(bytes([8]) * 32).decode(),
+            file_record_index=0, file_start_offset="0", file_length=str(workload.V3_PILOT_BYTES),
+            range_start="0", range_length=str(workload.V3_PILOT_BYTES), metadata_mdus="2", user_mdus="3",
+            first_blob="0", last_blob="132", population="133", sample_count="132", nonce_string="unused",
+            deadline_height="250", chain_id="polystore_291-1", accepted_sample_bitmap=base64.b64encode(bitmap).decode(),
+            obligations=[dict(slot=i, assigned_provider=AUDIT_ADDRESSES[i], payee=AUDIT_ADDRESSES[i],
+                              blob_count=str(count), sample_count="0", locked_fee=str(count))
+                         for i, count in enumerate(counts)],
+            acked_slots_mask=0, settled_slots_mask=0,
+            refunded_slots_mask=255 if refunded else 0, locked_fee="0" if refunded else "133",
+            expired=expired))
+
+    def validate_session(self, value, **kwargs):
+        return workload.validate_v3_session(value, session_id=self.SESSION, deal_id="7",
+            owner=AUDIT_ADDRESSES[8], providers=dict(enumerate(AUDIT_ADDRESSES[:8])), nonce=1,
+            polyfs_root=self.ROOT, integrity_root=self.INTEGRITY, chain_id="polystore_291-1",
+            deadline_height=250, **kwargs)
+
+    def test_session_bitmap_and_refund_authorities_fail_closed(self):
+        session, accepted = self.validate_session(self.session())
+        self.assertEqual((len(accepted), 17 in accepted, sum(int(o["blob_count"]) for o in session["obligations"])),
+                         (131, False, 133))
+        self.validate_session(self.session(expired=True), expired=True)
+        self.validate_session(self.session(expired=True, refunded=True), expired=True, refunded=True)
+        mutations = {
+            "wrong root": lambda s: s.update(polyfs_root=base64.b64encode(bytes(32)).decode()),
+            "wrong chain": lambda s: s.update(chain_id="other"),
+            "wrong deadline": lambda s: s.update(deadline_height="251"),
+            "wrong partition": lambda s: s["obligations"][0].update(blob_count="18"),
+            "premature refund": lambda s: s.update(refunded_slots_mask=255, locked_fee="0"),
+            "settled without ack": lambda s: s.update(settled_slots_mask=1),
+            "padding bit": lambda s: s.update(accepted_sample_bitmap=base64.b64encode(bytes([255]) * 17).decode()),
+        }
+        for name, mutate in mutations.items():
+            value = self.session()
+            mutate(value["session"])
+            with self.subTest(name=name), self.assertRaises(ValueError):
+                self.validate_session(value)
+
+    def test_open_response_is_exact_and_nonzero(self):
+        sid = bytes.fromhex(self.SESSION)
+        kind = b"/polystorechain.polystorechain.v1.MsgOpenRetrievalSessionV3Response"
+        suffix = (b"\x10" + workload._encode_varint(workload.V3_PILOT_BYTES) +
+                  b"\x18" + workload._encode_varint(133 * artifact.ENCODED_BLOB_BYTES) +
+                  b"\x20" + workload._encode_varint(132))
+        response = b"\x0a\x20" + sid + suffix
+        any_value = b"\x0a" + workload._encode_varint(len(kind)) + kind + b"\x12" + workload._encode_varint(len(response)) + response
+        raw = b"\x12" + workload._encode_varint(len(any_value)) + any_value
+        self.assertEqual(workload.opened_v3_session(dict(outcome="committed_success", data=raw.hex())), self.SESSION)
+        for changed in (raw + b"\x00", bytes([raw[0] ^ 1]) + raw[1:], raw.replace(sid, bytes(32))):
+            with self.assertRaises(ValueError):
+                workload.opened_v3_session(dict(outcome="committed_success", data=changed.hex()))
+
+    def test_provider_wave_and_committed_message_are_exact(self):
+        providers = dict(enumerate(AUDIT_ADDRESSES[:8]))
+        rows = [dict(status="success", http_status=200, session_id=self.SESSION, cleanup_status="complete",
+                     slot=i, provider=providers[i], proof_count=17 if i < 7 else 13,
+                     tx_hash=f"{i + 1:064x}") for i in range(8)]
+        self.assertEqual(workload.validate_v3_provider_outcomes(rows, providers, session_id=self.SESSION)["proof_count"], 132)
+        for field, bad in (("http_status", 202), ("cleanup_status", "pending"), ("tx_hash", rows[1]["tx_hash"])):
+            changed = copy.deepcopy(rows)
+            changed[0][field] = bad
+            with self.subTest(field=field), self.assertRaises(ValueError):
+                workload.validate_v3_provider_outcomes(changed, providers, session_id=self.SESSION)
+        message = {"@type": "/polystorechain.polystorechain.v1.MsgSubmitRetrievalSessionProofV3",
+                   "creator": providers[0], "slot": 0,
+                   "session_id": base64.b64encode(bytes.fromhex(self.SESSION)).decode(),
+                   "proofs": [{"ordinal": str(i)} for i in range(17)]}
+        self.assertEqual(workload.validate_v3_committed_message(message, kind="session-proof",
+            creator=providers[0], slot=0, session_id=self.SESSION, proof_count=17), list(range(17)))
+        duplicate = copy.deepcopy(message)
+        duplicate["proofs"][-1]["ordinal"] = "0"
+        with self.assertRaises(ValueError):
+            workload.validate_v3_committed_message(duplicate, kind="session-proof",
+                creator=providers[0], slot=0, session_id=self.SESSION, proof_count=17)
+
+
+
 class HealthyAuditViewsTest(unittest.TestCase):
+    def test_native_v3_cli_is_fixed_bounded_and_normal_audit_only(self):
+        common = ["diagnostic", "--mode", "native-v3-providers", "--binary", "/chain",
+                  "--library", "/lib", "--home", "/new-home"]
+        required = ["--gateway-binary", "/gateway", "--cli-binary", "/native-cli", "--product-source", "/source"]
+        for extra in ([], required + ["--timeout", "601"], required + ["--audit-profile", "c6"],
+                      required + ["--proof-only"]):
+            with self.subTest(extra=extra), patch.object(workload.sys, "argv", common + extra), \
+                 patch.object(workload.sys, "stderr"), patch.object(artifact, "FourValidatorLifecycle") as constructor:
+                with self.assertRaises(SystemExit) as error:
+                    workload.main()
+                self.assertEqual(error.exception.code, 2)
+                constructor.assert_not_called()
+        with patch.object(workload.sys, "argv", common + required + ["--timeout", "600"]), \
+             patch.object(artifact, "FourValidatorLifecycle") as constructor, \
+             patch.object(workload, "run_healthy", return_value="evidence") as run, patch("builtins.print"):
+            workload.main()
+            run.assert_called_once_with(constructor.return_value, "/gateway", "/native-cli", "/source",
+                                        native_v3=True, audit_profile="normal")
+
     def test_healthy_cli_requires_explicit_binaries_and_bounded_timeout(self):
         common = ["diagnostic", "--mode", "healthy-providers", "--binary", "/chain",
                   "--library", "/lib", "--home", "/new-home"]

--- a/scripts/test_retrieval_four_validator_workload.py
+++ b/scripts/test_retrieval_four_validator_workload.py
@@ -410,7 +410,8 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
 
     def test_provider_wave_and_committed_message_are_exact(self):
         providers = dict(enumerate(AUDIT_ADDRESSES[:8]))
-        rows = [dict(status="success", http_status=200, session_id="0x" + self.SESSION, cleanup_status="complete",
+        rows = [dict(status="success", http_status=200, curl_returncode=0,
+                     session_id="0x" + self.SESSION, cleanup_status="complete",
                      slot=i, provider=providers[i], proof_count=17 if i < 7 else 13,
                      tx_hash=f"{i + 1:064x}") for i in range(8)]
         self.assertEqual(workload.validate_v3_provider_outcomes(rows, providers, session_id=self.SESSION)["proof_count"], 132)
@@ -479,6 +480,104 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
             retained = lifecycle.doc["v3_http_phases"]["proofs"]
             self.assertEqual({row["provider"] for row in retained}, {"provider-a", "provider-b"})
             self.assertEqual({row["status"] for row in retained}, {"success", "driver_error"})
+
+    def test_session_proof_phase_retries_only_exact_pre_admission_busy(self):
+        providers = dict(enumerate(AUDIT_ADDRESSES[:8]))
+        requests = [dict(provider=providers[slot], url=f"http://provider/{slot}", body={})
+                    for slot in range(8)]
+
+        def run_case(tmp, phase, response):
+            lifecycle = SimpleNamespace(home=Path(tmp), doc={}, env={},
+                deadline=artifact.monotonic_ns() + 30 * 10**9, save=Mock(), remaining=Mock(return_value=1))
+            calls = {}
+            def run(argv, deadline, env):
+                slot = int(argv[-1].rsplit("/", 1)[-1])
+                calls[slot] = calls.get(slot, 0) + 1
+                body, status, returncode = response(slot, calls[slot])
+                Path(argv[argv.index("--output") + 1]).write_text(json.dumps(body))
+                return SimpleNamespace(stdout=str(status), stderr="", returncode=returncode)
+            with patch.object(artifact, "run_bounded_command", side_effect=run), \
+                 patch.object(workload, "require_free_disk", return_value=workload.V3_ABORT_FREE_BYTES), \
+                 patch.object(workload.time, "sleep"):
+                outcomes = workload.run_v3_http_phase(lifecycle, "/curl", requests, phase,
+                    max_in_flight=8, retry_pre_admission_busy=True)
+            return lifecycle, calls, outcomes
+
+        def success(slot):
+            return dict(status="success", session_id="0x" + self.SESSION,
+                        cleanup_status="complete", slot=slot, proof_count=17 if slot < 7 else 13,
+                        tx_hash=f"{slot + 1:064x}")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            def one_busy(slot, attempt):
+                if slot == 5 and attempt == 1:
+                    return ({"error": "retrieval submission busy",
+                             "hint": "retrieval submission capacity or signer busy"}, 429, 0)
+                return success(slot), 200, 0
+            lifecycle, calls, outcomes = run_case(tmp, "busy-then-success", one_busy)
+            self.assertEqual(calls, {slot: 2 if slot == 5 else 1 for slot in range(8)})
+            self.assertEqual(len(lifecycle.doc["v3_http_phases"]["busy-then-success"]), 9)
+            self.assertEqual(len(outcomes), 8)
+            self.assertEqual(workload.validate_v3_provider_outcomes(
+                outcomes, providers, session_id=self.SESSION)["proof_count"], 132)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            def unknown(slot, attempt):
+                if slot == 5:
+                    return ({"error": "retrieval submission busy",
+                             "hint": "retrieval submission capacity or signer busy",
+                             "tx_hash": "A" * 64}, 429, 0)
+                return success(slot), 200, 0
+            _, calls, outcomes = run_case(tmp, "unknown-429", unknown)
+            self.assertEqual(calls, {slot: 1 for slot in range(8)})
+            with self.assertRaisesRegex(ValueError,
+                    "provider .*http_status=429.*status=None.*retrieval submission busy"):
+                workload.validate_v3_provider_outcomes(outcomes, providers, session_id=self.SESSION)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            def nonzero_curl(slot, attempt):
+                return success(slot), 200, 7 if slot == 5 else 0
+            lifecycle = SimpleNamespace(home=Path(tmp), doc={}, env={},
+                deadline=artifact.monotonic_ns() + 10**9, save=Mock(), remaining=Mock(return_value=1))
+            calls = {}
+            def run(argv, deadline, env):
+                slot = int(argv[-1].rsplit("/", 1)[-1])
+                calls[slot] = calls.get(slot, 0) + 1
+                body, status, returncode = nonzero_curl(slot, calls[slot])
+                Path(argv[argv.index("--output") + 1]).write_text(json.dumps(body))
+                return SimpleNamespace(stdout=str(status), stderr="curl failed", returncode=returncode)
+            with patch.object(artifact, "run_bounded_command", side_effect=run), \
+                 patch.object(workload, "require_free_disk", return_value=workload.V3_ABORT_FREE_BYTES):
+                with self.assertRaisesRegex(ValueError, "provider .*exited 7"):
+                    workload.run_v3_http_phase(lifecycle, "/curl", requests, "nonzero-curl",
+                        max_in_flight=8, retry_pre_admission_busy=True)
+            retained = lifecycle.doc["v3_http_phases"]["nonzero-curl"]
+            self.assertEqual(len(retained), 8)
+            self.assertEqual(next(row for row in retained if row["provider"] == providers[5])["curl_returncode"], 7)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            lifecycle = SimpleNamespace(home=Path(tmp), doc={}, env={},
+                deadline=artifact.monotonic_ns() + 30 * 10**9, save=Mock(), remaining=Mock(return_value=1))
+            calls = 0
+            def run(argv, deadline, env):
+                nonlocal calls
+                calls += 1
+                path = Path(argv[argv.index("--output") + 1])
+                if calls == 1:
+                    path.write_text(json.dumps({"error": "retrieval submission busy",
+                        "hint": "retrieval submission capacity or signer busy"}))
+                    return SimpleNamespace(stdout="429", stderr="", returncode=0)
+                path.write_text("{")
+                return SimpleNamespace(stdout="200", stderr="", returncode=0)
+            with patch.object(artifact, "run_bounded_command", side_effect=run), \
+                 patch.object(workload, "require_free_disk", return_value=workload.V3_ABORT_FREE_BYTES), \
+                 patch.object(workload.time, "sleep"):
+                with self.assertRaises(ValueError):
+                    workload.run_v3_http_phase(lifecycle, "/curl", [requests[5]], "retry-parser-error",
+                        max_in_flight=1, retry_pre_admission_busy=True)
+            retained = lifecycle.doc["v3_http_phases"]["retry-parser-error"]
+            self.assertEqual((calls, len(retained), retained[0]["http_status"], retained[1]["status"]),
+                             (2, 2, 429, "driver_error"))
 
     def test_native_v3_provider_routes_use_gateway_auth_contract(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/test_retrieval_four_validator_workload.py
+++ b/scripts/test_retrieval_four_validator_workload.py
@@ -324,7 +324,7 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
             generation="1", owner=AUDIT_ADDRESSES[8], payer=AUDIT_ADDRESSES[8], nonce="1",
             polyfs_root=base64.b64encode(bytes.fromhex(self.ROOT)).decode(),
             integrity_root=base64.b64encode(bytes.fromhex(self.INTEGRITY)).decode(),
-            setup_digest=base64.b64encode(bytes([9]) * 32).decode(), plan_hash=base64.b64encode(bytes([8]) * 32).decode(),
+            setup_digest=base64.b64encode(bytes.fromhex(producer.SETUP_DIGEST)).decode(), plan_hash=base64.b64encode(bytes([8]) * 32).decode(),
             file_record_index=0, file_start_offset="0", file_length=str(workload.V3_PILOT_BYTES),
             range_start="0", range_length=str(workload.V3_PILOT_BYTES), metadata_mdus="2", user_mdus="3",
             first_blob="0", last_blob="132", population="133", sample_count="132", nonce_string="unused",
@@ -352,6 +352,7 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
             "wrong root": lambda s: s.update(polyfs_root=base64.b64encode(bytes(32)).decode()),
             "wrong chain": lambda s: s.update(chain_id="other"),
             "wrong deadline": lambda s: s.update(deadline_height="251"),
+            "wrong setup": lambda s: s.update(setup_digest=base64.b64encode(bytes([9]) * 32).decode()),
             "wrong partition": lambda s: s["obligations"][0].update(blob_count="18"),
             "premature refund": lambda s: s.update(refunded_slots_mask=255, locked_fee="0"),
             "settled without ack": lambda s: s.update(settled_slots_mask=1),
@@ -399,6 +400,74 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             workload.validate_v3_committed_message(duplicate, kind="session-proof",
                 creator=providers[0], slot=0, session_id=self.SESSION, proof_count=17)
+
+
+    def test_provider_endpoint_uses_address_not_assignment_slot(self):
+        lifecycle = SimpleNamespace(doc={"providers": [
+            {"address": AUDIT_ADDRESSES[1], "port": 19091},
+            {"address": AUDIT_ADDRESSES[0], "port": 19092},
+        ]})
+        self.assertEqual(workload.provider_http_url(lifecycle, AUDIT_ADDRESSES[0], "/sp/session-proof"),
+                         "http://127.0.0.1:19092/sp/session-proof")
+        with self.assertRaises(ValueError):
+            workload.provider_http_url(lifecycle, AUDIT_ADDRESSES[2], "/sp/session-proof")
+
+    def test_unfenced_v3_queries_choose_one_common_height(self):
+        calls = []
+        lifecycle = SimpleNamespace(nodes=[{"id": i} for i in range(4)],
+            wait_height=Mock(return_value=77))
+        session = self.session()
+        retained = {"generations": [{"deal_id": "7", "generation": "1",
+            "manifest_root": base64.b64encode(bytes.fromhex(self.ROOT)).decode()}]}
+        def query(node, route, height):
+            calls.append((node["id"], route, height))
+            return retained if route.endswith("retained-generations") else session
+        lifecycle.query = query
+        self.assertEqual(workload.v3_session_query(lifecycle, self.SESSION), session)
+        self.assertEqual(workload.v3_retained_generations(
+            lifecycle, deal_id="7", root=self.ROOT), retained)
+        self.assertEqual(lifecycle.wait_height.call_count, 2)
+        self.assertEqual({row[2] for row in calls}, {77})
+
+    def test_http_phase_drains_and_retains_provider_tagged_outcomes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            lifecycle = SimpleNamespace(home=Path(tmp), doc={}, env={},
+                deadline=artifact.monotonic_ns() + 10**9, save=Mock(), remaining=Mock(return_value=1))
+            requests = [dict(provider="provider-a", url="http://a/ok", body={}),
+                        dict(provider="provider-b", url="http://b/fail", body={})]
+            def run(argv, deadline, env):
+                if "/fail" in argv[-1]:
+                    raise ValueError("expected provider failure")
+                Path(argv[argv.index("--output") + 1]).write_text('{"status":"success"}')
+                return SimpleNamespace(stdout="200", stderr="", returncode=0)
+            with patch.object(artifact, "run_bounded_command", side_effect=run), \
+                 patch.object(workload, "require_free_disk", return_value=workload.V3_ABORT_FREE_BYTES):
+                with self.assertRaisesRegex(ValueError, "expected provider failure"):
+                    workload.run_v3_http_phase(lifecycle, "/curl", requests, "proofs", max_in_flight=2)
+            retained = lifecycle.doc["v3_http_phases"]["proofs"]
+            self.assertEqual({row["provider"] for row in retained}, {"provider-a", "provider-b"})
+            self.assertEqual({row["status"] for row in retained}, {"success", "driver_error"})
+
+    def test_disk_threshold_fails_closed(self):
+        with patch.object(workload.shutil, "disk_usage", return_value=SimpleNamespace(free=99)):
+            with self.assertRaisesRegex(ValueError, "found 99"):
+                workload.require_free_disk(Path("/"), 100, "pilot")
+
+    def test_session_list_is_retained_before_first_open_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            lifecycle = SimpleNamespace(home=Path(tmp), doc={"native_v3_generation": {
+                "candidate": {"integrity_root": "0x" + self.INTEGRITY}}},
+                signers={"owner0": AUDIT_ADDRESSES[8]}, chain="polystore_291-1",
+                wait_height=Mock(return_value=70), save=Mock())
+            deal = {"id": "7", "end_block": "1000",
+                    "manifest_root": base64.b64encode(bytes.fromhex(self.ROOT)).decode()}
+            with patch.object(workload, "v3_retained_generations", return_value={}), \
+                 self.assertRaisesRegex(ValueError, "open failed"):
+                workload.run_native_v3_sessions(lifecycle, deal=deal,
+                    providers=dict(enumerate(AUDIT_ADDRESSES[:8])),
+                    send=Mock(side_effect=ValueError("open failed")), wait=Mock(), curl="/curl")
+            self.assertEqual(lifecycle.doc["native_v3"]["sessions"], [])
+            lifecycle.save.assert_called()
 
 
 

--- a/scripts/test_retrieval_four_validator_workload.py
+++ b/scripts/test_retrieval_four_validator_workload.py
@@ -469,6 +469,29 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
             self.assertEqual(lifecycle.doc["native_v3"]["sessions"], [])
             lifecycle.save.assert_called()
 
+    def test_first_generation_empty_root_is_canonical_cli_hex(self):
+        candidate = dict(deal_id="7", expected_current_generation="0",
+            previous_polyfs_root="", polyfs_root="0x" + self.ROOT,
+            integrity_root="0x" + self.INTEGRITY, size_bytes=str(workload.V3_PILOT_BYTES),
+            total_mdus="5", witness_mdus="1", integrity_leaf_count="288",
+            commit_action="propose-deal-generation-v3", required_acceptances="12")
+        lifecycle = SimpleNamespace(signers={"owner0": AUDIT_ADDRESSES[8]},
+            nodes=[{"home": "/home", "rpc": 26657}], env={}, deadline=artifact.monotonic_ns() + 10**9,
+            binary=Path("/chain"), chain="polystore_291-1")
+        for spelling in ("", "0x"):
+            candidate["previous_polyfs_root"] = spelling
+            captured = []
+            def send(name, args):
+                captured.append(workload.transaction_job(lifecycle, lifecycle.signers[name], args))
+                raise ValueError("stop after scheduled proposal")
+            with self.subTest(spelling=spelling), self.assertRaisesRegex(ValueError, "stop after scheduled proposal"):
+                workload.admit_native_v3_generation(lifecycle,
+                    uploaded={"generation_candidate": copy.deepcopy(candidate)}, deal_id="7",
+                    providers=dict(enumerate(AUDIT_ADDRESSES)), send=send, curl="/curl")
+            argv = captured[0]["submit"]
+            self.assertNotIn("", argv)
+            self.assertEqual(argv[argv.index("--previous-polyfs-root") + 1], "0x")
+
 
 
 class HealthyAuditViewsTest(unittest.TestCase):

--- a/scripts/test_retrieval_settlement_adversarial.py
+++ b/scripts/test_retrieval_settlement_adversarial.py
@@ -33,21 +33,30 @@ class AdversarialSettlementTest(unittest.TestCase):
                 workload.assert_unchanged_retrieval(before, changed)
 
     def test_four_node_result_identity_and_gas_are_mandatory(self):
-        encoded = base64.b64encode(b'signed transaction').decode()
-        txhash = hashlib.sha256(b'signed transaction').hexdigest().upper()
+        raw = b'signed transaction'
+        encoded = base64.b64encode(raw).decode()
+        txhash = hashlib.sha256(raw).hexdigest().upper()
         result = dict(txhash=txhash, height=12, code=4, gas_wanted=20000000, gas_used=123,
                       outcome='committed_failure')
         for fault in (None, 'gas', 'hash', 'height', 'body'):
             def query(node, route):
-                response = dict(hash=txhash, height='12', tx=encoded,
-                    tx_result=dict(code=4, gas_wanted='20000000', gas_used='123'))
-                if node['node_id'] == '3':
-                    if fault == 'gas': response['tx_result']['gas_used'] = '124'
-                    if fault == 'hash': response['hash'] = '00' * 32
-                    if fault == 'height': response['height'] = '13'
-                    if fault == 'body': response['tx'] = base64.b64encode(b'other').decode()
-                return response
-            life = SimpleNamespace(nodes=[dict(node_id=str(i)) for i in range(4)], query=query)
+                bad = node['node_id'] == '3'
+                if route == '/block?height=12':
+                    block_tx = (base64.b64encode(b'other').decode() if bad and fault == 'hash' else
+                                'not-base64!' if bad and fault == 'body' else encoded)
+                    return {'block_id': {'hash': '11' * 32}, 'block': {
+                        'header': {'height': '13' if bad and fault == 'height' else '12',
+                                   'chain_id': 'polystore_291-1', 'app_hash': '22' * 32,
+                                   'time': '2026-01-01T00:00:00Z'},
+                        'data': {'txs': [block_tx]}}}
+                if route == '/block_results?height=12':
+                    return {'height': '12', 'txs_results': [dict(
+                        code=4, gas_wanted='20000000',
+                        gas_used='124' if bad and fault == 'gas' else '123')]}
+                self.fail('unexpected query ' + route)
+            life = SimpleNamespace(chain='polystore_291-1',
+                nodes=[dict(node_id=str(i)) for i in range(4)], query=query,
+                wait_height=Mock(return_value=13))
             if fault:
                 with self.assertRaises(ValueError): workload.verify_transaction_nodes(life, result)
             else:


### PR DESCRIPTION
Fixes normal audits for remote FATv3 providers and adds the bounded native-v3 proof diagnostic for #290/#291. Remote providers have authenticated metadata and shards but no uploader-local `slab_meta.json`; the legacy readiness decoder rejected FATv3 before generating an audit proof. The audit path now uses the existing generation lookup and cryptographic authentication. Regression cases cover valid metadata and corrupt metadata, witnesses and shards.

The diagnostic uses production K8 FATv3 upload, owner generation proposal, all twelve provider acceptances, finalization, and two 16 MiB native sessions (U=133/Q=132). It submits sampled proofs through the assigned provider-daemons with normal audits enabled, checks committed messages and authoritative bitmap changes across four validators, and verifies expiry/refund without an owner ACK. Only the exact pre-admission signer-busy HTTP response receives bounded retries; every attempt is retained and ambiguous outcomes fail closed. Gas/byte limits, concurrency, deadlines, heartbeats and disk use remain bounded.

Validation at `76d92bd7a277c8ea923abdb2ef4ae8483d9b18a3`:

- `python3 -m unittest discover -s scripts -p test_retrieval_four_validator_workload.py`: 32 passed.
- Full Linux gateway `go test ./...`: passed in 23.012 seconds against the identical gateway tree; focused FATv3 audit regressions passed.
- Independent and hosted Codex reviews: clean on the exact head. All 28 CI checks passed; merged as `498a69e8b17a76bfbb90df270d6dd56321fb1a80`.

Bounded Linux correctness smoke `native-v3-integration-006` passed in 534.025 seconds under the 600-second limit: sixteen committed-valid proof transactions and 264 newly accepted sample ordinals reconciled across all four validators, normal-audit coverage passed, and both unacknowledged sessions expired and refunded. Retained evidence is `/home/mikers/polystore-bench-290/runs/native-v3-integration-006/evidence.json` on the dedicated benchmark host. The harness is the exact head above; runtime binaries are frozen at `b7ea3a1058bcf2247307eec186b425c4a7c2c4d0`, with all four runtime component trees identical to the PR head. The generation remains retained for normal audits, so the retained-generation union cannot independently attribute release of each session reference.

This is a correctness and instrumentation prerequisite, with no retrieval-speed or sustained chain-capacity claim. HTTP timings combine proof construction, verification, simulation, signing and commit observation. Prepared-proof chain measurement follows separately under #290; v3 activates only in isolated test genesis.
