### PR TITLE
gateway: serve authenticated retrieval v3 chunks

### DIFF
--- a/docs/retrieval-v3-large-session-profile.md
+++ b/docs/retrieval-v3-large-session-profile.md
@@ -3,9 +3,9 @@
 Status: **contract reviewed; implementation partial and disabled by default**.
 This document fixes the wire-independent protocol choices for issue #291. The
 shared primitives, native generation admission, owner/sponsored session opening,
-sampled proof submission, per-provider ACK/settlement and expiry refunds are
-implemented. EVM parity, provider/client delivery integration and end-to-end
-activation qualification remain incomplete.
+sampled proof submission, provider data delivery, per-provider ACK/settlement
+and expiry refunds are implemented. Browser client integration, EVM parity and
+end-to-end activation qualification remain incomplete.
 Retrieval v2 remains unchanged.
 
 The initial v3 profile supports canonical, untransformed FAT v3 content in
@@ -686,8 +686,68 @@ that the provider stores the corresponding bytes.
 
 The vector belongs to the immutable generation artifacts. Reusing a generation
 with shifted absolute MDU coordinates requires new leaf hashes, as specified
-above. This representation does not by itself provide client integrity-path
-serving or qualify full-byte delivery.
+above. This representation does not by itself qualify browser retrieval or
+full-byte delivery.
+
+## Provider and user-gateway data route
+
+The existing `GET /sp/retrieval/mdu/{polyfs_root}/{mdu_index}` provider route
+serves a native v3 systematic-slot chunk when all of these fields are present:
+
+- `Accept: multipart/form-data; version=3`;
+- exactly one `X-PolyStore-Session-Id: 0x<32-byte session id>`;
+- exactly one canonical decimal `X-PolyStore-Slot` in `0..7`; and
+- exactly one canonical decimal `deal_id` plus one `owner` query value.
+
+Optional `X-PolyStore-Start-Blob-Index` and `X-PolyStore-Blob-Count` headers are
+strict hints: when supplied they must equal the frozen chunk. The requested root,
+deal, owner, user MDU, slot, provider signer and payee must match the committed
+session. Settled, acknowledged and refunded slots cannot deliver again. The
+existing `GET /gateway/mdu/{polyfs_root}/{mdu_index}` user-gateway route resolves
+the same frozen payee and proxies the same request. A v2 lookup must return an
+explicit not-found response before either route considers v3; v2 timeouts,
+malformed responses and server errors remain failures.
+
+The response uses the existing two-part multipart framing with `version=3`.
+The JSON `metadata` part contains:
+
+| Field | Value |
+| --- | --- |
+| `version` | `3` |
+| `session_id`, `context_hash`, `polyfs_root`, `integrity_root` | lowercase `0x` hex frozen authority |
+| `slot` | systematic slot number |
+| `mdu_index`, `blob_count`, `total_bytes` | canonical decimal strings |
+| `start_blob_index` | first slot-major leaf index |
+| `entries[]` | ordered `t`, `mdu_index`, `leaf_index`, `integrity_position`, `integrity_path` |
+
+Each `entries[].integrity_path` is an array of lowercase `0x`-encoded 32-byte
+siblings in leaf-to-root order. The `bytes` part concatenates one complete
+131072-byte encoded blob for each entry. One `(slot, MDU)` response has at most
+eight blobs and 1 MiB. The client uses one logical session across all required
+chunks, recomputes each coordinate-bound leaf, verifies every path against the
+frozen integrity root, and authenticates the FAT v3 metadata against the frozen
+PolyFS root before durable write, decode or ACK.
+
+Providers retain `integrity_index_v3.bin`, the complete duplicate-last internal
+Merkle levels derived from `integrity_leaves_v3.bin`. Generation acceptance
+builds it with bounded memory before publishing the immutable generation.
+Previously accepted inactive generations may build the derived index once on
+first retrieval under the existing response-capacity and generation-lease
+guards. The build is deduplicated, cancellation-aware, disk-reserved and
+atomically published. A hot chunk reads only its path. The index is never an
+authority: each returned blob is rehashed and its path is checked against the
+frozen root before response headers are written.
+
+The bounded one-user-MDU benchmark
+`BenchmarkRetrievalDataV3Hot1MiB` (Linux amd64, 10 iterations) measured a
+565545 ns cold build and a 3088-byte index for 96 leaves. After warming, the
+authenticated 1 MiB prepare path measured 479544 ns/op, 1101288 B/op and 633
+allocs/op. This small-fixture check covers index construction and the hot
+verification/allocation boundary; it is not a retrieval-throughput result.
+
+These routes remain unavailable on networks where retrieval v3 activation is
+zero. Browser client and EVM integration are still incomplete, so this provider
+slice alone does not satisfy the activation gate.
 
 The authenticated provider-daemon action is `POST /sp/generation-v3/accept`
 with `{"deal_id":0}` and the existing `X-PolyStore-Gateway-Auth` header. An

--- a/docs/retrieval-v3-large-session-profile.md
+++ b/docs/retrieval-v3-large-session-profile.md
@@ -689,9 +689,9 @@ with shifted absolute MDU coordinates requires new leaf hashes, as specified
 above. This representation does not by itself qualify browser retrieval or
 full-byte delivery.
 
-## Provider and user-gateway data route
+## Provider-daemon and user-gateway data route
 
-The existing `GET /sp/retrieval/mdu/{polyfs_root}/{mdu_index}` provider route
+The existing `GET /sp/retrieval/mdu/{polyfs_root}/{mdu_index}` provider-daemon route
 serves a native v3 systematic-slot chunk when all of these fields are present:
 
 - `Accept: multipart/form-data; version=3`;
@@ -728,7 +728,7 @@ chunks, recomputes each coordinate-bound leaf, verifies every path against the
 frozen integrity root, and authenticates the FAT v3 metadata against the frozen
 PolyFS root before durable write, decode or ACK.
 
-Providers retain `integrity_index_v3.bin`, the complete duplicate-last internal
+Provider daemons retain `integrity_index_v3.bin`, the complete duplicate-last internal
 Merkle levels derived from `integrity_leaves_v3.bin`. Generation acceptance
 builds it with bounded memory before publishing the immutable generation.
 Previously accepted inactive generations may build the derived index once on
@@ -738,6 +738,12 @@ atomically published. A hot chunk reads only its path. The index is never an
 authority: each returned blob is rehashed and its path is checked against the
 frozen root before response headers are written.
 
+The future native-v3 browser client must keep a first cold user-gateway request
+alive for up to 5 minutes 30 seconds, including the provider-daemon's 5-minute
+index-build bound. Caller cancellation stops the synchronous build while its
+response-capacity admission and generation lease remain held. Warm requests use
+the hot path above.
+
 The bounded one-user-MDU benchmark
 `BenchmarkRetrievalDataV3Hot1MiB` (Linux amd64, 10 iterations) measured a
 565545 ns cold build and a 3088-byte index for 96 leaves. After warming, the
@@ -746,8 +752,8 @@ allocs/op. This small-fixture check covers index construction and the hot
 verification/allocation boundary; it is not a retrieval-throughput result.
 
 These routes remain unavailable on networks where retrieval v3 activation is
-zero. Browser client and EVM integration are still incomplete, so this provider
-slice alone does not satisfy the activation gate.
+zero. Browser client and EVM integration are still incomplete, so this
+provider-daemon slice alone does not satisfy the activation gate.
 
 The authenticated provider-daemon action is `POST /sp/generation-v3/accept`
 with `{"deal_id":0}` and the existing `X-PolyStore-Gateway-Auth` header. An

--- a/polystore_gateway/generation_lifecycle.go
+++ b/polystore_gateway/generation_lifecycle.go
@@ -257,6 +257,10 @@ func openFrozenGeneration(dealID uint64, root ManifestRoot) (string, func(), err
 	// C2 and authenticated bytes supply readiness/layout. A sidecar cannot
 	// redirect a secured response or trigger repeated full metadata work.
 	dir, err := lookupDealGeneration(dealID, root, root.Canonical)
+	if err != nil {
+		release()
+		return "", func() {}, err
+	}
 	return dir, release, err
 }
 

--- a/polystore_gateway/generation_lifecycle_test.go
+++ b/polystore_gateway/generation_lifecycle_test.go
@@ -330,6 +330,35 @@ func TestGenerationPublicationRejectsConcurrentStagedWriter(t *testing.T) {
 	}
 }
 
