### PR TITLE
Measure native v3 proof transactions independently of provider preparation

### DIFF
--- a/bench/retrieval_session_capacity/native-k8-290/README.md
+++ b/bench/retrieval_session_capacity/native-k8-290/README.md
@@ -175,3 +175,34 @@ genesis. A retained result can establish production-route correctness and a
 bounded offered/committed diagnostic. A longer reviewed profile is required
 before quoting stable throughput, and delivered-file performance remains a
 separate measurement.
+
+## Native v3 chain-only diagnostic
+
+`native-v3-chain` keeps the same 16 MiB FAT v3 generation and normal audits,
+then opens eight sessions. Eight bounded exporter processes prepare and natively
+verify the 64 provider messages before measurement. The CLI simulates each exact
+message with `--generate-only --gas auto --gas-adjustment 1.6`; the measured
+submissions use those explicit gas limits, so proof generation and gas
+simulation are outside the clock. One warmup per systematic provider precedes
+56 transactions offered for eight seconds each at 1, 2, and 4 tx/s.
+
+The run requires complete current-epoch audit coverage, two blocks of signer
+sequence quiescence, and 60-block margins to the next audit anchor and session
+expiry. It retains exact blocks/results from all four validators, authoritative
+session bitmaps, signer sequences, gas, and Linux validator CPU ticks for the
+measured scheduler window. It sends no ACK and checks expiry/refund. The result
+is a finite local chain diagnostic; it does not qualify delivery, WAN behavior,
+steady-state capacity, or a phase RSS peak. Pre-merge runs are correctness
+smokes. Performance evidence is retained only from the reviewed landed harness.
+
+```sh
+python3 scripts/retrieval_four_validator_workload.py \
+  --mode native-v3-chain --audit-profile normal --timeout 600 \
+  --binary "$RETRIEVAL_BIN/polystorechaind" \
+  --library "$RETRIEVAL_LIBRARY" \
+  --gateway-binary "$RETRIEVAL_BIN/polystore_gateway" \
+  --cli-binary "$RETRIEVAL_BIN/polystore_cli" \
+  --proof-exporter "$RETRIEVAL_BIN/polystore_gateway.test" \
+  --product-source "$RETRIEVAL_REPO" \
+  --home "$RETRIEVAL_RUNS/native-v3-chain-001"
+```

