### PR TITLE
e2e: measure native provider load across an audit anchor

### DIFF
--- a/bench/retrieval_session_capacity/native-k8-290/README.md
+++ b/bench/retrieval_session_capacity/native-k8-290/README.md
@@ -176,9 +176,9 @@ bounded offered/committed diagnostic. A longer reviewed profile is required
 before quoting stable throughput, and delivered-file performance remains a
 separate measurement.
 
-## Native v3 provider-route cross-audit diagnostic
+## Native v3 provider-daemon cross-audit diagnostic
 
-`native-v3-providers-cross-audit` extends the same production provider route
+`native-v3-providers-cross-audit` extends the same production provider-daemon route
 without changing proof, gas, queue, or audit behavior. It opens sixteen fixed
 16 MiB sessions. One transaction per systematic provider warms the route
 outside the clock, then 120 transactions are offered round-robin across the

--- a/bench/retrieval_session_capacity/native-k8-290/README.md
+++ b/bench/retrieval_session_capacity/native-k8-290/README.md
@@ -193,8 +193,10 @@ route failure remains diagnostic evidence rather than being relabeled as a
 successful 2 transactions/s result. A successful run additionally verifies all
 128 warmup and measured proof transactions, all 2,112 accepted ordinals, the
 crossed audit coverage and its unique transactions, provider account sequences,