+func TestOpenFrozenGenerationReleasesMissingPaths(t *testing.T) {
+	useTempUploadDir(t)
+	root := mustTestManifestRoot(t, "missing-frozen-generation")
+	paths := append([]string{dealScopedDir(77, root)}, legacyGenerationPaths(root, root.Canonical)...)
+	assertReleased := func() {
+		t.Helper()
+		generationLifecycle.Lock()
+		defer generationLifecycle.Unlock()
+		for _, path := range paths {
+			absolute, err := filepath.Abs(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if use := generationLifecycle.uses[absolute]; use != nil {
+				t.Fatalf("missing generation retained a lifecycle reference for %s: %+v", absolute, use)
+			}
+		}
+	}
+	for i := 0; i < 3; i++ {
+		_, release, err := openFrozenGeneration(77, root)
+		if err == nil {
+			t.Fatal("opened a missing frozen generation")
+		}
+		assertReleased()
+		release()
+		assertReleased()
+	}
+}
+
 func TestGenerationRetentionAdvancesPastUnavailableBatch(t *testing.T) {
 	useTempUploadDir(t)
 	current := mustTestManifestRoot(t, "cursor-current")

--- a/polystore_gateway/go.mod
+++ b/polystore_gateway/go.mod
@@ -20,6 +20,7 @@ require (
 	go.etcd.io/bbolt v1.4.0-alpha.1
 	golang.org/x/crypto v0.45.0
 	golang.org/x/sync v0.18.0
+	golang.org/x/sys v0.38.0
 	polystorechain v0.0.0-00010101000000-000000000000
 )
 
@@ -221,7 +222,6 @@ require (
 	golang.org/x/exp v0.0.0-20251009144603-d2f985daa21b // indirect
 	golang.org/x/mod v0.30.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
-	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/telemetry v0.0.0-20251111182119-bc8e575c7b54 // indirect
 	golang.org/x/term v0.37.0 // indirect
 	golang.org/x/text v0.31.0 // indirect

--- a/polystore_gateway/main_test.go
+++ b/polystore_gateway/main_test.go
@@ -30,7 +30,7 @@ import (
 	"polystorechain/x/polystorechain/types"
 )
 
-func useTempUploadDir(t *testing.T) string {
+func useTempUploadDir(t testing.TB) string {
 	t.Helper()
 	old := uploadDir
 	dir := t.TempDir()
@@ -93,7 +93,7 @@ func mustTestManifestRoot(t *testing.T, tag string) ManifestRoot {
 	return root
 }
 
-func initCryptoForTest(t *testing.T) {
+func initCryptoForTest(t testing.TB) {
 	t.Helper()
 	if err := crypto_ffi.Init(trustedSetup); err != nil {
 		t.Fatalf("crypto_ffi.Init failed: %v", err)

--- a/polystore_gateway/mdu_viewer.go
+++ b/polystore_gateway/mdu_viewer.go
@@ -83,7 +83,13 @@ func GatewayMdu(w http.ResponseWriter, r *http.Request) {
 	// before current-deal owner/root checks, which cannot authorize a deputy or a
 	// sponsored request and must not revoke an already funded generation.
 	var onchainSession *types.RetrievalSession
-	if strings.HasPrefix(r.URL.Path, "/sp/retrieval/") && r.Header.Get("X-PolyStore-Session-Id") != "" {
+	sessionHeaders := r.Header.Values("X-PolyStore-Session-Id")
+	if len(sessionHeaders) > 1 {
+		writeJSONError(w, http.StatusBadRequest, "exactly one X-PolyStore-Session-Id header is required", "")
+		return
+	}
+	hasSession := len(sessionHeaders) == 1 && sessionHeaders[0] != ""
+	if strings.HasPrefix(r.URL.Path, "/sp/retrieval/") && hasSession {
 		ctx, releaseCapacity, err := admitRetrievalResponse(r.Context())
 		if err != nil {
 			writeJSONError(w, http.StatusServiceUnavailable, "provider proof capacity is busy", "")
@@ -103,6 +109,19 @@ func GatewayMdu(w http.ResponseWriter, r *http.Request) {
 		}
 		defer release()
 		response, height, queryErr := queryRetrievalSession(r.Context(), r.Header.Get("X-PolyStore-Session-Id"))
+		if errors.Is(queryErr, ErrSessionNotFound) {
+			responseV3, heightV3, errV3 := queryRetrievalSessionV3(r.Context(), r.Header.Get("X-PolyStore-Session-Id"))
+			if errV3 != nil {
+				status := http.StatusBadGateway
+				if errors.Is(errV3, ErrSessionNotFound) {
+					status = http.StatusNotFound
+				}
+				writeJSONError(w, status, "failed to load retrieval session", errV3.Error())
+				return
+			}
+			serveFrozenRetrievalDataV3(w, r, manifestRoot, mduIndex, responseV3, heightV3)
+			return
+		}
 		if queryErr != nil {
 			status := http.StatusBadGateway
 			if errors.Is(queryErr, ErrSessionNotFound) {
@@ -122,7 +141,7 @@ func GatewayMdu(w http.ResponseWriter, r *http.Request) {
 		onchainSession = &response.Session
 	}
 
-	if strings.HasPrefix(r.URL.Path, "/sp/retrieval/") && r.Header.Get("X-PolyStore-Session-Id") == "" {
+	if strings.HasPrefix(r.URL.Path, "/sp/retrieval/") && !hasSession {
 		serveCommittedRetrievalMetadata(w, r, manifestRoot, mduIndex)
 		return
 	}

--- a/polystore_gateway/mdu_viewer.go
+++ b/polystore_gateway/mdu_viewer.go
@@ -102,12 +102,15 @@ func GatewayMdu(w http.ResponseWriter, r *http.Request) {
 			writeJSONError(w, http.StatusBadRequest, "invalid session_id", err.Error())
 			return
 		}
-		release, err := claimRetrievalOperations([]string{key}, "")
-		if err != nil {
-			writeJSONError(w, http.StatusServiceUnavailable, "session is busy", err.Error())
-			return
+		retrievalV3 := acceptsRetrievalVersion(r, "3")
+		if !retrievalV3 {
+			release, err := claimRetrievalOperations([]string{key}, "")
+			if err != nil {
+				writeJSONError(w, http.StatusServiceUnavailable, "session is busy", err.Error())
+				return
+			}
+			defer release()
 		}
-		defer release()
 		response, height, queryErr := queryRetrievalSession(r.Context(), r.Header.Get("X-PolyStore-Session-Id"))
 		if errors.Is(queryErr, ErrSessionNotFound) {
 			responseV3, heightV3, errV3 := queryRetrievalSessionV3(r.Context(), r.Header.Get("X-PolyStore-Session-Id"))
@@ -128,6 +131,10 @@ func GatewayMdu(w http.ResponseWriter, r *http.Request) {
 				status = http.StatusNotFound
 			}
 			writeJSONError(w, status, "failed to load retrieval session", queryErr.Error())
+			return
+		}
+		if retrievalV3 {
+			writeJSONError(w, http.StatusNotAcceptable, "session does not support retrieval version 3", "")
 			return
 		}
 		if response.Session.ChallengeVersion == 2 {

--- a/polystore_gateway/retrieval_proof.go
+++ b/polystore_gateway/retrieval_proof.go
@@ -121,7 +121,7 @@ func authenticatedRetrievalMetadataForWith(ctx context.Context, dir string, key 
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		release, claimed, err := claimRetrievalPreparation(ctx, gateKey)
+		finish, claimed, err := claimRetrievalPreparation(ctx, gateKey)
 		if err != nil {
 			return nil, err
 		}
@@ -131,8 +131,8 @@ func authenticatedRetrievalMetadataForWith(ctx context.Context, dir string, key 
 		// Callers are already admitted. The synchronous owner keeps native
 		// preparation inside its own admission and generation lease. A live waiter
 		// rechecks the cache and becomes the next owner if this owner is canceled.
-		value, err := func() (*authenticatedGeneration, error) {
-			defer release()
+		value, err := func() (value *authenticatedGeneration, err error) {
+			defer func() { finish(err) }()
 			if err := ctx.Err(); err != nil {
 				return nil, err
 			}

--- a/polystore_gateway/retrieval_proof.go
+++ b/polystore_gateway/retrieval_proof.go
@@ -89,6 +89,17 @@ func authenticatedRetrievalMetadata(ctx context.Context, dir string, c retrieval
 }
 
 func authenticatedRetrievalMetadataFor(ctx context.Context, dir string, key retrievalGenerationKey) (*authenticatedGeneration, error) {
+	retrievalMetadataCache.Lock()
+	entry, found := retrievalMetadataCache.entries[key]
+	if found {
+		retrievalMetadataCache.clock++
+		entry.used = retrievalMetadataCache.clock
+		retrievalMetadataCache.entries[key] = entry
+	}
+	retrievalMetadataCache.Unlock()
+	if found {
+		return entry.value, nil
+	}
 	return authenticatedRetrievalMetadataForWith(ctx, dir, key, prepareRetrievalMetadata, retrievalMetadataCache.group.Do)
 }
 

--- a/polystore_gateway/retrieval_proof.go
+++ b/polystore_gateway/retrieval_proof.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -88,6 +89,10 @@ func authenticatedRetrievalMetadata(ctx context.Context, dir string, c retrieval
 }
 
 func authenticatedRetrievalMetadataFor(ctx context.Context, dir string, key retrievalGenerationKey) (*authenticatedGeneration, error) {
+	return authenticatedRetrievalMetadataForWith(ctx, dir, key, prepareRetrievalMetadata, retrievalMetadataCache.group.Do)
+}
+
+func authenticatedRetrievalMetadataForWith(ctx context.Context, dir string, key retrievalGenerationKey, prepare func(context.Context, string, retrievalGenerationKey) (*authenticatedGeneration, error), do func(string, func() (interface{}, error)) (interface{}, error, bool)) (*authenticatedGeneration, error) {
 	retrievalMetadataCache.Lock()
 	entry, found := retrievalMetadataCache.entries[key]
 	if found {
@@ -99,42 +104,55 @@ func authenticatedRetrievalMetadataFor(ctx context.Context, dir string, key retr
 	if found {
 		return entry.value, nil
 	}
-	// Callers are already admitted. Do (rather than detached work) keeps native
-	// preparation inside that admission bound even if the requesting client leaves.
-	value, err, _ := retrievalMetadataCache.group.Do(fmt.Sprintf("%#v", key), func() (interface{}, error) {
-		retrievalMetadataCache.Lock()
-		cached, ok := retrievalMetadataCache.entries[key]
-		retrievalMetadataCache.Unlock()
-		if ok {
-			return cached.value, nil
-		}
-		prepared, err := prepareRetrievalMetadata(ctx, dir, key)
-		if err != nil {
+	keyString := fmt.Sprintf("%#v", key)
+	for {
+		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		retrievalMetadataCache.Lock()
-		defer retrievalMetadataCache.Unlock()
-		if len(retrievalMetadataCache.entries) >= maxRetrievalResponses {
-			var oldest retrievalGenerationKey
-			age := ^uint64(0)
-			for k, v := range retrievalMetadataCache.entries {
-				if v.used < age {
-					oldest, age = k, v.used
-				}
+		// Callers are already admitted. Synchronous Do keeps native preparation
+		// inside the leader's admission and generation lease. A live waiter retries
+		// if that leader is canceled rather than inheriting its cancellation.
+		value, err, shared := do(keyString, func() (interface{}, error) {
+			retrievalMetadataCache.Lock()
+			cached, ok := retrievalMetadataCache.entries[key]
+			retrievalMetadataCache.Unlock()
+			if ok {
+				return cached.value, nil
 			}
-			delete(retrievalMetadataCache.entries, oldest)
+			prepared, err := prepare(ctx, dir, key)
+			if err != nil {
+				return nil, err
+			}
+			retrievalMetadataCache.Lock()
+			defer retrievalMetadataCache.Unlock()
+			if len(retrievalMetadataCache.entries) >= maxRetrievalResponses {
+				var oldest retrievalGenerationKey
+				age := ^uint64(0)
+				for k, v := range retrievalMetadataCache.entries {
+					if v.used < age {
+						oldest, age = k, v.used
+					}
+				}
+				delete(retrievalMetadataCache.entries, oldest)
+			}
+			retrievalMetadataCache.clock++
+			retrievalMetadataCache.entries[key] = generationCacheEntry{prepared, retrievalMetadataCache.clock}
+			return prepared, nil
+		})
+		if err != nil {
+			if callerErr := ctx.Err(); callerErr != nil {
+				return nil, callerErr
+			}
+			if shared && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
+				continue
+			}
+			return nil, err
 		}
-		retrievalMetadataCache.clock++
-		retrievalMetadataCache.entries[key] = generationCacheEntry{prepared, retrievalMetadataCache.clock}
-		return prepared, nil
-	})
-	if err != nil {
-		return nil, err
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		return value.(*authenticatedGeneration), nil
 	}
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-	return value.(*authenticatedGeneration), nil
 }
 
 func readExactArtifactRange(path string, size, offset, length uint64) ([]byte, error) {

--- a/polystore_gateway/retrieval_proof.go
+++ b/polystore_gateway/retrieval_proof.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -11,7 +10,6 @@ import (
 	"sync"
 
 	"golang.org/x/crypto/blake2s"
-	"golang.org/x/sync/singleflight"
 	"polystorechain/pkg/retrievalchallenge"
 	"polystorechain/x/crypto_ffi"
 	"polystorechain/x/polystorechain/types"
@@ -77,7 +75,6 @@ var retrievalMetadataCache = struct {
 	sync.Mutex
 	entries map[retrievalGenerationKey]generationCacheEntry
 	clock   uint64
-	group   singleflight.Group
 }{entries: make(map[retrievalGenerationKey]generationCacheEntry)}
 
 func authenticatedRetrievalMetadata(ctx context.Context, dir string, c retrievalchallenge.Context) (*authenticatedGeneration, error) {
@@ -100,10 +97,10 @@ func authenticatedRetrievalMetadataFor(ctx context.Context, dir string, key retr
 	if found {
 		return entry.value, nil
 	}
-	return authenticatedRetrievalMetadataForWith(ctx, dir, key, prepareRetrievalMetadata, retrievalMetadataCache.group.Do)
+	return authenticatedRetrievalMetadataForWith(ctx, dir, key, prepareRetrievalMetadata)
 }
 
-func authenticatedRetrievalMetadataForWith(ctx context.Context, dir string, key retrievalGenerationKey, prepare func(context.Context, string, retrievalGenerationKey) (*authenticatedGeneration, error), do func(string, func() (interface{}, error)) (interface{}, error, bool)) (*authenticatedGeneration, error) {
+func authenticatedRetrievalMetadataForWith(ctx context.Context, dir string, key retrievalGenerationKey, prepare func(context.Context, string, retrievalGenerationKey) (*authenticatedGeneration, error)) (*authenticatedGeneration, error) {
 	retrievalMetadataCache.Lock()
 	entry, found := retrievalMetadataCache.entries[key]
 	if found {
@@ -115,15 +112,30 @@ func authenticatedRetrievalMetadataForWith(ctx context.Context, dir string, key 
 	if found {
 		return entry.value, nil
 	}
-	keyString := fmt.Sprintf("%#v", key)
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, err
+	}
+	gateKey := fmt.Sprintf("retrieval-metadata:%s:%#v", abs, key)
 	for {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		// Callers are already admitted. Synchronous Do keeps native preparation
-		// inside the leader's admission and generation lease. A live waiter retries
-		// if that leader is canceled rather than inheriting its cancellation.
-		value, err, shared := do(keyString, func() (interface{}, error) {
+		release, claimed, err := claimRetrievalPreparation(ctx, gateKey)
+		if err != nil {
+			return nil, err
+		}
+		if !claimed {
+			continue
+		}
+		// Callers are already admitted. The synchronous owner keeps native
+		// preparation inside its own admission and generation lease. A live waiter
+		// rechecks the cache and becomes the next owner if this owner is canceled.
+		value, err := func() (*authenticatedGeneration, error) {
+			defer release()
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			retrievalMetadataCache.Lock()
 			cached, ok := retrievalMetadataCache.entries[key]
 			retrievalMetadataCache.Unlock()
@@ -149,20 +161,14 @@ func authenticatedRetrievalMetadataForWith(ctx context.Context, dir string, key 
 			retrievalMetadataCache.clock++
 			retrievalMetadataCache.entries[key] = generationCacheEntry{prepared, retrievalMetadataCache.clock}
 			return prepared, nil
-		})
+		}()
 		if err != nil {
-			if callerErr := ctx.Err(); callerErr != nil {
-				return nil, callerErr
-			}
-			if shared && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
-				continue
-			}
 			return nil, err
 		}
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		return value.(*authenticatedGeneration), nil
+		return value, nil
 	}
 }
 

--- a/polystore_gateway/retrieval_response.go
+++ b/polystore_gateway/retrieval_response.go
@@ -196,11 +196,18 @@ func serveFrozenRetrievalWindow(w http.ResponseWriter, r *http.Request, root Man
 }
 
 func writeRetrievalWindow(w http.ResponseWriter, metadata, window []byte) error {
+	return writeRetrievalWindowVersion(w, metadata, window, "2")
+}
+
+func writeRetrievalWindowVersion(w http.ResponseWriter, metadata, window []byte, version string) error {
 	if len(metadata) > maxRetrievalMetadataBytes || len(window) == 0 || len(window) > types.MDU_SIZE || len(window)%types.BLOB_SIZE != 0 {
 		return fmt.Errorf("invalid retrieval response bounds")
 	}
+	if version != "2" && version != "3" {
+		return fmt.Errorf("invalid retrieval response version")
+	}
 	writer := multipart.NewWriter(w)
-	w.Header().Set("Content-Type", mime.FormatMediaType("multipart/form-data", map[string]string{"boundary": writer.Boundary(), "version": "2"}))
+	w.Header().Set("Content-Type", mime.FormatMediaType("multipart/form-data", map[string]string{"boundary": writer.Boundary(), "version": version}))
 	w.Header().Set("Cache-Control", "no-store")
 	h := make(textproto.MIMEHeader)
 	h.Set("Content-Disposition", `form-data; name="metadata"`)

--- a/polystore_gateway/retrieval_v3_data.go
+++ b/polystore_gateway/retrieval_v3_data.go
@@ -1,0 +1,274 @@
+package main
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"mime"
+	"net/http"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"polystorechain/pkg/retrievalchallenge"
+	"polystorechain/x/polystorechain/types"
+)
+
+const integrityIndexColdBuildTimeoutV3 = 5 * time.Minute
+
+func acceptsRetrievalVersion(r *http.Request, version string) bool {
+	media, params, err := mime.ParseMediaType(r.Header.Get("Accept"))
+	return err == nil && media == "multipart/form-data" && params["version"] == version
+}
+
+type retrievalDataEntryV3 struct {
+	T                 string   `json:"t"`
+	MDUIndex          string   `json:"mdu_index"`
+	LeafIndex         uint32   `json:"leaf_index"`
+	IntegrityPosition string   `json:"integrity_position"`
+	IntegrityPath     []string `json:"integrity_path"`
+}
+
+type retrievalDataMetadataV3 struct {
+	Version       uint32                 `json:"version"`
+	SessionID     string                 `json:"session_id"`
+	ContextHash   string                 `json:"context_hash"`
+	PolyFSRoot    string                 `json:"polyfs_root"`
+	IntegrityRoot string                 `json:"integrity_root"`
+	Slot          uint32                 `json:"slot"`
+	MDUIndex      string                 `json:"mdu_index"`
+	StartBlob     uint32                 `json:"start_blob_index"`
+	BlobCount     string                 `json:"blob_count"`
+	TotalBytes    string                 `json:"total_bytes"`
+	Entries       []retrievalDataEntryV3 `json:"entries"`
+}
+
+type retrievalDataChunkV3 struct {
+	slot, startLeaf uint32
+	mdu             uint64
+	payee           string
+	t               []uint64
+}
+
+func parseRetrievalSlotV3(r *http.Request) (uint32, error) {
+	values := r.Header.Values("X-PolyStore-Slot")
+	if len(values) != 1 {
+		return 0, fmt.Errorf("exactly one X-PolyStore-Slot header is required")
+	}
+	parsed, err := strconv.ParseUint(values[0], 10, 32)
+	if err != nil || parsed > 7 || strconv.FormatUint(parsed, 10) != values[0] {
+		return 0, fmt.Errorf("invalid X-PolyStore-Slot header")
+	}
+	return uint32(parsed), nil
+}
+
+func frozenRetrievalDataChunkV3(f *frozenRetrievalSessionV3, root ManifestRoot, mdu, deal uint64, owner string, slot uint32) (retrievalDataChunkV3, error) {
+	if f == nil || deal != f.Context.DealID || owner != f.Session.Owner || root.Bytes != f.Context.PolyFSRoot || slot > 7 || mdu < f.Context.MetadataMDUs || mdu-f.Context.MetadataMDUs >= f.Context.UserMDUs {
+		return retrievalDataChunkV3{}, fmt.Errorf("request does not match frozen v3 session")
+	}
+	bit := uint32(1) << slot
+	if f.Session.AckedSlotsMask&bit != 0 || f.Session.SettledSlotsMask&bit != 0 || f.Session.RefundedSlotsMask&bit != 0 {
+		return retrievalDataChunkV3{}, fmt.Errorf("v3 slot is no longer eligible for delivery")
+	}
+	payee := ""
+	for _, obligation := range f.Session.Obligations {
+		if obligation.Slot == slot {
+			payee = obligation.Payee
+			break
+		}
+	}
+	if payee == "" {
+		return retrievalDataChunkV3{}, fmt.Errorf("slot is not represented in frozen v3 plan")
+	}
+	user := mdu - f.Context.MetadataMDUs
+	first, last := user*64, user*64+63
+	if first < f.Plan.First {
+		first = f.Plan.First
+	}
+	if last > f.Plan.Last {
+		last = f.Plan.Last
+	}
+	if first > last {
+		return retrievalDataChunkV3{}, fmt.Errorf("MDU does not intersect frozen v3 range")
+	}
+	delta := (uint64(slot) + 8 - first%8) % 8
+	if delta > last-first {
+		return retrievalDataChunkV3{}, fmt.Errorf("slot does not intersect requested MDU")
+	}
+	start := first + delta
+	chunk := retrievalDataChunkV3{slot: slot, mdu: mdu, payee: payee, t: make([]uint64, 0, 8)}
+	for value := start; value <= last; value += 8 {
+		chunk.t = append(chunk.t, value)
+		if last-value < 8 {
+			break
+		}
+	}
+	_, leaf, actualSlot, err := retrievalchallenge.SystematicCoordinateV3(chunk.t[0], f.Context.MetadataMDUs, f.Context.UserMDUs)
+	if err != nil || actualSlot != slot {
+		return retrievalDataChunkV3{}, fmt.Errorf("invalid frozen v3 data coordinate")
+	}
+	chunk.startLeaf = leaf
+	return chunk, nil
+}
+
+func validateRetrievalChunkHintsV3(r *http.Request, chunk retrievalDataChunkV3) error {
+	expected := map[string]string{
+		"X-PolyStore-Start-Blob-Index": strconv.FormatUint(uint64(chunk.startLeaf), 10),
+		"X-PolyStore-Blob-Count":       strconv.Itoa(len(chunk.t)),
+	}
+	for name, want := range expected {
+		values := r.Header.Values(name)
+		if len(values) > 1 || len(values) == 1 && values[0] != want {
+			return fmt.Errorf("%s does not match frozen v3 chunk", name)
+		}
+	}
+	return nil
+}
+
+func retrievalGenerationV3(f *frozenRetrievalSessionV3) retrievalGenerationKey {
+	return retrievalGenerationKey{Chain: f.Context.ChainID, Setup: f.Context.SetupDigest, Root: f.Context.PolyFSRoot, Integrity: f.Context.IntegrityRoot, Deal: f.Context.DealID, Generation: f.Context.Generation, Metadata: f.Context.MetadataMDUs, Users: f.Context.UserMDUs, Layout: retrievalchallenge.StripeK8M4, K: 8, M: 4, Version: 3}
+}
+
+func prepareRetrievalDataV3(ctx context.Context, dir string, f *frozenRetrievalSessionV3, chunk retrievalDataChunkV3) ([]byte, []byte, error) {
+	key := retrievalGenerationV3(f)
+	if _, err := authenticatedRetrievalMetadataFor(ctx, dir, key); err != nil {
+		return nil, nil, err
+	}
+	buildCtx, cancel := context.WithTimeout(ctx, integrityIndexColdBuildTimeoutV3)
+	defer cancel()
+	indexPath, err := ensureIntegrityIndexV3(buildCtx, dir, key)
+	if err != nil {
+		return nil, nil, err
+	}
+	rowStart := uint64(chunk.startLeaf % 8)
+	length := uint64(len(chunk.t)) * types.BLOB_SIZE
+	window, err := readExactArtifactRange(filepath.Join(dir, fmt.Sprintf("mdu_%d_slot_%d.bin", chunk.mdu, chunk.slot)), 8*types.BLOB_SIZE, rowStart*types.BLOB_SIZE, length)
+	if err != nil {
+		return nil, nil, err
+	}
+	leafCount := key.Users * retrievalchallenge.IntegrityLeavesPerUserMDU
+	entries := make([]retrievalDataEntryV3, len(chunk.t))
+	for i, t := range chunk.t {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
+		mdu, leaf, slot, err := retrievalchallenge.SystematicCoordinateV3(t, key.Metadata, key.Users)
+		if err != nil || mdu != chunk.mdu || slot != chunk.slot || leaf != chunk.startLeaf+uint32(i) {
+			return nil, nil, fmt.Errorf("noncanonical v3 chunk coordinate")
+		}
+		blob := window[uint64(i)*types.BLOB_SIZE : uint64(i+1)*types.BLOB_SIZE]
+		value, err := retrievalchallenge.IntegrityLeafV3(mdu, leaf, blob)
+		if err != nil {
+			return nil, nil, err
+		}
+		position := (mdu-key.Metadata)*retrievalchallenge.IntegrityLeavesPerUserMDU + uint64(leaf)
+		path, err := readIntegrityPathV3(indexPath, filepath.Join(dir, integrityLeavesV3File), position, leafCount)
+		if err != nil || !retrievalchallenge.VerifyIntegrityPathV3(value, position, leafCount, path, key.Integrity) {
+			return nil, nil, fmt.Errorf("v3 data blob %d/%d failed integrity verification", mdu, leaf)
+		}
+		encodedPath := make([]string, len(path))
+		for j := range path {
+			encodedPath[j] = "0x" + hex.EncodeToString(path[j][:])
+		}
+		entries[i] = retrievalDataEntryV3{T: strconv.FormatUint(t, 10), MDUIndex: strconv.FormatUint(mdu, 10), LeafIndex: leaf, IntegrityPosition: strconv.FormatUint(position, 10), IntegrityPath: encodedPath}
+	}
+	metadata, err := json.Marshal(retrievalDataMetadataV3{
+		Version: 3, SessionID: "0x" + hex.EncodeToString(f.Session.SessionId), ContextHash: "0x" + hex.EncodeToString(f.Hash[:]),
+		PolyFSRoot: "0x" + hex.EncodeToString(f.Context.PolyFSRoot[:]), IntegrityRoot: "0x" + hex.EncodeToString(f.Context.IntegrityRoot[:]),
+		Slot: chunk.slot, MDUIndex: strconv.FormatUint(chunk.mdu, 10), StartBlob: chunk.startLeaf, BlobCount: strconv.Itoa(len(chunk.t)), TotalBytes: strconv.FormatUint(length, 10), Entries: entries,
+	})
+	if err != nil || len(metadata) > maxRetrievalMetadataBytes {
+		return nil, nil, fmt.Errorf("v3 retrieval metadata exceeds response bound")
+	}
+	return metadata, window, nil
+}
+
+func serveFrozenRetrievalDataV3(w http.ResponseWriter, r *http.Request, root ManifestRoot, index uint64, response *types.QueryGetRetrievalSessionV3Response, height uint64) {
+	if !acceptsRetrievalVersion(r, "3") {
+		writeJSONError(w, http.StatusNotAcceptable, "retrieval v3 requires multipart/form-data; version=3", "")
+		return
+	}
+	f, err := freezeRetrievalSessionV3Response(response, height)
+	if err != nil {
+		writeJSONError(w, http.StatusConflict, "retrieval v3 authority unavailable", err.Error())
+		return
+	}
+	dealRaw := r.URL.Query().Get("deal_id")
+	deal, err := strconv.ParseUint(dealRaw, 10, 64)
+	if err != nil || strconv.FormatUint(deal, 10) != dealRaw || len(r.URL.Query()["deal_id"]) != 1 || len(r.URL.Query()["owner"]) != 1 {
+		writeJSONError(w, http.StatusBadRequest, "deal_id and owner are required", "")
+		return
+	}
+	slot, err := parseRetrievalSlotV3(r)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error(), "")
+		return
+	}
+	chunk, err := frozenRetrievalDataChunkV3(f, root, index, deal, r.URL.Query().Get("owner"), slot)
+	if err == nil {
+		err = validateRetrievalChunkHintsV3(r, chunk)
+	}
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "request does not match frozen v3 data chunk", err.Error())
+		return
+	}
+	_, signer, err := retrievalSigner(r.Context())
+	if err != nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "provider signing key unavailable", err.Error())
+		return
+	}
+	if signer != chunk.payee {
+		writeJSONError(w, http.StatusForbidden, "v3 session authorizes a different provider", "")
+		return
+	}
+	ctx, release, err := admitRetrievalResponse(r.Context())
+	if err != nil {
+		w.Header().Set("Retry-After", "1")
+		writeJSONError(w, http.StatusServiceUnavailable, "provider retrieval capacity is busy", "")
+		return
+	}
+	defer release()
+	dir, releaseGeneration, err := openFrozenGeneration(deal, root)
+	if err != nil {
+		writeJSONError(w, http.StatusNotFound, "retained generation unavailable", err.Error())
+		return
+	}
+	defer releaseGeneration()
+	metadata, window, err := prepareRetrievalDataV3(ctx, dir, f, chunk)
+	if err != nil {
+		status := http.StatusConflict
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			status = http.StatusServiceUnavailable
+		}
+		writeJSONError(w, status, "authenticated v3 data unavailable", err.Error())
+		return
+	}
+	w.Header().Set("X-PolyStore-Session-Id", "0x"+hex.EncodeToString(f.Session.SessionId))
+	w.Header().Set("X-PolyStore-Mdu-Index", strconv.FormatUint(chunk.mdu, 10))
+	w.Header().Set("X-PolyStore-Slot", strconv.FormatUint(uint64(chunk.slot), 10))
+	w.Header().Set("X-PolyStore-Start-Blob-Index", strconv.FormatUint(uint64(chunk.startLeaf), 10))
+	w.Header().Set("X-PolyStore-Blob-Count", strconv.Itoa(len(chunk.t)))
+	if err := writeRetrievalWindowVersion(w, metadata, window, "3"); err != nil {
+		return
+	}
+}
+
+func routerRetrievalDataProviderV3(r *http.Request, f *frozenRetrievalSessionV3, root ManifestRoot, mdu, deal uint64, owner string) (string, int, error) {
+	if !acceptsRetrievalVersion(r, "3") {
+		return "", http.StatusNotAcceptable, fmt.Errorf("retrieval v3 requires multipart/form-data; version=3")
+	}
+	slot, err := parseRetrievalSlotV3(r)
+	if err != nil {
+		return "", http.StatusBadRequest, err
+	}
+	chunk, err := frozenRetrievalDataChunkV3(f, root, mdu, deal, owner, slot)
+	if err != nil {
+		return "", http.StatusBadRequest, err
+	}
+	if err := validateRetrievalChunkHintsV3(r, chunk); err != nil {
+		return "", http.StatusBadRequest, err
+	}
+	return chunk.payee, http.StatusOK, nil
+}

--- a/polystore_gateway/retrieval_v3_data.go
+++ b/polystore_gateway/retrieval_v3_data.go
@@ -16,7 +16,10 @@ import (
 	"polystorechain/x/polystorechain/types"
 )
 
-const integrityIndexColdBuildTimeoutV3 = 5 * time.Minute
+const (
+	integrityIndexColdBuildTimeoutV3 = 5 * time.Minute
+	retrievalV3DataRouteTimeout      = integrityIndexColdBuildTimeoutV3 + 30*time.Second
+)
 
 func acceptsRetrievalVersion(r *http.Request, version string) bool {
 	media, params, err := mime.ParseMediaType(r.Header.Get("Accept"))

--- a/polystore_gateway/retrieval_v3_data_test.go
+++ b/polystore_gateway/retrieval_v3_data_test.go
@@ -209,6 +209,201 @@ func TestGatewayMduV3ServesOnlyVerifiedRequestedBytes(t *testing.T) {
 	}
 }
 
+func TestGatewayMduV3AllowsConcurrentChunksForOneSession(t *testing.T) {
+	frozen, key, _ := buildProviderV3ArtifactFixtureSize(t, RawMduCapacity+1024)
+	response := responseFromFrozenV3(frozen)
+	var chunks []retrievalDataChunkV3
+	for _, obligation := range frozen.Session.Obligations {
+		chunks = chunks[:0]
+		for mdu := key.Metadata; mdu < key.Metadata+key.Users; mdu++ {
+			chunk, err := frozenRetrievalDataChunkV3(frozen, ManifestRoot{Bytes: key.Root}, mdu, key.Deal, frozen.Session.Owner, obligation.Slot)
+			if err == nil {
+				chunks = append(chunks, chunk)
+			}
+		}
+		if len(chunks) >= 2 {
+			break
+		}
+	}
+	if len(chunks) < 2 || chunks[0].mdu == chunks[1].mdu || chunks[0].slot != chunks[1].slot {
+		t.Fatalf("fixture did not produce two distinct chunks for one provider: %+v", chunks)
+	}
+	signer := chunks[0].payee
+	setupMockCombinedOutput(t, func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		if len(args) >= 2 && args[0] == "keys" && args[1] == "show" {
+			return []byte(signer), nil
+		}
+		return nil, fmt.Errorf("unexpected command")
+	})
+	t.Setenv("POLYSTORE_PROVIDER_ADDRESS", signer)
+	initRetrievalDataTestDB(t)
+
+	firstQuery := make(chan struct{})
+	secondQuery := make(chan struct{})
+	releaseQueries := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseQueries) }) }
+	var queryMu sync.Mutex
+	v3Queries := 0
+	lcd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/retrieval-sessions-v3/"):
+			queryMu.Lock()
+			v3Queries++
+			queryNumber := v3Queries
+			queryMu.Unlock()
+			if queryNumber == 1 {
+				close(firstQuery)
+			} else if queryNumber == 2 {
+				close(secondQuery)
+			}
+			select {
+			case <-releaseQueries:
+			case <-r.Context().Done():
+				return
+			}
+			w.Header().Set(committedHeightHeader, strconv.FormatUint(frozen.Height, 10))
+			if err := (&jsonpb.Marshaler{OrigName: true}).Marshal(w, &response); err != nil {
+				t.Error(err)
+			}
+		case strings.Contains(r.URL.Path, "/retrieval-sessions/"):
+			http.NotFound(w, r)
+		default:
+			t.Errorf("unexpected LCD query %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	oldLCD := lcdBase
+	lcdBase = lcd.URL
+	testCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	var requests sync.WaitGroup
+	defer func() {
+		release()
+		cancel()
+		requests.Wait()
+		lcd.Close()
+		lcdBase = oldLCD
+	}()
+	root := "0x" + hex.EncodeToString(key.Root[:])
+	session := "0x" + hex.EncodeToString(frozen.Session.SessionId)
+	request := func(chunk retrievalDataChunkV3) *httptest.ResponseRecorder {
+		q := url.Values{"deal_id": {strconv.FormatUint(key.Deal, 10)}, "owner": {frozen.Session.Owner}}
+		r := httptest.NewRequest(http.MethodGet, "/sp/retrieval/mdu/"+root+"/"+strconv.FormatUint(chunk.mdu, 10)+"?"+q.Encode(), nil).WithContext(testCtx)
+		r = mux.SetURLVars(r, map[string]string{"cid": root, "index": strconv.FormatUint(chunk.mdu, 10)})
+		r.Header.Set("X-PolyStore-Session-Id", session)
+		r.Header.Set("Accept", "multipart/form-data; version=3")
+		r.Header.Set("X-PolyStore-Slot", strconv.FormatUint(uint64(chunk.slot), 10))
+		w := httptest.NewRecorder()
+		GatewayMdu(w, r)
+		return w
+	}
+	results := []chan *httptest.ResponseRecorder{make(chan *httptest.ResponseRecorder, 1), make(chan *httptest.ResponseRecorder, 1)}
+	start := func(i int) {
+		requests.Add(1)
+		go func() {
+			defer requests.Done()
+			results[i] <- request(chunks[i])
+		}()
+	}
+	start(0)
+	select {
+	case <-firstQuery:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first chunk did not reach the v3 authority query")
+	}
+	start(1)
+	select {
+	case <-secondQuery:
+		release()
+	case response := <-results[1]:
+		release()
+		t.Fatalf("second chunk was rejected before its v3 authority query: %d %s", response.Code, response.Body.String())
+	case <-time.After(2 * time.Second):
+		release()
+		t.Fatal("second chunk did not reach the v3 authority query")
+	}
+	for i, result := range results {
+		select {
+		case response := <-result:
+			if response.Code != http.StatusOK {
+				t.Fatalf("concurrent chunk %d failed: %d %s", i, response.Code, response.Body.String())
+			}
+			metadata, payload := decodeRetrievalDataResponseV3(t, response)
+			if metadata.MDUIndex != strconv.FormatUint(chunks[i].mdu, 10) || metadata.Slot != chunks[i].slot || len(payload) != len(chunks[i].t)*types.BLOB_SIZE {
+				t.Fatalf("concurrent chunk %d returned the wrong authenticated bytes: metadata=%+v bytes=%d", i, metadata, len(payload))
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("concurrent chunk %d did not complete", i)
+		}
+	}
+}
+
+func TestGatewayMduV3RejectsOlderSessionWithoutPersistence(t *testing.T) {
+	initRetrievalDataTestDB(t)
+	var id, root [32]byte
+	id[0], root[0] = 0x33, 0x44
+	response := types.QueryGetRetrievalSessionResponse{Session: types.RetrievalSession{
+		SessionId: id[:], ManifestRoot: root[:], OpenedHeight: 1, UpdatedHeight: 1, ExpiresAt: 100,
+		Status: types.RetrievalSessionStatus_RETRIEVAL_SESSION_STATUS_OPEN, BlobCount: 1, TotalBytes: types.BlobSizeBytes,
+	}}
+	lcd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/retrieval-sessions/") {
+			t.Errorf("unexpected LCD query %s", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		if err := (&jsonpb.Marshaler{OrigName: true}).Marshal(w, &response); err != nil {
+			t.Error(err)
+		}
+	}))
+	defer lcd.Close()
+	oldLCD := lcdBase
+	lcdBase = lcd.URL
+	defer func() { lcdBase = oldLCD }()
+	rootHex := "0x" + hex.EncodeToString(root[:])
+	r := httptest.NewRequest(http.MethodGet, "/sp/retrieval/mdu/"+rootHex+"/0?deal_id=0&owner=owner", nil)
+	r = mux.SetURLVars(r, map[string]string{"cid": rootHex, "index": "0"})
+	r.Header.Set("X-PolyStore-Session-Id", "0x"+hex.EncodeToString(id[:]))
+	r.Header.Set("Accept", "multipart/form-data; version=3")
+	r.Header.Set("X-PolyStore-Slot", "0")
+	w := httptest.NewRecorder()
+	GatewayMdu(w, r)
+	if w.Code != http.StatusNotAcceptable || !strings.Contains(w.Body.String(), "session does not support retrieval version 3") {
+		t.Fatalf("older session was not rejected at the version boundary: %d %s", w.Code, w.Body.String())
+	}
+	if frozenProofExists(t, frozenProofKey(id)) {
+		t.Fatal("version mismatch persisted a v2 proof")
+	}
+}
+
+func TestGatewayMduV2RetainsExclusiveSessionClaim(t *testing.T) {
+	id := strings.Repeat("55", 32)
+	release, err := claimRetrievalOperations([]string{"0x" + id}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+	queries := 0
+	lcd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		queries++
+		http.NotFound(w, r)
+	}))
+	defer lcd.Close()
+	oldLCD := lcdBase
+	lcdBase = lcd.URL
+	defer func() { lcdBase = oldLCD }()
+	root := "0x" + strings.Repeat("00", 32)
+	r := httptest.NewRequest(http.MethodGet, "/sp/retrieval/mdu/"+root+"/0", nil)
+	r = mux.SetURLVars(r, map[string]string{"cid": root, "index": "0"})
+	r.Header.Set("X-PolyStore-Session-Id", "0x"+id)
+	r.Header.Set("Accept", "multipart/form-data; version=2")
+	w := httptest.NewRecorder()
+	GatewayMdu(w, r)
+	if w.Code != http.StatusServiceUnavailable || queries != 0 {
+		t.Fatalf("v2 request escaped its exclusive claim: status=%d queries=%d body=%s", w.Code, queries, w.Body.String())
+	}
+}
+
 func TestFrozenRetrievalDataChunksCoverExactRange(t *testing.T) {
 	for _, tc := range []struct {
 		name               string

--- a/polystore_gateway/retrieval_v3_data_test.go
+++ b/polystore_gateway/retrieval_v3_data_test.go
@@ -26,6 +26,12 @@ import (
 	"polystorechain/x/polystorechain/types"
 )
 
+type retrievalV3DeadlineTransport func(*http.Request) (*http.Response, error)
+
+func (f retrievalV3DeadlineTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
 func responseFromFrozenV3(f *frozenRetrievalSessionV3) types.QueryGetRetrievalSessionV3Response {
 	anchor := make([]byte, 32)
 	anchor[0] = 42
@@ -341,6 +347,7 @@ func TestRouterGatewayMduV3PinsFrozenPayeeAndChunk(t *testing.T) {
 		t.Fatal(err)
 	}
 	providerHits := 0
+	var proxyDeadlines []time.Duration
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		providerHits++
 		if r.Header.Get("X-PolyStore-Session-Id") != session || r.Header.Get("X-PolyStore-Slot") != strconv.FormatUint(uint64(obligation.Slot), 10) || r.URL.Query().Has("provider") || r.URL.Query().Has("deputy") {
@@ -350,6 +357,21 @@ func TestRouterGatewayMduV3PinsFrozenPayeeAndChunk(t *testing.T) {
 		_, _ = w.Write([]byte("verified provider response"))
 	}))
 	defer upstream.Close()
+	originalV3Client := routerRetrievalV3HTTPClient
+	v3Transport, ok := originalV3Client.Transport.(*http.Transport)
+	if !ok || v3Transport.ResponseHeaderTimeout != retrievalV3DataRouteTimeout {
+		t.Fatalf("v3 proxy response-header timeout does not cover the cold route: %#v", originalV3Client.Transport)
+	}
+	routerRetrievalV3HTTPClient = &http.Client{Transport: retrievalV3DeadlineTransport(func(r *http.Request) (*http.Response, error) {
+		deadline, ok := r.Context().Deadline()
+		if !ok {
+			t.Error("v3 proxy request has no deadline")
+		} else {
+			proxyDeadlines = append(proxyDeadlines, time.Until(deadline))
+		}
+		return originalV3Client.Transport.RoundTrip(r)
+	})}
+	t.Cleanup(func() { routerRetrievalV3HTTPClient = originalV3Client })
 	lcd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case strings.Contains(r.URL.Path, "/retrieval-sessions-v3/"):
@@ -374,15 +396,28 @@ func TestRouterGatewayMduV3PinsFrozenPayeeAndChunk(t *testing.T) {
 	providerBaseCache = sync.Map{}
 	providerBaseCache.Store(obligation.Payee, &providerBaseCacheEntry{baseURL: upstream.URL, expires: time.Now().Add(time.Hour)})
 	q := url.Values{"deal_id": {"0"}, "owner": {frozen.Session.Owner}, "provider": {frozen.Session.Owner}, "deputy": {"1"}}
-	r := httptest.NewRequest(http.MethodGet, "/gateway/mdu/"+root+"/"+strconv.FormatUint(chunk.mdu, 10)+"?"+q.Encode(), nil)
-	r = mux.SetURLVars(r, map[string]string{"cid": root, "index": strconv.FormatUint(chunk.mdu, 10)})
-	r.Header.Set("X-PolyStore-Session-Id", session)
-	r.Header.Set("Accept", "multipart/form-data; version=3")
-	r.Header.Set("X-PolyStore-Slot", strconv.FormatUint(uint64(obligation.Slot), 10))
+	request := func(ctx context.Context) *http.Request {
+		r := httptest.NewRequest(http.MethodGet, "/gateway/mdu/"+root+"/"+strconv.FormatUint(chunk.mdu, 10)+"?"+q.Encode(), nil).WithContext(ctx)
+		r = mux.SetURLVars(r, map[string]string{"cid": root, "index": strconv.FormatUint(chunk.mdu, 10)})
+		r.Header.Set("X-PolyStore-Session-Id", session)
+		r.Header.Set("Accept", "multipart/form-data; version=3")
+		r.Header.Set("X-PolyStore-Slot", strconv.FormatUint(uint64(obligation.Slot), 10))
+		return r
+	}
 	w := httptest.NewRecorder()
-	RouterGatewayMdu(w, r)
-	if w.Code != http.StatusOK || w.Body.String() != "verified provider response" || providerHits != 1 {
-		t.Fatalf("v3 user-gateway routing failed: status=%d hits=%d body=%q", w.Code, providerHits, w.Body.String())
+	RouterGatewayMdu(w, request(context.Background()))
+	if w.Code != http.StatusOK || w.Body.String() != "verified provider response" {
+		t.Fatalf("v3 user-gateway routing failed: status=%d body=%q", w.Code, w.Body.String())
+	}
+	shortCtx, cancelShort := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancelShort()
+	w = httptest.NewRecorder()
+	RouterGatewayMdu(w, request(shortCtx))
+	if w.Code != http.StatusOK || w.Body.String() != "verified provider response" {
+		t.Fatalf("v3 user-gateway routing with caller deadline failed: status=%d body=%q", w.Code, w.Body.String())
+	}
+	if providerHits != 2 || len(proxyDeadlines) != 2 || proxyDeadlines[0] <= 60*time.Second || proxyDeadlines[0] > retrievalV3DataRouteTimeout || proxyDeadlines[1] <= 0 || proxyDeadlines[1] > 10*time.Second {
+		t.Fatalf("v3 proxy deadlines did not preserve route and caller bounds: hits=%d deadlines=%v", providerHits, proxyDeadlines)
 	}
 }
 

--- a/polystore_gateway/retrieval_v3_data_test.go
+++ b/polystore_gateway/retrieval_v3_data_test.go
@@ -1,0 +1,426 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cosmos/gogoproto/jsonpb"
+	"github.com/gorilla/mux"
+	"polystorechain/pkg/retrievalchallenge"
+	"polystorechain/x/polystorechain/types"
+)
+
+func responseFromFrozenV3(f *frozenRetrievalSessionV3) types.QueryGetRetrievalSessionV3Response {
+	anchor := make([]byte, 32)
+	anchor[0] = 42
+	return types.QueryGetRetrievalSessionV3Response{Session: f.Session, AnchorSeed: anchor}
+}
+
+func initRetrievalDataTestDB(t *testing.T) {
+	t.Helper()
+	previous := sessionDB
+	sessionDB = nil
+	if err := initSessionDB(filepath.Join(t.TempDir(), "sessions.db")); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = closeSessionDB(); sessionDB = previous })
+}
+
+func decodeRetrievalDataResponseV3(t *testing.T, response *httptest.ResponseRecorder) (retrievalDataMetadataV3, []byte) {
+	t.Helper()
+	media, params, err := mime.ParseMediaType(response.Header().Get("Content-Type"))
+	if err != nil || media != "multipart/form-data" || params["version"] != "3" {
+		t.Fatalf("unexpected v3 content type %q: %v", response.Header().Get("Content-Type"), err)
+	}
+	reader := multipart.NewReader(bytes.NewReader(response.Body.Bytes()), params["boundary"])
+	part, err := reader.NextPart()
+	if err != nil || part.FormName() != "metadata" {
+		t.Fatalf("missing metadata part: %v", err)
+	}
+	var metadata retrievalDataMetadataV3
+	if err := json.NewDecoder(part).Decode(&metadata); err != nil {
+		t.Fatal(err)
+	}
+	part, err = reader.NextPart()
+	if err != nil || part.FormName() != "bytes" {
+		t.Fatalf("missing bytes part: %v", err)
+	}
+	payload, err := io.ReadAll(part)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reader.NextPart(); err != io.EOF {
+		t.Fatalf("unexpected trailing multipart data: %v", err)
+	}
+	return metadata, payload
+}
+
+func TestGatewayMduV3ServesOnlyVerifiedRequestedBytes(t *testing.T) {
+	// Population 133 leaves exactly one data coordinate outside the 132 sampled
+	// proof ordinals. Deliver that coordinate's slot chunk and then corrupt that
+	// exact stored blob to prove the data path authenticates bytes independently.
+	size := uint64(132*retrievalchallenge.DataBlobPayloadBytes + 1)
+	frozen, key, dir := buildProviderV3ArtifactFixtureSize(t, size)
+	response := responseFromFrozenV3(frozen)
+	sampled := make(map[uint64]struct{}, len(frozen.Challenges))
+	for _, challenge := range frozen.Challenges {
+		sampled[challenge.T] = struct{}{}
+	}
+	var target uint64
+	found := false
+	for candidate := frozen.Plan.First; candidate <= frozen.Plan.Last; candidate++ {
+		if _, ok := sampled[candidate]; !ok {
+			target, found = candidate, true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("fixture has no unsampled data coordinate")
+	}
+	mdu, leaf, slot, err := retrievalchallenge.SystematicCoordinateV3(target, key.Metadata, key.Users)
+	if err != nil {
+		t.Fatal(err)
+	}
+	chunk, err := frozenRetrievalDataChunkV3(frozen, ManifestRoot{Bytes: key.Root}, mdu, key.Deal, frozen.Session.Owner, slot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer := chunk.payee
+	setupMockCombinedOutput(t, func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		if len(args) >= 2 && args[0] == "keys" && args[1] == "show" {
+			return []byte(signer), nil
+		}
+		return nil, fmt.Errorf("unexpected command")
+	})
+	t.Setenv("POLYSTORE_PROVIDER_ADDRESS", signer)
+	initRetrievalDataTestDB(t)
+	lcd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/retrieval-sessions-v3/"):
+			w.Header().Set(committedHeightHeader, strconv.FormatUint(frozen.Height, 10))
+			if err := (&jsonpb.Marshaler{OrigName: true}).Marshal(w, &response); err != nil {
+				t.Error(err)
+			}
+		case strings.Contains(r.URL.Path, "/retrieval-sessions/"):
+			http.NotFound(w, r)
+		default:
+			t.Errorf("unexpected LCD query %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer lcd.Close()
+	oldLCD := lcdBase
+	lcdBase = lcd.URL
+	defer func() { lcdBase = oldLCD }()
+	root := "0x" + hex.EncodeToString(key.Root[:])
+	session := "0x" + hex.EncodeToString(frozen.Session.SessionId)
+	invoke := func() *httptest.ResponseRecorder {
+		q := url.Values{"deal_id": {strconv.FormatUint(key.Deal, 10)}, "owner": {frozen.Session.Owner}}
+		r := httptest.NewRequest(http.MethodGet, "/sp/retrieval/mdu/"+root+"/"+strconv.FormatUint(mdu, 10)+"?"+q.Encode(), nil)
+		r = mux.SetURLVars(r, map[string]string{"cid": root, "index": strconv.FormatUint(mdu, 10)})
+		r.Header.Set("X-PolyStore-Session-Id", session)
+		r.Header.Set("Accept", "multipart/form-data; version=3")
+		r.Header.Set("X-PolyStore-Slot", strconv.FormatUint(uint64(slot), 10))
+		w := httptest.NewRecorder()
+		GatewayMdu(w, r)
+		return w
+	}
+	first := invoke()
+	if first.Code != http.StatusOK {
+		t.Fatalf("v3 data delivery failed: %d %s", first.Code, first.Body.String())
+	}
+	metadata, payload := decodeRetrievalDataResponseV3(t, first)
+	if metadata.Version != 3 || metadata.IntegrityRoot != "0x"+hex.EncodeToString(key.Integrity[:]) || len(metadata.Entries) != len(chunk.t) || len(payload) != len(chunk.t)*types.BLOB_SIZE || len(payload) > 1<<20 {
+		t.Fatalf("unexpected bounded v3 response: metadata=%+v bytes=%d", metadata, len(payload))
+	}
+	if metadata.SessionID != session || metadata.ContextHash != "0x"+hex.EncodeToString(frozen.Hash[:]) || metadata.PolyFSRoot != root || metadata.Slot != slot || metadata.MDUIndex != strconv.FormatUint(mdu, 10) || metadata.StartBlob != chunk.startLeaf {
+		t.Fatalf("v3 metadata does not match frozen authority: %+v", metadata)
+	}
+	leafCount := key.Users * retrievalchallenge.IntegrityLeavesPerUserMDU
+	for i, entry := range metadata.Entries {
+		ordinal, err := strconv.ParseUint(entry.T, 10, 64)
+		if err != nil || ordinal != chunk.t[i] {
+			t.Fatalf("entry %d has invalid ordinal %q", i, entry.T)
+		}
+		entryMDU, entryLeaf, entrySlot, err := retrievalchallenge.SystematicCoordinateV3(ordinal, key.Metadata, key.Users)
+		if err != nil || entryMDU != mdu || entrySlot != slot || entry.MDUIndex != strconv.FormatUint(entryMDU, 10) || entry.LeafIndex != entryLeaf {
+			t.Fatalf("entry %d has noncanonical coordinate: %+v", i, entry)
+		}
+		position, err := strconv.ParseUint(entry.IntegrityPosition, 10, 64)
+		wantPosition := (entryMDU-key.Metadata)*retrievalchallenge.IntegrityLeavesPerUserMDU + uint64(entryLeaf)
+		if err != nil || position != wantPosition {
+			t.Fatalf("entry %d has invalid integrity position %q", i, entry.IntegrityPosition)
+		}
+		path := make([][32]byte, len(entry.IntegrityPath))
+		for j, encoded := range entry.IntegrityPath {
+			raw, err := hex.DecodeString(strings.TrimPrefix(encoded, "0x"))
+			if err != nil || !strings.HasPrefix(encoded, "0x") || len(raw) != 32 {
+				t.Fatalf("entry %d has invalid integrity path element %d", i, j)
+			}
+			copy(path[j][:], raw)
+		}
+		blob := payload[i*types.BLOB_SIZE : (i+1)*types.BLOB_SIZE]
+		leafValue, err := retrievalchallenge.IntegrityLeafV3(entryMDU, entryLeaf, blob)
+		if err != nil || !retrievalchallenge.VerifyIntegrityPathV3(leafValue, position, leafCount, path, key.Integrity) {
+			t.Fatalf("entry %d payload does not verify against the frozen integrity root: %v", i, err)
+		}
+	}
+	if err := validateIntegrityIndexV3(filepath.Join(dir, integrityIndexV3File), key.Users*retrievalchallenge.IntegrityLeavesPerUserMDU); err != nil {
+		t.Fatalf("legacy generation did not retain its cold-built index: %v", err)
+	}
+
+	shardPath := filepath.Join(dir, fmt.Sprintf("mdu_%d_slot_%d.bin", mdu, slot))
+	shard, err := os.OpenFile(shardPath, os.O_RDWR, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := shard.WriteAt([]byte{0xff}, int64(uint64(leaf%8)*types.BLOB_SIZE+17)); err != nil {
+		_ = shard.Close()
+		t.Fatal(err)
+	}
+	if err := shard.Close(); err != nil {
+		t.Fatal(err)
+	}
+	corrupt := invoke()
+	if corrupt.Code == http.StatusOK || strings.HasPrefix(corrupt.Header().Get("Content-Type"), "multipart/form-data") {
+		t.Fatalf("served a corrupted requested blob: %d %s", corrupt.Code, corrupt.Body.String())
+	}
+}
+
+func TestFrozenRetrievalDataChunksCoverExactRange(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		rangeStart, length uint64
+	}{
+		{"1 KiB", 0, 1024},
+		{"unaligned MDU boundary", RawMduCapacity - 17, 1024},
+		{"1 GiB", 0, 1 << 30},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fileLength := tc.rangeStart + tc.length
+			users := 1 + (fileLength-1)/RawMduCapacity
+			response, height := frozenSessionV3FixtureRange(t, tc.rangeStart, tc.length, users)
+			frozen, err := freezeRetrievalSessionV3Response(response, height)
+			if err != nil {
+				t.Fatal(err)
+			}
+			root := ManifestRoot{Bytes: frozen.Context.PolyFSRoot}
+			seen := make(map[uint64]int, frozen.Plan.Population)
+			for mdu := frozen.Context.MetadataMDUs; mdu < frozen.Context.MetadataMDUs+frozen.Context.UserMDUs; mdu++ {
+				for _, obligation := range frozen.Session.Obligations {
+					chunk, err := frozenRetrievalDataChunkV3(frozen, root, mdu, frozen.Context.DealID, frozen.Session.Owner, obligation.Slot)
+					if err != nil {
+						continue
+					}
+					if chunk.mdu != mdu || chunk.slot != obligation.Slot || len(chunk.t) == 0 || len(chunk.t) > 8 || len(chunk.t)*types.BLOB_SIZE > 1<<20 {
+						t.Fatalf("invalid bounded chunk: %+v", chunk)
+					}
+					for _, ordinal := range chunk.t {
+						actualMDU, _, actualSlot, err := retrievalchallenge.SystematicCoordinateV3(ordinal, frozen.Context.MetadataMDUs, frozen.Context.UserMDUs)
+						if err != nil || actualMDU != mdu || actualSlot != obligation.Slot || ordinal < frozen.Plan.First || ordinal > frozen.Plan.Last {
+							t.Fatalf("noncanonical chunk coordinate t=%d mdu=%d slot=%d: %v", ordinal, mdu, obligation.Slot, err)
+						}
+						seen[ordinal]++
+					}
+				}
+			}
+			if uint64(len(seen)) != frozen.Plan.Population {
+				t.Fatalf("covered %d ordinals, want %d", len(seen), frozen.Plan.Population)
+			}
+			for ordinal := frozen.Plan.First; ordinal <= frozen.Plan.Last; ordinal++ {
+				if seen[ordinal] != 1 {
+					t.Fatalf("ordinal %d covered %d times", ordinal, seen[ordinal])
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkRetrievalDataV3Hot1MiB(b *testing.B) {
+	frozen, key, dir := buildProviderV3ArtifactFixtureSize(b, RawMduCapacity)
+	chunk, err := frozenRetrievalDataChunkV3(frozen, ManifestRoot{Bytes: key.Root}, key.Metadata, key.Deal, frozen.Session.Owner, 0)
+	if err != nil || len(chunk.t) != 8 {
+		b.Fatalf("invalid full-MDU benchmark chunk: %+v %v", chunk, err)
+	}
+	indexPath := filepath.Join(dir, integrityIndexV3File)
+	if err := os.Remove(indexPath); err != nil && !os.IsNotExist(err) {
+		b.Fatal(err)
+	}
+	coldStart := time.Now()
+	if _, err := ensureIntegrityIndexV3(b.Context(), dir, key); err != nil {
+		b.Fatal(err)
+	}
+	coldElapsed := time.Since(coldStart)
+	info, err := os.Stat(indexPath)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if metadata, payload, err := prepareRetrievalDataV3(b.Context(), dir, frozen, chunk); err != nil || len(metadata) == 0 || len(payload) != 1<<20 {
+		b.Fatalf("cannot warm 1 MiB retrieval: metadata=%d payload=%d err=%v", len(metadata), len(payload), err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		metadata, payload, err := prepareRetrievalDataV3(b.Context(), dir, frozen, chunk)
+		if err != nil || len(metadata) == 0 || len(payload) != 1<<20 {
+			b.Fatalf("hot 1 MiB retrieval failed: metadata=%d payload=%d err=%v", len(metadata), len(payload), err)
+		}
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(coldElapsed.Nanoseconds()), "cold-ns")
+	b.ReportMetric(float64(info.Size()), "index-bytes")
+}
+
+func TestGatewayMduDoesNotTreatV2AuthorityFailureAsV3(t *testing.T) {
+	initRetrievalDataTestDB(t)
+	v3Queries := 0
+	lcd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/retrieval-sessions-v3/") {
+			v3Queries++
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer lcd.Close()
+	oldLCD := lcdBase
+	lcdBase = lcd.URL
+	defer func() { lcdBase = oldLCD }()
+	root := strings.Repeat("00", 32)
+	r := httptest.NewRequest(http.MethodGet, "/sp/retrieval/mdu/0x"+root+"/4?deal_id=0&owner=owner", nil)
+	r = mux.SetURLVars(r, map[string]string{"cid": "0x" + root, "index": "4"})
+	r.Header.Set("X-PolyStore-Session-Id", "0x"+strings.Repeat("11", 32))
+	r.Header.Set("Accept", "multipart/form-data; version=3")
+	r.Header.Set("X-PolyStore-Slot", "0")
+	w := httptest.NewRecorder()
+	GatewayMdu(w, r)
+	if w.Code != http.StatusBadGateway || v3Queries != 0 {
+		t.Fatalf("v2 authority failure fell through to v3: status=%d v3_queries=%d", w.Code, v3Queries)
+	}
+}
+
+func TestGatewayMduRejectsDuplicateSessionAuthority(t *testing.T) {
+	root := strings.Repeat("00", 32)
+	r := httptest.NewRequest(http.MethodGet, "/sp/retrieval/mdu/0x"+root+"/4", nil)
+	r = mux.SetURLVars(r, map[string]string{"cid": "0x" + root, "index": "4"})
+	r.Header.Add("X-PolyStore-Session-Id", "0x"+strings.Repeat("11", 32))
+	r.Header.Add("X-PolyStore-Session-Id", "0x"+strings.Repeat("22", 32))
+	w := httptest.NewRecorder()
+	GatewayMdu(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("accepted duplicate session authority: %d %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRouterGatewayMduV3PinsFrozenPayeeAndChunk(t *testing.T) {
+	response, height := frozenSessionV3Fixture(t, retrievalchallenge.DataBlobPayloadBytes+1, 1)
+	frozen, err := freezeRetrievalSessionV3Response(response, height)
+	if err != nil {
+		t.Fatal(err)
+	}
+	query := responseFromFrozenV3(frozen)
+	obligation := frozen.Session.Obligations[0]
+	root := "0x" + hex.EncodeToString(frozen.Context.PolyFSRoot[:])
+	session := "0x" + hex.EncodeToString(frozen.Session.SessionId)
+	chunk, err := frozenRetrievalDataChunkV3(frozen, ManifestRoot{Bytes: frozen.Context.PolyFSRoot}, frozen.Context.MetadataMDUs, frozen.Context.DealID, frozen.Session.Owner, obligation.Slot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	providerHits := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		providerHits++
+		if r.Header.Get("X-PolyStore-Session-Id") != session || r.Header.Get("X-PolyStore-Slot") != strconv.FormatUint(uint64(obligation.Slot), 10) || r.URL.Query().Has("provider") || r.URL.Query().Has("deputy") {
+			t.Errorf("router changed frozen v3 request authority: %s", r.URL)
+		}
+		w.Header().Set("Content-Type", "multipart/form-data; boundary=frozen; version=3")
+		_, _ = w.Write([]byte("verified provider response"))
+	}))
+	defer upstream.Close()
+	lcd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/retrieval-sessions-v3/"):
+			w.Header().Set(committedHeightHeader, strconv.FormatUint(height, 10))
+			_ = (&jsonpb.Marshaler{OrigName: true}).Marshal(w, &query)
+		case strings.Contains(r.URL.Path, "/retrieval-sessions/"):
+			http.NotFound(w, r)
+		case strings.Contains(r.URL.Path, "/providers/"):
+			if !strings.HasSuffix(r.URL.Path, obligation.Payee) {
+				t.Errorf("resolved a provider other than the frozen payee: %s", r.URL.Path)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"provider": map[string]any{"endpoints": []string{mustHTTPMultiaddr(t, upstream.URL)}}})
+		default:
+			t.Errorf("unexpected LCD query %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer lcd.Close()
+	oldLCD := lcdBase
+	lcdBase = lcd.URL
+	defer func() { lcdBase = oldLCD }()
+	providerBaseCache = sync.Map{}
+	providerBaseCache.Store(obligation.Payee, &providerBaseCacheEntry{baseURL: upstream.URL, expires: time.Now().Add(time.Hour)})
+	q := url.Values{"deal_id": {"0"}, "owner": {frozen.Session.Owner}, "provider": {frozen.Session.Owner}, "deputy": {"1"}}
+	r := httptest.NewRequest(http.MethodGet, "/gateway/mdu/"+root+"/"+strconv.FormatUint(chunk.mdu, 10)+"?"+q.Encode(), nil)
+	r = mux.SetURLVars(r, map[string]string{"cid": root, "index": strconv.FormatUint(chunk.mdu, 10)})
+	r.Header.Set("X-PolyStore-Session-Id", session)
+	r.Header.Set("Accept", "multipart/form-data; version=3")
+	r.Header.Set("X-PolyStore-Slot", strconv.FormatUint(uint64(obligation.Slot), 10))
+	w := httptest.NewRecorder()
+	RouterGatewayMdu(w, r)
+	if w.Code != http.StatusOK || w.Body.String() != "verified provider response" || providerHits != 1 {
+		t.Fatalf("v3 user-gateway routing failed: status=%d hits=%d body=%q", w.Code, providerHits, w.Body.String())
+	}
+}
+
+func TestRetrievalDataV3RejectsAuthorityBoundsAndTerminalSlot(t *testing.T) {
+	response, height := frozenSessionV3Fixture(t, retrievalchallenge.DataBlobPayloadBytes+1, 1)
+	frozen, err := freezeRetrievalSessionV3Response(response, height)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := ManifestRoot{Bytes: frozen.Context.PolyFSRoot}
+	wrongRoot := root
+	wrongRoot.Bytes[0] ^= 1
+	slot := frozen.Session.Obligations[0].Slot
+	validMDU := frozen.Context.MetadataMDUs
+	for _, tc := range []struct {
+		name   string
+		root   ManifestRoot
+		mdu    uint64
+		deal   uint64
+		owner  string
+		slot   uint32
+		mutate func(*frozenRetrievalSessionV3)
+	}{
+		{"metadata MDU", root, validMDU - 1, frozen.Context.DealID, frozen.Session.Owner, slot, nil},
+		{"wrong root", wrongRoot, validMDU, frozen.Context.DealID, frozen.Session.Owner, slot, nil},
+		{"wrong deal", root, validMDU, frozen.Context.DealID + 1, frozen.Session.Owner, slot, nil},
+		{"wrong owner", root, validMDU, frozen.Context.DealID, frozen.Session.Owner + "x", slot, nil},
+		{"invalid slot", root, validMDU, frozen.Context.DealID, frozen.Session.Owner, 8, nil},
+		{"acked slot", root, validMDU, frozen.Context.DealID, frozen.Session.Owner, slot, func(f *frozenRetrievalSessionV3) { f.Session.AckedSlotsMask = 1 << slot }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			copy := *frozen
+			if tc.mutate != nil {
+				tc.mutate(&copy)
+			}
+			if _, err := frozenRetrievalDataChunkV3(&copy, tc.root, tc.mdu, tc.deal, tc.owner, tc.slot); err == nil {
+				t.Fatal("accepted mismatched or terminal v3 data authority")
+			}
+		})
+	}
+}

--- a/polystore_gateway/retrieval_v3_generation.go
+++ b/polystore_gateway/retrieval_v3_generation.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/hex"
@@ -81,18 +80,6 @@ func validateGenerationAdmissionV3(a *types.DealGenerationAdmissionV3, expectedD
 	return key, providers, nil
 }
 
-type contextReaderV3 struct {
-	ctx context.Context
-	r   io.Reader
-}
-
-func (r contextReaderV3) Read(p []byte) (int, error) {
-	if err := r.ctx.Err(); err != nil {
-		return 0, err
-	}
-	return r.r.Read(p)
-}
-
 func verifyIntegrityVectorV3(ctx context.Context, dir string, key retrievalGenerationKey, slot uint32, metadata *authenticatedGeneration) error {
 	path := filepath.Join(dir, integrityLeavesV3File)
 	f, err := os.Open(path)
@@ -105,10 +92,11 @@ func verifyIntegrityVectorV3(ctx context.Context, dir string, key retrievalGener
 	if err != nil || !info.Mode().IsRegular() || info.Size() != wantSize {
 		return fmt.Errorf("integrity leaf vector has invalid type or size")
 	}
-	root, err := retrievalchallenge.IntegrityRootV3Reader(bufio.NewReaderSize(contextReaderV3{ctx, f}, 1<<20), key.Users*retrievalchallenge.IntegrityLeavesPerUserMDU)
-	if err != nil || root != key.Integrity {
-		return fmt.Errorf("integrity leaf vector does not match authenticated header")
+	indexTemp, err := buildIntegrityIndexV3(ctx, dir, key)
+	if err != nil {
+		return err
 	}
+	defer os.Remove(indexTemp)
 	started := time.Now()
 	nextProgress := started.Add(generationVerificationProgressEveryV3)
 	for user := uint64(0); user < key.Users; user++ {
@@ -149,7 +137,7 @@ func verifyIntegrityVectorV3(ctx context.Context, dir string, key retrievalGener
 			nextProgress = now.Add(generationVerificationProgressEveryV3)
 		}
 	}
-	return nil
+	return publishImmutableArtifact(indexTemp, filepath.Join(dir, integrityIndexV3File))
 }
 
 func generationVerificationTimeoutV3(users uint64) (time.Duration, error) {

--- a/polystore_gateway/retrieval_v3_integrity_index.go
+++ b/polystore_gateway/retrieval_v3_integrity_index.go
@@ -1,0 +1,283 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sync/singleflight"
+	"golang.org/x/sys/unix"
+	"polystorechain/pkg/retrievalchallenge"
+)
+
+const (
+	integrityIndexV3File        = "integrity_index_v3.bin"
+	integrityIndexV3HeaderBytes = uint64(16)
+	integrityIndexDiskReserveV3 = uint64(64 << 20)
+)
+
+var integrityIndexV3Magic = [8]byte{'N', 'I', 'L', 'I', 'V', '3', 'I', '1'}
+var integrityIndexV3Builds singleflight.Group
+
+func integrityIndexV3NodeCount(leaves uint64) (uint64, error) {
+	if leaves == 0 || leaves > retrievalchallenge.MaxIntegrityLeaves {
+		return 0, fmt.Errorf("invalid v3 integrity leaf count")
+	}
+	var nodes uint64
+	for width := leaves; width > 1; {
+		width = (width + 1) / 2
+		nodes += width
+	}
+	return nodes, nil
+}
+
+func integrityIndexV3Size(leaves uint64) (uint64, error) {
+	nodes, err := integrityIndexV3NodeCount(leaves)
+	if err != nil || nodes > (math.MaxUint64-integrityIndexV3HeaderBytes)/32 {
+		return 0, fmt.Errorf("invalid v3 integrity index size")
+	}
+	return integrityIndexV3HeaderBytes + nodes*32, nil
+}
+
+func validateIntegrityIndexV3(path string, leaves uint64) error {
+	want, err := integrityIndexV3Size(leaves)
+	if err != nil {
+		return err
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil || !info.Mode().IsRegular() || uint64(info.Size()) != want {
+		return fmt.Errorf("v3 integrity index has invalid type or size")
+	}
+	var header [integrityIndexV3HeaderBytes]byte
+	if _, err := io.ReadFull(f, header[:]); err != nil || string(header[:8]) != string(integrityIndexV3Magic[:]) || binary.BigEndian.Uint64(header[8:]) != leaves {
+		return fmt.Errorf("v3 integrity index has invalid header")
+	}
+	return nil
+}
+
+func requireIntegrityIndexDiskV3(dir string, bytes uint64) error {
+	var stat unix.Statfs_t
+	if err := unix.Statfs(dir, &stat); err != nil {
+		return fmt.Errorf("cannot inspect v3 integrity index capacity: %w", err)
+	}
+	if stat.Bsize <= 0 || stat.Bavail < 0 {
+		return fmt.Errorf("invalid v3 integrity index filesystem capacity")
+	}
+	blockSize, availableBlocks := uint64(stat.Bsize), uint64(stat.Bavail)
+	if blockSize == 0 || availableBlocks > math.MaxUint64/blockSize {
+		return fmt.Errorf("invalid v3 integrity index filesystem capacity")
+	}
+	available := blockSize * availableBlocks
+	if bytes > math.MaxUint64-integrityIndexDiskReserveV3 || available < bytes+integrityIndexDiskReserveV3 {
+		return fmt.Errorf("insufficient disk capacity for v3 integrity index")
+	}
+	return nil
+}
+
+func integrityLeafCountV3(users uint64) (uint64, error) {
+	if users == 0 || users > retrievalchallenge.MaxIntegrityLeaves/retrievalchallenge.IntegrityLeavesPerUserMDU {
+		return 0, fmt.Errorf("invalid v3 user MDU count")
+	}
+	return users * retrievalchallenge.IntegrityLeavesPerUserMDU, nil
+}
+
+// buildIntegrityIndexV3 writes every internal level in order. The existing raw
+// leaf vector is level zero; later levels are read back from the same temporary
+// file, keeping memory independent of the generation size.
+func buildIntegrityIndexV3(ctx context.Context, dir string, key retrievalGenerationKey) (string, error) {
+	leaves, err := integrityLeafCountV3(key.Users)
+	if err != nil {
+		return "", err
+	}
+	wantSize, err := integrityIndexV3Size(leaves)
+	if err != nil {
+		return "", err
+	}
+	if err := requireIntegrityIndexDiskV3(dir, wantSize); err != nil {
+		return "", err
+	}
+	leafPath := filepath.Join(dir, integrityLeavesV3File)
+	leafFile, err := os.Open(leafPath)
+	if err != nil {
+		return "", err
+	}
+	defer leafFile.Close()
+	info, err := leafFile.Stat()
+	if err != nil || !info.Mode().IsRegular() || uint64(info.Size()) != leaves*32 {
+		return "", fmt.Errorf("integrity leaf vector has invalid type or size")
+	}
+
+	tmp, err := os.CreateTemp(dir, ".integrity-index-v3-*")
+	if err != nil {
+		return "", err
+	}
+	tmpPath := tmp.Name()
+	keep := false
+	defer func() {
+		_ = tmp.Close()
+		if !keep {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	var header [integrityIndexV3HeaderBytes]byte
+	copy(header[:8], integrityIndexV3Magic[:])
+	binary.BigEndian.PutUint64(header[8:], leaves)
+	if _, err := tmp.Write(header[:]); err != nil {
+		return "", err
+	}
+
+	source, sourceOffset, width := io.ReaderAt(leafFile), int64(0), leaves
+	var root [32]byte
+	for width > 1 {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		nextWidth := (width + 1) / 2
+		levelOffset, err := tmp.Seek(0, io.SeekCurrent)
+		if err != nil {
+			return "", err
+		}
+		reader := bufio.NewReaderSize(io.NewSectionReader(source, sourceOffset, int64(width*32)), 1<<20)
+		writer := bufio.NewWriterSize(tmp, 1<<20)
+		for i := uint64(0); i < nextWidth; i++ {
+			if i&0x3fff == 0 {
+				if err := ctx.Err(); err != nil {
+					return "", err
+				}
+			}
+			var left, right [32]byte
+			if _, err := io.ReadFull(reader, left[:]); err != nil {
+				return "", fmt.Errorf("read v3 integrity level: %w", err)
+			}
+			right = left
+			if 2*i+1 < width {
+				if _, err := io.ReadFull(reader, right[:]); err != nil {
+					return "", fmt.Errorf("read v3 integrity level: %w", err)
+				}
+			}
+			root = retrievalchallenge.IntegrityParentV3(left, right)
+			if _, err := writer.Write(root[:]); err != nil {
+				return "", err
+			}
+		}
+		if err := writer.Flush(); err != nil {
+			return "", err
+		}
+		source, sourceOffset, width = tmp, levelOffset, nextWidth
+	}
+	if root != key.Integrity {
+		return "", fmt.Errorf("integrity leaf vector does not match authenticated header")
+	}
+	if err := tmp.Sync(); err != nil {
+		return "", err
+	}
+	if err := tmp.Close(); err != nil {
+		return "", err
+	}
+	info, err = os.Stat(tmpPath)
+	if err != nil || uint64(info.Size()) != wantSize {
+		return "", fmt.Errorf("v3 integrity index build has invalid size")
+	}
+	keep = true
+	return tmpPath, nil
+}
+
+func ensureIntegrityIndexV3(ctx context.Context, dir string, key retrievalGenerationKey) (string, error) {
+	path := filepath.Join(dir, integrityIndexV3File)
+	leaves, err := integrityLeafCountV3(key.Users)
+	if err != nil {
+		return "", err
+	}
+	if err := validateIntegrityIndexV3(path, leaves); err == nil {
+		return path, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", err
+	}
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return "", err
+	}
+	value, err, _ := integrityIndexV3Builds.Do(fmt.Sprintf("%s:%#v", abs, key), func() (interface{}, error) {
+		if err := validateIntegrityIndexV3(path, leaves); err == nil {
+			return path, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+		tmp, err := buildIntegrityIndexV3(ctx, dir, key)
+		if err != nil {
+			return nil, err
+		}
+		defer os.Remove(tmp)
+		if err := publishImmutableArtifact(tmp, path); err != nil {
+			return nil, err
+		}
+		return path, validateIntegrityIndexV3(path, leaves)
+	})
+	if err != nil {
+		return "", err
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	return value.(string), nil
+}
+
+func readIntegrityPathV3(indexPath, leavesPath string, position, leafCount uint64) ([][32]byte, error) {
+	if position >= leafCount {
+		return nil, fmt.Errorf("invalid v3 integrity position")
+	}
+	if err := validateIntegrityIndexV3(indexPath, leafCount); err != nil {
+		return nil, err
+	}
+	leaves, err := os.Open(leavesPath)
+	if err != nil {
+		return nil, err
+	}
+	defer leaves.Close()
+	index, err := os.Open(indexPath)
+	if err != nil {
+		return nil, err
+	}
+	defer index.Close()
+	leafInfo, err := leaves.Stat()
+	if err != nil || !leafInfo.Mode().IsRegular() || uint64(leafInfo.Size()) != leafCount*32 {
+		return nil, fmt.Errorf("integrity leaf vector has invalid type or size")
+	}
+
+	path := make([][32]byte, 0, 23)
+	width, pos, levelOffset := leafCount, position, int64(integrityIndexV3HeaderBytes)
+	for level := 0; width > 1; level++ {
+		sibling := pos ^ 1
+		if sibling >= width {
+			sibling = pos
+		}
+		var node [32]byte
+		var reader io.ReaderAt = leaves
+		offset := int64(sibling * 32)
+		if level > 0 {
+			reader = index
+			offset = levelOffset + int64(sibling*32)
+		}
+		if _, err := reader.ReadAt(node[:], offset); err != nil {
+			return nil, fmt.Errorf("read v3 integrity path: %w", err)
+		}
+		path = append(path, node)
+		pos /= 2
+		if level > 0 {
+			levelOffset += int64(width * 32)
+		}
+		width = (width + 1) / 2
+	}
+	return path, nil
+}

--- a/polystore_gateway/retrieval_v3_integrity_index.go
+++ b/polystore_gateway/retrieval_v3_integrity_index.go
@@ -10,8 +10,8 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"sync"
 
-	"golang.org/x/sync/singleflight"
 	"golang.org/x/sys/unix"
 	"polystorechain/pkg/retrievalchallenge"
 )
@@ -23,7 +23,41 @@ const (
 )
 
 var integrityIndexV3Magic = [8]byte{'N', 'I', 'L', 'I', 'V', '3', 'I', '1'}
-var integrityIndexV3Builds singleflight.Group
+var integrityIndexV3Builds = struct {
+	sync.Mutex
+	active map[string]chan struct{}
+}{active: make(map[string]chan struct{})}
+
+// claimIntegrityIndexV3Build lets a canceled waiter leave without delaying the
+// current owner. An active waiter rechecks the published artifact after wake;
+// if the owner was canceled, one waiter becomes the next synchronous owner.
+func claimIntegrityIndexV3Build(ctx context.Context, key string) (release func(), claimed bool, err error) {
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
+	integrityIndexV3Builds.Lock()
+	if done := integrityIndexV3Builds.active[key]; done != nil {
+		integrityIndexV3Builds.Unlock()
+		select {
+		case <-ctx.Done():
+			return nil, false, ctx.Err()
+		case <-done:
+			if err := ctx.Err(); err != nil {
+				return nil, false, err
+			}
+			return nil, false, nil
+		}
+	}
+	done := make(chan struct{})
+	integrityIndexV3Builds.active[key] = done
+	integrityIndexV3Builds.Unlock()
+	return func() {
+		integrityIndexV3Builds.Lock()
+		delete(integrityIndexV3Builds.active, key)
+		close(done)
+		integrityIndexV3Builds.Unlock()
+	}, true, nil
+}
 
 func integrityIndexV3NodeCount(leaves uint64) (uint64, error) {
 	if leaves == 0 || leaves > retrievalchallenge.MaxIntegrityLeaves {
@@ -194,43 +228,67 @@ func buildIntegrityIndexV3(ctx context.Context, dir string, key retrievalGenerat
 }
 
 func ensureIntegrityIndexV3(ctx context.Context, dir string, key retrievalGenerationKey) (string, error) {
+	return ensureIntegrityIndexV3WithBuilder(ctx, dir, key, buildIntegrityIndexV3)
+}
+
+func ensureIntegrityIndexV3WithBuilder(ctx context.Context, dir string, key retrievalGenerationKey, build func(context.Context, string, retrievalGenerationKey) (string, error)) (string, error) {
 	path := filepath.Join(dir, integrityIndexV3File)
 	leaves, err := integrityLeafCountV3(key.Users)
 	if err != nil {
 		return "", err
 	}
-	if err := validateIntegrityIndexV3(path, leaves); err == nil {
-		return path, nil
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return "", err
-	}
-	abs, err := filepath.Abs(dir)
-	if err != nil {
-		return "", err
-	}
-	value, err, _ := integrityIndexV3Builds.Do(fmt.Sprintf("%s:%#v", abs, key), func() (interface{}, error) {
+	var buildKey string
+	for {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
 		if err := validateIntegrityIndexV3(path, leaves); err == nil {
 			return path, nil
 		} else if !errors.Is(err, os.ErrNotExist) {
-			return nil, err
+			return "", err
 		}
-		tmp, err := buildIntegrityIndexV3(ctx, dir, key)
+		if buildKey == "" {
+			abs, err := filepath.Abs(dir)
+			if err != nil {
+				return "", err
+			}
+			buildKey = fmt.Sprintf("%s:%#v", abs, key)
+		}
+		release, claimed, err := claimIntegrityIndexV3Build(ctx, buildKey)
 		if err != nil {
-			return nil, err
+			return "", err
 		}
-		defer os.Remove(tmp)
-		if err := publishImmutableArtifact(tmp, path); err != nil {
-			return nil, err
+		if !claimed {
+			continue
 		}
-		return path, validateIntegrityIndexV3(path, leaves)
-	})
-	if err != nil {
-		return "", err
+		value, err := func() (string, error) {
+			defer release()
+			if err := ctx.Err(); err != nil {
+				return "", err
+			}
+			if err := validateIntegrityIndexV3(path, leaves); err == nil {
+				return path, nil
+			} else if !errors.Is(err, os.ErrNotExist) {
+				return "", err
+			}
+			tmp, err := build(ctx, dir, key)
+			if err != nil {
+				return "", err
+			}
+			defer os.Remove(tmp)
+			if err := publishImmutableArtifact(tmp, path); err != nil {
+				return "", err
+			}
+			return path, validateIntegrityIndexV3(path, leaves)
+		}()
+		if err != nil {
+			return "", err
+		}
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		return value, nil
 	}
-	if err := ctx.Err(); err != nil {
-		return "", err
-	}
-	return value.(string), nil
 }
 
 func readIntegrityPathV3(indexPath, leavesPath string, position, leafCount uint64) ([][32]byte, error) {

--- a/polystore_gateway/retrieval_v3_integrity_index.go
+++ b/polystore_gateway/retrieval_v3_integrity_index.go
@@ -23,38 +23,49 @@ const (
 )
 
 var integrityIndexV3Magic = [8]byte{'N', 'I', 'L', 'I', 'V', '3', 'I', '1'}
+
+type retrievalPreparation struct {
+	done chan struct{}
+	err  error
+}
+
 var retrievalPreparations = struct {
 	sync.Mutex
-	active map[string]chan struct{}
-}{active: make(map[string]chan struct{})}
+	active map[string]*retrievalPreparation
+}{active: make(map[string]*retrievalPreparation)}
 
 // claimRetrievalPreparation lets a canceled waiter leave without delaying the
 // current owner. An active waiter rechecks the prepared artifact after wake;
 // if the owner was canceled, one waiter becomes the next synchronous owner.
-func claimRetrievalPreparation(ctx context.Context, key string) (release func(), claimed bool, err error) {
+// Permanent owner failures are returned to every active waiter without rebuilds.
+func claimRetrievalPreparation(ctx context.Context, key string) (finish func(error), claimed bool, err error) {
 	if err := ctx.Err(); err != nil {
 		return nil, false, err
 	}
 	retrievalPreparations.Lock()
-	if done := retrievalPreparations.active[key]; done != nil {
+	if preparation := retrievalPreparations.active[key]; preparation != nil {
 		retrievalPreparations.Unlock()
 		select {
 		case <-ctx.Done():
 			return nil, false, ctx.Err()
-		case <-done:
+		case <-preparation.done:
 			if err := ctx.Err(); err != nil {
 				return nil, false, err
+			}
+			if preparation.err != nil && !errors.Is(preparation.err, context.Canceled) && !errors.Is(preparation.err, context.DeadlineExceeded) {
+				return nil, false, preparation.err
 			}
 			return nil, false, nil
 		}
 	}
-	done := make(chan struct{})
-	retrievalPreparations.active[key] = done
+	preparation := &retrievalPreparation{done: make(chan struct{})}
+	retrievalPreparations.active[key] = preparation
 	retrievalPreparations.Unlock()
-	return func() {
+	return func(err error) {
 		retrievalPreparations.Lock()
+		preparation.err = err
 		delete(retrievalPreparations.active, key)
-		close(done)
+		close(preparation.done)
 		retrievalPreparations.Unlock()
 	}, true, nil
 }
@@ -254,15 +265,15 @@ func ensureIntegrityIndexV3WithBuilder(ctx context.Context, dir string, key retr
 			}
 			buildKey = fmt.Sprintf("integrity-index-v3:%s:%#v", abs, key)
 		}
-		release, claimed, err := claimRetrievalPreparation(ctx, buildKey)
+		finish, claimed, err := claimRetrievalPreparation(ctx, buildKey)
 		if err != nil {
 			return "", err
 		}
 		if !claimed {
 			continue
 		}
-		value, err := func() (string, error) {
-			defer release()
+		value, err := func() (value string, err error) {
+			defer func() { finish(err) }()
 			if err := ctx.Err(); err != nil {
 				return "", err
 			}

--- a/polystore_gateway/retrieval_v3_integrity_index.go
+++ b/polystore_gateway/retrieval_v3_integrity_index.go
@@ -23,21 +23,21 @@ const (
 )
 
 var integrityIndexV3Magic = [8]byte{'N', 'I', 'L', 'I', 'V', '3', 'I', '1'}
-var integrityIndexV3Builds = struct {
+var retrievalPreparations = struct {
 	sync.Mutex
 	active map[string]chan struct{}
 }{active: make(map[string]chan struct{})}
 
-// claimIntegrityIndexV3Build lets a canceled waiter leave without delaying the
-// current owner. An active waiter rechecks the published artifact after wake;
+// claimRetrievalPreparation lets a canceled waiter leave without delaying the
+// current owner. An active waiter rechecks the prepared artifact after wake;
 // if the owner was canceled, one waiter becomes the next synchronous owner.
-func claimIntegrityIndexV3Build(ctx context.Context, key string) (release func(), claimed bool, err error) {
+func claimRetrievalPreparation(ctx context.Context, key string) (release func(), claimed bool, err error) {
 	if err := ctx.Err(); err != nil {
 		return nil, false, err
 	}
-	integrityIndexV3Builds.Lock()
-	if done := integrityIndexV3Builds.active[key]; done != nil {
-		integrityIndexV3Builds.Unlock()
+	retrievalPreparations.Lock()
+	if done := retrievalPreparations.active[key]; done != nil {
+		retrievalPreparations.Unlock()
 		select {
 		case <-ctx.Done():
 			return nil, false, ctx.Err()
@@ -49,13 +49,13 @@ func claimIntegrityIndexV3Build(ctx context.Context, key string) (release func()
 		}
 	}
 	done := make(chan struct{})
-	integrityIndexV3Builds.active[key] = done
-	integrityIndexV3Builds.Unlock()
+	retrievalPreparations.active[key] = done
+	retrievalPreparations.Unlock()
 	return func() {
-		integrityIndexV3Builds.Lock()
-		delete(integrityIndexV3Builds.active, key)
+		retrievalPreparations.Lock()
+		delete(retrievalPreparations.active, key)
 		close(done)
-		integrityIndexV3Builds.Unlock()
+		retrievalPreparations.Unlock()
 	}, true, nil
 }
 
@@ -252,9 +252,9 @@ func ensureIntegrityIndexV3WithBuilder(ctx context.Context, dir string, key retr
 			if err != nil {
 				return "", err
 			}
-			buildKey = fmt.Sprintf("%s:%#v", abs, key)
+			buildKey = fmt.Sprintf("integrity-index-v3:%s:%#v", abs, key)
 		}
-		release, claimed, err := claimIntegrityIndexV3Build(ctx, buildKey)
+		release, claimed, err := claimRetrievalPreparation(ctx, buildKey)
 		if err != nil {
 			return "", err
 		}

--- a/polystore_gateway/retrieval_v3_integrity_index_test.go
+++ b/polystore_gateway/retrieval_v3_integrity_index_test.go
@@ -6,10 +6,75 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"polystorechain/pkg/retrievalchallenge"
 )
+
+type observedDoneContextV3 struct {
+	context.Context
+	once     sync.Once
+	observed chan struct{}
+}
+
+func (c *observedDoneContextV3) Done() <-chan struct{} {
+	c.once.Do(func() { close(c.observed) })
+	return c.Context.Done()
+}
+
+func waitIntegrityIndexV3Signal(t *testing.T, signal <-chan struct{}, name string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for %s", name)
+	}
+}
+
+func waitIntegrityIndexV3Result(t *testing.T, result <-chan error, name string) error {
+	t.Helper()
+	select {
+	case err := <-result:
+		return err
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for %s", name)
+		return nil
+	}
+}
+
+func ensureIntegrityIndexV3WithResources(ctx context.Context, dir string, key retrievalGenerationKey, build func(context.Context, string, retrievalGenerationKey) (string, error), held chan<- struct{}) (string, error) {
+	ctx, releaseResponse, err := admitRetrievalResponse(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer releaseResponse()
+	releaseGeneration, err := leaseGenerationPaths(dir)
+	if err != nil {
+		return "", err
+	}
+	defer releaseGeneration()
+	if held != nil {
+		close(held)
+	}
+	return ensureIntegrityIndexV3WithBuilder(ctx, dir, key, build)
+}
+
+func generationRefsV3Test(t *testing.T, path string) int {
+	t.Helper()
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	generationLifecycle.Lock()
+	defer generationLifecycle.Unlock()
+	if use := generationLifecycle.uses[abs]; use != nil {
+		return use.refs
+	}
+	return 0
+}
 
 func writeIntegrityLeavesFixtureV3(t *testing.T, dir string, count uint64) ([][32]byte, retrievalGenerationKey) {
 	t.Helper()
@@ -79,6 +144,117 @@ func TestIntegrityIndexV3CancellationLeavesNoPublishedArtifact(t *testing.T) {
 	if err != nil || len(matches) != 0 {
 		t.Fatalf("canceled build retained temporary files: %v %v", matches, err)
 	}
+}
+
+func TestIntegrityIndexV3ConcurrentCancellationOwnership(t *testing.T) {
+	t.Run("canceled waiter releases resources while leader completes", func(t *testing.T) {
+		dir := t.TempDir()
+		_, key := writeIntegrityLeavesFixtureV3(t, dir, retrievalchallenge.IntegrityLeavesPerUserMDU)
+		started, finish := make(chan struct{}), make(chan struct{})
+		var calls atomic.Int32
+		builder := func(ctx context.Context, dir string, key retrievalGenerationKey) (string, error) {
+			if calls.Add(1) != 1 {
+				return "", errors.New("concurrent waiter started a duplicate build")
+			}
+			close(started)
+			select {
+			case <-ctx.Done():
+				return "", ctx.Err()
+			case <-finish:
+				return buildIntegrityIndexV3(ctx, dir, key)
+			}
+		}
+		baselineResponses := len(retrievalResponses)
+		leaderResult := make(chan error, 1)
+		go func() {
+			_, err := ensureIntegrityIndexV3WithResources(t.Context(), dir, key, builder, nil)
+			leaderResult <- err
+		}()
+		waitIntegrityIndexV3Signal(t, started, "leader build")
+		waiterBase, cancelWaiter := context.WithCancel(t.Context())
+		waiterObserved := make(chan struct{})
+		waiterCtx := &observedDoneContextV3{Context: waiterBase, observed: waiterObserved}
+		waiterHeld, waiterResult := make(chan struct{}), make(chan error, 1)
+		go func() {
+			_, err := ensureIntegrityIndexV3WithResources(waiterCtx, dir, key, builder, waiterHeld)
+			waiterResult <- err
+		}()
+		waitIntegrityIndexV3Signal(t, waiterHeld, "waiter resources")
+		waitIntegrityIndexV3Signal(t, waiterObserved, "waiter gate entry")
+		if refs := generationRefsV3Test(t, dir); refs != 2 || len(retrievalResponses) != baselineResponses+2 {
+			t.Fatalf("concurrent requests did not hold their own resources: refs=%d responses=%d", refs, len(retrievalResponses)-baselineResponses)
+		}
+		cancelWaiter()
+		select {
+		case err := <-waiterResult:
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("canceled waiter returned %v", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("canceled waiter remained blocked behind leader")
+		}
+		if refs := generationRefsV3Test(t, dir); refs != 1 || len(retrievalResponses) != baselineResponses+1 || calls.Load() != 1 {
+			t.Fatalf("canceled waiter retained resources or duplicated work: refs=%d responses=%d calls=%d", refs, len(retrievalResponses)-baselineResponses, calls.Load())
+		}
+		close(finish)
+		if err := waitIntegrityIndexV3Result(t, leaderResult, "leader publication"); err != nil {
+			t.Fatal(err)
+		}
+		if refs := generationRefsV3Test(t, dir); refs != 0 || len(retrievalResponses) != baselineResponses {
+			t.Fatalf("leader retained resources after publication: refs=%d responses=%d", refs, len(retrievalResponses)-baselineResponses)
+		}
+	})
+
+	t.Run("active waiter retries after leader cancellation", func(t *testing.T) {
+		dir := t.TempDir()
+		_, key := writeIntegrityLeavesFixtureV3(t, dir, retrievalchallenge.IntegrityLeavesPerUserMDU)
+		leaderStarted := make(chan struct{})
+		var calls atomic.Int32
+		builder := func(ctx context.Context, dir string, key retrievalGenerationKey) (string, error) {
+			if calls.Add(1) == 1 {
+				close(leaderStarted)
+				<-ctx.Done()
+				return "", ctx.Err()
+			}
+			return buildIntegrityIndexV3(ctx, dir, key)
+		}
+		leaderCtx, cancelLeader := context.WithCancel(t.Context())
+		leaderResult := make(chan error, 1)
+		go func() {
+			_, err := ensureIntegrityIndexV3WithResources(leaderCtx, dir, key, builder, nil)
+			leaderResult <- err
+		}()
+		waitIntegrityIndexV3Signal(t, leaderStarted, "leader build")
+		waiterObserved := make(chan struct{})
+		waiterCtx := &observedDoneContextV3{Context: t.Context(), observed: waiterObserved}
+		waiterHeld := make(chan struct{})
+		waiterResult := make(chan error, 1)
+		go func() {
+			_, err := ensureIntegrityIndexV3WithResources(waiterCtx, dir, key, builder, waiterHeld)
+			waiterResult <- err
+		}()
+		waitIntegrityIndexV3Signal(t, waiterHeld, "waiter resources")
+		waitIntegrityIndexV3Signal(t, waiterObserved, "waiter gate entry")
+		if refs := generationRefsV3Test(t, dir); refs != 2 {
+			t.Fatalf("active waiter did not retain its generation lease: refs=%d", refs)
+		}
+		cancelLeader()
+		if err := waitIntegrityIndexV3Result(t, leaderResult, "leader cancellation"); !errors.Is(err, context.Canceled) {
+			t.Fatalf("canceled leader returned %v", err)
+		}
+		if err := waitIntegrityIndexV3Result(t, waiterResult, "waiter retry"); err != nil {
+			t.Fatalf("active waiter did not retry: %v", err)
+		}
+		if calls.Load() != 2 {
+			t.Fatalf("unexpected build count %d", calls.Load())
+		}
+		if err := validateIntegrityIndexV3(filepath.Join(dir, integrityIndexV3File), retrievalchallenge.IntegrityLeavesPerUserMDU); err != nil {
+			t.Fatalf("waiter did not publish a valid index: %v", err)
+		}
+		if refs := generationRefsV3Test(t, dir); refs != 0 {
+			t.Fatalf("completed requests retained generation resources: refs=%d", refs)
+		}
+	})
 }
 
 func TestIntegrityIndexV3RejectsWrongRootAndMalformedIndex(t *testing.T) {

--- a/polystore_gateway/retrieval_v3_integrity_index_test.go
+++ b/polystore_gateway/retrieval_v3_integrity_index_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"polystorechain/pkg/retrievalchallenge"
+)
+
+func writeIntegrityLeavesFixtureV3(t *testing.T, dir string, count uint64) ([][32]byte, retrievalGenerationKey) {
+	t.Helper()
+	leaves := make([][32]byte, count)
+	wire := make([]byte, count*32)
+	for i := range leaves {
+		leaves[i] = sha256.Sum256([]byte{byte(i), byte(i >> 8), byte(i >> 16)})
+		copy(wire[i*32:], leaves[i][:])
+	}
+	if err := os.WriteFile(filepath.Join(dir, integrityLeavesV3File), wire, 0600); err != nil {
+		t.Fatal(err)
+	}
+	root, err := retrievalchallenge.IntegrityRootV3(leaves)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return leaves, retrievalGenerationKey{Users: count / retrievalchallenge.IntegrityLeavesPerUserMDU, Integrity: root}
+}
+
+func TestIntegrityIndexV3BuildsCanonicalPathsAndRejectsCorruption(t *testing.T) {
+	dir := t.TempDir()
+	leaves, key := writeIntegrityLeavesFixtureV3(t, dir, retrievalchallenge.IntegrityLeavesPerUserMDU)
+	index, err := ensureIntegrityIndexV3(t.Context(), dir, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateIntegrityIndexV3(index, uint64(len(leaves))); err != nil {
+		t.Fatal(err)
+	}
+	for position, leaf := range leaves {
+		path, err := readIntegrityPathV3(index, filepath.Join(dir, integrityLeavesV3File), uint64(position), uint64(len(leaves)))
+		if err != nil || !retrievalchallenge.VerifyIntegrityPathV3(leaf, uint64(position), uint64(len(leaves)), path, key.Integrity) {
+			t.Fatalf("position %d has invalid canonical path: %v", position, err)
+		}
+	}
+	f, err := os.OpenFile(index, os.O_RDWR, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteAt([]byte{0xff}, int64(integrityIndexV3HeaderBytes+32)); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	path, err := readIntegrityPathV3(index, filepath.Join(dir, integrityLeavesV3File), 0, uint64(len(leaves)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retrievalchallenge.VerifyIntegrityPathV3(leaves[0], 0, uint64(len(leaves)), path, key.Integrity) {
+		t.Fatal("accepted a path through a corrupted derived index")
+	}
+}
+
+func TestIntegrityIndexV3CancellationLeavesNoPublishedArtifact(t *testing.T) {
+	dir := t.TempDir()
+	_, key := writeIntegrityLeavesFixtureV3(t, dir, retrievalchallenge.IntegrityLeavesPerUserMDU)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if _, err := ensureIntegrityIndexV3(ctx, dir, key); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected cancellation, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, integrityIndexV3File)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("canceled build published an index: %v", err)
+	}
+	matches, err := filepath.Glob(filepath.Join(dir, ".integrity-index-v3-*"))
+	if err != nil || len(matches) != 0 {
+		t.Fatalf("canceled build retained temporary files: %v %v", matches, err)
+	}
+}
+
+func TestIntegrityIndexV3RejectsWrongRootAndMalformedIndex(t *testing.T) {
+	dir := t.TempDir()
+	_, key := writeIntegrityLeavesFixtureV3(t, dir, retrievalchallenge.IntegrityLeavesPerUserMDU)
+	wrong := key
+	wrong.Integrity[0] ^= 1
+	if _, err := ensureIntegrityIndexV3(t.Context(), dir, wrong); err == nil {
+		t.Fatal("built an index for a mismatched authenticated root")
+	}
+	if err := os.WriteFile(filepath.Join(dir, integrityIndexV3File), make([]byte, 16), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ensureIntegrityIndexV3(t.Context(), dir, key); err == nil {
+		t.Fatal("replaced a malformed existing index")
+	}
+}

--- a/polystore_gateway/retrieval_v3_session_test.go
+++ b/polystore_gateway/retrieval_v3_session_test.go
@@ -4,13 +4,17 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	cosmosmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -290,46 +294,180 @@ func buildProviderV3ArtifactFixtureSize(t testing.TB, size uint64) (*frozenRetri
 	return frozen, key, newDir
 }
 
-func TestAuthenticatedRetrievalMetadataRetriesCanceledSharedLeader(t *testing.T) {
-	key := retrievalGenerationKey{Chain: "shared-cancellation-test", Root: [32]byte{1}, Generation: 1}
-	t.Cleanup(func() {
+func authenticatedRetrievalMetadataForWithResources(ctx context.Context, dir string, key retrievalGenerationKey, prepare func(context.Context, string, retrievalGenerationKey) (*authenticatedGeneration, error), held chan<- struct{}) (*authenticatedGeneration, error) {
+	ctx, releaseResponse, err := admitRetrievalResponse(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer releaseResponse()
+	releaseGeneration, err := leaseGenerationPaths(dir)
+	if err != nil {
+		return nil, err
+	}
+	defer releaseGeneration()
+	if held != nil {
+		close(held)
+	}
+	return authenticatedRetrievalMetadataForWith(ctx, dir, key, prepare)
+}
+
+func TestAuthenticatedRetrievalMetadataConcurrentCancellationOwnership(t *testing.T) {
+	cleanup := func(chain string) {
 		retrievalMetadataCache.Lock()
 		defer retrievalMetadataCache.Unlock()
 		for cached := range retrievalMetadataCache.entries {
-			if cached.Chain == key.Chain {
+			if cached.Chain == chain {
 				delete(retrievalMetadataCache.entries, cached)
 			}
 		}
-	})
-	prepared := &authenticatedGeneration{}
-	prepareCalls, doCalls := 0, 0
-	prepare := func(context.Context, string, retrievalGenerationKey) (*authenticatedGeneration, error) {
-		prepareCalls++
-		return prepared, nil
-	}
-	do := func(_ string, fn func() (interface{}, error)) (interface{}, error, bool) {
-		doCalls++
-		if doCalls == 1 {
-			return nil, context.Canceled, true
-		}
-		value, err := fn()
-		return value, err, false
-	}
-	got, err := authenticatedRetrievalMetadataForWith(t.Context(), t.TempDir(), key, prepare, do)
-	if err != nil || got != prepared || doCalls != 2 || prepareCalls != 1 {
-		t.Fatalf("active waiter did not retry canceled shared work: got=%p err=%v do=%d prepare=%d", got, err, doCalls, prepareCalls)
 	}
 
-	corrupt := fmt.Errorf("corrupt authenticated metadata")
-	key.Root[0] = 2
-	doCalls = 0
-	_, err = authenticatedRetrievalMetadataForWith(t.Context(), t.TempDir(), key, prepare, func(_ string, _ func() (interface{}, error)) (interface{}, error, bool) {
-		doCalls++
-		return nil, corrupt, true
+	t.Run("v2 canceled waiter promptly releases resources", func(t *testing.T) {
+		dir := t.TempDir()
+		key := retrievalGenerationKey{Chain: "metadata-waiter-cancellation", Root: [32]byte{1}, Generation: 1, Version: 2}
+		t.Cleanup(func() { cleanup(key.Chain) })
+		started, finish := make(chan struct{}), make(chan struct{})
+		workerCtx, cancelWorkers := context.WithCancel(t.Context())
+		var workers sync.WaitGroup
+		var finishOnce sync.Once
+		defer func() {
+			cancelWorkers()
+			finishOnce.Do(func() { close(finish) })
+			workers.Wait()
+		}()
+		var calls atomic.Int32
+		prepare := func(ctx context.Context, _ string, _ retrievalGenerationKey) (*authenticatedGeneration, error) {
+			if calls.Add(1) != 1 {
+				return nil, errors.New("concurrent waiter started duplicate metadata preparation")
+			}
+			close(started)
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-finish:
+				return &authenticatedGeneration{}, nil
+			}
+		}
+		baselineResponses := len(retrievalResponses)
+		leaderResult := make(chan error, 1)
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			_, err := authenticatedRetrievalMetadataForWithResources(workerCtx, dir, key, prepare, nil)
+			leaderResult <- err
+		}()
+		waitIntegrityIndexV3Signal(t, started, "metadata leader")
+
+		waiterBase, cancelWaiter := context.WithCancel(workerCtx)
+		waiterObserved := make(chan struct{})
+		waiterCtx := &observedDoneContextV3{Context: waiterBase, observed: waiterObserved}
+		waiterHeld, waiterResult := make(chan struct{}), make(chan error, 1)
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			_, err := authenticatedRetrievalMetadataForWithResources(waiterCtx, dir, key, prepare, waiterHeld)
+			waiterResult <- err
+		}()
+		waitIntegrityIndexV3Signal(t, waiterHeld, "metadata waiter resources")
+		waitIntegrityIndexV3Signal(t, waiterObserved, "metadata waiter gate entry")
+		if refs := generationRefsV3Test(t, dir); refs != 2 || len(retrievalResponses) != baselineResponses+2 {
+			t.Fatalf("metadata requests did not hold independent resources: refs=%d responses=%d", refs, len(retrievalResponses)-baselineResponses)
+		}
+		cancelWaiter()
+		if err := waitIntegrityIndexV3Result(t, waiterResult, "metadata waiter cancellation"); !errors.Is(err, context.Canceled) {
+			t.Fatalf("canceled metadata waiter returned %v", err)
+		}
+		if refs := generationRefsV3Test(t, dir); refs != 1 || len(retrievalResponses) != baselineResponses+1 || calls.Load() != 1 {
+			t.Fatalf("canceled metadata waiter retained resources or duplicated work: refs=%d responses=%d calls=%d", refs, len(retrievalResponses)-baselineResponses, calls.Load())
+		}
+		finishOnce.Do(func() { close(finish) })
+		if err := waitIntegrityIndexV3Result(t, leaderResult, "metadata leader completion"); err != nil {
+			t.Fatal(err)
+		}
+		if refs := generationRefsV3Test(t, dir); refs != 0 || len(retrievalResponses) != baselineResponses {
+			t.Fatalf("metadata leader retained resources: refs=%d responses=%d", refs, len(retrievalResponses)-baselineResponses)
+		}
 	})
-	if err != corrupt || doCalls != 1 {
-		t.Fatalf("non-cancellation error was retried: err=%v calls=%d", err, doCalls)
-	}
+
+	t.Run("v3 live waiter retries canceled leader", func(t *testing.T) {
+		dir := t.TempDir()
+		key := retrievalGenerationKey{Chain: "metadata-leader-cancellation", Root: [32]byte{2}, Generation: 1, Version: 3}
+		t.Cleanup(func() { cleanup(key.Chain) })
+		leaderStarted := make(chan struct{})
+		workerCtx, cancelWorkers := context.WithCancel(t.Context())
+		var workers sync.WaitGroup
+		defer func() {
+			cancelWorkers()
+			workers.Wait()
+		}()
+		prepared := &authenticatedGeneration{}
+		var calls atomic.Int32
+		prepare := func(ctx context.Context, _ string, _ retrievalGenerationKey) (*authenticatedGeneration, error) {
+			if calls.Add(1) == 1 {
+				close(leaderStarted)
+				<-ctx.Done()
+				return nil, ctx.Err()
+			}
+			return prepared, nil
+		}
+		leaderCtx, cancelLeader := context.WithCancel(workerCtx)
+		leaderResult := make(chan error, 1)
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			_, err := authenticatedRetrievalMetadataForWithResources(leaderCtx, dir, key, prepare, nil)
+			leaderResult <- err
+		}()
+		waitIntegrityIndexV3Signal(t, leaderStarted, "metadata leader")
+
+		waiterObserved := make(chan struct{})
+		waiterCtx := &observedDoneContextV3{Context: workerCtx, observed: waiterObserved}
+		waiterHeld := make(chan struct{})
+		waiterResult := make(chan struct {
+			value *authenticatedGeneration
+			err   error
+		}, 1)
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			value, err := authenticatedRetrievalMetadataForWithResources(waiterCtx, dir, key, prepare, waiterHeld)
+			waiterResult <- struct {
+				value *authenticatedGeneration
+				err   error
+			}{value, err}
+		}()
+		waitIntegrityIndexV3Signal(t, waiterHeld, "metadata waiter resources")
+		waitIntegrityIndexV3Signal(t, waiterObserved, "metadata waiter gate entry")
+		cancelLeader()
+		if err := waitIntegrityIndexV3Result(t, leaderResult, "metadata leader cancellation"); !errors.Is(err, context.Canceled) {
+			t.Fatalf("canceled metadata leader returned %v", err)
+		}
+		select {
+		case result := <-waiterResult:
+			if result.err != nil || result.value != prepared {
+				t.Fatalf("live metadata waiter did not retry: value=%p err=%v", result.value, result.err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("live metadata waiter did not retry")
+		}
+		if calls.Load() != 2 || generationRefsV3Test(t, dir) != 0 {
+			t.Fatalf("unexpected metadata retry state: calls=%d refs=%d", calls.Load(), generationRefsV3Test(t, dir))
+		}
+	})
+
+	t.Run("authentication error is not retried", func(t *testing.T) {
+		dir := t.TempDir()
+		key := retrievalGenerationKey{Chain: "metadata-authentication-error", Root: [32]byte{3}, Generation: 1, Version: 3}
+		corrupt := errors.New("corrupt authenticated metadata")
+		var calls atomic.Int32
+		_, err := authenticatedRetrievalMetadataForWith(t.Context(), dir, key, func(context.Context, string, retrievalGenerationKey) (*authenticatedGeneration, error) {
+			calls.Add(1)
+			return nil, corrupt
+		})
+		if !errors.Is(err, corrupt) || calls.Load() != 1 {
+			t.Fatalf("authentication error was retried: err=%v calls=%d", err, calls.Load())
+		}
+	})
 }
 
 func TestBuildProviderProofBatchV3UsesAuthenticatedArtifactsAndRealKZG(t *testing.T) {

--- a/polystore_gateway/retrieval_v3_session_test.go
+++ b/polystore_gateway/retrieval_v3_session_test.go
@@ -455,17 +455,67 @@ func TestAuthenticatedRetrievalMetadataConcurrentCancellationOwnership(t *testin
 		}
 	})
 
-	t.Run("authentication error is not retried", func(t *testing.T) {
+	t.Run("concurrent authentication error is prepared once", func(t *testing.T) {
 		dir := t.TempDir()
 		key := retrievalGenerationKey{Chain: "metadata-authentication-error", Root: [32]byte{3}, Generation: 1, Version: 3}
+		t.Cleanup(func() { cleanup(key.Chain) })
 		corrupt := errors.New("corrupt authenticated metadata")
+		started, failPreparation := make(chan struct{}), make(chan struct{})
+		workerCtx, cancelWorkers := context.WithCancel(t.Context())
+		var workers sync.WaitGroup
+		var failOnce sync.Once
+		defer func() {
+			cancelWorkers()
+			failOnce.Do(func() { close(failPreparation) })
+			workers.Wait()
+		}()
 		var calls atomic.Int32
-		_, err := authenticatedRetrievalMetadataForWith(t.Context(), dir, key, func(context.Context, string, retrievalGenerationKey) (*authenticatedGeneration, error) {
-			calls.Add(1)
-			return nil, corrupt
-		})
-		if !errors.Is(err, corrupt) || calls.Load() != 1 {
-			t.Fatalf("authentication error was retried: err=%v calls=%d", err, calls.Load())
+		prepare := func(ctx context.Context, _ string, _ retrievalGenerationKey) (*authenticatedGeneration, error) {
+			if calls.Add(1) == 1 {
+				close(started)
+			}
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-failPreparation:
+				return nil, corrupt
+			}
+		}
+		baselineResponses := len(retrievalResponses)
+		results := make(chan error, maxRetrievalResponses)
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			_, err := authenticatedRetrievalMetadataForWithResources(workerCtx, dir, key, prepare, nil)
+			results <- err
+		}()
+		waitIntegrityIndexV3Signal(t, started, "failed metadata owner")
+
+		for i := 1; i < maxRetrievalResponses; i++ {
+			observed := make(chan struct{})
+			held := make(chan struct{})
+			waiterCtx := &observedDoneContextV3{Context: workerCtx, observed: observed}
+			workers.Add(1)
+			go func() {
+				defer workers.Done()
+				_, err := authenticatedRetrievalMetadataForWithResources(waiterCtx, dir, key, prepare, held)
+				results <- err
+			}()
+			waitIntegrityIndexV3Signal(t, held, "failed metadata waiter resources")
+			waitIntegrityIndexV3Signal(t, observed, "failed metadata waiter gate entry")
+		}
+		if refs := generationRefsV3Test(t, dir); refs != maxRetrievalResponses || len(retrievalResponses) != baselineResponses+maxRetrievalResponses {
+			t.Fatalf("failed metadata waiters did not retain independent resources: refs=%d responses=%d", refs, len(retrievalResponses)-baselineResponses)
+		}
+		failOnce.Do(func() { close(failPreparation) })
+		for i := 0; i < maxRetrievalResponses; i++ {
+			if err := waitIntegrityIndexV3Result(t, results, "shared metadata failure"); !errors.Is(err, corrupt) {
+				t.Fatalf("metadata waiter returned %v", err)
+			}
+		}
+		workers.Wait()
+		if calls.Load() != 1 || generationRefsV3Test(t, dir) != 0 || len(retrievalResponses) != baselineResponses {
+			t.Fatalf("authentication failure was rebuilt or retained resources: calls=%d refs=%d responses=%d", calls.Load(), generationRefsV3Test(t, dir), len(retrievalResponses)-baselineResponses)
 		}
 	})
 }

--- a/polystore_gateway/retrieval_v3_session_test.go
+++ b/polystore_gateway/retrieval_v3_session_test.go
@@ -19,7 +19,11 @@ import (
 	"polystorechain/x/polystorechain/types"
 )
 
-func frozenSessionV3Fixture(t *testing.T, rangeLength, userMDUs uint64) (*types.QueryGetRetrievalSessionV3Response, uint64) {
+func frozenSessionV3Fixture(t testing.TB, rangeLength, userMDUs uint64) (*types.QueryGetRetrievalSessionV3Response, uint64) {
+	return frozenSessionV3FixtureRange(t, 0, rangeLength, userMDUs)
+}
+
+func frozenSessionV3FixtureRange(t testing.TB, rangeStart, rangeLength, userMDUs uint64) (*types.QueryGetRetrievalSessionV3Response, uint64) {
 	t.Helper()
 	oldChain := chainID
 	chainID = "polystore-test-1"
@@ -34,7 +38,8 @@ func frozenSessionV3Fixture(t *testing.T, rangeLength, userMDUs uint64) (*types.
 	for i := range providers {
 		providers[i][19] = byte(i + 1)
 	}
-	rng, err := retrievalchallenge.CheckedRangeV3(0, rangeLength, 0, rangeLength, userMDUs)
+	fileLength := rangeStart + rangeLength
+	rng, err := retrievalchallenge.CheckedRangeV3(0, fileLength, rangeStart, rangeLength, userMDUs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,7 +51,7 @@ func frozenSessionV3Fixture(t *testing.T, rangeLength, userMDUs uint64) (*types.
 	if err != nil {
 		t.Fatal(err)
 	}
-	id, err := (retrievalchallenge.SessionBindingV3{ChainID: chainID, Owner: ownerRaw, DealID: 0, Generation: 1, FileRecordIndex: 3, RangeStart: 0, RangeLength: rangeLength, PlanHash: planHash, Nonce: 7}).ID()
+	id, err := (retrievalchallenge.SessionBindingV3{ChainID: chainID, Owner: ownerRaw, DealID: 0, Generation: 1, FileRecordIndex: 3, RangeStart: rangeStart, RangeLength: rangeLength, PlanHash: planHash, Nonce: 7}).ID()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +63,7 @@ func frozenSessionV3Fixture(t *testing.T, rangeLength, userMDUs uint64) (*types.
 	copy(setup32[:], setup)
 	c := retrievalchallenge.ContextV3{
 		ChainID: chainID, SetupDigest: setup32, SessionID: id, SessionOwner: ownerRaw,
-		DealID: 0, Generation: 1, FileRecordIndex: 3, FileLength: rangeLength, RangeLength: rangeLength,
+		DealID: 0, Generation: 1, FileRecordIndex: 3, FileLength: fileLength, RangeStart: rangeStart, RangeLength: rangeLength,
 		MetadataMDUs: 4, UserMDUs: userMDUs, PlanHash: planHash, Population: rng.Population,
 		SampleCount: min(rng.Population, retrievalchallenge.MaxLargeSessionSamples), Nonce: 7,
 		PriceDenom: "stake", PricePerBlob: "1", BaseFee: "0",
@@ -71,7 +76,7 @@ func frozenSessionV3Fixture(t *testing.T, rangeLength, userMDUs uint64) (*types.
 	s := types.RetrievalSessionV3{
 		SessionId: id[:], ContextHash: hash[:], DealId: 0, Generation: 1, Owner: owner, Payer: owner,
 		PolyfsRoot: c.PolyFSRoot[:], IntegrityRoot: c.IntegrityRoot[:], SetupDigest: setup,
-		FileRecordIndex: 3, FileLength: rangeLength, RangeLength: rangeLength, MetadataMdus: 4, UserMdus: userMDUs,
+		FileRecordIndex: 3, FileLength: fileLength, RangeStart: rangeStart, RangeLength: rangeLength, MetadataMdus: 4, UserMdus: userMDUs,
 		PlanHash: planHash[:], FirstBlob: rng.First, LastBlob: rng.Last, Population: rng.Population,
 		SampleCount: c.SampleCount, Nonce: 7, PriceDenom: "stake", PricePerBlob: cosmosmath.OneInt(), BaseFee: cosmosmath.ZeroInt(),
 		Funding:        types.RetrievalSessionFunding_RETRIEVAL_SESSION_FUNDING_REQUESTER,
@@ -232,13 +237,29 @@ func TestRetrievalV3RecoveryOutcomeDoesNotAttributeRequestedSession(t *testing.T
 	}
 }
 
-func buildProviderV3ArtifactFixture(t *testing.T) (*frozenRetrievalSessionV3, retrievalGenerationKey, string) {
+func buildProviderV3ArtifactFixture(t testing.TB) (*frozenRetrievalSessionV3, retrievalGenerationKey, string) {
+	return buildProviderV3ArtifactFixtureSize(t, 1024)
+}
+
+func buildProviderV3ArtifactFixtureSize(t testing.TB, size uint64) (*frozenRetrievalSessionV3, retrievalGenerationKey, string) {
 	t.Helper()
 	useTempUploadDir(t)
 	initCryptoForTest(t)
 	const dealID = uint64(0)
 	payload := filepath.Join(t.TempDir(), "payload.bin")
-	if err := os.WriteFile(payload, bytes.Repeat([]byte{0x5a}, 1024), 0600); err != nil {
+	f, err := os.OpenFile(payload, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Truncate(int64(size)); err != nil {
+		_ = f.Close()
+		t.Fatal(err)
+	}
+	if _, err := f.WriteAt([]byte{0x5a}, 0); err != nil {
+		_ = f.Close()
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
 		t.Fatal(err)
 	}
 	result, newDir, err := mode2BuildArtifactsWithOptions(context.Background(), payload, dealID, "General:rs=8+4", "payload.bin", 0, mode2BuildOptions{fatVersion: 3})
@@ -248,7 +269,7 @@ func buildProviderV3ArtifactFixture(t *testing.T) (*frozenRetrievalSessionV3, re
 	metadataMDUs := uint64(1 + result.witnessMdus)
 	root := result.manifestRoot
 	integrity := result.integrityRoot
-	r, height := frozenSessionV3Fixture(t, 1024, result.userMdus)
+	r, height := frozenSessionV3Fixture(t, size, result.userMdus)
 	r.Session.PolyfsRoot = bytes.Clone(root.Bytes[:])
 	r.Session.IntegrityRoot = integrity[:]
 	r.Session.MetadataMdus = metadataMDUs
@@ -278,6 +299,9 @@ func TestBuildProviderProofBatchV3UsesAuthenticatedArtifactsAndRealKZG(t *testin
 	}
 	if err := verifyIntegrityVectorV3(t.Context(), dir, key, 0, metadata); err != nil {
 		t.Fatalf("generation ingest verification failed: %v", err)
+	}
+	if err := validateIntegrityIndexV3(filepath.Join(dir, integrityIndexV3File), key.Users*retrievalchallenge.IntegrityLeavesPerUserMDU); err != nil {
+		t.Fatalf("generation ingest did not publish the verified integrity index: %v", err)
 	}
 	slot, proofs, remaining, err := buildProviderProofBatchV3(t.Context(), frozen, signer)
 	if err != nil {

--- a/polystore_gateway/retrieval_v3_session_test.go
+++ b/polystore_gateway/retrieval_v3_session_test.go
@@ -290,6 +290,48 @@ func buildProviderV3ArtifactFixtureSize(t testing.TB, size uint64) (*frozenRetri
 	return frozen, key, newDir
 }
 
+func TestAuthenticatedRetrievalMetadataRetriesCanceledSharedLeader(t *testing.T) {
+	key := retrievalGenerationKey{Chain: "shared-cancellation-test", Root: [32]byte{1}, Generation: 1}
+	t.Cleanup(func() {
+		retrievalMetadataCache.Lock()
+		defer retrievalMetadataCache.Unlock()
+		for cached := range retrievalMetadataCache.entries {
+			if cached.Chain == key.Chain {
+				delete(retrievalMetadataCache.entries, cached)
+			}
+		}
+	})
+	prepared := &authenticatedGeneration{}
+	prepareCalls, doCalls := 0, 0
+	prepare := func(context.Context, string, retrievalGenerationKey) (*authenticatedGeneration, error) {
+		prepareCalls++
+		return prepared, nil
+	}
+	do := func(_ string, fn func() (interface{}, error)) (interface{}, error, bool) {
+		doCalls++
+		if doCalls == 1 {
+			return nil, context.Canceled, true
+		}
+		value, err := fn()
+		return value, err, false
+	}
+	got, err := authenticatedRetrievalMetadataForWith(t.Context(), t.TempDir(), key, prepare, do)
+	if err != nil || got != prepared || doCalls != 2 || prepareCalls != 1 {
+		t.Fatalf("active waiter did not retry canceled shared work: got=%p err=%v do=%d prepare=%d", got, err, doCalls, prepareCalls)
+	}
+
+	corrupt := fmt.Errorf("corrupt authenticated metadata")
+	key.Root[0] = 2
+	doCalls = 0
+	_, err = authenticatedRetrievalMetadataForWith(t.Context(), t.TempDir(), key, prepare, func(_ string, _ func() (interface{}, error)) (interface{}, error, bool) {
+		doCalls++
+		return nil, corrupt, true
+	})
+	if err != corrupt || doCalls != 1 {
+		t.Fatalf("non-cancellation error was retried: err=%v calls=%d", err, doCalls)
+	}
+}
+
 func TestBuildProviderProofBatchV3UsesAuthenticatedArtifactsAndRealKZG(t *testing.T) {
 	frozen, key, dir := buildProviderV3ArtifactFixture(t)
 	signer := frozen.Session.Obligations[0].AssignedProvider

--- a/polystore_gateway/router_proxy.go
+++ b/polystore_gateway/router_proxy.go
@@ -21,22 +21,35 @@ import (
 	"polystorechain/x/polystorechain/types"
 )
 
-var routerHTTPClient = &http.Client{
-	Transport: &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   4 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).DialContext,
-		TLSHandshakeTimeout:   4 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-		// Some provider requests (especially /gateway/upload which may ingest + upload
-		// Mode 2 stripes) can take longer than a few seconds before responding.
-		// Keep this generous so local-stack/E2E doesn't flake on slow machines/CI.
-		ResponseHeaderTimeout: 2 * time.Minute,
-		IdleConnTimeout:       90 * time.Second,
-		MaxIdleConns:          128,
-	},
+var routerHTTPTransport = &http.Transport{
+	Proxy: http.ProxyFromEnvironment,
+	DialContext: (&net.Dialer{
+		Timeout:   4 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}).DialContext,
+	TLSHandshakeTimeout:   4 * time.Second,
+	ExpectContinueTimeout: 1 * time.Second,
+	// Some provider requests (especially /gateway/upload which may ingest + upload
+	// Mode 2 stripes) can take longer than a few seconds before responding.
+	// Keep this generous so local-stack/E2E doesn't flake on slow machines/CI.
+	ResponseHeaderTimeout: 2 * time.Minute,
+	IdleConnTimeout:       90 * time.Second,
+	MaxIdleConns:          128,
+}
+
+var routerHTTPClient = &http.Client{Transport: routerHTTPTransport}
+
+var routerRetrievalV3HTTPClient = func() *http.Client {
+	transport := routerHTTPTransport.Clone()
+	transport.ResponseHeaderTimeout = retrievalV3DataRouteTimeout
+	return &http.Client{Transport: transport}
+}()
+
+func routerClientForRequest(r *http.Request, targetPath string, retrievalV3 bool) *http.Client {
+	if retrievalV3 && strings.HasPrefix(targetPath, "/sp/retrieval/mdu/") && acceptsRetrievalVersion(r, "3") {
+		return routerRetrievalV3HTTPClient
+	}
+	return routerHTTPClient
 }
 
 func copyUpstreamResponseHeaders(dst http.Header, src http.Header) {
@@ -133,7 +146,7 @@ func proxyToProviderBaseURL(w http.ResponseWriter, r *http.Request, providerBase
 	}
 }
 
-func tryProxyToProviderBaseURL(w http.ResponseWriter, r *http.Request, providerBaseURL string, retryMissingMetadata bool) (bool, error) {
+func tryProxyToProviderBaseURL(w http.ResponseWriter, r *http.Request, providerBaseURL string, retryMissingMetadata, retrievalV3 bool) (bool, error) {
 	base := strings.TrimRight(strings.TrimSpace(providerBaseURL), "/")
 	if base == "" {
 		return false, fmt.Errorf("provider base url is empty")
@@ -156,7 +169,7 @@ func tryProxyToProviderBaseURL(w http.ResponseWriter, r *http.Request, providerB
 	req.Header = r.Header.Clone()
 	req.Header.Set(gatewayAuthHeader, gatewayToProviderAuthToken())
 
-	resp, err := routerHTTPClient.Do(req)
+	resp, err := routerClientForRequest(r, targetPath, retrievalV3).Do(req)
 	if err != nil {
 		return false, err
 	}
@@ -396,7 +409,7 @@ func RouterGatewayFetch(w http.ResponseWriter, r *http.Request) {
 			lastErr = err
 			continue
 		}
-		ok, err := tryProxyToProviderBaseURL(w, r, baseURL, false)
+		ok, err := tryProxyToProviderBaseURL(w, r, baseURL, false, false)
 		if ok {
 			dealProviderCache.Store(dealID, &dealProviderCacheEntry{
 				provider: providerAddr,
@@ -427,7 +440,7 @@ func RouterGatewayFetch(w http.ResponseWriter, r *http.Request) {
 				lastErr = err
 				continue
 			}
-			ok, err := tryProxyToProviderBaseURL(w, r, baseURL, false)
+			ok, err := tryProxyToProviderBaseURL(w, r, baseURL, false, false)
 			if ok {
 				dealProviderCache.Store(dealID, &dealProviderCacheEntry{
 					provider: providerAddr,
@@ -472,7 +485,9 @@ func RouterGatewayMdu(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
-	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+	incomingCtx := r.Context()
+	v3RouteDeadline := time.Now().Add(retrievalV3DataRouteTimeout)
+	ctx, cancel := context.WithTimeout(incomingCtx, 60*time.Second)
 	defer cancel()
 	r = r.WithContext(ctx)
 	vars, q := mux.Vars(r), r.URL.Query()
@@ -492,6 +507,7 @@ func RouterGatewayMdu(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var providers []string
+	retrievalV3 := false
 	if sessionID := r.Header.Get("X-PolyStore-Session-Id"); sessionID != "" {
 		if len(r.Header.Values("X-PolyStore-Session-Id")) != 1 {
 			writeJSONError(w, http.StatusBadRequest, "ambiguous session_id", "")
@@ -513,6 +529,11 @@ func RouterGatewayMdu(w http.ResponseWriter, r *http.Request) {
 				writeJSONError(w, http.StatusConflict, "retrieval v3 authority unavailable", errV3.Error())
 				return
 			}
+			v3Ctx, cancelV3 := context.WithDeadline(incomingCtx, v3RouteDeadline)
+			defer cancelV3()
+			ctx = v3Ctx
+			r = r.WithContext(ctx)
+			retrievalV3 = true
 			provider, status, errV3 := routerRetrievalDataProviderV3(r, fV3, root, index, id, q.Get("owner"))
 			if errV3 != nil {
 				writeJSONError(w, status, "request does not match frozen v3 data chunk", errV3.Error())
@@ -623,7 +644,7 @@ func RouterGatewayMdu(w http.ResponseWriter, r *http.Request) {
 			lastErr = err
 			continue
 		}
-		handled, err := tryProxyToProviderBaseURL(w, r, base, r.Header.Get("X-PolyStore-Session-Id") == "")
+		handled, err := tryProxyToProviderBaseURL(w, r, base, r.Header.Get("X-PolyStore-Session-Id") == "", retrievalV3)
 		if handled {
 			return
 		}

--- a/polystore_gateway/router_proxy.go
+++ b/polystore_gateway/router_proxy.go
@@ -502,46 +502,67 @@ func RouterGatewayMdu(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		response, height, err := queryRetrievalSession(ctx, sessionID)
-		if err != nil {
-			writeJSONError(w, http.StatusBadGateway, "session authority unavailable", err.Error())
-			return
-		}
-		if response.Session.ChallengeVersion == 0 {
-			RouterGatewayFetch(w, r)
-			return
-		}
-		f, err := freezeRetrievalSessionResponse(response, height)
-		if err != nil {
-			writeJSONError(w, http.StatusConflict, "retrieval challenge unavailable", err.Error())
-			return
-		}
-		c, s := f.Context, f.Session
-		if id != c.DealID || q.Get("owner") != s.Owner || root.Bytes != c.Root || index != c.StartMDU {
-			writeJSONError(w, http.StatusBadRequest, "request does not match frozen session", "")
-			return
-		}
-		media, params, err := mime.ParseMediaType(r.Header.Get("Accept"))
-		if err != nil || media != "multipart/form-data" || params["version"] != "2" {
-			writeJSONError(w, http.StatusNotAcceptable, "retrieval v2 requires multipart/form-data; version=2", "")
-			return
-		}
-		for name, expected := range map[string]string{"X-PolyStore-Start-Blob-Index": strconv.FormatUint(uint64(c.StartLeaf), 10), "X-PolyStore-Blob-Count": strconv.FormatUint(c.BlobCount, 10)} {
-			if values := r.Header.Values(name); len(values) > 1 || (len(values) == 1 && values[0] != expected) {
-				writeJSONError(w, http.StatusBadRequest, "window hint does not match frozen session", "")
+		if errors.Is(err, ErrSessionNotFound) {
+			responseV3, heightV3, errV3 := queryRetrievalSessionV3(ctx, sessionID)
+			if errV3 != nil {
+				writeJSONError(w, http.StatusBadGateway, "session authority unavailable", errV3.Error())
 				return
 			}
+			fV3, errV3 := freezeRetrievalSessionV3Response(responseV3, heightV3)
+			if errV3 != nil {
+				writeJSONError(w, http.StatusConflict, "retrieval v3 authority unavailable", errV3.Error())
+				return
+			}
+			provider, status, errV3 := routerRetrievalDataProviderV3(r, fV3, root, index, id, q.Get("owner"))
+			if errV3 != nil {
+				writeJSONError(w, status, "request does not match frozen v3 data chunk", errV3.Error())
+				return
+			}
+			providers = []string{provider}
+			r.Header = r.Header.Clone()
+			r.Header.Set("X-PolyStore-Session-Id", "0x"+hex.EncodeToString(fV3.Session.SessionId))
+		} else {
+			if err != nil {
+				writeJSONError(w, http.StatusBadGateway, "session authority unavailable", err.Error())
+				return
+			}
+			if response.Session.ChallengeVersion == 0 {
+				RouterGatewayFetch(w, r)
+				return
+			}
+			f, err := freezeRetrievalSessionResponse(response, height)
+			if err != nil {
+				writeJSONError(w, http.StatusConflict, "retrieval challenge unavailable", err.Error())
+				return
+			}
+			c, s := f.Context, f.Session
+			if id != c.DealID || q.Get("owner") != s.Owner || root.Bytes != c.Root || index != c.StartMDU {
+				writeJSONError(w, http.StatusBadRequest, "request does not match frozen session", "")
+				return
+			}
+			media, params, err := mime.ParseMediaType(r.Header.Get("Accept"))
+			if err != nil || media != "multipart/form-data" || params["version"] != "2" {
+				writeJSONError(w, http.StatusNotAcceptable, "retrieval v2 requires multipart/form-data; version=2", "")
+				return
+			}
+			for name, expected := range map[string]string{"X-PolyStore-Start-Blob-Index": strconv.FormatUint(uint64(c.StartLeaf), 10), "X-PolyStore-Blob-Count": strconv.FormatUint(c.BlobCount, 10)} {
+				if values := r.Header.Values(name); len(values) > 1 || (len(values) == 1 && values[0] != expected) {
+					writeJSONError(w, http.StatusBadRequest, "window hint does not match frozen session", "")
+					return
+				}
+			}
+			if err := validateSessionFunding(s); err != nil {
+				writeJSONError(w, http.StatusBadGateway, "invalid session funding", err.Error())
+				return
+			}
+			if !c.Window.Contains(height) || (s.Status != types.RetrievalSessionStatus_RETRIEVAL_SESSION_STATUS_OPEN && s.Status != types.RetrievalSessionStatus_RETRIEVAL_SESSION_STATUS_USER_CONFIRMED && s.Status != types.RetrievalSessionStatus_RETRIEVAL_SESSION_STATUS_PROOF_SUBMITTED) {
+				writeJSONError(w, http.StatusConflict, "session is no longer eligible for delivery", "")
+				return
+			}
+			providers = []string{s.AuthorizedProofProvider}
+			r.Header = r.Header.Clone()
+			r.Header.Set("X-PolyStore-Session-Id", "0x"+hex.EncodeToString(s.SessionId))
 		}
-		if err := validateSessionFunding(s); err != nil {
-			writeJSONError(w, http.StatusBadGateway, "invalid session funding", err.Error())
-			return
-		}
-		if !c.Window.Contains(height) || (s.Status != types.RetrievalSessionStatus_RETRIEVAL_SESSION_STATUS_OPEN && s.Status != types.RetrievalSessionStatus_RETRIEVAL_SESSION_STATUS_USER_CONFIRMED && s.Status != types.RetrievalSessionStatus_RETRIEVAL_SESSION_STATUS_PROOF_SUBMITTED) {
-			writeJSONError(w, http.StatusConflict, "session is no longer eligible for delivery", "")
-			return
-		}
-		providers = []string{s.AuthorizedProofProvider}
-		r.Header = r.Header.Clone()
-		r.Header.Set("X-PolyStore-Session-Id", "0x"+hex.EncodeToString(s.SessionId))
 	} else {
 		var height uint64
 		if raw, exists := q["committed_height"]; exists {

--- a/polystorechain/pkg/retrievalchallenge/v3_integrity.go
+++ b/polystorechain/pkg/retrievalchallenge/v3_integrity.go
@@ -89,6 +89,13 @@ func integrityParentV3(left, right [32]byte) [32]byte {
 	return out
 }
 
+// IntegrityParentV3 derives one canonical internal node. Storage providers use
+// it to materialize an untrusted, seekable copy of the integrity tree; callers
+// must still verify every resulting path against the authenticated root.
+func IntegrityParentV3(left, right [32]byte) [32]byte {
+	return integrityParentV3(left, right)
+}
+
 func IntegrityRootV3(leaves [][32]byte) ([32]byte, error) {
 	if len(leaves) == 0 || uint64(len(leaves)) > MaxIntegrityLeaves {
 		return [32]byte{}, errors.New("invalid integrity leaf count")


### PR DESCRIPTION
## Problem

Retrieval v3 could authenticate sampled proof blobs, but the existing provider-daemon and user-gateway MDU routes could not return the full requested native-v3 byte range with cheap per-blob integrity. This left the provider-daemon data slice incomplete even though session authority and generation admission already existed.

## Change

- Serve frozen native-v3 systematic-slot chunks through the existing `/sp/retrieval/mdu` and `/gateway/mdu` routes, capped at eight blobs / 1 MiB per `(slot, MDU)` response.
- Bind every request to the committed session, owner, deal, root, range, provider signer, payee, and terminal slot masks, while preserving v2 fail-closed behavior.
- Build duplicate-last internal integrity levels during generation acceptance and cold-build them once for retained generations. Every returned blob is rehashed and its path is verified against the frozen authenticated integrity root before response headers are written.
- Allow concurrent explicit-v3 chunks within the existing admission limit. Preserve v2's exclusive session claim and reject v3 negotiation against an older session before persistence. Metadata and integrity-index preparation share the existing cancellable per-key gate. Canceled waiters release their response slot and generation lease promptly; a live waiter can take over after a canceled owner, while authentication errors fail closed.
- Keep index creation synchronous under the requesting generation lease and admission token. Canceled waiters release promptly; a remaining waiter retries if the builder cancels. The hot path reuses the published index.
- Keep the authenticated v3 route and pooled proxy header timeout within a 5m30s total bound so the synchronous five-minute cold build can finish; preserve shorter incoming deadlines and cancellation.
- Document the multipart-v3 metadata contract and the remaining browser, EVM, and activation work.

## Validation

- `polystorechain`: `go test -count=1 ./pkg/retrievalchallenge` — pass
- Actual user-gateway regression: long cold-route bound and shorter caller deadline both pass (`0.014s`).
- Linux final head `a668d4ddbb204d455024b186749ddc69731bcba0`: focused tests pass (`0.403s`), full `go test ./... -count=1` passes (gateway `23.114s`), and focused `go test -race` passes (`1.586s`). Real concurrent regressions cover canceled metadata waiters releasing admission and generation leases, live waiters taking over from canceled owners, and four concurrent callers sharing one permanent authentication failure. Test workers are canceled and joined before cleanup.
- Same-host sequential `BenchmarkRetrievalDataV3Hot1MiB`, 10 iterations per version:

| Version | ns/op | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| Before shared gate (`c5c33ac`) | 519,247 | 1,101,752 | 633 |
| Final (`a668d4d`) | 542,189 | 1,101,288 | 633 |

The cache-hit path preserves the existing lookup/return and allocation count. These short timing samples do not establish a speed change. The 96-leaf index occupies 3,088 bytes; large-generation cold-build timing remains unqualified.

The benchmark is a one-user-MDU integrity and allocation check, not a retrieval-throughput qualification. Retrieval v3 activation remains disabled and client/EVM integration is outside this PR.

All 28 CI checks pass for `a668d4d`; root and independent review accept it, and [Codex review is clean](https://github.com/Polynomialstore/polystore/pull/312#issuecomment-5615179590). Merged with owner authorization.

Refs #291.