--- a/polystore_gateway/retrieval_inventory_export_test.go
+++ b/polystore_gateway/retrieval_inventory_export_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -45,10 +46,20 @@ type inventoryExportItem struct {
 }
 
 type inventoryExportManifest struct {
-	ChainID        string                `json:"chain_id"`
-	TrustedSetup   string                `json:"trusted_setup"`
-	DeadlineUnixMS int64                 `json:"deadline_unix_ms"`
-	Sessions       []inventoryExportItem `json:"sessions"`
+	ChainID        string                  `json:"chain_id"`
+	TrustedSetup   string                  `json:"trusted_setup"`
+	DeadlineUnixMS int64                   `json:"deadline_unix_ms"`
+	Sessions       []inventoryExportItem   `json:"sessions,omitempty"`
+	V3Provider     string                  `json:"v3_provider,omitempty"`
+	V3Directory    string                  `json:"v3_artifact_directory,omitempty"`
+	V3Sessions     []inventoryV3ExportItem `json:"v3_sessions,omitempty"`
+}
+
+type inventoryV3ExportItem struct {
+	OutputPath string          `json:"output_path"`
+	SessionID  string          `json:"session_id"`
+	Height     uint64          `json:"height"`
+	View       json.RawMessage `json:"view"`
 }
 
 type inventoryExportResult struct {
@@ -59,6 +70,17 @@ type inventoryExportResult struct {
 	Seed         string  `json:"seed"`
 	WindowSHA256 string  `json:"window_sha256"`
 	GenerationMS float64 `json:"generation_ms"`
+}
+
+type inventoryV3ExportResult struct {
+	SessionID     string   `json:"session_id"`
+	MessagePath   string   `json:"message_path"`
+	MessageSHA256 string   `json:"message_sha256"`
+	ContextHash   string   `json:"context_hash"`
+	Seed          string   `json:"seed"`
+	Slot          uint32   `json:"slot"`
+	Ordinals      []uint64 `json:"ordinals"`
+	GenerationMS  float64  `json:"generation_ms"`
 }
 
 func freezeInventoryExport(item inventoryExportItem) (*frozenRetrievalSession, error) {
@@ -93,6 +115,69 @@ func writeInventoryExclusive(path string, value any) error {
 	if err != nil {
 		return err
 	}
+	return writeInventoryBytesExclusive(path, data)
+}
+
+func freezeInventoryV3Export(item inventoryV3ExportItem) (*frozenRetrievalSessionV3, error) {
+	if len(item.View) > maxSessionQueryBytes {
+		return nil, fmt.Errorf("oversized v3 session view")
+	}
+	var view types.QueryGetRetrievalSessionV3Response
+	if err := jsonpb.Unmarshal(bytes.NewReader(item.View), &view); err != nil {
+		return nil, err
+	}
+	f, err := freezeRetrievalSessionV3Response(&view, item.Height)
+	if err != nil {
+		return nil, err
+	}
+	if item.SessionID != hex.EncodeToString(f.Context.SessionID[:]) {
+		return nil, fmt.Errorf("wrong v3 session identity")
+	}
+	return f, nil
+}
+
+func exportInventoryV3(ctx context.Context, manifest inventoryExportManifest) ([]inventoryV3ExportResult, error) {
+	if manifest.V3Provider == "" || !filepath.IsAbs(manifest.V3Directory) || len(manifest.V3Sessions) < 1 || len(manifest.V3Sessions) > 8 || len(manifest.Sessions) != 0 {
+		return nil, fmt.Errorf("invalid bounded v3 inventory")
+	}
+	seen := map[string]bool{}
+	results := make([]inventoryV3ExportResult, 0, len(manifest.V3Sessions))
+	for _, item := range manifest.V3Sessions {
+		if ctx.Err() != nil || !filepath.IsAbs(item.OutputPath) || seen[item.SessionID] || seen[item.OutputPath] {
+			return nil, fmt.Errorf("invalid or duplicate v3 inventory identity/path")
+		}
+		seen[item.SessionID], seen[item.OutputPath] = true, true
+		f, err := freezeInventoryV3Export(item)
+		if err != nil {
+			return nil, err
+		}
+		started := time.Now()
+		slot, proofs, remaining, err := buildProviderProofBatchV3FromDirectory(ctx, f, manifest.V3Provider, manifest.V3Directory)
+		if err != nil {
+			return nil, err
+		}
+		if len(proofs) == 0 || remaining != 0 {
+			return nil, fmt.Errorf("incomplete v3 proof batch")
+		}
+		message := types.MsgSubmitRetrievalSessionProofV3{Creator: manifest.V3Provider, SessionId: f.Context.SessionID[:], Slot: slot, Proofs: proofs}
+		var encoded bytes.Buffer
+		if err := (&jsonpb.Marshaler{OrigName: true, EmitDefaults: true}).Marshal(&encoded, &message); err != nil {
+			return nil, err
+		}
+		if err := writeInventoryBytesExclusive(item.OutputPath, encoded.Bytes()); err != nil {
+			return nil, err
+		}
+		digest := sha256.Sum256(encoded.Bytes())
+		ordinals := make([]uint64, len(proofs))
+		for i := range proofs {
+			ordinals[i] = proofs[i].Ordinal
+		}
+		results = append(results, inventoryV3ExportResult{item.SessionID, item.OutputPath, hex.EncodeToString(digest[:]), hex.EncodeToString(f.Hash[:]), hex.EncodeToString(f.Seed[:]), slot, ordinals, float64(time.Since(started)) / float64(time.Millisecond)})
+	}
+	return results, nil
+}
+
+func writeInventoryBytesExclusive(path string, data []byte) error {
 	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
 	if err != nil {
 		return err
@@ -136,7 +221,7 @@ func TestExportFrozenRetrievalInventory(t *testing.T) {
 		t.Fatal("trailing manifest data")
 	}
 	deadline := time.UnixMilli(manifest.DeadlineUnixMS)
-	if len(manifest.Sessions) < 1 || len(manifest.Sessions) > 1700 || !deadline.After(time.Now()) || time.Until(deadline) > 2*time.Hour || !filepath.IsAbs(manifest.TrustedSetup) || manifest.ChainID == "" {
+	if (len(manifest.Sessions) < 1 && len(manifest.V3Sessions) < 1) || len(manifest.Sessions) > 1700 || !deadline.After(time.Now()) || time.Until(deadline) > 2*time.Hour || !filepath.IsAbs(manifest.TrustedSetup) || manifest.ChainID == "" {
 		t.Fatal("invalid bounded inventory")
 	}
 	previousChain := chainID
@@ -147,6 +232,18 @@ func TestExportFrozenRetrievalInventory(t *testing.T) {
 	}
 	ctx, cancel := context.WithDeadline(context.Background(), deadline)
 	defer cancel()
+	if len(manifest.V3Sessions) != 0 {
+		results, err := exportInventoryV3(ctx, manifest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := writeInventoryExclusive(manifestPath+".result.json", struct {
+			Messages []inventoryV3ExportResult `json:"messages"`
+		}{results}); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
 	seen := map[string]bool{}
 	results := make([]inventoryExportResult, 0, len(manifest.Sessions))
 	for _, item := range manifest.Sessions {
@@ -232,5 +329,43 @@ func TestInventoryExportRejectsChangedAuthorityAndOverwrite(t *testing.T) {
 	raw, err := os.ReadFile(path)
 	if err != nil || string(raw) != `"first"` {
 		t.Fatal("changed retained proof")
+	}
+}
+
+func TestInventoryV3ExportFreezesExactSessionAuthority(t *testing.T) {
+	r, height := frozenSessionV3Fixture(t, 1<<20, 1)
+	var encoded bytes.Buffer
+	if err := (&jsonpb.Marshaler{OrigName: true, EmitDefaults: true}).Marshal(&encoded, r); err != nil {
+		t.Fatal(err)
+	}
+	item := inventoryV3ExportItem{SessionID: hex.EncodeToString(r.Session.SessionId), Height: height, View: encoded.Bytes()}
+	frozen, err := freezeInventoryV3Export(item)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if frozen.Session.Obligations[0].Slot != 0 || frozen.Challenges[0].Ordinal != 0 {
+		t.Fatal("fixture did not retain zero-valued slot and ordinal authority")
+	}
+	for _, change := range []func(*inventoryV3ExportItem){
+		func(i *inventoryV3ExportItem) { i.SessionID = strings.Repeat("00", 32) },
+		func(i *inventoryV3ExportItem) { i.Height = 1 },
+		func(i *inventoryV3ExportItem) {
+			var changed types.QueryGetRetrievalSessionV3Response
+			if err := jsonpb.Unmarshal(bytes.NewReader(i.View), &changed); err != nil {
+				t.Fatal(err)
+			}
+			changed.Session.ContextHash[0] ^= 1
+			var raw bytes.Buffer
+			if err := (&jsonpb.Marshaler{OrigName: true, EmitDefaults: true}).Marshal(&raw, &changed); err != nil {
+				t.Fatal(err)
+			}
+			i.View = raw.Bytes()
+		},
+	} {
+		bad := item
+		change(&bad)
+		if _, err := freezeInventoryV3Export(bad); err == nil {
+			t.Fatal("accepted altered v3 export authority")
+		}
 	}
 }

--- a/polystore_gateway/retrieval_v3_session.go
+++ b/polystore_gateway/retrieval_v3_session.go
@@ -254,6 +254,17 @@ func buildProviderProofBatchV3(ctx context.Context, f *frozenRetrievalSessionV3,
 		return 0, nil, 0, err
 	}
 	defer release()
+	return buildProviderProofBatchV3FromDirectory(ctx, f, signer, dir)
+}
+
+// buildProviderProofBatchV3FromDirectory is the offline diagnostic seam for a
+// caller that already owns an immutable generation directory. It deliberately
+// retains the production authority, metadata, native proof, and signer checks.
+func buildProviderProofBatchV3FromDirectory(ctx context.Context, f *frozenRetrievalSessionV3, signer, dir string) (uint32, []types.RetrievalSampleProofV3, int, error) {
+	slot, challenges, remaining, err := providerChallengesV3(f, signer, 64)
+	if err != nil || len(challenges) == 0 {
+		return slot, nil, remaining, err
+	}
 	key := retrievalGenerationKey{Chain: f.Context.ChainID, Setup: f.Context.SetupDigest, Root: f.Context.PolyFSRoot, Integrity: f.Context.IntegrityRoot, Deal: f.Context.DealID, Generation: f.Context.Generation, Metadata: f.Context.MetadataMDUs, Users: f.Context.UserMDUs, Layout: retrievalchallenge.StripeK8M4, K: 8, M: 4, Version: 3}
 	metadata, err := authenticatedRetrievalMetadataFor(ctx, dir, key)
 	if err != nil {

--- a/polystore_gateway/retrieval_v3_session_test.go
+++ b/polystore_gateway/retrieval_v3_session_test.go
@@ -305,6 +305,33 @@ func TestBuildProviderProofBatchV3UsesAuthenticatedArtifactsAndRealKZG(t *testin
 	}
 }
 
+func TestBuildProviderProofBatchV3FromDirectoryRetainsProductionAuthentication(t *testing.T) {
+	frozen, _, dir := buildProviderV3ArtifactFixture(t)
+	signer := frozen.Session.Obligations[0].AssignedProvider
+	slot, proofs, remaining, err := buildProviderProofBatchV3FromDirectory(t.Context(), frozen, signer, dir)
+	if err != nil || slot != 0 || len(proofs) != 1 || remaining != 0 {
+		t.Fatalf("unexpected explicit-directory proof batch slot=%d proofs=%d remaining=%d err=%v", slot, len(proofs), remaining, err)
+	}
+	bad := filepath.Join(t.TempDir(), "generation")
+	if err := os.CopyFS(bad, os.DirFS(dir)); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(bad, fmt.Sprintf("mdu_%d_slot_0.bin", frozen.Context.MetadataMDUs))
+	f, err := os.OpenFile(path, os.O_RDWR, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteAt([]byte{0xff}, 19); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := buildProviderProofBatchV3FromDirectory(t.Context(), frozen, signer, bad); err == nil {
+		t.Fatal("explicit-directory builder accepted corrupted authenticated bytes")
+	}
+}
+
 func TestGenerationAcceptanceV3RejectsUnsampledIntegrityLeaf(t *testing.T) {
 	_, key, dir := buildProviderV3ArtifactFixture(t)
 	metadata, err := authenticatedRetrievalMetadataFor(t.Context(), dir, key)

--- a/scripts/retrieval_bench_artifact.py
+++ b/scripts/retrieval_bench_artifact.py
@@ -1488,9 +1488,11 @@ class FourValidatorLifecycle:
         retry_until = None
         future_detail = None
 
-        def read(response):
+        def read(response, deadline=None):
             body = bytearray()
             while len(body) <= MAX_COMMAND_OUTPUT_BYTES:
+                if deadline is not None and monotonic_ns() >= deadline:
+                    raise TimeoutError("node query future-height retry deadline exceeded")
                 self.remaining()
                 reader = getattr(response, "read1", response.read)
                 chunk = reader(min(65536, MAX_COMMAND_OUTPUT_BYTES - len(body) + 1))
@@ -1501,18 +1503,22 @@ class FourValidatorLifecycle:
             return bytes(body)
 
         while True:
-            if retry_until is not None and monotonic_ns() >= retry_until:
-                raise ValueError("node query HTTP 500: " + future_detail)
+            timeout = self.remaining()
+            if retry_until is not None:
+                retry_remaining = (retry_until - monotonic_ns()) / 1e9
+                if retry_remaining <= 0:
+                    raise ValueError("node query HTTP 500: " + future_detail)
+                timeout = min(timeout, retry_remaining)
             try:
-                with urllib.request.urlopen(request, timeout=self.remaining()) as response:
-                    body = read(response)
+                with urllib.request.urlopen(request, timeout=timeout) as response:
+                    body = read(response, retry_until)
                     if response.status != 200 or len(body) > MAX_COMMAND_OUTPUT_BYTES:
                         raise ValueError("invalid or oversized node response")
                     if height is not None and response.headers.get("x-cosmos-block-height") != str(height):
                         raise ValueError("economic response does not attest the requested height")
             except urllib.error.HTTPError as error:
                 try:
-                    body = read(error)
+                    body = read(error, retry_until)
                 finally:
                     error.close()
                 try:

--- a/scripts/retrieval_bench_artifact.py
+++ b/scripts/retrieval_bench_artifact.py
@@ -1484,23 +1484,56 @@ class FourValidatorLifecycle:
         headers = {} if height is None else {"x-cosmos-block-height": str(height)}
         port = node["rpc"] if height is None else node["api"]
         request = urllib.request.Request(f"http://127.0.0.1:{port}{route}", headers=headers)
-        with urllib.request.urlopen(request, timeout=self.remaining()) as response:
+        future_height = {"code": 2, "message": "codespace sdk code 26: invalid height: cannot query with height in the future; please provide a valid height", "details": []}
+        retry_until = None
+        future_detail = None
+
+        def read(response):
             body = bytearray()
             while len(body) <= MAX_COMMAND_OUTPUT_BYTES:
                 self.remaining()
-                chunk = response.read1(min(65536, MAX_COMMAND_OUTPUT_BYTES - len(body) + 1))
+                reader = getattr(response, "read1", response.read)
+                chunk = reader(min(65536, MAX_COMMAND_OUTPUT_BYTES - len(body) + 1))
                 if not chunk:
                     break
                 body.extend(chunk)
             self.remaining()
-            if response.status != 200 or len(body) > MAX_COMMAND_OUTPUT_BYTES:
-                raise ValueError("invalid or oversized node response")
-            if height is not None and response.headers.get("x-cosmos-block-height") != str(height):
-                raise ValueError("economic response does not attest the requested height")
-        value = json.loads(body)
-        if not isinstance(value, dict) or not value or value.get("error"):
-            raise ValueError("malformed node response")
-        return value if height is not None else value["result"]
+            return bytes(body)
+
+        while True:
+            if retry_until is not None and monotonic_ns() >= retry_until:
+                raise ValueError("node query HTTP 500: " + future_detail)
+            try:
+                with urllib.request.urlopen(request, timeout=self.remaining()) as response:
+                    body = read(response)
+                    if response.status != 200 or len(body) > MAX_COMMAND_OUTPUT_BYTES:
+                        raise ValueError("invalid or oversized node response")
+                    if height is not None and response.headers.get("x-cosmos-block-height") != str(height):
+                        raise ValueError("economic response does not attest the requested height")
+            except urllib.error.HTTPError as error:
+                try:
+                    body = read(error)
+                finally:
+                    error.close()
+                try:
+                    value = json.loads(body)
+                except (UnicodeDecodeError, json.JSONDecodeError):
+                    value = None
+                detail = body[-8192:].decode(errors="replace")
+                if height is not None and error.code == 500 and value == future_height:
+                    future_detail = detail
+                    retry_until = retry_until or min(self.deadline, monotonic_ns() + 5 * 10**9)
+                    if monotonic_ns() < retry_until:
+                        time.sleep(min(0.05, (retry_until - monotonic_ns()) / 1e9))
+                        continue
+                raise ValueError(f"node query HTTP {error.code}: {detail}") from error
+            try:
+                value = json.loads(body)
+            except (UnicodeDecodeError, json.JSONDecodeError) as error:
+                raise ValueError("malformed node response: " + body[-8192:].decode(errors="replace")) from error
+            if not isinstance(value, dict) or not value or value.get("error"):
+                raise ValueError("malformed node response: " + body[-8192:].decode(errors="replace"))
+            return value if height is not None else value["result"]
 
     def wait_height(self, minimum):
         while True:

--- a/scripts/retrieval_bench_artifact.py
+++ b/scripts/retrieval_bench_artifact.py
@@ -1499,6 +1499,8 @@ class FourValidatorLifecycle:
                 if not chunk:
                     break
                 body.extend(chunk)
+            if deadline is not None and monotonic_ns() >= deadline:
+                raise TimeoutError("node query future-height retry deadline exceeded")
             self.remaining()
             return bytes(body)
 

--- a/scripts/retrieval_four_validator_workload.py
+++ b/scripts/retrieval_four_validator_workload.py
@@ -729,7 +729,7 @@ def export_native_v3_chain_inventory(lifecycle, exporter, sessions, providers, d
                     producer.uint(message.get("slot", 0)) != slot or
                     [producer.uint(proof.get("ordinal", V3_MAX_SAMPLES)) for proof in message.get("proofs", [])] != row.get("ordinals")):
                 raise ValueError("v3 exporter changed frozen message/context/provider intent")
-            ordered.append(dict(session_index=session_index, slot=slot, provider=provider, **row))
+            ordered.append(dict(row, session_index=session_index, provider=provider))
     return dict(directory=str(inventory), manifests=[str(row[1]) for row in manifests], messages=ordered)
 
 

--- a/scripts/retrieval_four_validator_workload.py
+++ b/scripts/retrieval_four_validator_workload.py
@@ -651,17 +651,30 @@ def require_provider_quiescence(lifecycle, providers):
 
 
 def v3_generate_only_gas(lifecycle, message_path, provider):
-    source_raw = Path(message_path).read_bytes()
+    message_path = Path(message_path)
+    source_raw = message_path.read_bytes()
     if len(source_raw) > 8 * 1024 * 1024:
         raise ValueError("exported v3 message exceeds bound")
     source = json.loads(source_raw)
+    aliases = [name for name, address in lifecycle.signers.items() if address == provider]
+    if len(aliases) != 1:
+        raise ValueError("provider address does not identify exactly one simulation key")
     job = transaction_job(lifecycle, provider,
         ["retrieval-session-v3", "prove", str(message_path)], kind="submit-proof", gas="auto")
     argv = [*job["submit"], "--generate-only"]
+    argv[argv.index("--from") + 1] = aliases[0]
     deadline = min(lifecycle.deadline, artifact.monotonic_ns() + 60 * 10**9)
     result = artifact.run_bounded_command(argv, deadline,
         env={key: lifecycle.env[key] for key in ENV_KEYS if key in lifecycle.env})
-    if result.returncode or len(result.stdout.encode()) > 8 * 1024 * 1024:
+    stdout, stderr = result.stdout.encode(), result.stderr.encode()
+    diagnostic = message_path.with_name(message_path.name + ".gas-simulation.json")
+    with diagnostic.open("x") as output:
+        json.dump(dict(message_path=str(message_path), provider=provider, simulation_key=aliases[0], command=argv,
+            returncode=result.returncode, stdout_bytes=len(stdout), stderr_bytes=len(stderr),
+            stdout_sha256=hashlib.sha256(stdout).hexdigest(), stderr_sha256=hashlib.sha256(stderr).hexdigest(),
+            stdout_tail=stdout[-8192:].decode("utf-8", errors="replace"),
+            stderr_tail=stderr[-8192:].decode("utf-8", errors="replace")), output, separators=(",", ":"))
+    if result.returncode or len(stdout) > 8 * 1024 * 1024:
         raise ValueError("bounded v3 gas simulation failed")
     unsigned = json.loads(result.stdout)
     messages = unsigned.get("body", {}).get("messages", [])
@@ -677,7 +690,8 @@ def v3_generate_only_gas(lifecycle, message_path, provider):
     job = transaction_job(lifecycle, provider,
         ["retrieval-session-v3", "prove", str(message_path)], kind="submit-proof", gas=str(gas))
     return job, dict(message_sha256=hashlib.sha256(source_raw).hexdigest(), gas_limit=gas,
-                     simulation_stdout_sha256=hashlib.sha256(result.stdout.encode()).hexdigest())
+                     simulation_stdout_sha256=hashlib.sha256(stdout).hexdigest(),
+                     simulation_diagnostic=str(diagnostic))
 
 
 def export_native_v3_chain_inventory(lifecycle, exporter, sessions, providers, directories):

--- a/scripts/retrieval_four_validator_workload.py
+++ b/scripts/retrieval_four_validator_workload.py
@@ -755,6 +755,42 @@ def verify_native_v3_chain_transactions(lifecycle, rows, messages):
     return verified
 
 
+def native_v3_chain_committed_summary(sessions, messages, warmup_rows, measured_rows):
+    """Separate authoritative totals from the measured committed subset."""
+    warmup_ids = {row["id"] for row in warmup_rows}
+    measured_ids = {row["id"] for row in measured_rows}
+    if (len(warmup_ids) != len(warmup_rows) or len(measured_ids) != len(measured_rows) or
+            warmup_ids & measured_ids):
+        raise ValueError("native v3 chain committed transaction identities are inconsistent")
+    message_ids = {row["id"] for row in messages}
+    if len(message_ids) != len(messages) or message_ids != warmup_ids | measured_ids:
+        raise ValueError("native v3 chain messages differ from committed transaction inventory")
+    total_ordinals = measured_ordinals = 0
+    for index, session in enumerate(sessions):
+        accepted = session["accepted_sample_ordinals"]
+        expected = sorted(ordinal for row in messages if row["session_index"] == index
+                          for ordinal in row["ordinals"])
+        measured = sorted(ordinal for row in messages
+                          if row["session_index"] == index and row["id"] in measured_ids
+                          for ordinal in row["ordinals"])
+        if accepted != expected or any(ordinal not in accepted for ordinal in measured):
+            raise ValueError("authoritative session bitmap differs from committed proof messages")
+        total_ordinals += len(accepted)
+        measured_ordinals += len(measured)
+    return dict(total_committed_valid_proof_transactions=len(warmup_rows) + len(measured_rows),
+                measured_committed_valid_proof_transactions=len(measured_rows),
+                total_authoritative_new_sample_ordinals=total_ordinals,
+                measured_authoritative_new_sample_ordinals=measured_ordinals)
+
+
+def native_v3_chain_exporter_identity(value):
+    exporter = Path(value).resolve(strict=True)
+    if not exporter.is_file() or not os.access(exporter, os.X_OK):
+        raise ValueError("native v3 chain exporter must be executable")
+    return exporter, dict(native_chain_exporter=str(exporter),
+                          native_chain_exporter_sha256=artifact.sha256(exporter))
+
+
 def run_native_v3_chain(lifecycle, *, deal, providers, send, wait, audits, exporter, epoch_length):
     """Finite chain-only proof submission diagnostic; proof creation is untimed."""
     doc = lifecycle.doc["native_v3_chain"] = dict(qualification=False)
@@ -828,7 +864,8 @@ def run_native_v3_chain(lifecycle, *, deal, providers, send, wait, audits, expor
     doc["warmup_scheduler"] = artifact.schedule_transactions(warmup_jobs, max_in_flight=8,
         max_queued=8, max_queued_per_signer=1)
     warmup_rows = doc["warmup_scheduler"]["transactions"]
-    verify_native_v3_chain_transactions(lifecycle, warmup_rows, message_rows[:V3_CHAIN_WARMUPS])
+    warmup_verified = verify_native_v3_chain_transactions(
+        lifecycle, warmup_rows, message_rows[:V3_CHAIN_WARMUPS])
     warmup_height = max(row["height"] for row in warmup_rows)
     wait(warmup_height + 1)
     warm = v3_session_query(lifecycle, sessions[0]["session_id"], warmup_height)
@@ -902,8 +939,6 @@ def run_native_v3_chain(lifecycle, *, deal, providers, send, wait, audits, expor
     final_audits = audits(end_height, False, ready_epoch)
     if final_audits != current_audits:
         raise ValueError("current epoch audit authority/coverage changed during measurement")
-    all_rows = warmup_rows + verified
-    accepted_total = 0
     for index, row in enumerate(sessions):
         state = v3_session_query(lifecycle, row["session_id"], end_height)
         _, accepted = validate_v3_session(state, session_id=row["session_id"], deal_id=deal["id"], owner=owner,
@@ -913,10 +948,11 @@ def run_native_v3_chain(lifecycle, *, deal, providers, send, wait, audits, expor
                           for ordinal in message["ordinals"])
         if accepted != expected or len(accepted) != V3_MAX_SAMPLES:
             raise ValueError("authoritative session bitmap differs from committed proof messages")
-        row["after_proofs"] = state
-        accepted_total += len(accepted)
+        row.update(after_proofs=state, accepted_sample_ordinals=accepted)
+    committed_summary = native_v3_chain_committed_summary(
+        sessions, message_rows, warmup_verified, verified)
     doc.update(offered_proof_transactions=64, warmup_transactions=8, measured_transactions=56,
-        committed_valid_proof_transactions=len(all_rows), authoritative_new_sample_ordinals=accepted_total,
+        **committed_summary,
         measured_gas_wanted=sum(row["gas_wanted"] for row in verified),
         measured_gas_used=sum(row["gas_used"] for row in verified), delivery_verified=False,
         owner_acknowledged=False, qualification=False)
@@ -2222,10 +2258,9 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
             raise ValueError("proof exporter must be executable")
         artifact.integer(sustained["proof_gas"], "proof gas", 1, 64000000)
         sustained_offsets(sustained["step_seconds"], rate_scale)
+    native_chain_exporter = None
     if native_chain is not None:
-        export_binary = Path(native_chain["exporter"]).resolve(strict=True)
-        if not export_binary.is_file() or not os.access(export_binary, os.X_OK):
-            raise ValueError("native v3 chain exporter must be executable")
+        export_binary, native_chain_exporter = native_v3_chain_exporter_identity(native_chain["exporter"])
     curl = shutil.which("curl")
     if not curl:
         raise ValueError("curl is required for bounded multipart upload")
@@ -2332,6 +2367,8 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
             cli_source_sha256=artifact.sha256(source / "polystore_cli/src/main.rs"),
             curl_binary=curl, curl_sha256=artifact.sha256(curl),
             artifact_source_match="supplied binaries/library; build correspondence not attested")
+        if native_chain_exporter is not None:
+            doc["provenance"].update(native_chain_exporter)
         if doc["provenance"]["trusted_setup_sha256"] != producer.SETUP_DIGEST:
             raise ValueError("diagnostic requires the maintained trusted setup")
         lifecycle.prepare(audit_profile=audit_profile, provider_count=layout["provisioned_provider_signers"],
@@ -2511,7 +2548,7 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
         if native_v3:
             if native_chain is not None:
                 run_native_v3_chain(lifecycle, deal=deal, providers=providers, send=send, wait=wait,
-                                    audits=audits, exporter=native_chain["exporter"], epoch_length=epoch_length)
+                                    audits=audits, exporter=export_binary, epoch_length=epoch_length)
                 doc["status"] = "native_v3_chain_diagnostic_passed"
             else:
                 run_native_v3_sessions(lifecycle, deal=deal, providers=providers, send=send, wait=wait, curl=curl)

--- a/scripts/retrieval_four_validator_workload.py
+++ b/scripts/retrieval_four_validator_workload.py
@@ -49,6 +49,76 @@ V3_BUSY_MAX_ATTEMPTS = 4
 V3_BUSY_RETRY_SECONDS = 2
 V3_PREFLIGHT_FREE_BYTES = 2 * 1024**3
 V3_ABORT_FREE_BYTES = 768 * 1024**2
+V3_CHAIN_SESSIONS = 8
+V3_CHAIN_WARMUPS = 8
+V3_CHAIN_MEASURED = 56
+V3_CHAIN_MEASURED_CAP_SECONDS = 45
+
+
+def native_v3_chain_offsets():
+    """Fixed 1/2/4 tx/s stages: 8 + 16 + 32 = 56 transactions."""
+    return ([i * 10**9 for i in range(8)] +
+            [8 * 10**9 + i * 500_000_000 for i in range(16)] +
+            [16 * 10**9 + i * 250_000_000 for i in range(32)])
+
+
+def parse_proc_stat(raw, *, expected_pid=None):
+    """Parse only stable /proc/<pid>/stat identity and CPU fields."""
+    if not isinstance(raw, str) or ")" not in raw:
+        raise ValueError("invalid validator proc stat")
+    prefix, suffix = raw.rstrip("\n").rsplit(")", 1)
+    if "(" not in prefix:
+        raise ValueError("invalid validator proc stat command")
+    pid_text, _ = prefix.split("(", 1)
+    fields = suffix.strip().split()
+    if len(fields) < 20:
+        raise ValueError("short validator proc stat")
+    pid = producer.uint(pid_text.strip())
+    if expected_pid is not None and pid != expected_pid:
+        raise ValueError("validator proc stat PID changed")
+    return dict(pid=pid, user_ticks=producer.uint(fields[11]), system_ticks=producer.uint(fields[12]),
+                starttime_ticks=producer.uint(fields[19]))
+
+
+def validator_cpu_snapshot(lifecycle):
+    ticks = os.sysconf("SC_CLK_TCK")
+    if type(ticks) is not int or ticks <= 0:
+        raise ValueError("invalid Linux clock tick rate")
+    at = artifact.monotonic_ns()
+    rows = []
+    resources = lifecycle.doc.get("validator_resources", [])
+    for node in lifecycle.nodes:
+        matches = [row for row in resources if row.get("node_id") == node["node_id"]]
+        if len(matches) != 1:
+            raise ValueError("validator PID is not uniquely retained")
+        pid = producer.uint(matches[0]["pid"])
+        stat = parse_proc_stat(Path(f"/proc/{pid}/stat").read_text(), expected_pid=pid)
+        rows.append(dict(node_id=node["node_id"], **stat))
+    return dict(monotonic_ns=at, clock_ticks_per_second=ticks, validators=rows)
+
+
+def validator_cpu_delta(before, after):
+    if before["clock_ticks_per_second"] != after["clock_ticks_per_second"]:
+        raise ValueError("validator clock tick rate changed")
+    earlier = {row["node_id"]: row for row in before["validators"]}
+    later = {row["node_id"]: row for row in after["validators"]}
+    if set(earlier) != set(later) or after["monotonic_ns"] < before["monotonic_ns"]:
+        raise ValueError("validator CPU snapshot set or time changed")
+    rows = []
+    for node_id, start in earlier.items():
+        end = later[node_id]
+        if (end["pid"], end["starttime_ticks"]) != (start["pid"], start["starttime_ticks"]):
+            raise ValueError("validator process identity changed during measurement")
+        user, system = end["user_ticks"] - start["user_ticks"], end["system_ticks"] - start["system_ticks"]
+        if user < 0 or system < 0:
+            raise ValueError("validator CPU ticks moved backwards")
+        rows.append(dict(node_id=node_id, pid=start["pid"], starttime_ticks=start["starttime_ticks"],
+                         user_ticks=user, system_ticks=system,
+                         user_cpu_seconds=user / before["clock_ticks_per_second"],
+                         system_cpu_seconds=system / before["clock_ticks_per_second"]))
+    return dict(measurement_scope="measured scheduler window", monotonic_start_ns=before["monotonic_ns"],
+                monotonic_end_ns=after["monotonic_ns"], clock_ticks_per_second=before["clock_ticks_per_second"],
+                validators=rows)
 
 
 def require_free_disk(path, minimum, phase):
@@ -549,6 +619,326 @@ def _write_v3_refund(lifecycle, owner, session_id):
         json.dump(dict(creator=owner, session_id=base64.b64encode(bytes.fromhex(session_id)).decode()),
                   output, separators=(",", ":"))
     return path
+
+
+def provider_sequences(lifecycle, providers, height):
+    rows = {}
+    for address in providers.values():
+        values = []
+        for node in lifecycle.nodes:
+            response = lifecycle.query(node, "/cosmos/auth/v1beta1/accounts/" + address, height)
+            account = response.get("account", {})
+            while isinstance(account, dict) and isinstance(account.get("base_account"), dict):
+                account = account["base_account"]
+            if account.get("address") != address:
+                raise ValueError("provider account query returned another signer")
+            values.append((producer.uint(account.get("account_number", "")),
+                           producer.uint(account.get("sequence", ""))))
+        if any(value != values[0] for value in values[1:]):
+            raise ValueError("four validators disagree on provider sequence")
+        rows[address] = dict(account_number=values[0][0], sequence=values[0][1])
+    return rows
+
+
+def require_provider_quiescence(lifecycle, providers):
+    first = lifecycle.wait_height(1)
+    before = provider_sequences(lifecycle, providers, first)
+    second = lifecycle.wait_height(first + 2)
+    after = provider_sequences(lifecycle, providers, second)
+    if before != after:
+        raise ValueError("provider sequences changed during two-block quiescence fence")
+    return dict(first_height=first, second_height=second, sequences=after)
+
+
+def v3_generate_only_gas(lifecycle, message_path, provider):
+    source_raw = Path(message_path).read_bytes()
+    if len(source_raw) > 8 * 1024 * 1024:
+        raise ValueError("exported v3 message exceeds bound")
+    source = json.loads(source_raw)
+    job = transaction_job(lifecycle, provider,
+        ["retrieval-session-v3", "prove", str(message_path)], kind="submit-proof", gas="auto")
+    argv = [*job["submit"], "--generate-only"]
+    deadline = min(lifecycle.deadline, artifact.monotonic_ns() + 60 * 10**9)
+    result = artifact.run_bounded_command(argv, deadline,
+        env={key: lifecycle.env[key] for key in ENV_KEYS if key in lifecycle.env})
+    if result.returncode or len(result.stdout.encode()) > 8 * 1024 * 1024:
+        raise ValueError("bounded v3 gas simulation failed")
+    unsigned = json.loads(result.stdout)
+    messages = unsigned.get("body", {}).get("messages", [])
+    if len(messages) != 1 or messages[0].get("@type") != "/polystorechain.polystorechain.v1.MsgSubmitRetrievalSessionProofV3":
+        raise ValueError("generated transaction has the wrong message type/count")
+    actual = dict(messages[0])
+    actual.pop("@type")
+    if actual != source:
+        raise ValueError("gas simulation message differs from exported proof request")
+    gas = producer.uint(unsigned.get("auth_info", {}).get("fee", {}).get("gas_limit", ""))
+    if not 1 <= gas <= 64_000_000:
+        raise ValueError("simulated v3 gas exceeds chain diagnostic bound")
+    job = transaction_job(lifecycle, provider,
+        ["retrieval-session-v3", "prove", str(message_path)], kind="submit-proof", gas=str(gas))
+    return job, dict(message_sha256=hashlib.sha256(source_raw).hexdigest(), gas_limit=gas,
+                     simulation_stdout_sha256=hashlib.sha256(result.stdout.encode()).hexdigest())
+
+
+def export_native_v3_chain_inventory(lifecycle, exporter, sessions, providers, directories):
+    inventory = lifecycle.home / "native-v3-chain-inventory"
+    inventory.mkdir(mode=0o700)
+    deadline_ms = int(time.time() * 1000 + (lifecycle.deadline - artifact.monotonic_ns()) / 1e6)
+    manifests = []
+    for slot in range(V3_SYSTEMATIC_PROVIDERS):
+        provider = providers[slot]
+        directory = Path(directories[provider])
+        manifest = inventory / f"provider-{slot}.manifest.json"
+        requests = []
+        for index, session in enumerate(sessions):
+            requests.append(dict(session_id=session["session_id"], height=session["evidence_height"],
+                view=session["before_proofs"], output_path=str(inventory / f"provider-{slot}-session-{index}.json")))
+        manifest.write_text(json.dumps(dict(chain_id=lifecycle.chain,
+            trusted_setup=lifecycle.env["POLYSTORE_TRUSTED_SETUP"], deadline_unix_ms=deadline_ms,
+            v3_provider=provider, v3_artifact_directory=str(directory), v3_sessions=requests), separators=(",", ":")))
+        manifests.append((slot, manifest))
+    def run_one(item):
+        slot, manifest = item
+        env = dict(lifecycle.env, POLYSTORE_RETRIEVAL_EXPORT_MANIFEST=str(manifest))
+        result = artifact.run_bounded_command([str(exporter), "-test.run=^TestExportFrozenRetrievalInventory$", "-test.timeout=600s"],
+                                              lifecycle.deadline, env=env)
+        (inventory / f"provider-{slot}.log").write_text(result.stdout + result.stderr)
+        if result.returncode:
+            raise ValueError(f"provider {slot} v3 inventory export failed")
+        value = json.loads(Path(str(manifest) + ".result.json").read_text())
+        return slot, value.get("messages")
+    exported = {}
+    with ThreadPoolExecutor(max_workers=V3_SYSTEMATIC_PROVIDERS) as pool:
+        futures = [pool.submit(run_one, item) for item in manifests]
+        for future in futures:
+            slot, rows = future.result()
+            if not isinstance(rows, list) or len(rows) != V3_CHAIN_SESSIONS:
+                raise ValueError("v3 exporter returned incomplete provider inventory")
+            exported[slot] = rows
+    ordered = []
+    for session_index, session in enumerate(sessions):
+        for slot in range(V3_SYSTEMATIC_PROVIDERS):
+            row = exported[slot][session_index]
+            provider = providers[slot]
+            raw = Path(row["message_path"]).read_bytes()
+            message = json.loads(raw)
+            if (row.get("session_id") != session["session_id"] or row.get("slot") != slot or
+                    row.get("context_hash") != session["context_hash"] or
+                    row.get("seed") != session["seed"] or row.get("message_sha256") != hashlib.sha256(raw).hexdigest() or
+                    message.get("creator") != provider or producer.b64(message.get("session_id", ""), 32).hex() != session["session_id"] or
+                    producer.uint(message.get("slot", 0)) != slot or
+                    [producer.uint(proof.get("ordinal", V3_MAX_SAMPLES)) for proof in message.get("proofs", [])] != row.get("ordinals")):
+                raise ValueError("v3 exporter changed frozen message/context/provider intent")
+            ordered.append(dict(session_index=session_index, slot=slot, provider=provider, **row))
+    return dict(directory=str(inventory), manifests=[str(row[1]) for row in manifests], messages=ordered)
+
+
+def verify_native_v3_chain_transactions(lifecycle, rows, messages):
+    expected = {row["id"]: row for row in messages}
+    verified = []
+    for result in rows:
+        if result.get("outcome") != "committed_success" or result["id"] not in expected:
+            raise ValueError("native v3 chain submission was rejected or ambiguous")
+        result["validators"] = verify_transaction_nodes(lifecycle, result)
+        decoded = json.loads(lifecycle.cli(lifecycle.nodes[0]["home"], "query", "tx", result["txhash"], "--output", "json"))
+        committed = decoded.get("tx", {}).get("body", {}).get("messages", [])
+        raw = json.loads(Path(expected[result["id"]]["message_path"]).read_text())
+        if len(committed) != 1 or committed[0].get("@type") != "/polystorechain.polystorechain.v1.MsgSubmitRetrievalSessionProofV3":
+            raise ValueError("native v3 chain transaction has the wrong committed message")
+        actual = dict(committed[0])
+        actual.pop("@type")
+        if actual != raw:
+            raise ValueError("committed native v3 proof differs from prepared message")
+        verified.append(result)
+    if len({row["txhash"] for row in verified}) != len(verified):
+        raise ValueError("native v3 chain workload repeated a committed transaction")
+    return verified
+
+
+def run_native_v3_chain(lifecycle, *, deal, providers, send, wait, audits, exporter, epoch_length):
+    """Finite chain-only proof submission diagnostic; proof creation is untimed."""
+    doc = lifecycle.doc["native_v3_chain"] = dict(qualification=False)
+    owner = lifecycle.signers["owner0"]
+    systematic = {slot: providers[slot] for slot in range(V3_SYSTEMATIC_PROVIDERS)}
+    opened_at = lifecycle.wait_height(3)
+    deadline_height = opened_at + 180
+    if deadline_height >= producer.uint(deal["end_block"]):
+        raise ValueError("native chain sessions reach the deal end")
+    root = producer.b64(deal["manifest_root"], 32).hex()
+    integrity = lifecycle.doc["native_v3_generation"]["candidate"]["integrity_root"][2:]
+    sessions = doc["sessions"] = []
+    for nonce in range(1, V3_CHAIN_SESSIONS + 1):
+        path = lifecycle.home / f"native-chain-open-{nonce}.json"
+        path.write_text(json.dumps(dict(creator=owner, deal_id=str(deal["id"]), generation="1",
+            range=dict(file_record_index=0, file_start_offset="0", file_length=str(V3_PILOT_BYTES),
+                       range_start="0", range_length=str(V3_PILOT_BYTES)), nonce=str(nonce),
+            deadline_height=str(deadline_height)), separators=(",", ":")))
+        result = send("owner0", ["retrieval-session-v3", "open", str(path)])
+        result["validators"] = verify_transaction_nodes(lifecycle, result)
+        sessions.append(dict(session_id=opened_v3_session(result), nonce=nonce, open_transaction=result))
+        lifecycle.save()
+    evidence_height = wait(max(row["open_transaction"]["height"] for row in sessions) + 2)
+    for row in sessions:
+        view = v3_session_query(lifecycle, row["session_id"], evidence_height)
+        session, accepted = validate_v3_session(view, session_id=row["session_id"], deal_id=deal["id"],
+            owner=owner, providers=providers, nonce=row["nonce"], polyfs_root=root,
+            integrity_root=integrity, chain_id=lifecycle.chain, deadline_height=deadline_height)
+        if accepted:
+            raise ValueError("native chain session starts with accepted samples")
+        row.update(before_proofs=view, evidence_height=evidence_height,
+                   context_hash=producer.b64(session["context_hash"], 32).hex(),
+                   anchor_seed=producer.b64(view["anchor_seed"], 32).hex())
+        row["seed"] = hashlib.sha256(producer.lp("polystore/challenge-seed/v3") +
+            bytes.fromhex(row["context_hash"]) + bytes.fromhex(row["anchor_seed"])).hexdigest()
+    directories = {row["address"]: Path(row["directory"]) / "deals" / str(deal["id"]) / root
+                   for row in lifecycle.doc["providers"] if row["address"] in providers.values()}
+    inventory = export_native_v3_chain_inventory(lifecycle, Path(exporter).resolve(strict=True),
+                                                 sessions, providers, directories)
+    doc["inventory"] = inventory
+    by_slot = {slot: [] for slot in range(V3_SYSTEMATIC_PROVIDERS)}
+    for row in inventory["messages"]:
+        by_slot[row["slot"]].append(row)
+    def simulate_slot(slot):
+        values = []
+        for row in by_slot[slot]:
+            job, simulation = v3_generate_only_gas(lifecycle, row["message_path"], row["provider"])
+            values.append((row, job, simulation))
+        return values
+    simulated = []
+    with ThreadPoolExecutor(max_workers=V3_SYSTEMATIC_PROVIDERS) as pool:
+        for values in pool.map(simulate_slot, range(V3_SYSTEMATIC_PROVIDERS)):
+            simulated.extend(values)
+    if len(simulated) != V3_CHAIN_SESSIONS * V3_SYSTEMATIC_PROVIDERS:
+        raise ValueError("native v3 gas preflight omitted a prepared message")
+    indexed = {(row["session_index"], row["slot"]): (row, job, simulation)
+               for row, job, simulation in simulated}
+    doc["gas_preflight"] = [dict(session_index=row["session_index"], slot=row["slot"], **simulation)
+                            for row, _, simulation in simulated]
+    warmup_jobs, measured_jobs, message_rows = [], [], []
+    for session_index in range(V3_CHAIN_SESSIONS):
+        for slot in range(V3_SYSTEMATIC_PROVIDERS):
+            row, job, _ = indexed[(session_index, slot)]
+            item = dict(job, id=f"v3-chain-{session_index}-{slot}", operation_id=f"session-{session_index}",
+                        phase="warmup" if session_index == 0 else "measurement", offered_offset_ns=0)
+            (warmup_jobs if session_index == 0 else measured_jobs).append(item)
+            message_rows.append(dict(id=item["id"], **row))
+    warmup_deadline = min(lifecycle.deadline, artifact.monotonic_ns() + 60 * 10**9)
+    for job in warmup_jobs:
+        job["_deadline_ns"] = warmup_deadline
+    doc["warmup_scheduler"] = artifact.schedule_transactions(warmup_jobs, max_in_flight=8,
+        max_queued=8, max_queued_per_signer=1)
+    warmup_rows = doc["warmup_scheduler"]["transactions"]
+    verify_native_v3_chain_transactions(lifecycle, warmup_rows, message_rows[:V3_CHAIN_WARMUPS])
+    warmup_height = max(row["height"] for row in warmup_rows)
+    wait(warmup_height + 1)
+    warm = v3_session_query(lifecycle, sessions[0]["session_id"], warmup_height)
+    _, accepted = validate_v3_session(warm, session_id=sessions[0]["session_id"], deal_id=deal["id"], owner=owner,
+        providers=providers, nonce=1, polyfs_root=root, integrity_root=integrity,
+        chain_id=lifecycle.chain, deadline_height=deadline_height)
+    expected_warm = sorted(ordinal for row in message_rows[:8] for ordinal in row["ordinals"])
+    if accepted != expected_warm or len(accepted) != V3_MAX_SAMPLES:
+        raise ValueError("warmup bitmap differs from prepared proof messages")
+    quiescence = require_provider_quiescence(lifecycle, providers)
+    ready_height = quiescence["second_height"]
+    ready_epoch = (ready_height - 1) // epoch_length + 1
+    current_audits = audits(ready_height, False, ready_epoch)
+    if any(producer.uint(row["audit"].get("accepted_count", 0)) != producer.uint(row["audit"]["sample_count"])
+           for row in current_audits.values()):
+        raise ValueError("current epoch audit coverage is incomplete before measurement")
+    next_anchor = ready_epoch * epoch_length + 1
+    if next_anchor - ready_height < 60 or deadline_height - ready_height < 60:
+        raise ValueError("native chain measurement lacks sixty-block authority margin")
+    for row in sessions[1:]:
+        current = v3_session_query(lifecycle, row["session_id"], ready_height)
+        if current != row["before_proofs"]:
+            raise ValueError("prepared native chain session authority changed before timing")
+    offsets = native_v3_chain_offsets()
+    if len(offsets) != len(measured_jobs):
+        raise ValueError("native v3 chain schedule/profile mismatch")
+    for job, offset in zip(measured_jobs, offsets):
+        job["offered_offset_ns"] = offset
+    doc["measurement_preconditions"] = dict(ready_height=ready_height, epoch=ready_epoch,
+        next_anchor=next_anchor, session_deadline=deadline_height, audits=current_audits,
+        provider_quiescence=quiescence)
+    retained = doc["timed_scheduler_outcomes"] = []
+    capture_workload_metrics(lifecycle, "native_v3_chain_before", fenced=True)
+    before_cpu = validator_cpu_snapshot(lifecycle)
+    started = artifact.monotonic_ns()
+    phase_deadline = min(lifecycle.deadline, started + V3_CHAIN_MEASURED_CAP_SECONDS * 10**9)
+    for job in measured_jobs:
+        job["_deadline_ns"] = phase_deadline
+    scheduler = artifact.schedule_transactions(measured_jobs, max_in_flight=8, max_queued=56,
+        max_queued_per_signer=7, record_transaction=lambda row: retained.append(row),
+        heartbeat_seconds=45, stall_timeout_seconds=45)
+    finished = artifact.monotonic_ns()
+    after_cpu = validator_cpu_snapshot(lifecycle)
+    end_height = lifecycle.wait_height(1)
+    if finished - started > V3_CHAIN_MEASURED_CAP_SECONDS * 10**9:
+        raise ValueError("native v3 chain measured phase exceeded its absolute cap")
+    capture_workload_metrics(lifecycle, "native_v3_chain_after", fenced=True)
+    doc["measured_window"] = dict(monotonic_start_ns=started, monotonic_end_ns=finished,
+        elapsed_ns=finished-started, committed_end_height=end_height,
+        validator_cpu_before=before_cpu, validator_cpu_after=after_cpu,
+        validator_cpu_delta=validator_cpu_delta(before_cpu, after_cpu),
+        scope="scheduler submit and commit observation only; proof generation and gas simulation excluded; no RSS phase peak")
+    doc["scheduler"] = scheduler
+    verified = verify_native_v3_chain_transactions(lifecycle, scheduler["transactions"], message_rows[8:])
+    final_height = max(row["height"] for row in verified)
+    if final_height > end_height:
+        raise ValueError("committed proof lies beyond the measured end-height fence")
+    before_metrics = lifecycle.doc["commit_step_metrics"]["phases"]["native_v3_chain_before"]
+    first_height = min(row["sample"]["committed_height"] for row in before_metrics["nodes"]) + 1
+    reconcile_transaction_blocks(lifecycle, scheduler["transactions"], first_height, end_height,
+                                 lifecycle.home / "native-v3-chain-blocks.jsonl")
+    final_sequences = provider_sequences(lifecycle, providers, end_height)
+    expected_sequence_delta = {address: 0 for address in providers.values()}
+    for job in measured_jobs:
+        expected_sequence_delta[job["signer"]] += 1
+    for address, before in quiescence["sequences"].items():
+        if final_sequences[address]["sequence"] - before["sequence"] != expected_sequence_delta[address]:
+            raise ValueError("provider sequence changed outside the measured submission inventory")
+    if (end_height - 1) // epoch_length + 1 != ready_epoch:
+        raise ValueError("native v3 chain measurement crossed an audit epoch")
+    final_audits = audits(end_height, False, ready_epoch)
+    if final_audits != current_audits:
+        raise ValueError("current epoch audit authority/coverage changed during measurement")
+    all_rows = warmup_rows + verified
+    accepted_total = 0
+    for index, row in enumerate(sessions):
+        state = v3_session_query(lifecycle, row["session_id"], end_height)
+        _, accepted = validate_v3_session(state, session_id=row["session_id"], deal_id=deal["id"], owner=owner,
+            providers=providers, nonce=row["nonce"], polyfs_root=root, integrity_root=integrity,
+            chain_id=lifecycle.chain, deadline_height=deadline_height)
+        expected = sorted(ordinal for message in message_rows if message["session_index"] == index
+                          for ordinal in message["ordinals"])
+        if accepted != expected or len(accepted) != V3_MAX_SAMPLES:
+            raise ValueError("authoritative session bitmap differs from committed proof messages")
+        row["after_proofs"] = state
+        accepted_total += len(accepted)
+    doc.update(offered_proof_transactions=64, warmup_transactions=8, measured_transactions=56,
+        committed_valid_proof_transactions=len(all_rows), authoritative_new_sample_ordinals=accepted_total,
+        measured_gas_wanted=sum(row["gas_wanted"] for row in verified),
+        measured_gas_used=sum(row["gas_used"] for row in verified), delivery_verified=False,
+        owner_acknowledged=False, qualification=False)
+    wait(deadline_height + 2)
+    for row in sessions:
+        expired = v3_session_query(lifecycle, row["session_id"])
+        validate_v3_session(expired, session_id=row["session_id"], deal_id=deal["id"], owner=owner,
+            providers=providers, nonce=row["nonce"], polyfs_root=root, integrity_root=integrity,
+            chain_id=lifecycle.chain, deadline_height=deadline_height, expired=True)
+        refund = send("owner0", ["retrieval-session-v3", "refund", str(_write_v3_refund(lifecycle, owner, row["session_id"]))])
+        refund["validators"] = verify_transaction_nodes(lifecycle, refund)
+        row.update(expired_before_refund=expired, refund_transaction=refund)
+    wait(max(row["refund_transaction"]["height"] for row in sessions) + 1)
+    for row in sessions:
+        after = v3_session_query(lifecycle, row["session_id"])
+        validate_v3_session(after, session_id=row["session_id"], deal_id=deal["id"], owner=owner,
+            providers=providers, nonce=row["nonce"], polyfs_root=root, integrity_root=integrity,
+            chain_id=lifecycle.chain, deadline_height=deadline_height, expired=True, refunded=True)
+        row["after_refund"] = after
+    doc.update(status="native_v3_chain_diagnostic_finished", expiration_verified=True,
+               refunds_verified=True, qualification=False)
+    lifecycle.save()
 
 
 def admit_native_v3_generation(lifecycle, *, uploaded, deal_id, providers, send, curl):
@@ -1506,11 +1896,17 @@ def reconcile_sustained_blocks(lifecycle, journal):
     artifact.integer(last - first + 1, "fenced block count", 1, 1200)
     with sqlite3.connect(f"file:{journal}?mode=ro", uri=True) as db:
         results = [json.loads(row[0]) for row in db.execute("SELECT result FROM transactions")]
+    reconcile_transaction_blocks(lifecycle, results, first, last,
+                                 lifecycle.home / "sustained-blocks.jsonl")
+
+
+def reconcile_transaction_blocks(lifecycle, results, first, last, path):
+    """Retain raw block gas/bytes and validate workload txs on all validators."""
+    artifact.integer(last - first + 1, "fenced block count", 1, 1200)
     committed = [row for row in results if row["outcome"] in ("committed_success", "committed_failure")]
     expected = {row["txhash"]: row for row in committed}
     if len(expected) != len(committed):
         raise ValueError("journal repeats a committed transaction hash")
-    path = lifecycle.home / "sustained-blocks.jsonl"
     matched = set()
     with path.open("x") as output:
         for height in range(first, last + 1):
@@ -1802,8 +2198,10 @@ def run_sustained(lifecycle, deal, providers, send, command, audits, wait, expor
 
 
 def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustained=None,
-                native_v3=False, audit_profile="normal"):
+                native_v3=False, native_chain=None, audit_profile="normal"):
     """Real canonical ingest and normal audits; optional bounded retrieval workload."""
+    if native_chain is not None:
+        native_v3 = True
     if native_v3 and sustained is not None:
         raise ValueError("native v3 diagnostic and sustained v2 workload are distinct modes")
     k = 8 if native_v3 else sustained.get("k", 2) if sustained is not None else 2
@@ -1824,6 +2222,10 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
             raise ValueError("proof exporter must be executable")
         artifact.integer(sustained["proof_gas"], "proof gas", 1, 64000000)
         sustained_offsets(sustained["step_seconds"], rate_scale)
+    if native_chain is not None:
+        export_binary = Path(native_chain["exporter"]).resolve(strict=True)
+        if not export_binary.is_file() or not os.access(export_binary, os.X_OK):
+            raise ValueError("native v3 chain exporter must be executable")
     curl = shutil.which("curl")
     if not curl:
         raise ValueError("curl is required for bounded multipart upload")
@@ -1844,9 +2246,12 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
         doc["disk_guard"] = dict(preflight_free_bytes=preflight_free,
                                  preflight_minimum_bytes=V3_PREFLIGHT_FREE_BYTES,
                                  runtime_minimum_bytes=V3_ABORT_FREE_BYTES)
-    doc.update(mode="four-validator-native-v3-provider-diagnostic" if native_v3 else "four-validator-healthy-provider-diagnostic",
+    doc.update(mode=("four-validator-native-v3-chain-diagnostic" if native_chain is not None else
+                     "four-validator-native-v3-provider-diagnostic" if native_v3 else "four-validator-healthy-provider-diagnostic"),
         setup_transactions=[], providers=[],
-        workload=("one 16 MiB FAT v3 K8 deal; twelve production provider-daemons; two preopened native sessions"
+        workload=("one 16 MiB FAT v3 K8 deal; eight sessions; 64 native proof transactions with untimed proof preparation"
+                  if native_chain is not None else
+                  "one 16 MiB FAT v3 K8 deal; twelve production provider-daemons; two preopened native sessions"
                   if native_v3 else f"one real K{k} deal; {layout['assignments']} assigned provider-daemons; one normal audit epoch"),
         qualification=False, limits=["No capacity or delivered retrieval qualification",
             ("Provider HTTP durations combine proof generation, gas simulation, signing, broadcast, and commit observation"
@@ -2104,8 +2509,13 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
         check_providers()
         doc.update(status="healthy_provider_audit_diagnostic_passed", audit_coverage_verified=True)
         if native_v3:
-            run_native_v3_sessions(lifecycle, deal=deal, providers=providers, send=send, wait=wait, curl=curl)
-            doc["status"] = "native_v3_provider_diagnostic_passed"
+            if native_chain is not None:
+                run_native_v3_chain(lifecycle, deal=deal, providers=providers, send=send, wait=wait,
+                                    audits=audits, exporter=native_chain["exporter"], epoch_length=epoch_length)
+                doc["status"] = "native_v3_chain_diagnostic_passed"
+            else:
+                run_native_v3_sessions(lifecycle, deal=deal, providers=providers, send=send, wait=wait, curl=curl)
+                doc["status"] = "native_v3_provider_diagnostic_passed"
         elif sustained is not None:
             run_sustained(lifecycle, deal, providers, send, command, audits, wait, **sustained)
     except BaseException as error:
@@ -2140,7 +2550,7 @@ def main():
     for flag in ("fixture-k8", "fixture-k2", "gateway-binary", "cli-binary", "product-source", "proof-exporter"):
         parser.add_argument("--" + flag)
     parser.add_argument("--mode", choices=("settlement-smoke", "healthy-providers", "sustained-providers",
-                                           "native-v3-providers"), default="settlement-smoke")
+                                           "native-v3-providers", "native-v3-chain"), default="settlement-smoke")
     parser.add_argument("--timeout", type=int, default=600)
     parser.add_argument("--audit-profile", choices=("normal", "c6"), default="normal")
     parser.add_argument("--step-seconds", type=int, default=180, help="Each of five offered-rate steps; 4 is a same-path pilot")
@@ -2169,6 +2579,14 @@ def main():
         print(run_healthy(artifact.FourValidatorLifecycle(**options, sustained=True), gateway, cli, source,
             sustained=dict(exporter=exporter, step_seconds=step_seconds, proof_gas=proof_gas, k=sustained_k,
                            rate_scale=sustained_rate_scale, deputy_count=sustained_deputies), audit_profile=audit_profile))
+    elif mode == "native-v3-chain":
+        if (not gateway or not cli or not source or not exporter or k8 or k2 or proof_only or
+                proof_gas is not None or step_seconds != 180 or sustained_k != 2 or
+                sustained_rate_scale != 1 or sustained_deputies != 8 or
+                options["timeout"] > 600 or audit_profile != "normal"):
+            parser.error("native-v3-chain requires product binaries/source and --proof-exporter, normal audits, timeout <= 600, and fixed profile")
+        print(run_healthy(artifact.FourValidatorLifecycle(**options), gateway, cli, source,
+                          native_chain=dict(exporter=exporter), audit_profile="normal"))
     elif (exporter or proof_gas is not None or step_seconds != 180 or sustained_k != 2 or
           sustained_rate_scale != 1 or sustained_deputies != 8):
         parser.error("exporter, proof gas, sustained K and pilot duration require sustained-providers")

--- a/scripts/test_retrieval_four_validator_workload.py
+++ b/scripts/test_retrieval_four_validator_workload.py
@@ -651,9 +651,75 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
             self.assertNotIn("", argv)
             self.assertEqual(argv[argv.index("--previous-polyfs-root") + 1], "0x")
 
+    def test_native_chain_fixed_profile_proc_accounting_and_identity(self):
+        offsets = workload.native_v3_chain_offsets()
+        self.assertEqual((len(offsets), offsets[:2], offsets[7:10], offsets[-1]),
+                         (56, [0, 10**9], [7*10**9, 8*10**9, 8_500_000_000], 23_750_000_000))
+        fields = ["S"] + ["0"] * 18 + ["999"] + ["0"] * 4
+        fields[11], fields[12] = "101", "17"
+        parsed = workload.parse_proc_stat("42 (validator worker) name) " + " ".join(fields), expected_pid=42)
+        self.assertEqual(parsed, dict(pid=42, user_ticks=101, system_ticks=17, starttime_ticks=999))
+        with self.assertRaises(ValueError):
+            workload.parse_proc_stat("42 (validator) " + " ".join(fields), expected_pid=43)
+        before = dict(monotonic_ns=10, clock_ticks_per_second=100,
+                      validators=[dict(node_id="n", pid=42, starttime_ticks=999, user_ticks=101, system_ticks=17)])
+        after = copy.deepcopy(before)
+        after.update(monotonic_ns=20)
+        after["validators"][0].update(user_ticks=121, system_ticks=22)
+        delta = workload.validator_cpu_delta(before, after)
+        self.assertEqual((delta["validators"][0]["user_cpu_seconds"], delta["validators"][0]["system_cpu_seconds"]), (.2, .05))
+        after["validators"][0]["starttime_ticks"] += 1
+        with self.assertRaisesRegex(ValueError, "identity"):
+            workload.validator_cpu_delta(before, after)
+        after = copy.deepcopy(before)
+        after.update(monotonic_ns=20)
+        after["validators"][0]["user_ticks"] -= 1
+        with self.assertRaisesRegex(ValueError, "backwards"):
+            workload.validator_cpu_delta(before, after)
+
+    def test_generate_only_preflight_pins_exact_default_emitting_message_and_explicit_gas(self):
+        message = dict(creator=AUDIT_ADDRESSES[0], session_id=base64.b64encode(bytes.fromhex(self.SESSION)).decode(),
+                       slot=0, proofs=[dict(ordinal="0", proof=dict(mdu_index="0", blob_index="0"))])
+        unsigned = dict(body=dict(messages=[dict(**{"@type": "/polystorechain.polystorechain.v1.MsgSubmitRetrievalSessionProofV3"}, **message)]),
+                        auth_info=dict(fee=dict(gas_limit="13530000")))
+        life = SimpleNamespace(binary=Path("/chain"), chain="polystore_290-1", deadline=10**18,
+            nodes=[dict(home="/home", rpc=26657)], env={"GOMAXPROCS": "2"})
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "message.json"
+            path.write_text(json.dumps(message))
+            result = SimpleNamespace(returncode=0, stdout=json.dumps(unsigned), stderr="")
+            with patch.object(artifact, "run_bounded_command", return_value=result) as run:
+                job, evidence = workload.v3_generate_only_gas(life, path, AUDIT_ADDRESSES[0])
+            self.assertEqual(evidence["gas_limit"], 13_530_000)
+            self.assertEqual(job["submit"][job["submit"].index("--gas") + 1], "13530000")
+            self.assertEqual(run.call_args.args[0][-1], "--generate-only")
+            changed = copy.deepcopy(unsigned)
+            changed["body"]["messages"][0]["slot"] = 1
+            with patch.object(artifact, "run_bounded_command", return_value=SimpleNamespace(
+                    returncode=0, stdout=json.dumps(changed), stderr="")), self.assertRaisesRegex(ValueError, "differs"):
+                workload.v3_generate_only_gas(life, path, AUDIT_ADDRESSES[0])
+
 
 
 class HealthyAuditViewsTest(unittest.TestCase):
+    def test_native_v3_chain_cli_requires_exporter_and_fixed_profile(self):
+        common = ["diagnostic", "--mode", "native-v3-chain", "--binary", "/chain",
+                  "--library", "/lib", "--home", "/new-home"]
+        required = ["--gateway-binary", "/gateway", "--cli-binary", "/native-cli",
+                    "--product-source", "/source", "--proof-exporter", "/exporter"]
+        for extra in ([], required + ["--proof-gas", "100"], required + ["--audit-profile", "c6"]):
+            with self.subTest(extra=extra), patch.object(workload.sys, "argv", common + extra), \
+                 patch.object(workload.sys, "stderr"), patch.object(artifact, "FourValidatorLifecycle") as constructor:
+                with self.assertRaises(SystemExit):
+                    workload.main()
+                constructor.assert_not_called()
+        with patch.object(workload.sys, "argv", common + required), \
+             patch.object(artifact, "FourValidatorLifecycle") as constructor, \
+             patch.object(workload, "run_healthy", return_value="evidence") as run, patch("builtins.print"):
+            workload.main()
+            run.assert_called_once_with(constructor.return_value, "/gateway", "/native-cli", "/source",
+                                        native_chain=dict(exporter="/exporter"), audit_profile="normal")
+
     def test_native_v3_cli_is_fixed_bounded_and_normal_audit_only(self):
         common = ["diagnostic", "--mode", "native-v3-providers", "--binary", "/chain",
                   "--library", "/lib", "--home", "/new-home"]

--- a/scripts/test_retrieval_four_validator_workload.py
+++ b/scripts/test_retrieval_four_validator_workload.py
@@ -677,6 +677,31 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "backwards"):
             workload.validator_cpu_delta(before, after)
 
+    def test_native_chain_summary_excludes_warmup_from_measured_counts(self):
+        sessions = [dict(accepted_sample_ordinals=[0, 1]),
+                    dict(accepted_sample_ordinals=[2, 3, 4])]
+        messages = [dict(id="warmup", session_index=0, ordinals=[0, 1]),
+                    dict(id="measured", session_index=1, ordinals=[2, 3, 4])]
+        summary = workload.native_v3_chain_committed_summary(
+            sessions, messages, [dict(id="warmup")], [dict(id="measured")])
+        self.assertEqual(summary, dict(total_committed_valid_proof_transactions=2,
+            measured_committed_valid_proof_transactions=1,
+            total_authoritative_new_sample_ordinals=5,
+            measured_authoritative_new_sample_ordinals=3))
+        with self.assertRaisesRegex(ValueError, "messages differ"):
+            workload.native_v3_chain_committed_summary(
+                sessions, messages, [dict(id="warmup")], [dict(id="other")])
+
+    def test_native_chain_exporter_identity_records_exact_executable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            exporter = Path(tmp) / "exporter"
+            exporter.write_bytes(b"native-v3-exporter")
+            exporter.chmod(0o700)
+            resolved, identity = workload.native_v3_chain_exporter_identity(exporter)
+            self.assertEqual(resolved, exporter.resolve())
+            self.assertEqual(identity, dict(native_chain_exporter=str(exporter.resolve()),
+                native_chain_exporter_sha256=hashlib.sha256(exporter.read_bytes()).hexdigest()))
+
     def test_generate_only_preflight_pins_exact_default_emitting_message_and_explicit_gas(self):
         message = dict(creator=AUDIT_ADDRESSES[0], session_id=base64.b64encode(bytes.fromhex(self.SESSION)).decode(),
                        slot=0, proofs=[dict(ordinal="0", proof=dict(mdu_index="0", blob_index="0"))])

--- a/scripts/test_retrieval_four_validator_workload.py
+++ b/scripts/test_retrieval_four_validator_workload.py
@@ -692,6 +692,52 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
             workload.native_v3_chain_committed_summary(
                 sessions, messages, [dict(id="warmup")], [dict(id="other")])
 
+    def test_native_chain_inventory_assembles_all_exported_provider_messages(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            providers = dict(enumerate(AUDIT_ADDRESSES[:8]))
+            sessions = []
+            for index in range(8):
+                sessions.append(dict(session_id=f"{index + 1:064x}", evidence_height=70,
+                    before_proofs={}, context_hash=f"{index + 9:064x}", seed=f"{index + 17:064x}"))
+            directories = {}
+            for provider in providers.values():
+                directories[provider] = home / provider
+                directories[provider].mkdir()
+            lifecycle = SimpleNamespace(home=home, chain="polystore_290-1",
+                env={"POLYSTORE_TRUSTED_SETUP": "/setup"},
+                deadline=artifact.monotonic_ns() + 30 * 10**9)
+
+            def export(argv, deadline, env):
+                manifest_path = Path(env["POLYSTORE_RETRIEVAL_EXPORT_MANIFEST"])
+                manifest = json.loads(manifest_path.read_text())
+                provider = manifest["v3_provider"]
+                slot = next(index for index, address in providers.items() if address == provider)
+                rows = []
+                for index, request in enumerate(manifest["v3_sessions"]):
+                    message_path = Path(request["output_path"])
+                    message = dict(creator=provider,
+                        session_id=base64.b64encode(bytes.fromhex(request["session_id"])).decode(),
+                        slot=str(slot), proofs=[dict(ordinal=str(slot))])
+                    raw = json.dumps(message, separators=(",", ":")).encode()
+                    message_path.write_bytes(raw)
+                    rows.append(dict(session_id=request["session_id"], message_path=str(message_path),
+                        message_sha256=hashlib.sha256(raw).hexdigest(),
+                        context_hash=sessions[index]["context_hash"], seed=sessions[index]["seed"],
+                        slot=slot, ordinals=[slot], generation_ms=1.0))
+                Path(str(manifest_path) + ".result.json").write_text(json.dumps({"messages": rows}))
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+            with patch.object(artifact, "run_bounded_command", side_effect=export):
+                inventory = workload.export_native_v3_chain_inventory(
+                    lifecycle, Path("/exporter"), sessions, providers, directories)
+            self.assertEqual(len(inventory["manifests"]), 8)
+            self.assertEqual(len(inventory["messages"]), 64)
+            self.assertEqual([(row["session_index"], row["slot"]) for row in inventory["messages"]],
+                             [(session, slot) for session in range(8) for slot in range(8)])
+            self.assertEqual([row["provider"] for row in inventory["messages"][:8]],
+                             list(providers.values()))
+
     def test_native_chain_exporter_identity_records_exact_executable(self):
         with tempfile.TemporaryDirectory() as tmp:
             exporter = Path(tmp) / "exporter"

--- a/scripts/test_retrieval_four_validator_workload.py
+++ b/scripts/test_retrieval_four_validator_workload.py
@@ -2,6 +2,7 @@
 import base64
 import copy
 import hashlib
+import io
 import json
 from pathlib import Path
 import sqlite3
@@ -9,6 +10,7 @@ import subprocess
 import tempfile
 from types import SimpleNamespace
 import unittest
+import urllib.error
 from unittest.mock import Mock, patch
 
 import retrieval_bench_artifact as artifact
@@ -71,6 +73,48 @@ def settlement_fixture():
 
 
 class FourValidatorWorkloadTest(unittest.TestCase):
+    FUTURE_HEIGHT = json.dumps({"code": 2, "message": "codespace sdk code 26: invalid height: cannot query with height in the future; please provide a valid height", "details": []}).encode()
+
+    @staticmethod
+    def query_response(value, height="7"):
+        response = io.BytesIO(json.dumps(value).encode())
+        response.status = 200
+        response.headers = {"x-cosmos-block-height": height}
+        return response
+
+    @classmethod
+    def query_error(cls, body=None):
+        return urllib.error.HTTPError("http://node/query", 500, "Internal Server Error", {}, io.BytesIO(body or cls.FUTURE_HEIGHT))
+
+    def query_lifecycle(self):
+        lifecycle = object.__new__(artifact.FourValidatorLifecycle)
+        lifecycle.deadline = 100 * 10**9
+        lifecycle.remaining = Mock(return_value=1)
+        return lifecycle
+
+    def test_fixed_height_query_retries_only_future_height_error(self):
+        lifecycle = self.query_lifecycle()
+        delayed = [self.query_error(), self.query_response({"session": {"id": "ready"}})]
+        with patch.object(artifact.urllib.request, "urlopen", side_effect=delayed) as opened, \
+                patch.object(artifact, "monotonic_ns", return_value=0), patch.object(artifact.time, "sleep") as sleep:
+            self.assertEqual(lifecycle.query({"api": 1317, "rpc": 26657}, "/query", 7), {"session": {"id": "ready"}})
+        self.assertEqual(opened.call_count, 2)
+        sleep.assert_called_once()
+
+        for body in (b'{"code":2,"message":"other","details":[]}', b"not-json"):
+            with self.subTest(body=body), patch.object(artifact.urllib.request, "urlopen", side_effect=[self.query_error(body)]) as opened:
+                with self.assertRaisesRegex(ValueError, "node query HTTP 500"):
+                    lifecycle.query({"api": 1317, "rpc": 26657}, "/query", 7)
+                opened.assert_called_once()
+
+    def test_fixed_height_query_future_height_retry_is_bounded(self):
+        lifecycle = self.query_lifecycle()
+        with patch.object(artifact.urllib.request, "urlopen", side_effect=[self.query_error()]) as opened, \
+                patch.object(artifact, "monotonic_ns", side_effect=[0, 5 * 10**9]):
+            with self.assertRaisesRegex(ValueError, "invalid height: cannot query with height in the future"):
+                lifecycle.query({"api": 1317, "rpc": 26657}, "/query", 7)
+        opened.assert_called_once()
+
     def test_transaction_verification_uses_fenced_blocks_not_tx_indexes(self):
         raw = b"signed transaction"
         txhash = hashlib.sha256(raw).hexdigest().upper()

--- a/scripts/test_retrieval_four_validator_workload.py
+++ b/scripts/test_retrieval_four_validator_workload.py
@@ -754,21 +754,41 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
         unsigned = dict(body=dict(messages=[dict(**{"@type": "/polystorechain.polystorechain.v1.MsgSubmitRetrievalSessionProofV3"}, **message)]),
                         auth_info=dict(fee=dict(gas_limit="13530000")))
         life = SimpleNamespace(binary=Path("/chain"), chain="polystore_290-1", deadline=10**18,
-            nodes=[dict(home="/home", rpc=26657)], env={"GOMAXPROCS": "2"})
+            nodes=[dict(home="/home", rpc=26657)], env={"GOMAXPROCS": "2"},
+            signers={"provider0": AUDIT_ADDRESSES[0]})
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "message.json"
             path.write_text(json.dumps(message))
             result = SimpleNamespace(returncode=0, stdout=json.dumps(unsigned), stderr="")
             with patch.object(artifact, "run_bounded_command", return_value=result) as run:
                 job, evidence = workload.v3_generate_only_gas(life, path, AUDIT_ADDRESSES[0])
+            diagnostic = json.loads(Path(evidence["simulation_diagnostic"]).read_text())
+            self.assertEqual((diagnostic["returncode"], diagnostic["simulation_key"]), (0, "provider0"))
             self.assertEqual(evidence["gas_limit"], 13_530_000)
             self.assertEqual(job["submit"][job["submit"].index("--gas") + 1], "13530000")
             self.assertEqual(run.call_args.args[0][-1], "--generate-only")
+            self.assertEqual(run.call_args.args[0][run.call_args.args[0].index("--from") + 1], "provider0")
+            self.assertEqual(job["submit"][job["submit"].index("--from") + 1], AUDIT_ADDRESSES[0])
             changed = copy.deepcopy(unsigned)
             changed["body"]["messages"][0]["slot"] = 1
+            changed_path = Path(tmp) / "changed.json"
+            changed_path.write_text(json.dumps(message))
             with patch.object(artifact, "run_bounded_command", return_value=SimpleNamespace(
                     returncode=0, stdout=json.dumps(changed), stderr="")), self.assertRaisesRegex(ValueError, "differs"):
-                workload.v3_generate_only_gas(life, path, AUDIT_ADDRESSES[0])
+                workload.v3_generate_only_gas(life, changed_path, AUDIT_ADDRESSES[0])
+
+            failed_path = Path(tmp) / "failed.json"
+            failed_path.write_text(json.dumps(message))
+            failed = SimpleNamespace(returncode=1, stdout="partial output", stderr="simulation rejected")
+            with patch.object(artifact, "run_bounded_command", return_value=failed), \
+                 self.assertRaisesRegex(ValueError, "bounded v3 gas simulation failed"):
+                workload.v3_generate_only_gas(life, failed_path, AUDIT_ADDRESSES[0])
+            diagnostic = json.loads(Path(str(failed_path) + ".gas-simulation.json").read_text())
+            self.assertEqual((diagnostic["returncode"], diagnostic["simulation_key"]), (1, "provider0"))
+            self.assertEqual(diagnostic["stdout_tail"], "partial output")
+            self.assertEqual(diagnostic["stderr_tail"], "simulation rejected")
+            self.assertEqual(diagnostic["stdout_bytes"], len(b"partial output"))
+            self.assertEqual(diagnostic["stderr_bytes"], len(b"simulation rejected"))
 
 
 

--- a/scripts/test_retrieval_four_validator_workload.py
+++ b/scripts/test_retrieval_four_validator_workload.py
@@ -89,7 +89,7 @@ class FourValidatorWorkloadTest(unittest.TestCase):
     def query_lifecycle(self):
         lifecycle = object.__new__(artifact.FourValidatorLifecycle)
         lifecycle.deadline = 100 * 10**9
-        lifecycle.remaining = Mock(return_value=1)
+        lifecycle.remaining = Mock(return_value=30)
         return lifecycle
 
     def test_fixed_height_query_retries_only_future_height_error(self):
@@ -99,6 +99,7 @@ class FourValidatorWorkloadTest(unittest.TestCase):
                 patch.object(artifact, "monotonic_ns", return_value=0), patch.object(artifact.time, "sleep") as sleep:
             self.assertEqual(lifecycle.query({"api": 1317, "rpc": 26657}, "/query", 7), {"session": {"id": "ready"}})
         self.assertEqual(opened.call_count, 2)
+        self.assertEqual(opened.call_args_list[1].kwargs["timeout"], 5)
         sleep.assert_called_once()
 
         for body in (b'{"code":2,"message":"other","details":[]}', b"not-json"):


### PR DESCRIPTION
The current retrieval harness measures provider HTTP handling, which includes proof generation and gas simulation and cannot isolate native v3 chain submission capacity. This adds a finite chain-only diagnostic that prepares and natively verifies exact production proof messages before timing, pre-simulates their gas with the SDK's production 1.6 adjustment, then submits 8 warmups and 56 measured transactions through the existing four-validator scheduler using the assigned provider signers.

The diagnostic uses the production FAT v3 authority, challenge, proof-building, and native-verification path through a narrow explicit-directory exporter seam. Before timing it requires complete normal-audit coverage, stable open sessions, two blocks of provider-sequence quiescence, and 60-block margins to the next audit anchor and session expiry. It retains all-validator block/result/message/bitmap checks, explicit total and measured transaction and ordinal counts, exporter identity, gas, bounded Linux validator CPU tick deltas, expiry, and refunds. It sends no client ACK.

Validation:

- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=scripts python3 -m unittest scripts/test_retrieval_four_validator_workload.py` — 40 passed
- `go test . -count=1` in `polystore_gateway` on Linux — passed in 23.097s
- Focused real-proof exporter tests cover successful production proof construction and corrupted-shard rejection
- Python compilation and `git diff --check` pass

The pre-merge Linux smoke uses eight 16 MiB sessions (U=133/Q=132), with 64 proof transactions / 1,056 accepted sample ordinals in total and an explicitly separated measured subset of 56 transactions / 924 ordinals. All four validators reconcile exact messages, transaction results and session bitmaps. Proof generation and SDK gas simulation occur before the measured interval.

The initial complete proof workload exposed an application-query race during refunds: Comet can announce a height before the SDK query store serves it. The shared fixed-height query helper now retries only the exact SDK future-height response at the requested height, retains bounded deadlines, and fails on unrelated errors. The earlier failed run remains failed; final smoke `native-v3-chain-smoke-004` passed on `8d7522588d2eb9b8e5b8eb6f98e11bca09e14f86` in 550.032 seconds, including all eight expiry/refund checks. Its measured interval was 28.042 seconds; setup and protocol height waits are excluded from that interval. The isolated regression replay completed 5,112 fixed-height queries with zero failures, versus 42 reproduced future-height errors before the fix.

This is a bounded pre-merge correctness diagnostic. It does not establish sustained capacity across audit epochs, delivered retrieval throughput, WAN behavior, restart behavior, or a phase RSS peak. Retained performance evidence requires the reviewed landed harness.

Refs #290 and #291.