-raw blocks/results on all four validators, Linux validator CPU ticks, and all
-sixteen expiry/refund paths. It does not send an ACK or verify delivery.
+raw blocks/results on all four validators, Linux validator CPU ticks covering
+the fixed HTTP schedule, drain, and crossed-audit completion, and all sixteen
+expiry/refund paths. Scheduler HTTP duration remains a separate measurement. It
+does not send an ACK or verify delivery.
 
 ```sh
 python3 scripts/retrieval_four_validator_workload.py \

--- a/bench/retrieval_session_capacity/native-k8-290/README.md
+++ b/bench/retrieval_session_capacity/native-k8-290/README.md
@@ -176,6 +176,42 @@ bounded offered/committed diagnostic. A longer reviewed profile is required
 before quoting stable throughput, and delivered-file performance remains a
 separate measurement.
 
+## Native v3 provider-route cross-audit diagnostic
+
+`native-v3-providers-cross-audit` extends the same production provider route
+without changing proof, gas, queue, or audit behavior. It opens sixteen fixed
+16 MiB sessions. One transaction per systematic provider warms the route
+outside the clock, then 120 transactions are offered round-robin across the
+eight assigned signers at 2 transactions/s for 60 seconds. Each signer has at
+most one request in flight. The HTTP clock includes proof generation, native
+verification, gas simulation, signing, broadcast, and commit observation.
+
+The run aligns its measured start 30 blocks before the next normal audit anchor
+and requires the profile to cross exactly that one anchor. It retains the actual
+offered, queued, completed, and failed request counts, so backlog or a bounded
+route failure remains diagnostic evidence rather than being relabeled as a
+successful 2 transactions/s result. A successful run additionally verifies all
+128 warmup and measured proof transactions, all 2,112 accepted ordinals, the
+crossed audit coverage and its unique transactions, provider account sequences,
+raw blocks/results on all four validators, Linux validator CPU ticks, and all
+sixteen expiry/refund paths. It does not send an ACK or verify delivery.
+
+```sh
+python3 scripts/retrieval_four_validator_workload.py \
+  --mode native-v3-providers-cross-audit --audit-profile normal --timeout 900 \
+  --binary "$RETRIEVAL_BIN/polystorechaind" \
+  --library "$RETRIEVAL_LIBRARY" \
+  --gateway-binary "$RETRIEVAL_BIN/polystore_gateway" \
+  --cli-binary "$RETRIEVAL_BIN/polystore_cli" \
+  --product-source "$RETRIEVAL_REPO" \
+  --home "$RETRIEVAL_RUNS/native-v3-provider-cross-audit-001"
+```
+
+This is a finite local constant-offer diagnostic. It does not establish a
+sustained operating point across multiple epochs, WAN behavior, phase RSS peak,
+or delivered-byte capacity. A retained performance result requires this harness
+to land before collection.
+
 ## Native v3 chain-only diagnostic
 
 `native-v3-chain` keeps the same 16 MiB FAT v3 generation and normal audits,

--- a/scripts/retrieval_four_validator_workload.py
+++ b/scripts/retrieval_four_validator_workload.py
@@ -2405,6 +2405,9 @@ def reconcile_transaction_blocks(lifecycle, results, first, last, path, observe_
     expected = {row["txhash"]: row for row in committed}
     if len(expected) != len(committed):
         raise ValueError("journal repeats a committed transaction hash")
+    # Comet reports canonical=false for the current BlockStore tip. Fence every
+    # validator past the retained interval before treating that as disagreement.
+    lifecycle.wait_height(last + 1)
     matched = set()
     with path.open("x") as output:
         for height in range(first, last + 1):

--- a/scripts/retrieval_four_validator_workload.py
+++ b/scripts/retrieval_four_validator_workload.py
@@ -53,6 +53,11 @@ V3_CHAIN_SESSIONS = 8
 V3_CHAIN_WARMUPS = 8
 V3_CHAIN_MEASURED = 56
 V3_CHAIN_MEASURED_CAP_SECONDS = 45
+V3_CROSS_AUDIT_SESSIONS = 16
+V3_CROSS_AUDIT_WARMUPS = 8
+V3_CROSS_AUDIT_MEASURED = 120
+V3_CROSS_AUDIT_OFFER_SECONDS = 60
+V3_CROSS_AUDIT_DRAIN_SECONDS = 30
 
 
 def native_v3_chain_offsets():
@@ -60,6 +65,16 @@ def native_v3_chain_offsets():
     return ([i * 10**9 for i in range(8)] +
             [8 * 10**9 + i * 500_000_000 for i in range(16)] +
             [16 * 10**9 + i * 250_000_000 for i in range(32)])
+
+
+def native_v3_cross_audit_schedule():
+    """Fifteen sessions by eight providers, offered round-robin at 2 tx/s."""
+    rows = []
+    for index in range(V3_CROSS_AUDIT_MEASURED):
+        rows.append(dict(index=index, session_index=1 + index // V3_SYSTEMATIC_PROVIDERS,
+                         slot=index % V3_SYSTEMATIC_PROVIDERS,
+                         offered_offset_ns=index * 500_000_000))
+    return rows
 
 
 def parse_proc_stat(raw, *, expected_pid=None):
@@ -280,6 +295,64 @@ def opened_v3_session(result, *, logical_bytes=V3_PILOT_BYTES):
     return raw[sid_offset:sid_offset + 32].hex()
 
 
+def _run_v3_http_request(lifecycle, curl, request, phase, index, directory,
+                         phase_deadline, retry_pre_admission_busy):
+    """Run one provider request with the production route's exact safe-busy retry."""
+    attempts = []
+    limit = V3_BUSY_MAX_ATTEMPTS if retry_pre_admission_busy else 1
+    offered_ns = request.get("offered_ns")
+    for attempt in range(1, limit + 1):
+        if attempt > 1:
+            if artifact.monotonic_ns() + V3_BUSY_RETRY_SECONDS * 10**9 >= phase_deadline:
+                break
+            time.sleep(V3_BUSY_RETRY_SECONDS)
+        path = directory / f"{phase}-{index}-{attempt}.json"
+        began = artifact.monotonic_ns()
+        request_deadline = min(phase_deadline,
+                               began + request.get("timeout_seconds", 180) * 10**9)
+        try:
+            result = artifact.run_bounded_command([
+                curl, "--silent", "--show-error", "--max-time", str(request.get("timeout_seconds", 180)),
+                "--request", "POST", "--header", "Content-Type: application/json",
+                "--header", "X-PolyStore-Gateway-Auth: " + V3_PROVIDER_AUTH_TOKEN,
+                "--data", json.dumps(request["body"], separators=(",", ":")),
+                "--max-filesize", str(1024 * 1024), "--output", str(path),
+                "--write-out", "%{http_code}", request["url"],
+            ], request_deadline, env=lifecycle.env)
+            with path.open("rb") as source:
+                raw = source.read(1024 * 1024 + 1)
+            if len(raw) > 1024 * 1024:
+                raise ValueError("v3 HTTP response exceeds 1 MiB")
+            body = json.loads(raw)
+            if not isinstance(body, dict):
+                raise ValueError("v3 HTTP response must be a JSON object")
+            try:
+                code = producer.uint(result.stdout.strip())
+            except ValueError as error:
+                raise ValueError("v3 HTTP request did not return a status code") from error
+            row = dict(body, http_status=code, provider=request["provider"], attempt=attempt,
+                       request_index=index, request_id=request.get("id"), offered_ns=offered_ns,
+                       request_started_ns=began, request_finished_ns=artifact.monotonic_ns(),
+                       stderr=result.stderr[-8192:], curl_returncode=result.returncode)
+            attempts.append(row)
+            if result.returncode != 0:
+                return attempts, ValueError(
+                    f"v3 HTTP request for provider {request['provider']!r} exited {result.returncode}")
+            busy = (code == 429 and set(body) == {"error", "hint"} and
+                    body.get("error") == "retrieval submission busy" and
+                    body.get("hint") == "retrieval submission capacity or signer busy")
+            if not retry_pre_admission_busy or not busy:
+                return attempts, None
+        except BaseException as error:
+            attempts.append(dict(status="driver_error", provider=request["provider"], attempt=attempt,
+                                 request_index=index, request_id=request.get("id"), offered_ns=offered_ns,
+                                 error=str(error)[-8192:], request_finished_ns=artifact.monotonic_ns()))
+            return attempts, error
+        finally:
+            path.unlink(missing_ok=True)
+    return attempts, None
+
+
 def run_v3_http_phase(lifecycle, curl, requests, phase, *, max_in_flight,
                       retry_pre_admission_busy=False):
     """Run one bounded disjoint-signer HTTP phase and retain every outcome."""
@@ -297,61 +370,10 @@ def run_v3_http_phase(lifecycle, curl, requests, phase, *, max_in_flight,
     completed = []
     retained = lifecycle.doc.setdefault("v3_http_phases", {}).setdefault(phase, [])
 
-    def execute(index, request):
-        attempts = []
-        limit = V3_BUSY_MAX_ATTEMPTS if retry_pre_admission_busy else 1
-        request_deadline = min(phase_deadline,
-                               started + request.get("timeout_seconds", 180) * 10**9)
-        for attempt in range(1, limit + 1):
-            if attempt > 1:
-                if artifact.monotonic_ns() + V3_BUSY_RETRY_SECONDS * 10**9 >= request_deadline:
-                    break
-                time.sleep(V3_BUSY_RETRY_SECONDS)
-            path = directory / f"{phase}-{index}-{attempt}.json"
-            began = artifact.monotonic_ns()
-            try:
-                result = artifact.run_bounded_command([
-                    curl, "--silent", "--show-error", "--max-time", str(request.get("timeout_seconds", 180)),
-                    "--request", "POST", "--header", "Content-Type: application/json",
-                    "--header", "X-PolyStore-Gateway-Auth: " + V3_PROVIDER_AUTH_TOKEN,
-                    "--data", json.dumps(request["body"], separators=(",", ":")),
-                    "--max-filesize", str(1024 * 1024), "--output", str(path),
-                    "--write-out", "%{http_code}", request["url"],
-                ], request_deadline, env=lifecycle.env)
-                with path.open("rb") as source:
-                    raw = source.read(1024 * 1024 + 1)
-                if len(raw) > 1024 * 1024:
-                    raise ValueError("v3 HTTP response exceeds 1 MiB")
-                body = json.loads(raw)
-                if not isinstance(body, dict):
-                    raise ValueError("v3 HTTP response must be a JSON object")
-                try:
-                    code = producer.uint(result.stdout.strip())
-                except ValueError as error:
-                    raise ValueError("v3 HTTP request did not return a status code") from error
-                row = dict(body, http_status=code, provider=request["provider"], attempt=attempt,
-                           request_started_ns=began, request_finished_ns=artifact.monotonic_ns(),
-                           stderr=result.stderr[-8192:], curl_returncode=result.returncode)
-                attempts.append(row)
-                if result.returncode != 0:
-                    return attempts, ValueError(
-                        f"v3 HTTP request for provider {request['provider']!r} exited {result.returncode}")
-                busy = (code == 429 and set(body) == {"error", "hint"} and
-                        body.get("error") == "retrieval submission busy" and
-                        body.get("hint") == "retrieval submission capacity or signer busy")
-                if not retry_pre_admission_busy or not busy:
-                    return attempts, None
-            except BaseException as error:
-                attempts.append(dict(status="driver_error", provider=request["provider"], attempt=attempt,
-                                     error=str(error)[-8192:], request_finished_ns=artifact.monotonic_ns()))
-                return attempts, error
-            finally:
-                path.unlink(missing_ok=True)
-        return attempts, None
-
     errors = []
     with ThreadPoolExecutor(max_workers=max_in_flight) as executor:
-        pending = {executor.submit(execute, index, request): request
+        pending = {executor.submit(_run_v3_http_request, lifecycle, curl, request, phase, index,
+                                   directory, phase_deadline, retry_pre_admission_busy): request
                    for index, request in enumerate(requests)}
         while pending:
             done, _ = wait_futures(pending, timeout=1, return_when=FIRST_COMPLETED)
@@ -400,6 +422,108 @@ def run_v3_http_phase(lifecycle, curl, requests, phase, *, max_in_flight,
     lifecycle.save()
     print(json.dumps(heartbeat, sort_keys=True), flush=True)
     return sorted(completed, key=lambda row: row["provider"])
+
+
+def run_v3_http_schedule(lifecycle, curl, requests, phase):
+    """Offer a fixed provider HTTP schedule with one in-flight request per signer."""
+    offsets = [row.get("offered_offset_ns") for row in requests]
+    if (not requests or len(requests) > 128 or
+            any(type(value) is not int or value < 0 for value in offsets) or
+            offsets != sorted(offsets) or
+            len({row.get("id") for row in requests}) != len(requests) or
+            not 1 <= len({row.get("provider") for row in requests}) <= V3_SYSTEMATIC_PROVIDERS):
+        raise ValueError("invalid bounded v3 HTTP schedule")
+    require_free_disk(lifecycle.home, V3_ABORT_FREE_BYTES, phase)
+    directory = lifecycle.home / "v3-http"
+    directory.mkdir(mode=0o700, exist_ok=True)
+    started = artifact.monotonic_ns()
+    phase_deadline = min(lifecycle.deadline, started +
+        (V3_CROSS_AUDIT_OFFER_SECONDS + V3_CROSS_AUDIT_DRAIN_SECONDS) * 10**9)
+    scheduled = [dict(row, offered_ns=started + row["offered_offset_ns"], timeout_seconds=30)
+                 for row in requests]
+    retained = lifecycle.doc.setdefault("v3_http_phases", {}).setdefault(phase, [])
+    summary = lifecycle.doc.setdefault("v3_http_schedules", {}).setdefault(phase, dict(
+        monotonic_start_ns=started, offered_window_ns=V3_CROSS_AUDIT_OFFER_SECONDS * 10**9,
+        drain_cap_ns=V3_CROSS_AUDIT_DRAIN_SECONDS * 10**9, total=len(requests),
+        offered=0, completed=0, queued=0, in_flight=0, max_in_flight_per_provider=1,
+        max_queued=0, max_in_flight=0, max_dispatch_lag_ns=0,
+        timing_scope="provider HTTP includes proof generation, local verification, gas simulation, signing, broadcast and commit observation"))
+    queued, next_index, active, pending, completed, errors = [], 0, set(), {}, [], []
+    last_heartbeat = last_progress = started
+    with ThreadPoolExecutor(max_workers=V3_SYSTEMATIC_PROVIDERS) as executor:
+        while len(completed) < len(scheduled) and (not errors or pending):
+            now = artifact.monotonic_ns()
+            if not errors:
+                while next_index < len(scheduled) and scheduled[next_index]["offered_ns"] <= now:
+                    queued.append(next_index)
+                    next_index += 1
+                for index in list(queued):
+                    request = scheduled[index]
+                    if request["provider"] in active:
+                        continue
+                    queued.remove(index)
+                    active.add(request["provider"])
+                    pending[executor.submit(_run_v3_http_request, lifecycle, curl, request, phase,
+                        index, directory, phase_deadline, True)] = (index, request)
+            timeout = .1
+            if not pending and next_index < len(scheduled) and not errors:
+                timeout = min(timeout, max(0, (scheduled[next_index]["offered_ns"] - now) / 1e9))
+            if pending:
+                done = wait_futures(pending, timeout=timeout, return_when=FIRST_COMPLETED)[0]
+            else:
+                time.sleep(timeout)
+                done = set()
+            now = artifact.monotonic_ns()
+            for future in done:
+                index, request = pending.pop(future)
+                active.remove(request["provider"])
+                future_error = None
+                try:
+                    attempts, future_error = future.result()
+                except BaseException as error:
+                    attempts = [dict(status="driver_error", provider=request["provider"],
+                        request_index=index, request_id=request["id"], offered_ns=request["offered_ns"],
+                        error=str(error)[-8192:], request_finished_ns=now)]
+                    future_error = error
+                retained.extend(attempts)
+                if future_error is not None:
+                    errors.append(future_error)
+                else:
+                    completed.append(attempts[-1])
+                    last_progress = now
+            summary.update(offered=next_index, completed=len(completed), queued=len(queued),
+                           in_flight=len(pending), elapsed_ns=now-started,
+                           seconds_since_progress=(now-last_progress)/1e9)
+            summary["max_queued"] = max(summary["max_queued"], len(queued))
+            summary["max_in_flight"] = max(summary["max_in_flight"], len(pending))
+            if completed:
+                summary["max_dispatch_lag_ns"] = max(summary["max_dispatch_lag_ns"],
+                    max(row["request_started_ns"] - row["offered_ns"] for row in completed))
+            if now - last_heartbeat >= 60 * 10**9:
+                heartbeat = dict(phase=phase, **{key: summary[key] for key in (
+                    "offered", "completed", "queued", "in_flight", "elapsed_ns", "seconds_since_progress")})
+                lifecycle.doc.setdefault("progress", []).append(heartbeat)
+                lifecycle.save()
+                print(json.dumps(heartbeat, sort_keys=True), flush=True)
+                last_heartbeat = now
+            elif done:
+                lifecycle.save()
+            if not errors:
+                try:
+                    lifecycle.remaining()
+                    if now >= phase_deadline:
+                        raise TimeoutError(f"{phase} exceeded its fixed offer and drain cap")
+                    require_free_disk(lifecycle.home, V3_ABORT_FREE_BYTES, phase)
+                except BaseException as error:
+                    errors.append(error)
+    finished = artifact.monotonic_ns()
+    summary.update(monotonic_end_ns=finished, elapsed_ns=finished-started,
+                   offered=next_index, completed=len(completed), queued=len(queued), in_flight=0,
+                   terminal_error=str(errors[0])[-8192:] if errors else None)
+    lifecycle.save()
+    if errors:
+        raise errors[0]
+    return sorted(completed, key=lambda row: row["request_index"])
 
 
 def v3_session_query(lifecycle, session_id, height=None):
@@ -610,6 +734,308 @@ def run_native_v3_sessions(lifecycle, *, deal, providers, send, wait, curl):
                samples_per_session=V3_MAX_SAMPLES, delivery_verified=False, owner_acknowledged=False,
                qualification=False, timing_scope="provider HTTP includes proof generation, local verification, gas simulation, signing, broadcast and commit observation",
                retention_limit="normal audits retain the same generation, so retained-generation union cannot independently attribute session reference release")
+    lifecycle.save()
+
+
+def classify_cross_audit_transaction(lifecycle, transaction, providers, deal_id, epoch):
+    """Return one exact committed system-audit transaction or reject provider extras."""
+    txhash = transaction["txhash"].upper()
+    decoded = json.loads(lifecycle.cli(lifecycle.nodes[0]["home"], "query", "tx", txhash, "--output", "json"))
+    if decoded.get("txhash", "").upper() != txhash or producer.uint(decoded.get("height", "")) != transaction["height"]:
+        raise ValueError("decoded cross-audit transaction identity differs from committed block")
+    messages = decoded.get("tx", {}).get("body", {}).get("messages", [])
+    provider_messages = [row for row in messages if row.get("creator") in providers.values()]
+    if not provider_messages:
+        return None
+    if len(messages) != 1 or len(provider_messages) != 1:
+        raise ValueError("provider transaction contains an unexpected message set")
+    message = provider_messages[0]
+    if (message.get("@type") != "/polystorechain.polystorechain.v1.MsgProveLiveness" or
+            producer.uint(message.get("deal_id", "")) != producer.uint(deal_id) or
+            producer.uint(message.get("epoch_id", "")) != epoch or
+            set(message).intersection({"user_receipt", "system_proof", "user_receipt_batch", "session_proof"}) != {"system_proof"} or
+            not isinstance(message.get("system_proof"), dict) or not message["system_proof"] or
+            producer.uint(transaction.get("code", 0)) != 0):
+        raise ValueError("provider transaction is not a successful crossed-epoch system audit")
+    provider = message["creator"]
+    return dict(txhash=txhash, height=transaction["height"], provider=provider,
+                slot=next(slot for slot, address in providers.items() if address == provider),
+                code=producer.uint(transaction.get("code", 0)), gas_wanted=transaction["gas_wanted"],
+                gas_used=transaction["gas_used"])
+
+
+def reconcile_cross_audit_sequences(before, after, providers, proof_transactions,
+                                    audit_transactions, audit_views):
+    """Bind signer sequence deltas to unique successful proof and audit transactions."""
+    if set(before) != set(after) or set(before) != set(providers.values()):
+        raise ValueError("provider sequence fence has the wrong signer set")
+    proof_counts = {address: 0 for address in providers.values()}
+    hashes = set()
+    for row in proof_transactions:
+        txhash, provider = row.get("txhash"), row.get("provider")
+        if (not isinstance(txhash, str) or not re.fullmatch(r"[0-9A-F]{64}", txhash) or
+                txhash in hashes or provider not in proof_counts or row.get("outcome") != "committed_success"):
+            raise ValueError("proof transaction sequence inventory is not unique committed success")
+        hashes.add(txhash)
+        proof_counts[provider] += 1
+    audit_counts = {address: 0 for address in providers.values()}
+    audit_hashes = set()
+    for row in audit_transactions:
+        txhash, provider = row.get("txhash"), row.get("provider")
+        if (not isinstance(txhash, str) or not re.fullmatch(r"[0-9A-F]{64}", txhash) or
+                txhash in hashes or txhash in audit_hashes or provider not in audit_counts or
+                producer.uint(row.get("code", 1)) != 0):
+            raise ValueError("audit transaction sequence inventory is not unique committed success")
+        audit_hashes.add(txhash)
+        audit_counts[provider] += 1
+    for slot, provider in providers.items():
+        view = audit_views.get(slot)
+        if not isinstance(view, dict):
+            raise ValueError("crossed audit inventory omits a provider")
+        required = producer.uint(view.get("audit", {}).get("sample_count", ""))
+        accepted = producer.uint(view.get("audit", {}).get("accepted_count", ""))
+        if accepted != required:
+            raise ValueError("crossed audit coverage is incomplete")
+        if audit_counts[provider] != accepted:
+            raise ValueError("crossed audit bitmap does not equal unique committed audit transactions")
+    rows = []
+    for provider in providers.values():
+        start, end = before[provider], after[provider]
+        if start["account_number"] != end["account_number"]:
+            raise ValueError("provider account number changed")
+        actual = end["sequence"] - start["sequence"]
+        expected = proof_counts[provider] + audit_counts[provider]
+        if actual != expected:
+            raise ValueError("provider sequence changed outside unique workload and audit transactions")
+        rows.append(dict(provider=provider, before=start["sequence"], after=end["sequence"],
+                         proof_transactions=proof_counts[provider], audit_transactions=audit_counts[provider],
+                         expected_delta=expected, actual_delta=actual))
+    return rows
+
+
+def wait_for_crossed_audits(lifecycle, audits, epoch_length, expected_epoch, deadline_height):
+    """Wait briefly for one crossed epoch's complete current audit coverage."""
+    started = artifact.monotonic_ns()
+    deadline = min(lifecycle.deadline, started + 30 * 10**9)
+    attempts, last_error = [], None
+    while artifact.monotonic_ns() < deadline:
+        height = lifecycle.wait_height(1)
+        observed = (height - 1) // epoch_length + 1
+        if observed > expected_epoch or height >= deadline_height - 10:
+            raise ValueError("cross-audit verification left its single-epoch/session margin")
+        if observed < expected_epoch:
+            attempts.append(dict(height=height, waiting_for_epoch=expected_epoch))
+            time.sleep(min(.2, lifecycle.remaining()))
+            continue
+        try:
+            views = audits(height, False, expected_epoch)
+            accepted = sum(producer.uint(row["audit"].get("accepted_count", 0)) for row in views.values())
+            required = sum(producer.uint(row["audit"]["sample_count"]) for row in views.values())
+            attempts.append(dict(height=height, accepted=accepted, required=required))
+            if accepted == required:
+                return dict(height=height, audits=views, attempts=attempts)
+            last_error = f"accepted {accepted} of {required}"
+        except ValueError as error:
+            last_error = str(error)[-1024:]
+            attempts.append(dict(height=height, error=last_error))
+        time.sleep(min(.2, lifecycle.remaining()))
+    raise TimeoutError("crossed audit coverage did not complete within 30 seconds: " + str(last_error))
+
+
+def run_native_v3_cross_audit(lifecycle, *, deal, providers, send, wait, curl, audits, epoch_length):
+    """Fixed provider-route load spanning exactly one normal storage-audit anchor."""
+    doc = lifecycle.doc["native_v3_cross_audit"] = dict(qualification=False)
+    owner = lifecycle.signers["owner0"]
+    opened_at = lifecycle.wait_height(3)
+    deadline_height = opened_at + 300
+    if deadline_height >= producer.uint(deal["end_block"]):
+        raise ValueError("cross-audit sessions reach the deal end")
+    root = producer.b64(deal["manifest_root"], 32).hex()
+    integrity = lifecycle.doc["native_v3_generation"]["candidate"]["integrity_root"][2:]
+    sessions = doc["sessions"] = []
+    for nonce in range(1, V3_CROSS_AUDIT_SESSIONS + 1):
+        path = lifecycle.home / f"native-cross-audit-open-{nonce}.json"
+        with path.open("x") as output:
+            json.dump(dict(creator=owner, deal_id=str(deal["id"]), generation="1",
+                range=dict(file_record_index=0, file_start_offset="0", file_length=str(V3_PILOT_BYTES),
+                           range_start="0", range_length=str(V3_PILOT_BYTES)), nonce=str(nonce),
+                deadline_height=str(deadline_height)), output, separators=(",", ":"))
+        result = send("owner0", ["retrieval-session-v3", "open", str(path)])
+        result["validators"] = verify_transaction_nodes(lifecycle, result)
+        sessions.append(dict(session_id=opened_v3_session(result), nonce=nonce,
+                             open_transaction=result))
+        lifecycle.save()
+    evidence_height = wait(max(row["open_transaction"]["height"] for row in sessions) + 2)
+    for row in sessions:
+        view = v3_session_query(lifecycle, row["session_id"], evidence_height)
+        _, accepted = validate_v3_session(view, session_id=row["session_id"], deal_id=deal["id"],
+            owner=owner, providers=providers, nonce=row["nonce"], polyfs_root=root,
+            integrity_root=integrity, chain_id=lifecycle.chain, deadline_height=deadline_height)
+        if accepted:
+            raise ValueError("cross-audit session starts with accepted samples")
+        row["before_proofs"] = view
+    warmup_requests = [dict(id=f"warmup-{slot}", provider=providers[slot],
+        url=provider_http_url(lifecycle, providers[slot], "/sp/session-proof"),
+        body=dict(session_id=sessions[0]["session_id"]), timeout_seconds=30)
+        for slot in range(V3_SYSTEMATIC_PROVIDERS)]
+    warmup_outcomes = run_v3_http_phase(lifecycle, curl, warmup_requests, "cross-audit-warmup",
+        max_in_flight=V3_SYSTEMATIC_PROVIDERS, retry_pre_admission_busy=True)
+    validate_v3_provider_outcomes(warmup_outcomes, providers, session_id=sessions[0]["session_id"])
+    warmup_transactions = []
+    for outcome in warmup_outcomes:
+        tx = committed_v3_http_tx(lifecycle, outcome, kind="session-proof", creator=outcome["provider"],
+            slot=producer.uint(outcome["slot"]), session_id=sessions[0]["session_id"],
+            proof_count=producer.uint(outcome["proof_count"]))
+        tx.update(provider=outcome["provider"], operation_id=outcome["request_id"])
+        if tx["outcome"] != "committed_success":
+            raise ValueError("warmup provider reported success for a failed proof transaction")
+        warmup_transactions.append(tx)
+    warmup_height = max(row["height"] for row in warmup_transactions)
+    wait(warmup_height + 1)
+    warmup_view = v3_session_query(lifecycle, sessions[0]["session_id"], warmup_height)
+    _, warmup_accepted = validate_v3_session(warmup_view, session_id=sessions[0]["session_id"],
+        deal_id=deal["id"], owner=owner, providers=providers, nonce=1, polyfs_root=root,
+        integrity_root=integrity, chain_id=lifecycle.chain, deadline_height=deadline_height)
+    if warmup_accepted != sorted(ordinal for row in warmup_transactions for ordinal in row["ordinals"]):
+        raise ValueError("warmup bitmap differs from committed proof messages")
+    doc["warmup_proof_transactions"] = warmup_transactions
+    lifecycle.save()
+    current = lifecycle.wait_height(1)
+    ready_epoch = (current - 1) // epoch_length + 1
+    next_anchor = ready_epoch * epoch_length + 1
+    target_height = next_anchor - 30
+    if target_height - current < 4 or deadline_height - (target_height + 60) < 40:
+        raise ValueError("cross-audit profile lacks alignment or session deadline margin")
+    quiescence = require_provider_quiescence(lifecycle, providers)
+    ready_height = quiescence["second_height"]
+    current_audits = audits(ready_height, False, ready_epoch)
+    if any(producer.uint(row["audit"].get("accepted_count", 0)) != producer.uint(row["audit"]["sample_count"])
+           for row in current_audits.values()):
+        raise ValueError("current audit coverage is incomplete before cross-audit load")
+    for row in sessions[1:]:
+        if v3_session_query(lifecycle, row["session_id"], ready_height) != row["before_proofs"]:
+            raise ValueError("prepared cross-audit session changed before timing")
+    if lifecycle.wait_height(1) > target_height:
+        raise ValueError("cross-audit preflight missed its fixed start alignment")
+    wait(target_height)
+    scheduled_start_height = lifecycle.wait_height(1)
+    if scheduled_start_height > target_height + 1:
+        raise ValueError("cross-audit start moved beyond its fixed anchor alignment")
+    schedule = native_v3_cross_audit_schedule()
+    requests = []
+    for item in schedule:
+        session = sessions[item["session_index"]]
+        requests.append(dict(item, id=f"measured-{item['session_index']}-{item['slot']}",
+            provider=providers[item["slot"]],
+            url=provider_http_url(lifecycle, providers[item["slot"]], "/sp/session-proof"),
+            body=dict(session_id=session["session_id"])))
+    doc["measurement_preconditions"] = dict(evidence_height=evidence_height, ready_height=ready_height,
+        ready_epoch=ready_epoch, next_anchor=next_anchor, target_height=target_height,
+        scheduled_start_height=scheduled_start_height,
+        session_deadline=deadline_height, audits=current_audits, provider_quiescence=quiescence)
+    capture_workload_metrics(lifecycle, "native_v3_cross_audit_before", fenced=True)
+    before_cpu = validator_cpu_snapshot(lifecycle)
+    outcomes = run_v3_http_schedule(lifecycle, curl, requests, "cross-audit-measured")
+    after_cpu = validator_cpu_snapshot(lifecycle)
+    measured_end_height = lifecycle.wait_height(1)
+    capture_workload_metrics(lifecycle, "native_v3_cross_audit_after", fenced=True)
+    doc["measured_window"] = dict(monotonic_start_ns=before_cpu["monotonic_ns"],
+        monotonic_end_ns=after_cpu["monotonic_ns"],
+        elapsed_ns=after_cpu["monotonic_ns"]-before_cpu["monotonic_ns"],
+        committed_end_height=measured_end_height, validator_cpu_before=before_cpu,
+        validator_cpu_after=after_cpu, validator_cpu_delta=validator_cpu_delta(before_cpu, after_cpu),
+        scope="fixed HTTP offer and bounded drain; includes proof generation, local verification, gas simulation, signing, broadcast and commit observation; no RSS phase peak")
+    grouped = {index: [] for index in range(1, V3_CROSS_AUDIT_SESSIONS)}
+    for outcome in outcomes:
+        grouped[schedule[outcome["request_index"]]["session_index"]].append(outcome)
+    transactions = doc["measured_proof_transactions"] = []
+    for session_index, session_outcomes in grouped.items():
+        session = sessions[session_index]
+        validate_v3_provider_outcomes(session_outcomes, providers, session_id=session["session_id"])
+        for outcome in session_outcomes:
+            tx = committed_v3_http_tx(lifecycle, outcome, kind="session-proof",
+                creator=outcome["provider"], slot=producer.uint(outcome["slot"]),
+                session_id=session["session_id"], proof_count=producer.uint(outcome["proof_count"]))
+            tx.update(provider=outcome["provider"], operation_id=outcome["request_id"],
+                      session_index=session_index)
+            if tx["outcome"] != "committed_success" or producer.uint(tx["height"]) > measured_end_height:
+                raise ValueError("measured provider outcome is not a committed in-window success")
+            transactions.append(tx)
+        lifecycle.save()
+    if len(transactions) != V3_CROSS_AUDIT_MEASURED:
+        raise ValueError("measured provider phase omitted a proof transaction")
+    lifecycle.save()
+    crossed = wait_for_crossed_audits(lifecycle, audits, epoch_length, ready_epoch + 1, deadline_height)
+    post_quiescence = require_provider_quiescence(lifecycle, providers)
+    final_height = post_quiescence["second_height"]
+    if (final_height - 1) // epoch_length + 1 != ready_epoch + 1:
+        raise ValueError("cross-audit profile crossed more than one epoch")
+    prior_final = audits(final_height, True, ready_epoch)
+    for slot, view in prior_final.items():
+        if any(view[name] != current_audits[slot][name] for name in ("canonical_context", "seed", "epoch_length")):
+            raise ValueError("prior audit authority changed across its finalization")
+    crossed_final = audits(final_height, False, ready_epoch + 1)
+    if crossed_final != crossed["audits"]:
+        raise ValueError("crossed audit evidence changed after provider quiescence")
+    before_metrics = lifecycle.doc["commit_step_metrics"]["phases"]["native_v3_cross_audit_before"]
+    first_height = min(row["sample"]["committed_height"] for row in before_metrics["nodes"]) + 1
+    proof_hashes = {row["txhash"].upper() for row in transactions}
+    audit_transactions = []
+    def observe_transaction(transaction):
+        if transaction["txhash"].upper() in proof_hashes:
+            return
+        row = classify_cross_audit_transaction(
+            lifecycle, transaction, providers, deal["id"], ready_epoch + 1)
+        if row is not None:
+            audit_transactions.append(row)
+    reconcile_transaction_blocks(lifecycle, transactions, first_height, final_height,
+        lifecycle.home / "native-v3-cross-audit-blocks.jsonl", observe_transaction=observe_transaction)
+    final_sequences = provider_sequences(lifecycle, providers, final_height)
+    doc["audit_transactions"] = audit_transactions
+    doc["provider_sequence_reconciliation"] = reconcile_cross_audit_sequences(
+        quiescence["sequences"], final_sequences, providers, transactions,
+        audit_transactions, crossed_final)
+    for index, row in enumerate(sessions):
+        state = v3_session_query(lifecycle, row["session_id"], final_height)
+        _, accepted = validate_v3_session(state, session_id=row["session_id"], deal_id=deal["id"],
+            owner=owner, providers=providers, nonce=row["nonce"], polyfs_root=root,
+            integrity_root=integrity, chain_id=lifecycle.chain, deadline_height=deadline_height)
+        source = warmup_transactions if index == 0 else [tx for tx in transactions if tx["session_index"] == index]
+        expected = sorted(ordinal for tx in source for ordinal in tx["ordinals"])
+        if accepted != expected or len(accepted) != V3_MAX_SAMPLES:
+            raise ValueError("authoritative session bitmap differs from committed proof messages")
+        row.update(after_proofs=state, accepted_sample_ordinals=accepted,
+                   proof_transactions=source)
+    doc.update(offered_proof_transactions=V3_CROSS_AUDIT_WARMUPS + V3_CROSS_AUDIT_MEASURED,
+        warmup_transactions=V3_CROSS_AUDIT_WARMUPS, measured_offered_transactions=V3_CROSS_AUDIT_MEASURED,
+        total_committed_valid_proof_transactions=len(warmup_transactions) + len(transactions),
+        measured_committed_valid_proof_transactions=len(transactions),
+        total_authoritative_new_sample_ordinals=sum(len(row["accepted_sample_ordinals"]) for row in sessions),
+        measured_authoritative_new_sample_ordinals=sum(len(row["accepted_sample_ordinals"]) for row in sessions[1:]),
+        crossed_audit_epoch=ready_epoch + 1, crossed_audit=crossed_final,
+        measured_gas_wanted=sum(row["gas_wanted"] for row in transactions),
+        measured_gas_used=sum(row["gas_used"] for row in transactions),
+        delivery_verified=False, owner_acknowledged=False, qualification=False)
+    wait(deadline_height + 2)
+    for row in sessions:
+        expired = v3_session_query(lifecycle, row["session_id"])
+        validate_v3_session(expired, session_id=row["session_id"], deal_id=deal["id"], owner=owner,
+            providers=providers, nonce=row["nonce"], polyfs_root=root, integrity_root=integrity,
+            chain_id=lifecycle.chain, deadline_height=deadline_height, expired=True)
+        refund = send("owner0", ["retrieval-session-v3", "refund",
+                                  str(_write_v3_refund(lifecycle, owner, row["session_id"]))])
+        refund["validators"] = verify_transaction_nodes(lifecycle, refund)
+        row.update(expired_before_refund=expired, refund_transaction=refund)
+        lifecycle.save()
+    wait(max(row["refund_transaction"]["height"] for row in sessions) + 1)
+    for row in sessions:
+        after = v3_session_query(lifecycle, row["session_id"])
+        validate_v3_session(after, session_id=row["session_id"], deal_id=deal["id"], owner=owner,
+            providers=providers, nonce=row["nonce"], polyfs_root=root, integrity_root=integrity,
+            chain_id=lifecycle.chain, deadline_height=deadline_height, expired=True, refunded=True)
+        row["after_refund"] = after
+    doc.update(status="native_v3_cross_audit_diagnostic_finished", expiration_verified=True,
+               refunds_verified=True, qualification=False)
     lifecycle.save()
 
 
@@ -1950,7 +2376,7 @@ def reconcile_sustained_blocks(lifecycle, journal):
                                  lifecycle.home / "sustained-blocks.jsonl")
 
 
-def reconcile_transaction_blocks(lifecycle, results, first, last, path):
+def reconcile_transaction_blocks(lifecycle, results, first, last, path, observe_transaction=None):
     """Retain raw block gas/bytes and validate workload txs on all validators."""
     artifact.integer(last - first + 1, "fenced block count", 1, 1200)
     committed = [row for row in results if row["outcome"] in ("committed_success", "committed_failure")]
@@ -1986,6 +2412,9 @@ def reconcile_transaction_blocks(lifecycle, results, first, last, path):
                     raise ValueError("committed workload transaction differs from retained journal")
                 tx["operation_id"] = row["operation_id"]
                 matched.add(tx["txhash"])
+            if observe_transaction is not None:
+                for tx in summary["transactions"]:
+                    observe_transaction(tx)
             output.write(json.dumps(summary, sort_keys=True) + "\n")
     if matched != set(expected):
         raise ValueError("fenced blocks omit a committed workload transaction")
@@ -2248,9 +2677,12 @@ def run_sustained(lifecycle, deal, providers, send, command, audits, wait, expor
 
 
 def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustained=None,
-                native_v3=False, native_chain=None, audit_profile="normal"):
+                native_v3=False, native_chain=None, native_cross_audit=False,
+                audit_profile="normal"):
     """Real canonical ingest and normal audits; optional bounded retrieval workload."""
     if native_chain is not None:
+        native_v3 = True
+    if native_cross_audit:
         native_v3 = True
     if native_v3 and sustained is not None:
         raise ValueError("native v3 diagnostic and sustained v2 workload are distinct modes")
@@ -2296,10 +2728,13 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
                                  preflight_minimum_bytes=V3_PREFLIGHT_FREE_BYTES,
                                  runtime_minimum_bytes=V3_ABORT_FREE_BYTES)
     doc.update(mode=("four-validator-native-v3-chain-diagnostic" if native_chain is not None else
+                     "four-validator-native-v3-cross-audit-diagnostic" if native_cross_audit else
                      "four-validator-native-v3-provider-diagnostic" if native_v3 else "four-validator-healthy-provider-diagnostic"),
         setup_transactions=[], providers=[],
         workload=("one 16 MiB FAT v3 K8 deal; eight sessions; 64 native proof transactions with untimed proof preparation"
                   if native_chain is not None else
+                  "one 16 MiB FAT v3 K8 deal; sixteen sessions; 128 production-route proof transactions across one normal audit anchor"
+                  if native_cross_audit else
                   "one 16 MiB FAT v3 K8 deal; twelve production provider-daemons; two preopened native sessions"
                   if native_v3 else f"one real K{k} deal; {layout['assignments']} assigned provider-daemons; one normal audit epoch"),
         qualification=False, limits=["No capacity or delivered retrieval qualification",
@@ -2564,6 +2999,10 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
                 run_native_v3_chain(lifecycle, deal=deal, providers=providers, send=send, wait=wait,
                                     audits=audits, exporter=export_binary, epoch_length=epoch_length)
                 doc["status"] = "native_v3_chain_diagnostic_passed"
+            elif native_cross_audit:
+                run_native_v3_cross_audit(lifecycle, deal=deal, providers=providers, send=send, wait=wait,
+                                          curl=curl, audits=audits, epoch_length=epoch_length)
+                doc["status"] = "native_v3_cross_audit_diagnostic_passed"
             else:
                 run_native_v3_sessions(lifecycle, deal=deal, providers=providers, send=send, wait=wait, curl=curl)
                 doc["status"] = "native_v3_provider_diagnostic_passed"
@@ -2601,7 +3040,8 @@ def main():
     for flag in ("fixture-k8", "fixture-k2", "gateway-binary", "cli-binary", "product-source", "proof-exporter"):
         parser.add_argument("--" + flag)
     parser.add_argument("--mode", choices=("settlement-smoke", "healthy-providers", "sustained-providers",
-                                           "native-v3-providers", "native-v3-chain"), default="settlement-smoke")
+                                           "native-v3-providers", "native-v3-providers-cross-audit",
+                                           "native-v3-chain"), default="settlement-smoke")
     parser.add_argument("--timeout", type=int, default=600)
     parser.add_argument("--audit-profile", choices=("normal", "c6"), default="normal")
     parser.add_argument("--step-seconds", type=int, default=180, help="Each of five offered-rate steps; 4 is a same-path pilot")
@@ -2647,6 +3087,12 @@ def main():
             parser.error("native-v3-providers requires product binaries/source, normal audits, timeout <= 600, and excludes fixtures/--proof-only")
         print(run_healthy(artifact.FourValidatorLifecycle(**options), gateway, cli, source,
                           native_v3=True, audit_profile="normal"))
+    elif mode == "native-v3-providers-cross-audit":
+        if (not gateway or not cli or not source or k8 or k2 or proof_only or
+                options["timeout"] > 900 or audit_profile != "normal"):
+            parser.error("native-v3-providers-cross-audit requires product binaries/source, normal audits, timeout <= 900, and excludes fixtures/--proof-only")
+        print(run_healthy(artifact.FourValidatorLifecycle(**options), gateway, cli, source,
+                          native_cross_audit=True, audit_profile="normal"))
     elif mode == "healthy-providers":
         if not gateway or not cli or not source or k8 or k2 or proof_only or options["timeout"] > 600:
             parser.error("healthy-providers requires --gateway-binary/--cli-binary/--product-source, timeout <= 600, and excludes fixtures/--proof-only")

--- a/scripts/retrieval_four_validator_workload.py
+++ b/scripts/retrieval_four_validator_workload.py
@@ -580,15 +580,19 @@ def committed_v3_http_tx(lifecycle, row, *, kind, creator, slot, deal_id=None,
     """Bind an HTTP result to exact committed bytes and all four validators."""
     txhash = row["tx_hash"].upper()
     response = lifecycle.query(lifecycle.nodes[0], "/tx?hash=0x" + txhash)
+    code = producer.uint(response["tx_result"].get("code", 0))
     result = dict(txhash=response["hash"], height=producer.uint(response["height"]),
-                  code=response["tx_result"].get("code", 0),
-                  gas_wanted=response["tx_result"]["gas_wanted"],
-                  gas_used=response["tx_result"]["gas_used"],
+                  code=code,
+                  gas_wanted=producer.uint(response["tx_result"]["gas_wanted"]),
+                  gas_used=producer.uint(response["tx_result"]["gas_used"]),
                   raw_log=response["tx_result"].get("log", ""),
-                  outcome="committed_success" if not response["tx_result"].get("code", 0) else "committed_failure")
+                  outcome="committed_success" if code == 0 else "committed_failure")
     artifact.committed_tx(result, txhash)
     result["validators"] = verify_transaction_nodes(lifecycle, result)
     decoded = json.loads(lifecycle.cli(lifecycle.nodes[0]["home"], "query", "tx", txhash, "--output", "json"))
+    if (decoded.get("txhash", "").upper() != txhash or
+            producer.uint(decoded.get("height", "")) != result["height"]):
+        raise ValueError("decoded HTTP transaction identity differs from committed RPC result")
     messages = decoded.get("tx", {}).get("body", {}).get("messages", [])
     if len(messages) != 1:
         raise ValueError("committed HTTP transaction must contain exactly one message")

--- a/scripts/retrieval_four_validator_workload.py
+++ b/scripts/retrieval_four_validator_workload.py
@@ -835,33 +835,88 @@ def reconcile_cross_audit_sequences(before, after, providers, proof_transactions
     return rows
 
 
-def wait_for_crossed_audits(lifecycle, audits, epoch_length, expected_epoch, deadline_height):
-    """Wait briefly for one crossed epoch's complete current audit coverage."""
-    started = artifact.monotonic_ns()
-    deadline = min(lifecycle.deadline, started + 30 * 10**9)
-    attempts, last_error = [], None
-    while artifact.monotonic_ns() < deadline:
-        height = lifecycle.wait_height(1)
-        observed = (height - 1) // epoch_length + 1
-        if observed > expected_epoch or height >= deadline_height - 10:
-            raise ValueError("cross-audit verification left its single-epoch/session margin")
-        if observed < expected_epoch:
-            attempts.append(dict(height=height, waiting_for_epoch=expected_epoch))
-            time.sleep(min(.2, lifecycle.remaining()))
+def crossed_audit_events(results, height, providers, deal_id, expected_counts):
+    """Extract only successful system-audit completion events from one committed block."""
+    if producer.uint(results.get("height", 0)) != height:
+        raise ValueError("cross-audit signal block result has the wrong height")
+    responses = results.get("txs_results")
+    responses = [] if responses is None else responses
+    if not isinstance(responses, list) or len(responses) > 65536:
+        raise ValueError("cross-audit signal has malformed transaction results")
+    accepted = set()
+    for response in responses:
+        if not isinstance(response, dict) or producer.uint(response.get("code", 0)) != 0:
             continue
-        try:
-            views = audits(height, False, expected_epoch)
-            accepted = sum(producer.uint(row["audit"].get("accepted_count", 0)) for row in views.values())
-            required = sum(producer.uint(row["audit"]["sample_count"]) for row in views.values())
-            attempts.append(dict(height=height, accepted=accepted, required=required))
-            if accepted == required:
-                return dict(height=height, audits=views, attempts=attempts)
-            last_error = f"accepted {accepted} of {required}"
-        except ValueError as error:
-            last_error = str(error)[-1024:]
-            attempts.append(dict(height=height, error=last_error))
-        time.sleep(min(.2, lifecycle.remaining()))
-    raise TimeoutError("crossed audit coverage did not complete within 30 seconds: " + str(last_error))
+        events = response.get("events", [])
+        if not isinstance(events, list) or len(events) > 4096:
+            raise ValueError("cross-audit signal has malformed events")
+        for event in events:
+            if not isinstance(event, dict) or event.get("type") != "prove_liveness":
+                continue
+            attributes = event.get("attributes", [])
+            if not isinstance(attributes, list) or len(attributes) > 64:
+                raise ValueError("cross-audit signal has malformed attributes")
+            pairs = []
+            for attribute in attributes:
+                if not isinstance(attribute, dict) or not isinstance(attribute.get("key"), str) or not isinstance(attribute.get("value"), str):
+                    raise ValueError("cross-audit signal has malformed attributes")
+                pairs.append((attribute["key"], attribute["value"]))
+            if len(dict(pairs)) != len(pairs):
+                raise ValueError("cross-audit signal repeats an event attribute")
+            fields = dict(pairs)
+            provider = fields.get("provider")
+            if (fields.get("challenge_kind") != "2" or fields.get("deal_id") != str(deal_id) or
+                    provider not in providers.values()):
+                continue
+            ordinal = producer.uint(fields.get("challenge_ordinal", ""))
+            if ordinal >= expected_counts[provider]:
+                raise ValueError("cross-audit signal reports an out-of-range ordinal")
+            accepted.add((provider, ordinal))
+    return accepted
+
+
+def wait_for_crossed_audit_signal(lifecycle, providers, deal_id, expected_counts,
+                                  epoch_length, expected_epoch, deadline_height):
+    """Use each node-zero block result once as the cheap crossed-audit completion signal."""
+    if (set(expected_counts) != set(providers.values()) or
+            any(not isinstance(count, int) or count <= 0 for count in expected_counts.values())):
+        raise ValueError("cross-audit signal expected counts do not match the providers")
+    started = artifact.monotonic_ns()
+    original_deadline = lifecycle.deadline
+    deadline = min(original_deadline, started + 30 * 10**9)
+    node = lifecycle.nodes[0]
+    next_height = (expected_epoch - 1) * epoch_length + 1
+    accepted, attempts = set(), []
+    lifecycle.deadline = deadline
+    try:
+        while artifact.monotonic_ns() < deadline:
+            status = lifecycle.query(node, "/status")
+            if (status.get("node_info", {}).get("id") != node["node_id"] or
+                    status.get("node_info", {}).get("network") != lifecycle.chain):
+                raise ValueError("cross-audit signal RPC belongs to a different node or chain")
+            latest = producer.uint(status.get("sync_info", {}).get("latest_block_height", 0))
+            while next_height <= latest:
+                if artifact.monotonic_ns() >= deadline:
+                    raise TimeoutError("crossed audit event signal did not complete within 30 seconds")
+                observed = (next_height - 1) // epoch_length + 1
+                if observed > expected_epoch or next_height >= deadline_height - 10:
+                    raise ValueError("cross-audit verification left its single-epoch/session margin")
+                results = lifecycle.query(node, f"/block_results?height={next_height}")
+                accepted.update(crossed_audit_events(
+                    results, next_height, providers, deal_id, expected_counts))
+                attempts.append(dict(height=next_height, accepted=len(accepted),
+                                     required=sum(expected_counts.values())))
+                if all(sum(1 for address, _ in accepted if address == provider) == required
+                       for provider, required in expected_counts.items()):
+                    fenced = lifecycle.wait_height(next_height)
+                    return dict(height=fenced, signal_height=next_height,
+                                signal_node_id=node["node_id"], accepted_events=len(accepted),
+                                required_events=sum(expected_counts.values()), attempts=attempts)
+                next_height += 1
+            time.sleep(min(.2, lifecycle.remaining()))
+        raise TimeoutError("crossed audit event signal did not complete within 30 seconds")
+    finally:
+        lifecycle.deadline = original_deadline
 
 
 def open_cross_audit_measurement(lifecycle, target_height):
@@ -903,12 +958,22 @@ def validate_v3_http_receipt_fence(transactions, fence):
     return maximum
 
 
-def close_cross_audit_measurement(lifecycle, audits, epoch_length, expected_epoch,
-                                  deadline_height, before_cpu, measured_end_height):
-    """Close the CPU fence only after the crossed audit is complete on all validators."""
-    crossed = wait_for_crossed_audits(
-        lifecycle, audits, epoch_length, expected_epoch, deadline_height)
+def close_cross_audit_measurement(lifecycle, audits, providers, deal_id, expected_counts,
+                                  epoch_length, expected_epoch, deadline_height,
+                                  before_cpu, measured_end_height):
+    """Fence audit execution in CPU, then validate its state across all validators."""
+    crossed = wait_for_crossed_audit_signal(
+        lifecycle, providers, deal_id, expected_counts, epoch_length, expected_epoch, deadline_height)
     after_cpu = validator_cpu_snapshot(lifecycle)
+    views = audits(crossed["height"], False, expected_epoch)
+    if set(views) != set(providers):
+        raise ValueError("crossed audit state does not cover every provider slot")
+    for slot, view in views.items():
+        provider = providers[slot]
+        if (producer.uint(view["audit"].get("sample_count", 0)) != expected_counts[provider] or
+                producer.uint(view["audit"].get("accepted_count", 0)) != expected_counts[provider]):
+            raise ValueError("crossed audit state is incomplete after its event signal")
+    crossed["audits"] = views
     capture_workload_metrics(lifecycle, "native_v3_cross_audit_after", fenced=True)
     lifecycle.doc["native_v3_cross_audit"]["measured_window"] = dict(
         monotonic_start_ns=before_cpu["monotonic_ns"],
@@ -920,7 +985,9 @@ def close_cross_audit_measurement(lifecycle, audits, epoch_length, expected_epoc
         validator_cpu_after=after_cpu,
         validator_cpu_delta=validator_cpu_delta(before_cpu, after_cpu),
         scope=("fixed HTTP offer, bounded drain, and crossed-audit completion; includes proof generation, "
-               "local verification, gas simulation, signing, broadcast and commit observation; no RSS phase peak"))
+               "local verification, gas simulation, signing, broadcast, bounded node-zero event observation, "
+               "and the all-validator height fence; excludes the later four-validator LCD audit-state validation; "
+               "no RSS phase peak"))
     return crossed
 
 
@@ -1015,8 +1082,11 @@ def run_native_v3_cross_audit(lifecycle, *, deal, providers, send, wait, curl, a
     outcomes = run_v3_http_schedule(lifecycle, curl, requests, "cross-audit-measured")
     receipt_fence = doc["proof_receipt_fence"] = fence_v3_http_receipts(lifecycle)
     measured_end_height = receipt_fence["provider_rpc_observed_height"]
-    crossed = close_cross_audit_measurement(lifecycle, audits, epoch_length, ready_epoch + 1,
-        deadline_height, before_cpu, measured_end_height)
+    expected_audit_counts = {providers[slot]: producer.uint(view["audit"]["sample_count"])
+                             for slot, view in current_audits.items()}
+    crossed = close_cross_audit_measurement(lifecycle, audits, providers, deal["id"],
+        expected_audit_counts, epoch_length, ready_epoch + 1, deadline_height,
+        before_cpu, measured_end_height)
     grouped = {index: [] for index in range(1, V3_CROSS_AUDIT_SESSIONS)}
     for outcome in outcomes:
         grouped[schedule[outcome["request_index"]]["session_index"]].append(outcome)

--- a/scripts/retrieval_four_validator_workload.py
+++ b/scripts/retrieval_four_validator_workload.py
@@ -346,7 +346,8 @@ def _run_v3_http_request(lifecycle, curl, request, phase, index, directory,
         except BaseException as error:
             attempts.append(dict(status="driver_error", provider=request["provider"], attempt=attempt,
                                  request_index=index, request_id=request.get("id"), offered_ns=offered_ns,
-                                 error=str(error)[-8192:], request_finished_ns=artifact.monotonic_ns()))
+                                 request_started_ns=began, error=str(error)[-8192:],
+                                 request_finished_ns=artifact.monotonic_ns()))
             return attempts, error
         finally:
             path.unlink(missing_ok=True)
@@ -465,6 +466,7 @@ def run_v3_http_schedule(lifecycle, curl, requests, phase):
                     active.add(request["provider"])
                     pending[executor.submit(_run_v3_http_request, lifecycle, curl, request, phase,
                         index, directory, phase_deadline, True)] = (index, request)
+                summary["max_in_flight"] = max(summary["max_in_flight"], len(pending))
             timeout = .1
             if not pending and next_index < len(scheduled) and not errors:
                 timeout = min(timeout, max(0, (scheduled[next_index]["offered_ns"] - now) / 1e9))
@@ -490,15 +492,13 @@ def run_v3_http_schedule(lifecycle, curl, requests, phase):
                     errors.append(future_error)
                 else:
                     completed.append(attempts[-1])
+                    summary["max_dispatch_lag_ns"] = max(summary["max_dispatch_lag_ns"],
+                        attempts[0]["request_started_ns"] - attempts[0]["offered_ns"])
                     last_progress = now
             summary.update(offered=next_index, completed=len(completed), queued=len(queued),
                            in_flight=len(pending), elapsed_ns=now-started,
                            seconds_since_progress=(now-last_progress)/1e9)
             summary["max_queued"] = max(summary["max_queued"], len(queued))
-            summary["max_in_flight"] = max(summary["max_in_flight"], len(pending))
-            if completed:
-                summary["max_dispatch_lag_ns"] = max(summary["max_dispatch_lag_ns"],
-                    max(row["request_started_ns"] - row["offered_ns"] for row in completed))
             if now - last_heartbeat >= 60 * 10**9:
                 heartbeat = dict(phase=phase, **{key: summary[key] for key in (
                     "offered", "completed", "queued", "in_flight", "elapsed_ns", "seconds_since_progress")})

--- a/scripts/retrieval_four_validator_workload.py
+++ b/scripts/retrieval_four_validator_workload.py
@@ -864,6 +864,45 @@ def wait_for_crossed_audits(lifecycle, audits, epoch_length, expected_epoch, dea
     raise TimeoutError("crossed audit coverage did not complete within 30 seconds: " + str(last_error))
 
 
+def open_cross_audit_measurement(lifecycle, target_height):
+    """Capture the expensive metric boundary before the exact schedule-start fence."""
+    capture_workload_metrics(lifecycle, "native_v3_cross_audit_before", fenced=True)
+    lifecycle.wait_height(target_height)
+    before_cpu = validator_cpu_snapshot(lifecycle)
+    scheduled_start_height = lifecycle.wait_height(1)
+    if scheduled_start_height > target_height + 1:
+        raise ValueError("cross-audit start moved beyond its fixed anchor alignment")
+    return before_cpu, scheduled_start_height
+
+
+def fence_v3_http_receipts(lifecycle):
+    """Fence all validators to the provider RPC's committed tip after HTTP completion."""
+    node = lifecycle.nodes[0]
+    status = lifecycle.query(node, "/status")
+    if (status.get("node_info", {}).get("id") != node["node_id"] or
+            status.get("node_info", {}).get("network") != lifecycle.chain):
+        raise ValueError("provider RPC status belongs to a different node or chain")
+    observed = producer.uint(status.get("sync_info", {}).get("latest_block_height", 0))
+    if observed < 1:
+        raise ValueError("provider RPC status has no committed height")
+    fenced = lifecycle.wait_height(observed)
+    if fenced < observed:
+        raise ValueError("all-validator proof receipt fence did not reach the provider RPC tip")
+    return dict(provider_rpc_node_id=node["node_id"], provider_rpc_observed_height=observed,
+                all_validator_height=fenced)
+
+
+def validate_v3_http_receipt_fence(transactions, fence):
+    """Bind decoded provider receipts to the post-HTTP committed-height cutoff."""
+    if not transactions:
+        raise ValueError("provider HTTP phase has no committed receipts")
+    heights = [producer.uint(row.get("height", 0)) for row in transactions]
+    maximum = max(heights)
+    if min(heights) < 1 or maximum > producer.uint(fence.get("provider_rpc_observed_height", 0)):
+        raise ValueError("provider HTTP receipt committed outside its fenced phase")
+    return maximum
+
+
 def close_cross_audit_measurement(lifecycle, audits, epoch_length, expected_epoch,
                                   deadline_height, before_cpu, measured_end_height):
     """Close the CPU fence only after the crossed audit is complete on all validators."""
@@ -960,10 +999,6 @@ def run_native_v3_cross_audit(lifecycle, *, deal, providers, send, wait, curl, a
             raise ValueError("prepared cross-audit session changed before timing")
     if lifecycle.wait_height(1) > target_height:
         raise ValueError("cross-audit preflight missed its fixed start alignment")
-    wait(target_height)
-    scheduled_start_height = lifecycle.wait_height(1)
-    if scheduled_start_height > target_height + 1:
-        raise ValueError("cross-audit start moved beyond its fixed anchor alignment")
     schedule = native_v3_cross_audit_schedule()
     requests = []
     for item in schedule:
@@ -972,14 +1007,14 @@ def run_native_v3_cross_audit(lifecycle, *, deal, providers, send, wait, curl, a
             provider=providers[item["slot"]],
             url=provider_http_url(lifecycle, providers[item["slot"]], "/sp/session-proof"),
             body=dict(session_id=session["session_id"])))
+    before_cpu, scheduled_start_height = open_cross_audit_measurement(lifecycle, target_height)
     doc["measurement_preconditions"] = dict(evidence_height=evidence_height, ready_height=ready_height,
         ready_epoch=ready_epoch, next_anchor=next_anchor, target_height=target_height,
         scheduled_start_height=scheduled_start_height,
         session_deadline=deadline_height, audits=current_audits, provider_quiescence=quiescence)
-    capture_workload_metrics(lifecycle, "native_v3_cross_audit_before", fenced=True)
-    before_cpu = validator_cpu_snapshot(lifecycle)
     outcomes = run_v3_http_schedule(lifecycle, curl, requests, "cross-audit-measured")
-    measured_end_height = lifecycle.wait_height(1)
+    receipt_fence = doc["proof_receipt_fence"] = fence_v3_http_receipts(lifecycle)
+    measured_end_height = receipt_fence["provider_rpc_observed_height"]
     crossed = close_cross_audit_measurement(lifecycle, audits, epoch_length, ready_epoch + 1,
         deadline_height, before_cpu, measured_end_height)
     grouped = {index: [] for index in range(1, V3_CROSS_AUDIT_SESSIONS)}
@@ -995,12 +1030,14 @@ def run_native_v3_cross_audit(lifecycle, *, deal, providers, send, wait, curl, a
                 session_id=session["session_id"], proof_count=producer.uint(outcome["proof_count"]))
             tx.update(provider=outcome["provider"], operation_id=outcome["request_id"],
                       session_index=session_index)
-            if tx["outcome"] != "committed_success" or producer.uint(tx["height"]) > measured_end_height:
+            if tx["outcome"] != "committed_success":
                 raise ValueError("measured provider outcome is not a committed in-window success")
             transactions.append(tx)
         lifecycle.save()
     if len(transactions) != V3_CROSS_AUDIT_MEASURED:
         raise ValueError("measured provider phase omitted a proof transaction")
+    doc["measured_window"]["proof_receipt_max_height"] = validate_v3_http_receipt_fence(
+        transactions, receipt_fence)
     lifecycle.save()
     post_quiescence = require_provider_quiescence(lifecycle, providers)
     final_height = post_quiescence["second_height"]

--- a/scripts/retrieval_four_validator_workload.py
+++ b/scripts/retrieval_four_validator_workload.py
@@ -864,6 +864,27 @@ def wait_for_crossed_audits(lifecycle, audits, epoch_length, expected_epoch, dea
     raise TimeoutError("crossed audit coverage did not complete within 30 seconds: " + str(last_error))
 
 
+def close_cross_audit_measurement(lifecycle, audits, epoch_length, expected_epoch,
+                                  deadline_height, before_cpu, measured_end_height):
+    """Close the CPU fence only after the crossed audit is complete on all validators."""
+    crossed = wait_for_crossed_audits(
+        lifecycle, audits, epoch_length, expected_epoch, deadline_height)
+    after_cpu = validator_cpu_snapshot(lifecycle)
+    capture_workload_metrics(lifecycle, "native_v3_cross_audit_after", fenced=True)
+    lifecycle.doc["native_v3_cross_audit"]["measured_window"] = dict(
+        monotonic_start_ns=before_cpu["monotonic_ns"],
+        monotonic_end_ns=after_cpu["monotonic_ns"],
+        elapsed_ns=after_cpu["monotonic_ns"] - before_cpu["monotonic_ns"],
+        proof_phase_end_height=measured_end_height,
+        crossed_audit_completion_height=crossed["height"],
+        validator_cpu_before=before_cpu,
+        validator_cpu_after=after_cpu,
+        validator_cpu_delta=validator_cpu_delta(before_cpu, after_cpu),
+        scope=("fixed HTTP offer, bounded drain, and crossed-audit completion; includes proof generation, "
+               "local verification, gas simulation, signing, broadcast and commit observation; no RSS phase peak"))
+    return crossed
+
+
 def run_native_v3_cross_audit(lifecycle, *, deal, providers, send, wait, curl, audits, epoch_length):
     """Fixed provider-route load spanning exactly one normal storage-audit anchor."""
     doc = lifecycle.doc["native_v3_cross_audit"] = dict(qualification=False)
@@ -958,15 +979,9 @@ def run_native_v3_cross_audit(lifecycle, *, deal, providers, send, wait, curl, a
     capture_workload_metrics(lifecycle, "native_v3_cross_audit_before", fenced=True)
     before_cpu = validator_cpu_snapshot(lifecycle)
     outcomes = run_v3_http_schedule(lifecycle, curl, requests, "cross-audit-measured")
-    after_cpu = validator_cpu_snapshot(lifecycle)
     measured_end_height = lifecycle.wait_height(1)
-    capture_workload_metrics(lifecycle, "native_v3_cross_audit_after", fenced=True)
-    doc["measured_window"] = dict(monotonic_start_ns=before_cpu["monotonic_ns"],
-        monotonic_end_ns=after_cpu["monotonic_ns"],
-        elapsed_ns=after_cpu["monotonic_ns"]-before_cpu["monotonic_ns"],
-        committed_end_height=measured_end_height, validator_cpu_before=before_cpu,
-        validator_cpu_after=after_cpu, validator_cpu_delta=validator_cpu_delta(before_cpu, after_cpu),
-        scope="fixed HTTP offer and bounded drain; includes proof generation, local verification, gas simulation, signing, broadcast and commit observation; no RSS phase peak")
+    crossed = close_cross_audit_measurement(lifecycle, audits, epoch_length, ready_epoch + 1,
+        deadline_height, before_cpu, measured_end_height)
     grouped = {index: [] for index in range(1, V3_CROSS_AUDIT_SESSIONS)}
     for outcome in outcomes:
         grouped[schedule[outcome["request_index"]]["session_index"]].append(outcome)
@@ -987,7 +1002,6 @@ def run_native_v3_cross_audit(lifecycle, *, deal, providers, send, wait, curl, a
     if len(transactions) != V3_CROSS_AUDIT_MEASURED:
         raise ValueError("measured provider phase omitted a proof transaction")
     lifecycle.save()
-    crossed = wait_for_crossed_audits(lifecycle, audits, epoch_length, ready_epoch + 1, deadline_height)
     post_quiescence = require_provider_quiescence(lifecycle, providers)
     final_height = post_quiescence["second_height"]
     if (final_height - 1) // epoch_length + 1 != ready_epoch + 1:
@@ -1012,6 +1026,8 @@ def run_native_v3_cross_audit(lifecycle, *, deal, providers, send, wait, curl, a
             audit_transactions.append(row)
     reconcile_transaction_blocks(lifecycle, transactions, first_height, final_height,
         lifecycle.home / "native-v3-cross-audit-blocks.jsonl", observe_transaction=observe_transaction)
+    if any(row["height"] > crossed["height"] for row in audit_transactions):
+        raise ValueError("crossed audit transaction committed after the CPU measurement fence")
     final_sequences = provider_sequences(lifecycle, providers, final_height)
     doc["audit_transactions"] = audit_transactions
     doc["provider_sequence_reconciliation"] = reconcile_cross_audit_sequences(

--- a/scripts/retrieval_four_validator_workload.py
+++ b/scripts/retrieval_four_validator_workload.py
@@ -759,11 +759,11 @@ def run_native_v3_sessions(lifecycle, *, deal, providers, send, wait, curl):
     lifecycle.save()
 
 
-def classify_cross_audit_transaction(lifecycle, transaction, providers, deal_id, epoch):
+def classify_cross_audit_transaction(lifecycle, transaction, height, providers, deal_id, epoch):
     """Return one exact committed system-audit transaction or reject provider extras."""
     txhash = transaction["txhash"].upper()
     decoded = json.loads(lifecycle.cli(lifecycle.nodes[0]["home"], "query", "tx", txhash, "--output", "json"))
-    if decoded.get("txhash", "").upper() != txhash or producer.uint(decoded.get("height", "")) != transaction["height"]:
+    if decoded.get("txhash", "").upper() != txhash or producer.uint(decoded.get("height", "")) != height:
         raise ValueError("decoded cross-audit transaction identity differs from committed block")
     messages = decoded.get("tx", {}).get("body", {}).get("messages", [])
     provider_messages = [row for row in messages if row.get("creator") in providers.values()]
@@ -780,7 +780,7 @@ def classify_cross_audit_transaction(lifecycle, transaction, providers, deal_id,
             producer.uint(transaction.get("code", 0)) != 0):
         raise ValueError("provider transaction is not a successful crossed-epoch system audit")
     provider = message["creator"]
-    return dict(txhash=txhash, height=transaction["height"], provider=provider,
+    return dict(txhash=txhash, height=height, provider=provider,
                 slot=next(slot for slot, address in providers.items() if address == provider),
                 code=producer.uint(transaction.get("code", 0)), gas_wanted=transaction["gas_wanted"],
                 gas_used=transaction["gas_used"])
@@ -1003,11 +1003,11 @@ def run_native_v3_cross_audit(lifecycle, *, deal, providers, send, wait, curl, a
     first_height = min(row["sample"]["committed_height"] for row in before_metrics["nodes"]) + 1
     proof_hashes = {row["txhash"].upper() for row in transactions}
     audit_transactions = []
-    def observe_transaction(transaction):
+    def observe_transaction(transaction, height):
         if transaction["txhash"].upper() in proof_hashes:
             return
         row = classify_cross_audit_transaction(
-            lifecycle, transaction, providers, deal["id"], ready_epoch + 1)
+            lifecycle, transaction, height, providers, deal["id"], ready_epoch + 1)
         if row is not None:
             audit_transactions.append(row)
     reconcile_transaction_blocks(lifecycle, transactions, first_height, final_height,
@@ -2436,7 +2436,7 @@ def reconcile_transaction_blocks(lifecycle, results, first, last, path, observe_
                 matched.add(tx["txhash"])
             if observe_transaction is not None:
                 for tx in summary["transactions"]:
-                    observe_transaction(tx)
+                    observe_transaction(tx, height)
             output.write(json.dumps(summary, sort_keys=True) + "\n")
     if matched != set(expected):
         raise ValueError("fenced blocks omit a committed workload transaction")

--- a/scripts/retrieval_four_validator_workload.py
+++ b/scripts/retrieval_four_validator_workload.py
@@ -597,6 +597,24 @@ def committed_v3_http_tx(lifecycle, row, *, kind, creator, slot, deal_id=None,
     return result
 
 
+def verify_v3_refund_transaction(lifecycle, result, *, owner, session_id):
+    """Bind a refund receipt to its exact owner/session message on all validators."""
+    result["validators"] = verify_transaction_nodes(lifecycle, result)
+    txhash = result["txhash"].upper()
+    decoded = json.loads(lifecycle.cli(
+        lifecycle.nodes[0]["home"], "query", "tx", txhash, "--output", "json"))
+    messages = decoded.get("tx", {}).get("body", {}).get("messages", [])
+    if (decoded.get("txhash", "").upper() != txhash or
+            producer.uint(decoded.get("height", "")) != producer.uint(result["height"]) or
+            len(messages) != 1 or
+            messages[0].get("@type") != "/polystorechain.polystorechain.v1.MsgRefundRetrievalSessionV3" or
+            messages[0].get("creator") != owner or
+            producer.b64(messages[0].get("session_id", ""), 32).hex() != session_id):
+        raise ValueError("committed v3 refund differs from the intended owner/session")
+    result["message"] = messages[0]
+    return result
+
+
 def validate_v3_candidate(value, *, deal_id):
     candidate = value.get("generation_candidate")
     if not isinstance(candidate, dict):
@@ -716,7 +734,7 @@ def run_native_v3_sessions(lifecycle, *, deal, providers, send, wait, curl):
             raise ValueError("expired v3 session retained its anchor")
         row["expired_before_refund"] = expired
         refunded = send("owner0", ["retrieval-session-v3", "refund", str(_write_v3_refund(lifecycle, owner, row["session_id"]))])
-        refunded["validators"] = verify_transaction_nodes(lifecycle, refunded)
+        verify_v3_refund_transaction(lifecycle, refunded, owner=owner, session_id=row["session_id"])
         wait(refunded["height"] + 1)
         after = v3_session_query(lifecycle, row["session_id"], refunded["height"])
         validate_v3_session(after, session_id=row["session_id"], deal_id=deal["id"], owner=owner,
@@ -1024,7 +1042,7 @@ def run_native_v3_cross_audit(lifecycle, *, deal, providers, send, wait, curl, a
             chain_id=lifecycle.chain, deadline_height=deadline_height, expired=True)
         refund = send("owner0", ["retrieval-session-v3", "refund",
                                   str(_write_v3_refund(lifecycle, owner, row["session_id"]))])
-        refund["validators"] = verify_transaction_nodes(lifecycle, refund)
+        verify_v3_refund_transaction(lifecycle, refund, owner=owner, session_id=row["session_id"])
         row.update(expired_before_refund=expired, refund_transaction=refund)
         lifecycle.save()
     wait(max(row["refund_transaction"]["height"] for row in sessions) + 1)
@@ -1403,7 +1421,7 @@ def run_native_v3_chain(lifecycle, *, deal, providers, send, wait, audits, expor
             providers=providers, nonce=row["nonce"], polyfs_root=root, integrity_root=integrity,
             chain_id=lifecycle.chain, deadline_height=deadline_height, expired=True)
         refund = send("owner0", ["retrieval-session-v3", "refund", str(_write_v3_refund(lifecycle, owner, row["session_id"]))])
-        refund["validators"] = verify_transaction_nodes(lifecycle, refund)
+        verify_v3_refund_transaction(lifecycle, refund, owner=owner, session_id=row["session_id"])
         row.update(expired_before_refund=expired, refund_transaction=refund)
     wait(max(row["refund_transaction"]["height"] for row in sessions) + 1)
     for row in sessions:

--- a/scripts/retrieval_four_validator_workload.py
+++ b/scripts/retrieval_four_validator_workload.py
@@ -580,7 +580,7 @@ def committed_v3_http_tx(lifecycle, row, *, kind, creator, slot, deal_id=None,
     """Bind an HTTP result to exact committed bytes and all four validators."""
     txhash = row["tx_hash"].upper()
     response = lifecycle.query(lifecycle.nodes[0], "/tx?hash=0x" + txhash)
-    result = dict(txhash=response["hash"], height=response["height"],
+    result = dict(txhash=response["hash"], height=producer.uint(response["height"]),
                   code=response["tx_result"].get("code", 0),
                   gas_wanted=response["tx_result"]["gas_wanted"],
                   gas_used=response["tx_result"]["gas_used"],

--- a/scripts/test_retrieval_four_validator_workload.py
+++ b/scripts/test_retrieval_four_validator_workload.py
@@ -1010,6 +1010,59 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
         self.assertEqual(window["proof_phase_end_height"], 299)
         self.assertIn("crossed-audit completion", window["scope"])
 
+    def test_cross_audit_start_fence_follows_metrics_and_target_wait(self):
+        events = []
+        lifecycle = SimpleNamespace()
+
+        def capture(*args, **kwargs):
+            events.append("metrics-before")
+
+        def wait_height(minimum):
+            events.append(f"wait-{minimum}")
+            return 271 if minimum == 271 else 272
+
+        def cpu_snapshot(*args):
+            events.append("cpu-before")
+            return {"monotonic_ns": 10, "validators": []}
+
+        lifecycle.wait_height = Mock(side_effect=wait_height)
+        with patch.object(workload, "capture_workload_metrics", side_effect=capture), \
+                patch.object(workload, "validator_cpu_snapshot", side_effect=cpu_snapshot):
+            before, height = workload.open_cross_audit_measurement(lifecycle, 271)
+        self.assertEqual((before["monotonic_ns"], height), (10, 272))
+        self.assertEqual(events, ["metrics-before", "wait-271", "cpu-before", "wait-1"])
+
+        lifecycle.wait_height = Mock(side_effect=[271, 273])
+        with patch.object(workload, "capture_workload_metrics"), \
+                patch.object(workload, "validator_cpu_snapshot", return_value=before), \
+                self.assertRaisesRegex(ValueError, "fixed anchor alignment"):
+            workload.open_cross_audit_measurement(lifecycle, 271)
+
+    def test_cross_audit_receipt_fence_uses_provider_rpc_tip(self):
+        node = {"node": "unused", "node_id": "provider-rpc"}
+        status = {"node_info": {"id": "provider-rpc", "network": "chain"},
+                  "sync_info": {"latest_block_height": "219"}}
+
+        def wait_height(minimum):
+            # The old wait_height(1) cutoff could observe the lagging tip 218.
+            return 218 if minimum == 1 else minimum
+
+        lifecycle = SimpleNamespace(nodes=[node], chain="chain", query=Mock(return_value=status),
+                                    wait_height=Mock(side_effect=wait_height))
+        fence = workload.fence_v3_http_receipts(lifecycle)
+        self.assertEqual(fence, {"provider_rpc_node_id": "provider-rpc",
+            "provider_rpc_observed_height": 219, "all_validator_height": 219})
+        lifecycle.wait_height.assert_called_once_with(219)
+        self.assertEqual(workload.validate_v3_http_receipt_fence(
+            [{"height": "217"}, {"height": 219}], fence), 219)
+        with self.assertRaisesRegex(ValueError, "outside its fenced phase"):
+            workload.validate_v3_http_receipt_fence([{"height": "220"}], fence)
+
+        lifecycle.query.return_value = copy.deepcopy(status)
+        lifecycle.query.return_value["node_info"]["id"] = "other-node"
+        with self.assertRaisesRegex(ValueError, "different node or chain"):
+            workload.fence_v3_http_receipts(lifecycle)
+
     def test_cross_audit_cpu_fence_is_not_closed_after_audit_failure(self):
         lifecycle = SimpleNamespace(doc={"native_v3_cross_audit": {}})
         with patch.object(workload, "wait_for_crossed_audits", side_effect=TimeoutError("delayed audit")), \

--- a/scripts/test_retrieval_four_validator_workload.py
+++ b/scripts/test_retrieval_four_validator_workload.py
@@ -524,9 +524,13 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
             self.assertEqual(transaction["outcome"], "committed_success")
             transaction["operation_id"] = "measured-1-0"
             output = Path(home) / "blocks.jsonl"
-            workload.reconcile_transaction_blocks(lifecycle, [transaction], 219, 219, output)
+            observed = []
+            workload.reconcile_transaction_blocks(
+                lifecycle, [transaction], 219, 219, output,
+                observe_transaction=lambda row, height: observed.append((row, height)))
             retained = json.loads(output.read_text())
             self.assertEqual(retained["transactions"][0]["operation_id"], "measured-1-0")
+            self.assertEqual(observed, [(retained["transactions"][0], 219)])
             self.assertEqual(lifecycle.doc["committed_block_reconciliation"]["committed_workload_transactions"], 1)
             for field, value in (("txhash", "AB" * 32), ("height", "220")):
                 changed = copy.deepcopy(decoded)
@@ -939,21 +943,49 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
 
     def test_cross_audit_transaction_classification_binds_committed_system_proof(self):
         providers = dict(enumerate(AUDIT_ADDRESSES))
-        txhash = "A" * 64
+        raw = b"production-shaped-crossed-audit-transaction"
+        txhash = hashlib.sha256(raw).hexdigest().upper()
         message = {"@type": "/polystorechain.polystorechain.v1.MsgProveLiveness",
                    "creator": providers[3], "deal_id": "7", "epoch_id": "4",
                    "system_proof": {"mdu_index": "2"}}
         decoded = dict(txhash=txhash, height="301", tx={"body": {"messages": [message]}})
-        lifecycle = SimpleNamespace(nodes=[{"home": "/home"}],
-                                    cli=Mock(return_value=json.dumps(decoded)))
-        transaction = dict(txhash=txhash, height=301, code=0, gas_wanted=10, gas_used=9)
-        row = workload.classify_cross_audit_transaction(lifecycle, transaction, providers, "7", 4)
-        self.assertEqual((row["provider"], row["slot"], row["txhash"]),
-                         (providers[3], 3, txhash))
-        message["session_proof"] = {}
-        lifecycle.cli.return_value = json.dumps(decoded)
-        with self.assertRaisesRegex(ValueError, "not a successful"):
-            workload.classify_cross_audit_transaction(lifecycle, transaction, providers, "7", 4)
+        block = {"block_id": {"hash": "CD" * 32}, "block": {
+            "header": {"height": "301", "chain_id": "chain", "time": "time", "app_hash": "EF" * 32},
+            "data": {"txs": [base64.b64encode(raw).decode()]}}}
+        block_results = {"height": "301", "txs_results": [{
+            "code": "0", "gas_wanted": "10", "gas_used": "9"}]}
+        commit = {"canonical": True, "signed_header": {"header": block["block"]["header"],
+            "commit": {"height": "301", "block_id": block["block_id"]}}}
+        def query(node, path):
+            if path.startswith("/block_results"):
+                return block_results
+            if path.startswith("/block?"):
+                return block
+            if path.startswith("/commit?"):
+                return commit
+            raise AssertionError(path)
+        with tempfile.TemporaryDirectory() as home:
+            lifecycle = SimpleNamespace(home=Path(home), chain="chain",
+                nodes=[{"home": "/home", "node_id": str(index)} for index in range(4)],
+                cli=Mock(return_value=json.dumps(decoded)), query=query, remaining=Mock(), doc={})
+            rows = []
+            def observe(transaction, height):
+                rows.append(workload.classify_cross_audit_transaction(
+                    lifecycle, transaction, height, providers, "7", 4))
+            workload.reconcile_transaction_blocks(
+                lifecycle, [], 301, 301, Path(home) / "blocks.jsonl",
+                observe_transaction=observe)
+            self.assertEqual((rows[0]["provider"], rows[0]["slot"], rows[0]["txhash"], rows[0]["height"]),
+                             (providers[3], 3, txhash, 301))
+            lifecycle.cli.return_value = json.dumps(dict(decoded, height="302"))
+            with self.assertRaisesRegex(ValueError, "identity differs"):
+                workload.classify_cross_audit_transaction(
+                    lifecycle, rows[0], 301, providers, "7", 4)
+            message["session_proof"] = {}
+            lifecycle.cli.return_value = json.dumps(decoded)
+            with self.assertRaisesRegex(ValueError, "not a successful"):
+                workload.classify_cross_audit_transaction(
+                    lifecycle, rows[0], 301, providers, "7", 4)
 
     def test_native_chain_summary_excludes_warmup_from_measured_counts(self):
         sessions = [dict(accepted_sample_ordinals=[0, 1]),

--- a/scripts/test_retrieval_four_validator_workload.py
+++ b/scripts/test_retrieval_four_validator_workload.py
@@ -984,31 +984,118 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
         before = {"monotonic_ns": 10, "validators": []}
         after = {"monotonic_ns": 30, "validators": []}
         lifecycle = SimpleNamespace(doc={"native_v3_cross_audit": {}})
+        providers = {0: AUDIT_ADDRESSES[0]}
+        expected = {AUDIT_ADDRESSES[0]: 1}
+        views = {0: {"audit": {"sample_count": "1", "accepted_count": "1"}}}
 
-        def wait_for_audits(*args):
-            events.append("audit-complete")
-            return {"height": 303, "audits": {}}
+        def wait_for_signal(*args):
+            events.append("event-signal-and-all-node-fence")
+            return {"height": 303, "signal_height": 303}
 
         def cpu_snapshot(*args):
             events.append("cpu-after")
             return after
 
+        def audits(*args):
+            events.append("four-node-audit-validation")
+            return views
+
         def capture(*args, **kwargs):
             events.append("metrics-after")
 
-        with patch.object(workload, "wait_for_crossed_audits", side_effect=wait_for_audits), \
+        with patch.object(workload, "wait_for_crossed_audit_signal", side_effect=wait_for_signal), \
                 patch.object(workload, "validator_cpu_snapshot", side_effect=cpu_snapshot), \
                 patch.object(workload, "capture_workload_metrics", side_effect=capture), \
                 patch.object(workload, "validator_cpu_delta", return_value={"cpu": "delta"}):
             crossed = workload.close_cross_audit_measurement(
-                lifecycle, Mock(), 100, 4, 500, before, 299)
+                lifecycle, audits, providers, "0", expected, 100, 4, 500, before, 299)
 
-        self.assertEqual(events, ["audit-complete", "cpu-after", "metrics-after"])
+        self.assertEqual(events, ["event-signal-and-all-node-fence", "cpu-after",
+                                  "four-node-audit-validation", "metrics-after"])
         self.assertEqual(crossed["height"], 303)
+        self.assertEqual(crossed["audits"], views)
         window = lifecycle.doc["native_v3_cross_audit"]["measured_window"]
         self.assertEqual(window["crossed_audit_completion_height"], 303)
         self.assertEqual(window["proof_phase_end_height"], 299)
         self.assertIn("crossed-audit completion", window["scope"])
+
+    def test_crossed_audit_signal_uses_production_block_events_and_bounded_fence(self):
+        provider = AUDIT_ADDRESSES[0]
+        providers = {0: provider}
+        expected = {provider: 1}
+        event = {"type": "prove_liveness", "attributes": [
+            {"key": "provider", "value": provider},
+            {"key": "deal_id", "value": "0"},
+            {"key": "challenge_kind", "value": "2"},
+            {"key": "challenge_ordinal", "value": "0"},
+            {"key": "tier", "value": "gold"},
+            {"key": "reward_amount", "value": "1stake"},
+        ]}
+        block_results = {"height": "301", "txs_results": [
+            {"code": "0", "gas_wanted": "2000000", "gas_used": "613056",
+             "events": [event]},
+        ]}
+        original_deadline = artifact.monotonic_ns() + 60 * 10**9
+        lifecycle = SimpleNamespace(deadline=original_deadline, chain="chain",
+            nodes=[{"node_id": "node0"}])
+
+        def query(node, path):
+            self.assertLess(lifecycle.deadline, original_deadline)
+            if path == "/status":
+                return {"node_info": {"id": "node0", "network": "chain"},
+                        "sync_info": {"latest_block_height": "301"}}
+            self.assertEqual(path, "/block_results?height=301")
+            return block_results
+
+        def wait_height(height):
+            self.assertEqual(height, 301)
+            self.assertLess(lifecycle.deadline, original_deadline)
+            return 302
+
+        lifecycle.query = Mock(side_effect=query)
+        lifecycle.wait_height = Mock(side_effect=wait_height)
+        lifecycle.remaining = lambda: max(0, (lifecycle.deadline - artifact.monotonic_ns()) / 1e9)
+        result = workload.wait_for_crossed_audit_signal(
+            lifecycle, providers, "0", expected, 100, 4, 500)
+        self.assertEqual(result["height"], 302)
+        self.assertEqual(result["signal_height"], 301)
+        self.assertEqual(result["accepted_events"], 1)
+        self.assertEqual(lifecycle.deadline, original_deadline)
+
+        def fail_fence(height):
+            self.assertLess(lifecycle.deadline, original_deadline)
+            raise TimeoutError("bounded all-node fence")
+
+        lifecycle.wait_height.side_effect = fail_fence
+        with self.assertRaisesRegex(TimeoutError, "bounded all-node fence"):
+            workload.wait_for_crossed_audit_signal(
+                lifecycle, providers, "0", expected, 100, 4, 500)
+        self.assertEqual(lifecycle.deadline, original_deadline)
+
+        failed = copy.deepcopy(block_results)
+        failed["txs_results"][0]["code"] = "7"
+        self.assertEqual(workload.crossed_audit_events(
+            failed, 301, providers, "0", expected), set())
+        for index, value in ((0, AUDIT_ADDRESSES[1]), (1, "1"), (2, "1")):
+            wrong_identity = copy.deepcopy(block_results)
+            wrong_identity["txs_results"][0]["events"][0]["attributes"][index]["value"] = value
+            with self.subTest(attribute=index):
+                self.assertEqual(workload.crossed_audit_events(
+                    wrong_identity, 301, providers, "0", expected), set())
+        out_of_range = copy.deepcopy(block_results)
+        out_of_range["txs_results"][0]["events"][0]["attributes"][3]["value"] = "1"
+        with self.assertRaisesRegex(ValueError, "out-of-range ordinal"):
+            workload.crossed_audit_events(out_of_range, 301, providers, "0", expected)
+        duplicate = copy.deepcopy(block_results)
+        duplicate["txs_results"][0]["events"].append(copy.deepcopy(event))
+        self.assertEqual(len(workload.crossed_audit_events(
+            duplicate, 301, providers, "0", expected)), 1)
+        repeated_attribute = copy.deepcopy(block_results)
+        repeated_attribute["txs_results"][0]["events"][0]["attributes"].append(
+            {"key": "provider", "value": provider})
+        with self.assertRaisesRegex(ValueError, "repeats an event attribute"):
+            workload.crossed_audit_events(
+                repeated_attribute, 301, providers, "0", expected)
 
     def test_cross_audit_start_fence_follows_metrics_and_target_wait(self):
         events = []
@@ -1065,12 +1152,13 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
 
     def test_cross_audit_cpu_fence_is_not_closed_after_audit_failure(self):
         lifecycle = SimpleNamespace(doc={"native_v3_cross_audit": {}})
-        with patch.object(workload, "wait_for_crossed_audits", side_effect=TimeoutError("delayed audit")), \
+        with patch.object(workload, "wait_for_crossed_audit_signal", side_effect=TimeoutError("delayed audit")), \
                 patch.object(workload, "validator_cpu_snapshot") as cpu_snapshot, \
                 patch.object(workload, "capture_workload_metrics") as capture, \
                 self.assertRaisesRegex(TimeoutError, "delayed audit"):
             workload.close_cross_audit_measurement(
-                lifecycle, Mock(), 100, 4, 500, {"monotonic_ns": 10}, 299)
+                lifecycle, Mock(), {0: AUDIT_ADDRESSES[0]}, "0", {AUDIT_ADDRESSES[0]: 1},
+                100, 4, 500, {"monotonic_ns": 10}, 299)
         cpu_snapshot.assert_not_called()
         capture.assert_not_called()
         self.assertNotIn("measured_window", lifecycle.doc["native_v3_cross_audit"])

--- a/scripts/test_retrieval_four_validator_workload.py
+++ b/scripts/test_retrieval_four_validator_workload.py
@@ -951,6 +951,49 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
             workload.reconcile_cross_audit_sequences(
                 before, after, providers, proofs, audit_transactions[:-1], views)
 
+    def test_cross_audit_cpu_fence_waits_for_delayed_audit_completion(self):
+        events = []
+        before = {"monotonic_ns": 10, "validators": []}
+        after = {"monotonic_ns": 30, "validators": []}
+        lifecycle = SimpleNamespace(doc={"native_v3_cross_audit": {}})
+
+        def wait_for_audits(*args):
+            events.append("audit-complete")
+            return {"height": 303, "audits": {}}
+
+        def cpu_snapshot(*args):
+            events.append("cpu-after")
+            return after
+
+        def capture(*args, **kwargs):
+            events.append("metrics-after")
+
+        with patch.object(workload, "wait_for_crossed_audits", side_effect=wait_for_audits), \
+                patch.object(workload, "validator_cpu_snapshot", side_effect=cpu_snapshot), \
+                patch.object(workload, "capture_workload_metrics", side_effect=capture), \
+                patch.object(workload, "validator_cpu_delta", return_value={"cpu": "delta"}):
+            crossed = workload.close_cross_audit_measurement(
+                lifecycle, Mock(), 100, 4, 500, before, 299)
+
+        self.assertEqual(events, ["audit-complete", "cpu-after", "metrics-after"])
+        self.assertEqual(crossed["height"], 303)
+        window = lifecycle.doc["native_v3_cross_audit"]["measured_window"]
+        self.assertEqual(window["crossed_audit_completion_height"], 303)
+        self.assertEqual(window["proof_phase_end_height"], 299)
+        self.assertIn("crossed-audit completion", window["scope"])
+
+    def test_cross_audit_cpu_fence_is_not_closed_after_audit_failure(self):
+        lifecycle = SimpleNamespace(doc={"native_v3_cross_audit": {}})
+        with patch.object(workload, "wait_for_crossed_audits", side_effect=TimeoutError("delayed audit")), \
+                patch.object(workload, "validator_cpu_snapshot") as cpu_snapshot, \
+                patch.object(workload, "capture_workload_metrics") as capture, \
+                self.assertRaisesRegex(TimeoutError, "delayed audit"):
+            workload.close_cross_audit_measurement(
+                lifecycle, Mock(), 100, 4, 500, {"monotonic_ns": 10}, 299)
+        cpu_snapshot.assert_not_called()
+        capture.assert_not_called()
+        self.assertNotIn("measured_window", lifecycle.doc["native_v3_cross_audit"])
+
     def test_cross_audit_transaction_classification_binds_committed_system_proof(self):
         providers = dict(enumerate(AUDIT_ADDRESSES))
         raw = b"production-shaped-crossed-audit-transaction"

--- a/scripts/test_retrieval_four_validator_workload.py
+++ b/scripts/test_retrieval_four_validator_workload.py
@@ -499,6 +499,33 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
         self.assertEqual(transaction["height"], 219)
         self.assertIsInstance(transaction["height"], int)
 
+    def test_refund_receipt_binds_decoded_owner_and_session(self):
+        owner = AUDIT_ADDRESSES[8]
+        txhash = "CD" * 32
+        message = {"@type": "/polystorechain.polystorechain.v1.MsgRefundRetrievalSessionV3",
+                   "creator": owner,
+                   "session_id": base64.b64encode(bytes.fromhex(self.SESSION)).decode()}
+        decoded = {"txhash": txhash, "height": "301",
+                   "tx": {"body": {"messages": [message]}}}
+        lifecycle = SimpleNamespace(nodes=[{"home": "/home"}],
+            cli=Mock(return_value=json.dumps(decoded)))
+        result = dict(txhash=txhash, height=301, code=0, gas_wanted=500000, gas_used=400000)
+        validators = [{"node_id": str(index)} for index in range(4)]
+        with patch.object(workload, "verify_transaction_nodes", return_value=validators):
+            verified = workload.verify_v3_refund_transaction(
+                lifecycle, result, owner=owner, session_id=self.SESSION)
+        self.assertEqual((verified["message"], verified["validators"]), (message, validators))
+        for field, value in (("creator", AUDIT_ADDRESSES[7]),
+                             ("session_id", base64.b64encode(bytes(32)).decode())):
+            changed = copy.deepcopy(decoded)
+            changed["tx"]["body"]["messages"][0][field] = value
+            lifecycle.cli.return_value = json.dumps(changed)
+            with self.subTest(field=field), patch.object(
+                    workload, "verify_transaction_nodes", return_value=validators), \
+                    self.assertRaisesRegex(ValueError, "intended owner/session"):
+                workload.verify_v3_refund_transaction(
+                    lifecycle, copy.deepcopy(result), owner=owner, session_id=self.SESSION)
+
 
     def test_provider_endpoint_uses_address_not_assignment_slot(self):
         lifecycle = SimpleNamespace(doc={"providers": [

--- a/scripts/test_retrieval_four_validator_workload.py
+++ b/scripts/test_retrieval_four_validator_workload.py
@@ -481,6 +481,24 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
             workload.validate_v3_committed_message(duplicate, kind="session-proof",
                 creator=providers[0], slot=0, session_id=self.SESSION, proof_count=17)
 
+    def test_committed_v3_http_transaction_normalizes_lcd_string_height(self):
+        provider = AUDIT_ADDRESSES[0]
+        txhash = "AB" * 32
+        response = {"hash": txhash, "height": "219", "tx_result": {
+            "code": 0, "gas_wanted": "2000000", "gas_used": "479121"}}
+        message = {"@type": "/polystorechain.polystorechain.v1.MsgSubmitRetrievalSessionProofV3",
+                   "creator": provider, "slot": "0",
+                   "session_id": base64.b64encode(bytes.fromhex(self.SESSION)).decode(),
+                   "proofs": [{"ordinal": "0"}]}
+        lifecycle = SimpleNamespace(nodes=[{"home": "/home"}], query=Mock(return_value=response),
+            cli=Mock(return_value=json.dumps({"tx": {"body": {"messages": [message]}}})))
+        with patch.object(workload, "verify_transaction_nodes", return_value=[]):
+            transaction = workload.committed_v3_http_tx(lifecycle,
+                {"tx_hash": txhash}, kind="session-proof", creator=provider, slot=0,
+                session_id=self.SESSION, proof_count=1)
+        self.assertEqual(transaction["height"], 219)
+        self.assertIsInstance(transaction["height"], int)
+
 
     def test_provider_endpoint_uses_address_not_assignment_slot(self):
         lifecycle = SimpleNamespace(doc={"providers": [

--- a/scripts/test_retrieval_four_validator_workload.py
+++ b/scripts/test_retrieval_four_validator_workload.py
@@ -723,6 +723,8 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
             retained = lifecycle.doc["v3_http_phases"]["retry-parser-error"]
             self.assertEqual((calls, len(retained), retained[0]["http_status"], retained[1]["status"]),
                              (2, 2, 429, "driver_error"))
+            self.assertLessEqual(retained[1]["request_started_ns"],
+                                 retained[1]["request_finished_ns"])
 
     def test_native_v3_provider_routes_use_gateway_auth_contract(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -899,6 +901,32 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
             retained = lifecycle.doc["v3_http_phases"]["scheduled-failure"]
             self.assertEqual({row.get("status") for row in retained}, {"driver_error", "success"})
             self.assertIn("Expecting property name", lifecycle.doc["v3_http_schedules"]["scheduled-failure"]["terminal_error"])
+
+    def test_cross_audit_scheduler_metrics_use_initial_dispatch_and_peak_pending(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            lifecycle = SimpleNamespace(home=Path(tmp), doc={}, env={},
+                deadline=artifact.monotonic_ns() + 10 * 10**9, save=Mock(), remaining=Mock(return_value=1))
+            requests = [dict(id=f"r{index}", provider=f"provider-{index}", offered_offset_ns=0,
+                             url=f"http://provider/{index}", body={}) for index in range(2)]
+
+            def completed_after_retry(_lifecycle, _curl, request, _phase, index, _directory,
+                                      _deadline, _retry):
+                offered = request["offered_ns"]
+                first = dict(http_status=429, provider=request["provider"], request_index=index,
+                    request_id=request["id"], offered_ns=offered, request_started_ns=offered + 3,
+                    request_finished_ns=offered + 4)
+                terminal = dict(status="success", provider=request["provider"], request_index=index,
+                    request_id=request["id"], offered_ns=offered,
+                    request_started_ns=offered + 2_000_000_003,
+                    request_finished_ns=offered + 2_000_000_004)
+                return [first, terminal], None
+
+            with patch.object(workload, "_run_v3_http_request", side_effect=completed_after_retry), \
+                 patch.object(workload, "require_free_disk", return_value=workload.V3_ABORT_FREE_BYTES):
+                workload.run_v3_http_schedule(lifecycle, "/curl", requests, "scheduled-metrics")
+            summary = lifecycle.doc["v3_http_schedules"]["scheduled-metrics"]
+            self.assertEqual(summary["max_dispatch_lag_ns"], 3)
+            self.assertEqual(summary["max_in_flight"], 2)
 
     def test_cross_audit_scheduler_enforces_shared_offer_and_drain_deadline(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/test_retrieval_four_validator_workload.py
+++ b/scripts/test_retrieval_four_validator_workload.py
@@ -481,23 +481,62 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
             workload.validate_v3_committed_message(duplicate, kind="session-proof",
                 creator=providers[0], slot=0, session_id=self.SESSION, proof_count=17)
 
-    def test_committed_v3_http_transaction_normalizes_lcd_string_height(self):
+    def test_committed_v3_http_transaction_normalizes_rpc_numbers_and_reconciles_raw_block(self):
         provider = AUDIT_ADDRESSES[0]
-        txhash = "AB" * 32
+        raw = b"production-shaped-signed-transaction"
+        txhash = hashlib.sha256(raw).hexdigest().upper()
         response = {"hash": txhash, "height": "219", "tx_result": {
-            "code": 0, "gas_wanted": "2000000", "gas_used": "479121"}}
+            "code": "0", "gas_wanted": "2000000", "gas_used": "479121"}}
         message = {"@type": "/polystorechain.polystorechain.v1.MsgSubmitRetrievalSessionProofV3",
                    "creator": provider, "slot": "0",
                    "session_id": base64.b64encode(bytes.fromhex(self.SESSION)).decode(),
                    "proofs": [{"ordinal": "0"}]}
-        lifecycle = SimpleNamespace(nodes=[{"home": "/home"}], query=Mock(return_value=response),
-            cli=Mock(return_value=json.dumps({"tx": {"body": {"messages": [message]}}})))
-        with patch.object(workload, "verify_transaction_nodes", return_value=[]):
+        block = {"block_id": {"hash": "CD" * 32}, "block": {
+            "header": {"height": "219", "chain_id": "chain", "time": "time", "app_hash": "EF" * 32},
+            "data": {"txs": [base64.b64encode(raw).decode()]}}}
+        block_results = {"height": "219", "txs_results": [{
+            "code": "0", "gas_wanted": "2000000", "gas_used": "479121"}]}
+        commit = {"canonical": True, "signed_header": {"header": block["block"]["header"],
+            "commit": {"height": "219", "block_id": block["block_id"]}}}
+        decoded = {"txhash": txhash, "height": "219", "tx": {"body": {"messages": [message]}}}
+        def query(node, path):
+            if path.startswith("/tx?"):
+                return response
+            if path.startswith("/block_results"):
+                return block_results
+            if path.startswith("/block?"):
+                return block
+            if path.startswith("/commit?"):
+                return commit
+            raise AssertionError(path)
+        with tempfile.TemporaryDirectory() as home:
+            lifecycle = SimpleNamespace(home=Path(home), chain="chain",
+                nodes=[{"home": "/home", "node_id": str(index)} for index in range(4)],
+                query=query, wait_height=Mock(return_value=220), remaining=Mock(), doc={},
+                cli=Mock(return_value=json.dumps(decoded)))
             transaction = workload.committed_v3_http_tx(lifecycle,
                 {"tx_hash": txhash}, kind="session-proof", creator=provider, slot=0,
                 session_id=self.SESSION, proof_count=1)
-        self.assertEqual(transaction["height"], 219)
-        self.assertIsInstance(transaction["height"], int)
+            self.assertEqual({key: transaction[key] for key in ("height", "code", "gas_wanted", "gas_used")},
+                             {"height": 219, "code": 0, "gas_wanted": 2000000, "gas_used": 479121})
+            self.assertTrue(all(isinstance(transaction[key], int)
+                                for key in ("height", "code", "gas_wanted", "gas_used")))
+            self.assertEqual(transaction["outcome"], "committed_success")
+            transaction["operation_id"] = "measured-1-0"
+            output = Path(home) / "blocks.jsonl"
+            workload.reconcile_transaction_blocks(lifecycle, [transaction], 219, 219, output)
+            retained = json.loads(output.read_text())
+            self.assertEqual(retained["transactions"][0]["operation_id"], "measured-1-0")
+            self.assertEqual(lifecycle.doc["committed_block_reconciliation"]["committed_workload_transactions"], 1)
+            for field, value in (("txhash", "AB" * 32), ("height", "220")):
+                changed = copy.deepcopy(decoded)
+                changed[field] = value
+                lifecycle.cli.return_value = json.dumps(changed)
+                with self.subTest(decoded_identity=field), self.assertRaisesRegex(
+                        ValueError, "decoded HTTP transaction identity"):
+                    workload.committed_v3_http_tx(lifecycle,
+                        {"tx_hash": txhash}, kind="session-proof", creator=provider, slot=0,
+                        session_id=self.SESSION, proof_count=1)
 
     def test_refund_receipt_binds_decoded_owner_and_session(self):
         owner = AUDIT_ADDRESSES[8]

--- a/scripts/test_retrieval_four_validator_workload.py
+++ b/scripts/test_retrieval_four_validator_workload.py
@@ -8,6 +8,8 @@ from pathlib import Path
 import sqlite3
 import subprocess
 import tempfile
+import threading
+import time
 from types import SimpleNamespace
 import unittest
 import urllib.error
@@ -722,6 +724,153 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "backwards"):
             workload.validator_cpu_delta(before, after)
 
+    def test_cross_audit_profile_and_provider_scheduler_are_fixed_and_serial_per_signer(self):
+        profile = workload.native_v3_cross_audit_schedule()
+        self.assertEqual((len(profile), profile[0], profile[-1]), (120,
+            dict(index=0, session_index=1, slot=0, offered_offset_ns=0),
+            dict(index=119, session_index=15, slot=7, offered_offset_ns=59_500_000_000)))
+        self.assertEqual({slot: sum(row["slot"] == slot for row in profile) for slot in range(8)},
+                         {slot: 15 for slot in range(8)})
+        with tempfile.TemporaryDirectory() as tmp:
+            lifecycle = SimpleNamespace(home=Path(tmp), doc={}, env={},
+                deadline=artifact.monotonic_ns() + 10 * 10**9, save=Mock(), remaining=Mock(return_value=1))
+            lock, active, maxima = threading.Lock(), {}, {}
+            requests = []
+            for index in range(8):
+                provider = f"provider-{index % 2}"
+                requests.append(dict(id=f"r{index}", provider=provider,
+                    offered_offset_ns=0, url=f"http://provider/{provider}/{index}", body={}))
+            def run(argv, deadline, env):
+                provider = argv[-1].split("/")[-2]
+                with lock:
+                    active[provider] = active.get(provider, 0) + 1
+                    maxima[provider] = max(maxima.get(provider, 0), active[provider])
+                time.sleep(.005)
+                Path(argv[argv.index("--output") + 1]).write_text('{"status":"success"}')
+                with lock:
+                    active[provider] -= 1
+                return SimpleNamespace(stdout="200", stderr="", returncode=0)
+            with patch.object(artifact, "run_bounded_command", side_effect=run), \
+                 patch.object(workload, "require_free_disk", return_value=workload.V3_ABORT_FREE_BYTES):
+                rows = workload.run_v3_http_schedule(lifecycle, "/curl", requests, "fixed-schedule")
+            self.assertEqual([row["request_id"] for row in rows], [f"r{i}" for i in range(8)])
+            self.assertEqual(maxima, {"provider-0": 1, "provider-1": 1})
+            summary = lifecycle.doc["v3_http_schedules"]["fixed-schedule"]
+            self.assertEqual((summary["offered"], summary["completed"], summary["queued"], summary["in_flight"]),
+                             (8, 8, 0, 0))
+
+    def test_cross_audit_scheduler_retries_only_exact_busy_and_retains_drained_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            lifecycle = SimpleNamespace(home=Path(tmp), doc={}, env={},
+                deadline=artifact.monotonic_ns() + 10 * 10**9, save=Mock(), remaining=Mock(return_value=1))
+            requests = [dict(id=f"r{index}", provider=f"provider-{index}", offered_offset_ns=0,
+                             url=f"http://provider/{index}", body={}) for index in range(2)]
+            calls = {}
+            def busy_then_success(argv, deadline, env):
+                index = int(argv[-1].rsplit("/", 1)[-1])
+                calls[index] = calls.get(index, 0) + 1
+                if index == 0 and calls[index] == 1:
+                    body, status = ({"error": "retrieval submission busy",
+                        "hint": "retrieval submission capacity or signer busy"}, 429)
+                else:
+                    body, status = ({"status": "success"}, 200)
+                Path(argv[argv.index("--output") + 1]).write_text(json.dumps(body))
+                return SimpleNamespace(stdout=str(status), stderr="", returncode=0)
+            with patch.object(artifact, "run_bounded_command", side_effect=busy_then_success), \
+                 patch.object(workload, "require_free_disk", return_value=workload.V3_ABORT_FREE_BYTES), \
+                 patch.object(workload.time, "sleep"):
+                rows = workload.run_v3_http_schedule(lifecycle, "/curl", requests, "scheduled-busy")
+            self.assertEqual((calls, len(rows), len(lifecycle.doc["v3_http_phases"]["scheduled-busy"])),
+                             ({0: 2, 1: 1}, 2, 3))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            lifecycle = SimpleNamespace(home=Path(tmp), doc={}, env={},
+                deadline=artifact.monotonic_ns() + 10 * 10**9, save=Mock(), remaining=Mock(return_value=1))
+            def one_failure(argv, deadline, env):
+                index = int(argv[-1].rsplit("/", 1)[-1])
+                path = Path(argv[argv.index("--output") + 1])
+                if index == 0:
+                    path.write_text("{")
+                else:
+                    path.write_text('{"status":"success"}')
+                return SimpleNamespace(stdout="200", stderr="", returncode=0)
+            with patch.object(artifact, "run_bounded_command", side_effect=one_failure), \
+                 patch.object(workload, "require_free_disk", return_value=workload.V3_ABORT_FREE_BYTES), \
+                 self.assertRaises(ValueError):
+                workload.run_v3_http_schedule(lifecycle, "/curl", requests, "scheduled-failure")
+            retained = lifecycle.doc["v3_http_phases"]["scheduled-failure"]
+            self.assertEqual({row.get("status") for row in retained}, {"driver_error", "success"})
+            self.assertIn("Expecting property name", lifecycle.doc["v3_http_schedules"]["scheduled-failure"]["terminal_error"])
+
+    def test_cross_audit_scheduler_enforces_shared_offer_and_drain_deadline(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            lifecycle = SimpleNamespace(home=Path(tmp), doc={}, env={},
+                deadline=artifact.monotonic_ns() + 10 * 10**9, save=Mock(), remaining=Mock(return_value=1))
+            request = dict(id="deadline", provider="provider", offered_offset_ns=0,
+                           url="http://provider/0", body={})
+            def run(argv, deadline, env):
+                Path(argv[argv.index("--output") + 1]).write_text('{"status":"success"}')
+                return SimpleNamespace(stdout="200", stderr="", returncode=0)
+            with patch.object(artifact, "run_bounded_command", side_effect=run), \
+                 patch.object(workload, "require_free_disk", return_value=workload.V3_ABORT_FREE_BYTES), \
+                 patch.object(workload, "V3_CROSS_AUDIT_OFFER_SECONDS", 0), \
+                 patch.object(workload, "V3_CROSS_AUDIT_DRAIN_SECONDS", 0), \
+                 self.assertRaisesRegex(TimeoutError, "fixed offer and drain cap"):
+                workload.run_v3_http_schedule(lifecycle, "/curl", [request], "scheduled-deadline")
+            self.assertEqual(lifecycle.doc["v3_http_schedules"]["scheduled-deadline"]["completed"], 1)
+
+    def test_cross_audit_sequence_reconciliation_counts_measured_proofs_and_audits(self):
+        providers = dict(enumerate(AUDIT_ADDRESSES))
+        before = {address: dict(account_number=slot, sequence=10) for slot, address in providers.items()}
+        views = {slot: {"audit": {"sample_count": "8", "accepted_count": "8"}}
+                 for slot in providers}
+        proofs = []
+        for slot in range(8):
+            for index in range(15):
+                proofs.append(dict(txhash=f"{slot * 15 + index + 1:064X}", provider=providers[slot],
+                                   outcome="committed_success"))
+        audit_transactions = []
+        for slot, provider in providers.items():
+            for index in range(8):
+                audit_transactions.append(dict(txhash=f"{1000 + slot * 8 + index:064X}", provider=provider,
+                                               code=0))
+        after = copy.deepcopy(before)
+        for slot, address in providers.items():
+            after[address]["sequence"] += 8 + (15 if slot < 8 else 0)
+        rows = workload.reconcile_cross_audit_sequences(
+            before, after, providers, proofs, audit_transactions, views)
+        self.assertEqual([(row["proof_transactions"], row["audit_transactions"], row["actual_delta"])
+                          for row in rows], [(15, 8, 23)] * 8 + [(0, 8, 8)] * 4)
+        after[providers[9]]["sequence"] += 1
+        with self.assertRaisesRegex(ValueError, "outside unique workload and audit"):
+            workload.reconcile_cross_audit_sequences(
+                before, after, providers, proofs, audit_transactions, views)
+        after[providers[9]]["sequence"] -= 1
+        with self.assertRaisesRegex(ValueError, "not unique"):
+            workload.reconcile_cross_audit_sequences(
+                before, after, providers, proofs + [proofs[0]], audit_transactions, views)
+        with self.assertRaisesRegex(ValueError, "bitmap does not equal"):
+            workload.reconcile_cross_audit_sequences(
+                before, after, providers, proofs, audit_transactions[:-1], views)
+
+    def test_cross_audit_transaction_classification_binds_committed_system_proof(self):
+        providers = dict(enumerate(AUDIT_ADDRESSES))
+        txhash = "A" * 64
+        message = {"@type": "/polystorechain.polystorechain.v1.MsgProveLiveness",
+                   "creator": providers[3], "deal_id": "7", "epoch_id": "4",
+                   "system_proof": {"mdu_index": "2"}}
+        decoded = dict(txhash=txhash, height="301", tx={"body": {"messages": [message]}})
+        lifecycle = SimpleNamespace(nodes=[{"home": "/home"}],
+                                    cli=Mock(return_value=json.dumps(decoded)))
+        transaction = dict(txhash=txhash, height=301, code=0, gas_wanted=10, gas_used=9)
+        row = workload.classify_cross_audit_transaction(lifecycle, transaction, providers, "7", 4)
+        self.assertEqual((row["provider"], row["slot"], row["txhash"]),
+                         (providers[3], 3, txhash))
+        message["session_proof"] = {}
+        lifecycle.cli.return_value = json.dumps(decoded)
+        with self.assertRaisesRegex(ValueError, "not a successful"):
+            workload.classify_cross_audit_transaction(lifecycle, transaction, providers, "7", 4)
+
     def test_native_chain_summary_excludes_warmup_from_measured_counts(self):
         sessions = [dict(accepted_sample_ordinals=[0, 1]),
                     dict(accepted_sample_ordinals=[2, 3, 4])]
@@ -838,6 +987,25 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
 
 
 class HealthyAuditViewsTest(unittest.TestCase):
+    def test_native_v3_cross_audit_cli_is_fixed_bounded_and_normal_audit_only(self):
+        common = ["diagnostic", "--mode", "native-v3-providers-cross-audit", "--binary", "/chain",
+                  "--library", "/lib", "--home", "/new-home"]
+        required = ["--gateway-binary", "/gateway", "--cli-binary", "/native-cli", "--product-source", "/source"]
+        for extra in ([], required + ["--timeout", "901"], required + ["--audit-profile", "c6"],
+                      required + ["--proof-only"]):
+            with self.subTest(extra=extra), patch.object(workload.sys, "argv", common + extra), \
+                 patch.object(workload.sys, "stderr"), patch.object(artifact, "FourValidatorLifecycle") as constructor:
+                with self.assertRaises(SystemExit) as error:
+                    workload.main()
+                self.assertEqual(error.exception.code, 2)
+                constructor.assert_not_called()
+        with patch.object(workload.sys, "argv", common + required + ["--timeout", "900"]), \
+             patch.object(artifact, "FourValidatorLifecycle") as constructor, \
+             patch.object(workload, "run_healthy", return_value="evidence") as run, patch("builtins.print"):
+            workload.main()
+            run.assert_called_once_with(constructor.return_value, "/gateway", "/native-cli", "/source",
+                                        native_cross_audit=True, audit_profile="normal")
+
     def test_native_v3_chain_cli_requires_exporter_and_fixed_profile(self):
         common = ["diagnostic", "--mode", "native-v3-chain", "--binary", "/chain",
                   "--library", "/lib", "--home", "/new-home"]

--- a/scripts/test_retrieval_four_validator_workload.py
+++ b/scripts/test_retrieval_four_validator_workload.py
@@ -499,6 +499,12 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
         commit = {"canonical": True, "signed_header": {"header": block["block"]["header"],
             "commit": {"height": "219", "block_id": block["block_id"]}}}
         decoded = {"txhash": txhash, "height": "219", "tx": {"body": {"messages": [message]}}}
+        tip_advanced = False
+        def wait_height(height):
+            nonlocal tip_advanced
+            self.assertEqual(height, 220)
+            tip_advanced = True
+            return height
         def query(node, path):
             if path.startswith("/tx?"):
                 return response
@@ -507,12 +513,12 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
             if path.startswith("/block?"):
                 return block
             if path.startswith("/commit?"):
-                return commit
+                return dict(commit, canonical=tip_advanced)
             raise AssertionError(path)
         with tempfile.TemporaryDirectory() as home:
             lifecycle = SimpleNamespace(home=Path(home), chain="chain",
                 nodes=[{"home": "/home", "node_id": str(index)} for index in range(4)],
-                query=query, wait_height=Mock(return_value=220), remaining=Mock(), doc={},
+                query=query, wait_height=Mock(side_effect=wait_height), remaining=Mock(), doc={},
                 cli=Mock(return_value=json.dumps(decoded)))
             transaction = workload.committed_v3_http_tx(lifecycle,
                 {"tx_hash": txhash}, kind="session-proof", creator=provider, slot=0,
@@ -522,12 +528,16 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
             self.assertTrue(all(isinstance(transaction[key], int)
                                 for key in ("height", "code", "gas_wanted", "gas_used")))
             self.assertEqual(transaction["outcome"], "committed_success")
+            tip_advanced = False
+            lifecycle.wait_height.reset_mock()
             transaction["operation_id"] = "measured-1-0"
             output = Path(home) / "blocks.jsonl"
             observed = []
+            self.assertFalse(query(lifecycle.nodes[0], "/commit?height=219")["canonical"])
             workload.reconcile_transaction_blocks(
                 lifecycle, [transaction], 219, 219, output,
                 observe_transaction=lambda row, height: observed.append((row, height)))
+            lifecycle.wait_height.assert_called_once_with(220)
             retained = json.loads(output.read_text())
             self.assertEqual(retained["transactions"][0]["operation_id"], "measured-1-0")
             self.assertEqual(observed, [(retained["transactions"][0], 219)])
@@ -967,7 +977,8 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as home:
             lifecycle = SimpleNamespace(home=Path(home), chain="chain",
                 nodes=[{"home": "/home", "node_id": str(index)} for index in range(4)],
-                cli=Mock(return_value=json.dumps(decoded)), query=query, remaining=Mock(), doc={})
+                cli=Mock(return_value=json.dumps(decoded)), query=query,
+                wait_height=Mock(return_value=302), remaining=Mock(), doc={})
             rows = []
             def observe(transaction, height):
                 rows.append(workload.classify_cross_audit_transaction(
@@ -975,6 +986,7 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
             workload.reconcile_transaction_blocks(
                 lifecycle, [], 301, 301, Path(home) / "blocks.jsonl",
                 observe_transaction=observe)
+            lifecycle.wait_height.assert_called_once_with(302)
             self.assertEqual((rows[0]["provider"], rows[0]["slot"], rows[0]["txhash"], rows[0]["height"]),
                              (providers[3], 3, txhash, 301))
             lifecycle.cli.return_value = json.dumps(dict(decoded, height="302"))

--- a/scripts/test_retrieval_sustained.py
+++ b/scripts/test_retrieval_sustained.py
@@ -356,6 +356,7 @@ class SustainedTest(unittest.TestCase):
                         value["transactions"][0]["gas_used"] += 1
                     return value
                 life = SimpleNamespace(home=Path(home), chain="chain", nodes=list(range(4)), remaining=Mock(),
+                    wait_height=Mock(return_value=12),
                     query=query, doc=dict(commit_step_metrics=dict(phases=phases)))
                 with patch.object(artifact, "committed_block_summary", side_effect=summarize):
                     if corrupt:


### PR DESCRIPTION
The native v3 diagnostics previously tested provider HTTP proofs and chain throughput separately. This adds a bounded workload that submits proofs through the production provider-daemon route while normal storage audits cross an epoch boundary: 16 FATv3 sessions, 8 warmups, and 120 requests offered across 8 systematic providers at 2 requests/s for 60 seconds, with one request in flight per signer.

The harness records queue and completion timing, failures, and dispatch lag; reconciles proof and audit transactions against raw blocks/results on all four validators; and verifies provider sequence deltas. Sessions expire without owner acknowledgement, followed by refunds bound to the exact owner and session. This profile establishes a finite local diagnostic; sustained capacity and distributed deployment qualification remain in #290.

The shared reconciliation path now normalizes production LCD/Comet numeric fields, passes the enclosing block height to audit observation, and waits for all four validators to advance beyond the final retained block before requiring a canonical commit. Strict identity, application hash, transaction, and result checks remain enforced. Comet exposes a noncanonical seen commit at its current tip; the pinned source and regression cover that availability boundary. The original failing smoke004 RPC response was not retained, so its later replay establishes immutable block agreement rather than the original response value.

The measured CPU window closes after a single-node scan of successful audit events and an all-validator committed-height fence. Each block result is scanned once; the scan and fence share a 30-second deadline. Full four-validator LCD audit-state validation runs once after CPU sampling, and raw transaction reconciliation remains authoritative. CPU scope explicitly includes the bounded event observer and height fence. It records separate HTTP proof-end and audit-completion heights, rejects any audit committed beyond that fence, and emits no completed CPU window when the bounded audit wait fails. HTTP scheduler duration remains separate. Dispatch lag uses each request's first attempt, excluding retry backoff; peak in-flight work is recorded before completed futures are removed. Every HTTP attempt retains its own timestamps, including driver errors. The metrics scrape precedes the final start-alignment wait; CPU sampling begins after that wait. After HTTP completion, the provider RPC committed tip defines the receipt cutoff and all four validators must reach it. Decoded receipts must fit that retained cutoff, so a temporarily lagging validator cannot falsely reject a valid proof.

Validation at `bb9eabd8cd97045fe17a0935af297b2aae00cad7`:

- Retrieval Python discovery: 98 tests: 97 pass, 1 skip; `py_compile` and `git diff --check` pass. Regressions cover delayed audit completion, failed waits, production numeric fields, enclosing block heights, and current-tip canonical availability, retry-independent dispatch lag, instantaneous completion peaks, delayed start scrapes, and lagging-validator receipt fences, production-shaped audit events, duplicate/foreign/failed event rejection, bounded fences, and deadline restoration.
- Earlier `3058bd3` smoke005 passes the unchanged protocol path in 736.043s: 8/8 warmups, 120/120 measured committed-valid transactions, 1,980 measured authoritative sample ordinals, and four-validator agreement across H272–326. Twelve normal epoch-4 audits, twelve exact provider sequence deltas, sixteen full session bitmaps, and sixteen expiry refunds all reconcile; locked fees end at zero and anchors clear.
- Smoke005 CPU timing excluded some delayed audit work and is not qualified as total crossed-audit CPU cost. A later operating-point collection will use the corrected landed measurement code. Focused regressions validate these measurement-only fixes without repeating the expensive pre-merge workload.
- No owner ACK, file delivery, settled provider payment, sustained throughput, or WAN performance is claimed. Smoke001–004 remain failed and unqualified; retained evidence is preserved.
- Smoke005 evidence SHA-256: `5d518cd458ced75fb6863b6ef67a16952b41ebae1ced85c939c833d4c194084b`; blocks SHA-256: `6f69c2fbb5859c1bbef0de25475f96c016f5e5b0680bc07b54149910c002417a`. All owned workload processes stopped cleanly.
- All 28 CI checks pass for this head. Root and independent review accept it; [Codex review is clean](https://github.com/Polynomialstore/polystore/pull/311#issuecomment-5615286702). Merged with owner authorization.

Part of #290 and #291.
