### PR TITLE
chain: add native v3 EVM parity

### DIFF
--- a/docs/retrieval-v3-large-session-profile.md
+++ b/docs/retrieval-v3-large-session-profile.md
@@ -4,8 +4,9 @@ Status: **contract reviewed; implementation partial and disabled by default**.
 This document fixes the wire-independent protocol choices for issue #291. The
 shared primitives, native generation admission, owner/sponsored session opening,
 sampled proof submission, provider data delivery, per-provider ACK/settlement
-and expiry refunds are implemented. Browser client integration, EVM parity and
-end-to-end activation qualification remain incomplete.
+and expiry refunds are implemented. The EVM precompile exposes the same eight
+native v3 actions. Browser orchestration and end-to-end activation qualification
+remain incomplete.
 Retrieval v2 remains unchanged.
 
 The initial v3 profile supports canonical, untransformed FAT v3 content in
@@ -752,17 +753,17 @@ allocs/op. This small-fixture check covers index construction and the hot
 verification/allocation boundary; it is not a retrieval-throughput result.
 
 These routes remain unavailable on networks where retrieval v3 activation is
-zero. Browser client and EVM integration are still incomplete, so this
-provider-daemon slice alone does not satisfy the activation gate.
+zero. Browser orchestration is still incomplete, so the provider-daemon and EVM
+adapter slices alone do not satisfy the activation gate.
 
 The authenticated provider-daemon action is `POST /sp/generation-v3/accept`
 with `{"deal_id":0}` and the existing `X-PolyStore-Gateway-Auth` header. An
 optional `provider` must equal the daemon's actual signing address. The action
 queries the proposed generation and derives the provider slot; callers do not
-supply acceptance roots or digests. Owner proposal/finalization remain native
-CLI actions. Acceptance uses the same signer coordination and durable pending
-transaction state as normal audits; an uncertain broadcast requires
-reconciliation before further signing.
+supply acceptance roots or digests. Owners may propose and finalize through the
+native CLI or the EVM adapter. Acceptance uses the same signer coordination and
+durable pending transaction state as normal audits; an uncertain broadcast
+requires reconciliation before further signing.
 
 ## Provider-daemon sampled proof action
 
@@ -786,3 +787,25 @@ remains blocked unless the exact operation's accepted effects establish its
 outcome. A recovered transaction is not evidence that a different requested
 session is complete; callers must query current session state before deciding
 whether more proofs or a delivery acknowledgement are required.
+
+## EVM adapter
+
+The existing PolyStore precompile exposes `proposeDealGenerationV3`,
+`acceptDealGenerationV3`, `finalizeDealGenerationV3`,
+`openRetrievalSessionV3`, `openRetrievalSessionV3Sponsored`,
+`submitRetrievalSessionProofV3`, `acknowledgeRetrievalObligationV3` and
+`refundRetrievalSessionV3`. The EVM caller maps directly to the native message
+creator. In particular, the sponsored-open caller funds the request and each
+provider action remains subject to the native frozen-provider authority check.
+All methods are nonpayable; attached EVM value is rejected before native state
+changes.
+
+Successful owner and sponsored opens emit
+`RetrievalSessionV3Opened(uint64 indexed dealId, address indexed requester,
+bytes32 sessionId)`. The session ID is copied from the native response, including
+an exact idempotent nonce replay. Receipts do not contain the full frozen plan or
+payment state; clients must query the authoritative native session by this ID.
+The adapter uses the existing native-action journal, proof pricing and block
+limits, so EVM revert and out-of-gas roll back generation, session, voucher,
+funding, retention and event effects together. This ABI parity does not enable
+v3 on a deployed network and does not complete browser retrieval orchestration.

--- a/polystore-website/src/lib/polystorePrecompile.ts
+++ b/polystore-website/src/lib/polystorePrecompile.ts
@@ -272,6 +272,439 @@ export const POLYSTORE_PRECOMPILE_ABI = [
     outputs: [{ name: 'ok', type: 'bool' }],
   },
   {
+    type: 'function',
+    name: 'proposeDealGenerationV3',
+    stateMutability: 'nonpayable',
+    inputs: [
+      {
+        name: 'dealId',
+        type: 'uint64',
+      },
+      {
+        name: 'previousPolyfsRoot',
+        type: 'bytes',
+      },
+      {
+        name: 'polyfsRoot',
+        type: 'bytes',
+      },
+      {
+        name: 'integrityRoot',
+        type: 'bytes',
+      },
+      {
+        name: 'size',
+        type: 'uint64',
+      },
+      {
+        name: 'totalMdus',
+        type: 'uint64',
+      },
+      {
+        name: 'witnessMdus',
+        type: 'uint64',
+      },
+      {
+        name: 'integrityLeafCount',
+        type: 'uint64',
+      },
+      {
+        name: 'expectedCurrentGeneration',
+        type: 'uint64',
+      },
+    ],
+    outputs: [
+      {
+        name: 'generation',
+        type: 'uint64',
+      },
+    ],
+  },
+  {
+    type: 'function',
+    name: 'acceptDealGenerationV3',
+    stateMutability: 'nonpayable',
+    inputs: [
+      {
+        name: 'dealId',
+        type: 'uint64',
+      },
+      {
+        name: 'slot',
+        type: 'uint32',
+      },
+      {
+        name: 'acceptanceDigest',
+        type: 'bytes',
+      },
+    ],
+    outputs: [
+      {
+        name: 'accepted',
+        type: 'bool',
+      },
+    ],
+  },
+  {
+    type: 'function',
+    name: 'finalizeDealGenerationV3',
+    stateMutability: 'nonpayable',
+    inputs: [
+      {
+        name: 'dealId',
+        type: 'uint64',
+      },
+      {
+        name: 'generation',
+        type: 'uint64',
+      },
+      {
+        name: 'polyfsRoot',
+        type: 'bytes',
+      },
+    ],
+    outputs: [
+      {
+        name: 'success',
+        type: 'bool',
+      },
+    ],
+  },
+  {
+    type: 'function',
+    name: 'openRetrievalSessionV3',
+    stateMutability: 'nonpayable',
+    inputs: [
+      {
+        name: 'dealId',
+        type: 'uint64',
+      },
+      {
+        name: 'generation',
+        type: 'uint64',
+      },
+      {
+        name: 'range',
+        type: 'tuple',
+        components: [
+          {
+            name: 'fileRecordIndex',
+            type: 'uint32',
+          },
+          {
+            name: 'fileStartOffset',
+            type: 'uint64',
+          },
+          {
+            name: 'fileLength',
+            type: 'uint64',
+          },
+          {
+            name: 'rangeStart',
+            type: 'uint64',
+          },
+          {
+            name: 'rangeLength',
+            type: 'uint64',
+          },
+        ],
+      },
+      {
+        name: 'nonce',
+        type: 'uint64',
+      },
+      {
+        name: 'deadlineHeight',
+        type: 'uint64',
+      },
+    ],
+    outputs: [
+      {
+        name: 'sessionId',
+        type: 'bytes32',
+      },
+      {
+        name: 'logicalRequestedBytes',
+        type: 'uint64',
+      },
+      {
+        name: 'billedEncodedBytes',
+        type: 'uint64',
+      },
+      {
+        name: 'sampleCount',
+        type: 'uint64',
+      },
+    ],
+  },
+  {
+    type: 'function',
+    name: 'openRetrievalSessionV3Sponsored',
+    stateMutability: 'nonpayable',
+    inputs: [
+      {
+        name: 'dealId',
+        type: 'uint64',
+      },
+      {
+        name: 'generation',
+        type: 'uint64',
+      },
+      {
+        name: 'range',
+        type: 'tuple',
+        components: [
+          {
+            name: 'fileRecordIndex',
+            type: 'uint32',
+          },
+          {
+            name: 'fileStartOffset',
+            type: 'uint64',
+          },
+          {
+            name: 'fileLength',
+            type: 'uint64',
+          },
+          {
+            name: 'rangeStart',
+            type: 'uint64',
+          },
+          {
+            name: 'rangeLength',
+            type: 'uint64',
+          },
+        ],
+      },
+      {
+        name: 'nonce',
+        type: 'uint64',
+      },
+      {
+        name: 'deadlineHeight',
+        type: 'uint64',
+      },
+      {
+        name: 'maxTotalFee',
+        type: 'uint256',
+      },
+      {
+        name: 'authType',
+        type: 'uint8',
+      },
+      {
+        name: 'allowlistLeafIndex',
+        type: 'uint32',
+      },
+      {
+        name: 'allowlistMerklePath',
+        type: 'bytes32[]',
+      },
+      {
+        name: 'voucherRedeemer',
+        type: 'string',
+      },
+      {
+        name: 'voucherManifestRoot',
+        type: 'bytes',
+      },
+      {
+        name: 'voucherProvider',
+        type: 'string',
+      },
+      {
+        name: 'voucherStartMduIndex',
+        type: 'uint64',
+      },
+      {
+        name: 'voucherStartBlobIndex',
+        type: 'uint32',
+      },
+      {
+        name: 'voucherBlobCount',
+        type: 'uint64',
+      },
+      {
+        name: 'voucherExpiresAt',
+        type: 'uint64',
+      },
+      {
+        name: 'voucherNonce',
+        type: 'uint64',
+      },
+      {
+        name: 'voucherSignature',
+        type: 'bytes',
+      },
+    ],
+    outputs: [
+      {
+        name: 'sessionId',
+        type: 'bytes32',
+      },
+      {
+        name: 'logicalRequestedBytes',
+        type: 'uint64',
+      },
+      {
+        name: 'billedEncodedBytes',
+        type: 'uint64',
+      },
+      {
+        name: 'sampleCount',
+        type: 'uint64',
+      },
+    ],
+  },
+  {
+    type: 'function',
+    name: 'submitRetrievalSessionProofV3',
+    stateMutability: 'nonpayable',
+    inputs: [
+      {
+        name: 'sessionId',
+        type: 'bytes32',
+      },
+      {
+        name: 'slot',
+        type: 'uint32',
+      },
+      {
+        name: 'proofs',
+        type: 'tuple[]',
+        components: [
+          {
+            name: 'ordinal',
+            type: 'uint64',
+          },
+          {
+            name: 'proof',
+            type: 'tuple',
+            components: [
+              {
+                name: 'mduIndex',
+                type: 'uint64',
+              },
+              {
+                name: 'mduRootFr',
+                type: 'bytes',
+              },
+              {
+                name: 'manifestOpening',
+                type: 'bytes',
+              },
+              {
+                name: 'rootTableDuCommitment',
+                type: 'bytes',
+              },
+              {
+                name: 'rootTableDuMerklePath',
+                type: 'bytes[]',
+              },
+              {
+                name: 'blobCommitment',
+                type: 'bytes',
+              },
+              {
+                name: 'merklePath',
+                type: 'bytes[]',
+              },
+              {
+                name: 'blobIndex',
+                type: 'uint32',
+              },
+              {
+                name: 'zValue',
+                type: 'bytes',
+              },
+              {
+                name: 'yValue',
+                type: 'bytes',
+              },
+              {
+                name: 'kzgOpeningProof',
+                type: 'bytes',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    outputs: [
+      {
+        name: 'newlyAccepted',
+        type: 'uint32',
+      },
+      {
+        name: 'settled',
+        type: 'bool',
+      },
+    ],
+  },
+  {
+    type: 'function',
+    name: 'acknowledgeRetrievalObligationV3',
+    stateMutability: 'nonpayable',
+    inputs: [
+      {
+        name: 'sessionId',
+        type: 'bytes32',
+      },
+      {
+        name: 'slot',
+        type: 'uint32',
+      },
+      {
+        name: 'ackDigest',
+        type: 'bytes',
+      },
+    ],
+    outputs: [
+      {
+        name: 'settled',
+        type: 'bool',
+      },
+    ],
+  },
+  {
+    type: 'function',
+    name: 'refundRetrievalSessionV3',
+    stateMutability: 'nonpayable',
+    inputs: [
+      {
+        name: 'sessionId',
+        type: 'bytes32',
+      },
+    ],
+    outputs: [
+      {
+        name: 'refunded',
+        type: 'bool',
+      },
+    ],
+  },
+  {
+    type: 'event',
+    name: 'RetrievalSessionV3Opened',
+    inputs: [
+      {
+        name: 'dealId',
+        type: 'uint64',
+        indexed: true,
+      },
+      {
+        name: 'requester',
+        type: 'address',
+        indexed: true,
+      },
+      {
+        name: 'sessionId',
+        type: 'bytes32',
+        indexed: false,
+      },
+    ],
+  },
+  {
     type: 'event',
     name: 'DealCreated',
     inputs: [
@@ -348,6 +781,38 @@ export type SponsoredRetrievalSessionInput = RetrievalSessionInput & {
   allowlistMerklePath: Hex[]
   voucherRedeemer: string
   voucherProvider: string
+  voucherExpiresAt: bigint
+  voucherNonce: bigint
+  voucherSignature: Hex
+}
+
+export type RetrievalRangeV3Input = {
+  fileRecordIndex: number
+  fileStartOffset: bigint
+  fileLength: bigint
+  rangeStart: bigint
+  rangeLength: bigint
+}
+
+export type RetrievalSessionV3Input = {
+  dealId: bigint
+  generation: bigint
+  range: RetrievalRangeV3Input
+  nonce: bigint
+  deadlineHeight: bigint
+}
+
+export type SponsoredRetrievalSessionV3Input = RetrievalSessionV3Input & {
+  maxTotalFee: bigint
+  authType: number
+  allowlistLeafIndex: number
+  allowlistMerklePath: Hex[]
+  voucherRedeemer: string
+  voucherManifestRoot: Hex
+  voucherProvider: string
+  voucherStartMduIndex: bigint
+  voucherStartBlobIndex: number
+  voucherBlobCount: bigint
   voucherExpiresAt: bigint
   voucherNonce: bigint
   voucherSignature: Hex

--- a/polystore-website/src/lib/retrievalAbi.test.ts
+++ b/polystore-website/src/lib/retrievalAbi.test.ts
@@ -2,12 +2,16 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import { readFile } from 'node:fs/promises'
 import { encodeFunctionData, type Abi } from 'viem'
-import { encodeRetrievalV2Data, type RetrievalSessionV2Input, type SponsoredRetrievalSessionInput } from './polystorePrecompile'
+import { POLYSTORE_PRECOMPILE_ABI, encodeRetrievalV2Data, type RetrievalSessionV2Input, type SponsoredRetrievalSessionInput } from './polystorePrecompile'
 
-test('secured browser encoders match the actual chain v2 overloads including frozen payee', async () => {
+async function chainABI(): Promise<Abi> {
   const source = await readFile(new URL('../../../polystorechain/precompiles/polystore/polystore.go', import.meta.url), 'utf8')
   const start = source.indexOf('const polystoreABIJSON = `') + 'const polystoreABIJSON = `'.length
-  const abi = JSON.parse(source.slice(start, source.indexOf('`', start))) as Abi
+  return JSON.parse(source.slice(start, source.indexOf('`', start))) as Abi
+}
+
+test('secured browser encoders match the actual chain v2 overloads including frozen payee', async () => {
+  const abi = await chainABI()
   const session: RetrievalSessionV2Input & SponsoredRetrievalSessionInput = {
     dealId: 9007199254740993n, provider: 'nil-assigned', authorizedProofProvider: 'nil-deputy',
     startMduIndex: 65536n, startBlobIndex: 8, blobCount: 2n, expiresAt: 9007199254740993n, nonce: 9007199254740995n,
@@ -19,4 +23,28 @@ test('secured browser encoders match the actual chain v2 overloads including fro
     assert.equal(selected.length, 1)
     assert.equal(encodeRetrievalV2Data(method, [session]), encodeFunctionData({ abi: selected, functionName: method, args: [[session]] }))
   }
+})
+
+test('browser mirrors every native v3 method and opening receipt exactly', async () => {
+  const names = new Set([
+    'proposeDealGenerationV3', 'acceptDealGenerationV3', 'finalizeDealGenerationV3',
+    'openRetrievalSessionV3', 'openRetrievalSessionV3Sponsored', 'submitRetrievalSessionProofV3',
+    'acknowledgeRetrievalObligationV3', 'refundRetrievalSessionV3', 'RetrievalSessionV3Opened',
+  ])
+  const select = (abi: Abi) => abi.filter((entry) => 'name' in entry && names.has(entry.name))
+  assert.deepEqual(select(POLYSTORE_PRECOMPILE_ABI), select(await chainABI()))
+
+  const proof = {
+    ordinal: 0n,
+    proof: {
+      mduIndex: 2n, mduRootFr: '0x01', manifestOpening: '0x02', rootTableDuCommitment: '0x03',
+      rootTableDuMerklePath: ['0x04'], blobCommitment: '0x05', merklePath: ['0x06'],
+      blobIndex: 0, zValue: '0x07', yValue: '0x08', kzgOpeningProof: '0x09',
+    },
+  }
+  const chain = await chainABI()
+  assert.equal(
+    encodeFunctionData({ abi: POLYSTORE_PRECOMPILE_ABI, functionName: 'submitRetrievalSessionProofV3', args: [`0x${'11'.repeat(32)}`, 0, [proof]] }),
+    encodeFunctionData({ abi: chain, functionName: 'submitRetrievalSessionProofV3', args: [`0x${'11'.repeat(32)}`, 0, [proof]] }),
+  )
 })

--- a/polystore-website/src/lib/retrievalAbi.test.ts
+++ b/polystore-website/src/lib/retrievalAbi.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { readFile } from 'node:fs/promises'
-import { encodeFunctionData, type Abi } from 'viem'
+import { encodeFunctionData, type Abi, type Hex } from 'viem'
 import { POLYSTORE_PRECOMPILE_ABI, encodeRetrievalV2Data, type RetrievalSessionV2Input, type SponsoredRetrievalSessionInput } from './polystorePrecompile'
 
 async function chainABI(): Promise<Abi> {
@@ -41,10 +41,11 @@ test('browser mirrors every native v3 method and opening receipt exactly', async
       rootTableDuMerklePath: ['0x04'], blobCommitment: '0x05', merklePath: ['0x06'],
       blobIndex: 0, zValue: '0x07', yValue: '0x08', kzgOpeningProof: '0x09',
     },
-  }
+  } as const
   const chain = await chainABI()
+  const sessionId = `0x${'11'.repeat(32)}` as Hex
   assert.equal(
-    encodeFunctionData({ abi: POLYSTORE_PRECOMPILE_ABI, functionName: 'submitRetrievalSessionProofV3', args: [`0x${'11'.repeat(32)}`, 0, [proof]] }),
-    encodeFunctionData({ abi: chain, functionName: 'submitRetrievalSessionProofV3', args: [`0x${'11'.repeat(32)}`, 0, [proof]] }),
+    encodeFunctionData({ abi: POLYSTORE_PRECOMPILE_ABI, functionName: 'submitRetrievalSessionProofV3', args: [sessionId, 0, [proof]] }),
+    encodeFunctionData({ abi: chain, functionName: 'submitRetrievalSessionProofV3', args: [sessionId, 0, [proof]] }),
   )
 })

--- a/polystorechain/app/precompile_native_test.go
+++ b/polystorechain/app/precompile_native_test.go
@@ -133,6 +133,35 @@ func nativeEVM(t *testing.T, a *App, ctx sdk.Context) (*vm.EVM, *statedb.StateDB
 	return evm, state
 }
 
+func TestNativePrecompileRejectsAttachedValue(t *testing.T) {
+	a, baseCtx := nativePrecompileApp(t)
+	ctx, _ := baseCtx.CacheContext()
+	caller := common.HexToAddress("0xaa11")
+	callerNative := sdk.AccAddress(caller.Bytes())
+	denom := evmtypes.GetEVMCoinDenom()
+	funds := sdk.NewCoins(sdk.NewInt64Coin(denom, 10))
+	require.NoError(t, a.BankKeeper.MintCoins(ctx, types.ModuleName, funds))
+	require.NoError(t, a.BankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, callerNative, funds))
+	evm, state := nativeEVM(t, a, ctx)
+	api, err := abi.JSON(strings.NewReader(`[{"name":"requestProviderLink","type":"function","stateMutability":"nonpayable","inputs":[{"name":"operator","type":"string"}],"outputs":[{"name":"ok","type":"bool"}]}]`))
+	require.NoError(t, err)
+	input, err := api.Pack("requestProviderLink", sdk.AccAddress(common.HexToAddress("0xaa12").Bytes()).String())
+	require.NoError(t, err)
+	beforeEvents := append(sdk.Events(nil), ctx.EventManager().Events()...)
+
+	beforeCaller := state.GetBalance(caller)
+	beforePrecompile := state.GetBalance(polystoreprecompile.Address)
+	_, _, err = evm.Call(caller, polystoreprecompile.Address, input, 5_000_000, uint256.NewInt(1))
+	require.ErrorIs(t, err, vm.ErrExecutionReverted)
+	require.Equal(t, beforeCaller, state.GetBalance(caller))
+	require.Equal(t, beforePrecompile, state.GetBalance(polystoreprecompile.Address))
+	present, err := a.PolyStoreChainKeeper.PendingProviderLinks.Has(ctx, callerNative.String())
+	require.NoError(t, err)
+	require.False(t, present)
+	require.NoError(t, state.Commit())
+	require.Equal(t, beforeEvents, ctx.EventManager().Events())
+}
+
 func TestNativePrecompileBankRollback(t *testing.T) {
 	a, baseCtx := nativePrecompileApp(t)
 	api, err := abi.JSON(strings.NewReader(`[{"name":"createDeal","type":"function","inputs":[{"type":"uint64"},{"type":"string"},{"type":"uint256"},{"type":"uint256"}],"outputs":[{"type":"uint64"}]}]`))

--- a/polystorechain/app/precompile_retrieval_v3_test.go
+++ b/polystorechain/app/precompile_retrieval_v3_test.go
@@ -1,0 +1,419 @@
+package app
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"math/big"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"cosmossdk.io/collections"
+	"cosmossdk.io/log"
+	sdkmath "cosmossdk.io/math"
+	storetypes "cosmossdk.io/store/types"
+	abci "github.com/cometbft/cometbft/abci/types"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	dbm "github.com/cosmos/cosmos-db"
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	evmtypes "github.com/cosmos/evm/x/vm/types"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"polystorechain/pkg/retrievalchallenge"
+	polystoreprecompile "polystorechain/precompiles/polystore"
+	"polystorechain/x/crypto_ffi"
+	"polystorechain/x/polystorechain/keeper"
+	"polystorechain/x/polystorechain/types"
+)
+
+const openRetrievalSessionV3ABI = `[{"type":"function","name":"openRetrievalSessionV3","stateMutability":"nonpayable","inputs":[{"name":"dealId","type":"uint64"},{"name":"generation","type":"uint64"},{"name":"range","type":"tuple","components":[{"name":"fileRecordIndex","type":"uint32"},{"name":"fileStartOffset","type":"uint64"},{"name":"fileLength","type":"uint64"},{"name":"rangeStart","type":"uint64"},{"name":"rangeLength","type":"uint64"}]},{"name":"nonce","type":"uint64"},{"name":"deadlineHeight","type":"uint64"}],"outputs":[{"name":"sessionId","type":"bytes32"},{"name":"logicalRequestedBytes","type":"uint64"},{"name":"billedEncodedBytes","type":"uint64"},{"name":"sampleCount","type":"uint64"}]},{"type":"event","name":"RetrievalSessionV3Opened","inputs":[{"name":"dealId","type":"uint64","indexed":true},{"name":"requester","type":"address","indexed":true},{"name":"sessionId","type":"bytes32","indexed":false}]}]`
+
+type evmRetrievalRangeV3 struct {
+	FileRecordIndex uint32
+	FileStartOffset uint64
+	FileLength      uint64
+	RangeStart      uint64
+	RangeLength     uint64
+}
+
+type evmChainedProofV3 struct {
+	MduIndex              uint64
+	MduRootFr             []byte
+	ManifestOpening       []byte
+	RootTableDuCommitment []byte
+	RootTableDuMerklePath [][]byte
+	BlobCommitment        []byte
+	MerklePath            [][]byte
+	BlobIndex             uint32
+	ZValue                []byte
+	YValue                []byte
+	KzgOpeningProof       []byte
+}
+
+type evmSampleProofV3 struct {
+	Ordinal uint64
+	Proof   evmChainedProofV3
+}
+
+func setupNativeV3Open(t *testing.T, owner common.Address) (*App, sdk.Context, abi.ABI, types.Deal) {
+	t.Helper()
+	a, ctx := nativePrecompileApp(t)
+	ctx = ctx.WithGasMeter(storetypes.NewInfiniteGasMeter())
+	params := types.DefaultParams()
+	params.BaseRetrievalFee = sdk.NewInt64Coin(sdk.DefaultBondDenom, 2)
+	params.RetrievalPricePerBlob = sdk.NewInt64Coin(sdk.DefaultBondDenom, 3)
+	require.NoError(t, a.PolyStoreChainKeeper.Params.Set(ctx, params))
+	require.NoError(t, a.PolyStoreChainKeeper.RetrievalV2ActivatedHeight.Set(ctx, 1))
+	require.NoError(t, a.PolyStoreChainKeeper.RetrievalV3ActivatedHeight.Set(ctx, 1))
+	require.NoError(t, a.PolyStoreChainKeeper.StorageAuditEpochLength.Set(ctx, params.EpochLenBlocks))
+
+	providers := make([]string, 12)
+	slots := make([]*types.DealSlot, 12)
+	for i := range providers {
+		address := sdk.AccAddress(bytes.Repeat([]byte{byte(0x40 + i)}, 20)).String()
+		providers[i] = address
+		slots[i] = &types.DealSlot{Slot: uint32(i), Provider: address, Status: types.SlotStatus_SLOT_STATUS_ACTIVE}
+		require.NoError(t, a.PolyStoreChainKeeper.Providers.Set(ctx, address, types.Provider{Address: address, Status: "Active"}))
+	}
+	root := bytes.Repeat([]byte{0x61}, 32)
+	deal := types.Deal{Id: 19, Owner: sdk.AccAddress(owner.Bytes()).String(), ManifestRoot: root, Size_: 64 * 126976,
+		EscrowBalance: sdkmath.NewInt(100), StartBlock: 1, EndBlock: 100, CurrentGen: 1,
+		TotalMdus: 3, WitnessMdus: 1, RedundancyMode: 2,
+		Mode2Profile: &types.StripeReplicaProfile{K: 8, M: 4}, Mode2Slots: slots,
+		MaxMonthlySpend: sdkmath.ZeroInt(), SpendWindowSpent: sdkmath.ZeroInt()}
+	require.NoError(t, a.PolyStoreChainKeeper.Deals.Set(ctx, deal.Id, deal))
+	setup, err := hex.DecodeString(types.RetrievalSetupDigest)
+	require.NoError(t, err)
+	require.NoError(t, a.PolyStoreChainKeeper.AdmittedDealGenerationsV3.Set(ctx, deal.Id, types.DealGenerationAdmissionV3{
+		DealId: deal.Id, Owner: deal.Owner, Generation: deal.CurrentGen,
+		PreviousPolyfsRoot: bytes.Repeat([]byte{0x60}, 32), PolyfsRoot: root, IntegrityRoot: bytes.Repeat([]byte{0x62}, 32),
+		Size_: deal.Size_, TotalMdus: deal.TotalMdus, WitnessMdus: deal.WitnessMdus, MetadataMdus: 2, UserMdus: 1,
+		IntegrityLeafCount: 96, SetupDigest: setup, Providers: providers, AcceptedSlotsMask: (1 << 12) - 1, ChainId: ctx.ChainID(),
+	}))
+	require.NoError(t, a.BankKeeper.MintCoins(ctx, types.ModuleName, sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 100))))
+	api, err := abi.JSON(strings.NewReader(openRetrievalSessionV3ABI))
+	require.NoError(t, err)
+	return a, ctx, api, deal
+}
+
+func packNativeV3Open(t *testing.T, api abi.ABI, deal types.Deal, nonce uint64) []byte {
+	t.Helper()
+	input, err := api.Pack("openRetrievalSessionV3", deal.Id, deal.CurrentGen,
+		evmRetrievalRangeV3{FileRecordIndex: 1, FileLength: 1024, RangeLength: 1024}, nonce, uint64(30))
+	require.NoError(t, err)
+	return input
+}
+
+func TestNativeEVMV3OpenReceiptReplayAndRollback(t *testing.T) {
+	t.Run("receipt_and_replay", func(t *testing.T) {
+		owner := common.HexToAddress("0xd001")
+		a, ctx, api, deal := setupNativeV3Open(t, owner)
+		input := packNativeV3Open(t, api, deal, 1)
+		var sessionID [32]byte
+		var charged sdkmath.Int
+		for attempt := 0; attempt < 2; attempt++ {
+			evm, state := nativeEVM(t, a, ctx)
+			output, _, err := evm.Call(owner, polystoreprecompile.Address, input, 8_000_000, uint256.NewInt(0))
+			require.NoError(t, err)
+			decoded, err := api.Methods["openRetrievalSessionV3"].Outputs.Unpack(output)
+			require.NoError(t, err)
+			gotID := decoded[0].([32]byte)
+			if attempt == 0 {
+				sessionID = gotID
+			} else {
+				require.Equal(t, sessionID, gotID)
+			}
+			require.Len(t, state.Logs(), 1)
+			log := state.Logs()[0]
+			require.Equal(t, polystoreprecompile.Address, log.Address)
+			require.Equal(t, []common.Hash{api.Events["RetrievalSessionV3Opened"].ID, common.BigToHash(sdkmath.NewIntFromUint64(deal.Id).BigInt()), common.BytesToHash(owner.Bytes())}, log.Topics)
+			data, err := api.Events["RetrievalSessionV3Opened"].Inputs.NonIndexed().Unpack(log.Data)
+			require.NoError(t, err)
+			require.Equal(t, sessionID, data[0])
+			require.NoError(t, state.Commit())
+			storedDeal, err := a.PolyStoreChainKeeper.Deals.Get(ctx, deal.Id)
+			require.NoError(t, err)
+			if attempt == 0 {
+				charged = storedDeal.EscrowBalance
+			} else {
+				require.Equal(t, charged, storedDeal.EscrowBalance, "exact retry must not charge twice")
+			}
+		}
+	})
+
+	// Measure the complete native call once, then fail the identical call on its
+	// final unit of gas. This reaches the session and retention writes before
+	// EVM rollback instead of exhausting only the ABI/admission charge.
+	calibrationOwner := common.HexToAddress("0xd021")
+	calibrationApp, calibrationCtx, calibrationAPI, calibrationDeal := setupNativeV3Open(t, calibrationOwner)
+	calibrationInput := packNativeV3Open(t, calibrationAPI, calibrationDeal, 1)
+	calibrationEVM, _ := nativeEVM(t, calibrationApp, calibrationCtx)
+	const calibrationLimit = uint64(8_000_000)
+	_, calibrationLeft, err := calibrationEVM.Call(calibrationOwner, polystoreprecompile.Address, calibrationInput, calibrationLimit, uint256.NewInt(0))
+	require.NoError(t, err)
+	lateOOGGas := calibrationLimit - calibrationLeft - 1
+	require.LessOrEqual(t, lateOOGGas, uint64(^uint32(0)))
+
+	for _, tc := range []struct {
+		name   string
+		gas    uint32
+		revert bool
+		result byte
+	}{{"caught_revert", 8_000_000, true, 0}, {"caught_out_of_gas_after_writes", uint32(lateOOGGas), false, 1}} {
+		t.Run(tc.name, func(t *testing.T) {
+			child := common.HexToAddress("0xd011")
+			a, ctx, api, deal := setupNativeV3Open(t, child)
+			input := packNativeV3Open(t, api, deal, 1)
+			beforeEvents := append(sdk.Events(nil), ctx.EventManager().Events()...)
+			evm, state := nativeEVM(t, a, ctx)
+			outer := common.HexToAddress("0xd012")
+			state.SetCode(outer, callAndReturn(child, 10_000_000, false))
+			state.SetCode(child, callAndReturn(polystoreprecompile.Address, tc.gas, tc.revert))
+			result, _, err := evm.Call(common.HexToAddress("0xd013"), outer, input, 14_000_000, uint256.NewInt(0))
+			require.NoError(t, err)
+			require.Equal(t, tc.result, result[31])
+			require.Empty(t, state.Logs())
+			require.NoError(t, state.Commit())
+			storedDeal, err := a.PolyStoreChainKeeper.Deals.Get(ctx, deal.Id)
+			require.NoError(t, err)
+			require.Equal(t, deal.EscrowBalance, storedDeal.EscrowBalance)
+			noncePresent, err := a.PolyStoreChainKeeper.RetrievalSessionV3NonceIDs.Has(ctx,
+				collections.Join(collections.Join(deal.Owner, deal.Id), uint64(1)))
+			require.NoError(t, err)
+			require.False(t, noncePresent)
+			_, err = a.PolyStoreChainKeeper.RetrievalSessionLiveCount.Get(ctx)
+			require.ErrorIs(t, err, collections.ErrNotFound)
+			_, err = a.PolyStoreChainKeeper.RetrievalSessionGenerationCount.Get(ctx)
+			require.ErrorIs(t, err, collections.ErrNotFound)
+			count := 0
+			require.NoError(t, a.PolyStoreChainKeeper.RetrievalSessionsV3.Walk(ctx, nil, func(_ []byte, _ types.RetrievalSessionV3) (bool, error) {
+				count++
+				return false, nil
+			}))
+			require.Zero(t, count)
+			require.Equal(t, beforeEvents, ctx.EventManager().Events())
+			if tc.gas == uint32(lateOOGGas) {
+				require.Greater(t, uint64(tc.gas), uint64(220_000))
+				t.Logf("v3 open late OOG gas=%d calibrated successful gas=%d", tc.gas, lateOOGGas+1)
+			}
+		})
+	}
+}
+
+const submitRetrievalSessionProofV3ABI = `[{"type":"function","name":"submitRetrievalSessionProofV3","stateMutability":"nonpayable","inputs":[{"name":"sessionId","type":"bytes32"},{"name":"slot","type":"uint32"},{"name":"proofs","type":"tuple[]","components":[{"name":"ordinal","type":"uint64"},{"name":"proof","type":"tuple","components":[{"name":"mduIndex","type":"uint64"},{"name":"mduRootFr","type":"bytes"},{"name":"manifestOpening","type":"bytes"},{"name":"rootTableDuCommitment","type":"bytes"},{"name":"rootTableDuMerklePath","type":"bytes[]"},{"name":"blobCommitment","type":"bytes"},{"name":"merklePath","type":"bytes[]"},{"name":"blobIndex","type":"uint32"},{"name":"zValue","type":"bytes"},{"name":"yValue","type":"bytes"},{"name":"kzgOpeningProof","type":"bytes"}]}]}],"outputs":[{"name":"newlyAccepted","type":"uint32"},{"name":"settled","type":"bool"}]}]`
+
+func appChallengeContextV3(t *testing.T, s types.RetrievalSessionV3) retrievalchallenge.ContextV3 {
+	t.Helper()
+	var setup, id, root, integrity, plan [32]byte
+	copy(setup[:], s.SetupDigest)
+	copy(id[:], s.SessionId)
+	copy(root[:], s.PolyfsRoot)
+	copy(integrity[:], s.IntegrityRoot)
+	copy(plan[:], s.PlanHash)
+	owner, err := sdk.AccAddressFromBech32(s.Owner)
+	require.NoError(t, err)
+	payer, err := sdk.AccAddressFromBech32(s.Payer)
+	require.NoError(t, err)
+	var owner20, payer20 [20]byte
+	copy(owner20[:], owner)
+	copy(payer20[:], payer)
+	c := retrievalchallenge.ContextV3{
+		ChainID: s.ChainId, SetupDigest: setup, SessionID: id, SessionOwner: owner20,
+		DealID: s.DealId, Generation: s.Generation, PolyFSRoot: root, IntegrityRoot: integrity,
+		FileRecordIndex: s.FileRecordIndex, FileStartOffset: s.FileStartOffset, FileLength: s.FileLength,
+		RangeStart: s.RangeStart, RangeLength: s.RangeLength, MetadataMDUs: s.MetadataMdus, UserMDUs: s.UserMdus,
+		PlanHash: plan, Population: s.Population, SampleCount: s.SampleCount, Nonce: s.Nonce,
+		PriceDenom: s.PriceDenom, PricePerBlob: s.PricePerBlob.String(), BaseFee: s.BaseFee.String(),
+		CompletionBurnBPS: s.CompletionBurnBps, FundingKind: uint8(s.Funding), FundingPayer: payer20,
+		Window:  retrievalchallenge.Window{Snapshot: s.SnapshotHeight, Anchor: s.AnchorHeight, First: s.FirstResponseHeight, Deadline: s.DeadlineHeight},
+		DealEnd: s.DealEndHeight,
+	}
+	h, err := c.Hash()
+	require.NoError(t, err)
+	require.Equal(t, s.ContextHash, h[:])
+	return c
+}
+
+func TestSignedEVMV3ProofUsesProductionGasAndRollsBackOutOfGas(t *testing.T) {
+	if runGenesisTestInFreshProcess(t) {
+		return
+	}
+	key, err := crypto.HexToECDSA("1123456789012345678901234567890123456789012345678901234567890123")
+	require.NoError(t, err)
+	caller := crypto.PubkeyToAddress(key.PublicKey)
+	owner := sdk.AccAddress(caller.Bytes())
+	a := New(log.NewNopLogger(), dbm.NewMemDB(), nil, true,
+		simtestutil.AppOptionsMap{"home": t.TempDir(), "evm.evm-chain-id": evmtypes.DefaultEVMChainID},
+		baseapp.SetChainID(SimAppChainID))
+	defer func() { require.NoError(t, a.Close()) }()
+	valSet, err := simtestutil.CreateRandomValidatorSet()
+	require.NoError(t, err)
+	funds := sdkmath.NewInt(1_000_000_000).MulRaw(1_000_000_000)
+	module := authtypes.NewModuleAddress(types.ModuleName)
+	genesis, err := simtestutil.GenesisStateWithValSet(a.AppCodec(), a.DefaultGenesis(), valSet,
+		[]authtypes.GenesisAccount{authtypes.NewBaseAccount(owner, nil, 0, 0)},
+		banktypes.Balance{Address: owner.String(), Coins: sdk.NewCoins(sdk.NewCoin("aatom", funds))},
+		banktypes.Balance{Address: module.String(), Coins: sdk.NewCoins(sdk.NewInt64Coin("stake", 100))})
+	require.NoError(t, err)
+	var bank banktypes.GenesisState
+	a.AppCodec().MustUnmarshalJSON(genesis[banktypes.ModuleName], &bank)
+	bank.DenomMetadata = append(bank.DenomMetadata, banktypes.Metadata{
+		Description: "EVM fee token metadata", Base: "aatom", Display: "atom", Name: "Atom", Symbol: "ATOM",
+		DenomUnits: []*banktypes.DenomUnit{{Denom: "aatom", Exponent: 0, Aliases: []string{"uatom"}}, {Denom: "atom", Exponent: 18}},
+	})
+	genesis[banktypes.ModuleName] = a.AppCodec().MustMarshalJSON(&bank)
+	evmGenesis := evmtypes.DefaultGenesisState()
+	evmGenesis.Params.ActiveStaticPrecompiles = append(evmGenesis.Params.ActiveStaticPrecompiles, polystoreprecompile.AddressHex)
+	genesis[evmtypes.ModuleName] = a.AppCodec().MustMarshalJSON(evmGenesis)
+	rawGenesis, err := json.Marshal(genesis)
+	require.NoError(t, err)
+	_, err = a.InitChain(&abci.RequestInitChain{ChainId: SimAppChainID, AppStateBytes: rawGenesis,
+		ConsensusParams: &cmtproto.ConsensusParams{Block: &cmtproto.BlockParams{MaxGas: 64_000_000, MaxBytes: 2_097_152}}})
+	require.NoError(t, err)
+	finalize := func(height int64, txs ...[]byte) *abci.ResponseFinalizeBlock {
+		response, err := a.FinalizeBlock(&abci.RequestFinalizeBlock{Height: height, Hash: bytes.Repeat([]byte{byte(height)}, 32),
+			Time: time.Unix(height, 0), ProposerAddress: valSet.Validators[0].Address, Txs: txs})
+		require.NoError(t, err)
+		_, err = a.Commit()
+		require.NoError(t, err)
+		return response
+	}
+	require.NoError(t, crypto_ffi.Init("../trusted_setup.txt"))
+	rawFixture, err := os.ReadFile("../x/polystorechain/keeper/testdata/proof_admission_k8.json")
+	require.NoError(t, err)
+	var fixture struct {
+		Root   []byte               `json:"root"`
+		Proofs []types.ChainedProof `json:"proofs"`
+	}
+	require.NoError(t, json.Unmarshal(rawFixture, &fixture))
+	require.NotEmpty(t, fixture.Proofs)
+
+	setup := a.NewContextLegacy(false, cmtproto.Header{Height: 1, ChainID: SimAppChainID})
+	params := types.DefaultParams()
+	params.BaseRetrievalFee = sdk.NewInt64Coin("stake", 2)
+	params.RetrievalPricePerBlob = sdk.NewInt64Coin("stake", 3)
+	require.NoError(t, a.PolyStoreChainKeeper.Params.Set(setup, params))
+	require.NoError(t, a.PolyStoreChainKeeper.RetrievalV2ActivatedHeight.Set(setup, 1))
+	require.NoError(t, a.PolyStoreChainKeeper.RetrievalV3ActivatedHeight.Set(setup, 1))
+	require.NoError(t, a.PolyStoreChainKeeper.StorageAuditEpochLength.Set(setup, params.EpochLenBlocks))
+	providers := make([]string, 12)
+	slots := make([]*types.DealSlot, 12)
+	for i := range providers {
+		address := sdk.AccAddress(bytes.Repeat([]byte{byte(0x70 + i)}, 20)).String()
+		if i == 0 {
+			address = owner.String()
+		}
+		providers[i] = address
+		slots[i] = &types.DealSlot{Slot: uint32(i), Provider: address, Status: types.SlotStatus_SLOT_STATUS_ACTIVE}
+		require.NoError(t, a.PolyStoreChainKeeper.Providers.Set(setup, address, types.Provider{Address: address, Status: "Active"}))
+	}
+	deal := types.Deal{Id: 27, Owner: owner.String(), ManifestRoot: fixture.Root, Size_: 64 * retrievalchallenge.DataBlobPayloadBytes,
+		EscrowBalance: sdkmath.NewInt(100), StartBlock: 1, EndBlock: 100, CurrentGen: 1,
+		TotalMdus: 3, WitnessMdus: 1, RedundancyMode: 2, Mode2Profile: &types.StripeReplicaProfile{K: 8, M: 4}, Mode2Slots: slots,
+		MaxMonthlySpend: sdkmath.ZeroInt(), SpendWindowSpent: sdkmath.ZeroInt()}
+	require.NoError(t, a.PolyStoreChainKeeper.Deals.Set(setup, deal.Id, deal))
+	setupDigest, err := hex.DecodeString(types.RetrievalSetupDigest)
+	require.NoError(t, err)
+	require.NoError(t, a.PolyStoreChainKeeper.AdmittedDealGenerationsV3.Set(setup, deal.Id, types.DealGenerationAdmissionV3{
+		DealId: deal.Id, Owner: deal.Owner, Generation: deal.CurrentGen, PreviousPolyfsRoot: bytes.Repeat([]byte{0x60}, 32),
+		PolyfsRoot: fixture.Root, IntegrityRoot: bytes.Repeat([]byte{0x62}, 32), Size_: deal.Size_, TotalMdus: deal.TotalMdus,
+		WitnessMdus: 1, MetadataMdus: 2, UserMdus: 1, IntegrityLeafCount: 96, SetupDigest: setupDigest,
+		Providers: providers, AcceptedSlotsMask: (1 << 12) - 1, ChainId: SimAppChainID,
+	}))
+	opened, err := keeper.NewMsgServerImpl(a.PolyStoreChainKeeper).OpenRetrievalSessionV3(setup, &types.MsgOpenRetrievalSessionV3{
+		Creator: owner.String(), DealId: deal.Id, Generation: deal.CurrentGen,
+		Range: types.RetrievalRangeV3{FileRecordIndex: 1, FileLength: 1024, RangeLength: 1024}, Nonce: 1, DeadlineHeight: 20,
+	})
+	require.NoError(t, err)
+	finalize(1)
+	finalize(2)
+	query := retrievalNativeQuery(t, a)
+	session, err := a.PolyStoreChainKeeper.RetrievalSessionsV3.Get(query, opened.SessionId)
+	require.NoError(t, err)
+	anchor, err := a.PolyStoreChainKeeper.ChallengeAnchors.Get(query, session.AnchorHeight)
+	require.NoError(t, err)
+	challengeContext := appChallengeContextV3(t, session)
+	seed, err := challengeContext.Seed(anchor.Seed)
+	require.NoError(t, err)
+	challenges, err := challengeContext.Challenges(seed[:])
+	require.NoError(t, err)
+	require.Len(t, challenges, 1)
+	require.Equal(t, uint32(0), challenges[0].Slot)
+	require.Equal(t, uint32(0), challenges[0].LeafIndex)
+	blob := make([]byte, types.BLOB_SIZE)
+	for i := 31; i < len(blob); i += 32 {
+		blob[i] = byte(1 + (i/32)%251)
+	}
+	commitment, err := crypto_ffi.CommitReceivedBlob(blob)
+	require.NoError(t, err)
+	proof := fixture.Proofs[0]
+	require.Equal(t, commitment, proof.BlobCommitment)
+	proof.ZValue = bytes.Clone(challenges[0].Z[:])
+	proof.KzgOpeningProof, proof.YValue, err = crypto_ffi.ComputeBlobProof(blob, proof.ZValue)
+	require.NoError(t, err)
+
+	api, err := abi.JSON(strings.NewReader(submitRetrievalSessionProofV3ABI))
+	require.NoError(t, err)
+	var sessionID [32]byte
+	copy(sessionID[:], session.SessionId)
+	wire := evmChainedProofV3{MduIndex: proof.MduIndex, MduRootFr: proof.MduRootFr, ManifestOpening: proof.ManifestOpening,
+		RootTableDuCommitment: proof.RootTableDuCommitment, RootTableDuMerklePath: proof.RootTableDuMerklePath,
+		BlobCommitment: proof.BlobCommitment, MerklePath: proof.MerklePath, BlobIndex: proof.BlobIndex,
+		ZValue: proof.ZValue, YValue: proof.YValue, KzgOpeningProof: proof.KzgOpeningProof}
+	input, err := api.Pack("submitRetrievalSessionProofV3", sessionID, uint32(0), []evmSampleProofV3{{Ordinal: challenges[0].Ordinal, Proof: wire}})
+	require.NoError(t, err)
+	precompile, err := polystoreprecompile.New(&a.PolyStoreChainKeeper)
+	require.NoError(t, err)
+	static := precompile.RequiredGas(input)
+	price := big.NewInt(1_000_000_000)
+	sign := func(nonce, gas uint64) []byte {
+		tx := ethtypes.NewTransaction(nonce, polystoreprecompile.Address, big.NewInt(0), gas, price, input)
+		signer := ethtypes.LatestSignerForChainID(new(big.Int).SetUint64(evmtypes.DefaultEVMChainID))
+		signed, err := ethtypes.SignTx(tx, signer, key)
+		require.NoError(t, err)
+		msg := &evmtypes.MsgEthereumTx{}
+		require.NoError(t, msg.FromSignedEthereumTx(signed, signer))
+		cosmosTx, err := msg.BuildTx(a.TxConfig().NewTxBuilder(), "aatom")
+		require.NoError(t, err)
+		raw, err := a.TxConfig().TxEncoder()(cosmosTx)
+		require.NoError(t, err)
+		require.LessOrEqual(t, len(raw), 2_097_152)
+		return raw
+	}
+	for i, gas := range []uint64{static + keeper.ProofCryptoGas - 1, 20_000_000} {
+		result := finalize(int64(i+3), sign(uint64(i), gas)).TxResults[0]
+		require.Zero(t, result.Code, result.Log)
+		receipt, err := evmtypes.DecodeTxResponse(result.Data)
+		require.NoError(t, err)
+		require.Equal(t, receipt.GasUsed, uint64(result.GasUsed))
+		stored, err := a.PolyStoreChainKeeper.RetrievalSessionsV3.Get(retrievalNativeQuery(t, a), session.SessionId)
+		require.NoError(t, err)
+		if i == 0 {
+			require.Equal(t, "out of gas", receipt.VmError)
+			require.Equal(t, gas, receipt.GasUsed)
+			require.Zero(t, stored.Obligations[0].SampleCount)
+			require.Equal(t, make([]byte, len(stored.AcceptedSampleBitmap)), stored.AcceptedSampleBitmap)
+			require.Zero(t, stored.SettledSlotsMask)
+			require.Empty(t, receipt.Logs)
+		} else {
+			require.Empty(t, receipt.VmError)
+			require.Equal(t, uint64(1), stored.Obligations[0].SampleCount)
+			require.Equal(t, byte(1), stored.AcceptedSampleBitmap[0]&1)
+			require.Zero(t, stored.SettledSlotsMask)
+			require.Less(t, receipt.GasUsed, gas)
+		}
+		require.GreaterOrEqual(t, receipt.GasUsed, static+keeper.ProofCryptoGas-1)
+		t.Logf("v3 proof gas limit=%d static=%d crypto=%d used=%d", gas, static, keeper.ProofCryptoGas, receipt.GasUsed)
+	}
+}

--- a/polystorechain/app/precompile_retrieval_v3_test.go
+++ b/polystorechain/app/precompile_retrieval_v3_test.go
@@ -39,6 +39,12 @@ import (
 
 const openRetrievalSessionV3ABI = `[{"type":"function","name":"openRetrievalSessionV3","stateMutability":"nonpayable","inputs":[{"name":"dealId","type":"uint64"},{"name":"generation","type":"uint64"},{"name":"range","type":"tuple","components":[{"name":"fileRecordIndex","type":"uint32"},{"name":"fileStartOffset","type":"uint64"},{"name":"fileLength","type":"uint64"},{"name":"rangeStart","type":"uint64"},{"name":"rangeLength","type":"uint64"}]},{"name":"nonce","type":"uint64"},{"name":"deadlineHeight","type":"uint64"}],"outputs":[{"name":"sessionId","type":"bytes32"},{"name":"logicalRequestedBytes","type":"uint64"},{"name":"billedEncodedBytes","type":"uint64"},{"name":"sampleCount","type":"uint64"}]},{"type":"event","name":"RetrievalSessionV3Opened","inputs":[{"name":"dealId","type":"uint64","indexed":true},{"name":"requester","type":"address","indexed":true},{"name":"sessionId","type":"bytes32","indexed":false}]}]`
 
+const sponsoredRetrievalSessionV3ABI = `[
+{"type":"function","name":"openRetrievalSessionV3Sponsored","stateMutability":"nonpayable","inputs":[{"name":"dealId","type":"uint64"},{"name":"generation","type":"uint64"},{"name":"range","type":"tuple","components":[{"name":"fileRecordIndex","type":"uint32"},{"name":"fileStartOffset","type":"uint64"},{"name":"fileLength","type":"uint64"},{"name":"rangeStart","type":"uint64"},{"name":"rangeLength","type":"uint64"}]},{"name":"nonce","type":"uint64"},{"name":"deadlineHeight","type":"uint64"},{"name":"maxTotalFee","type":"uint256"},{"name":"authType","type":"uint8"},{"name":"allowlistLeafIndex","type":"uint32"},{"name":"allowlistMerklePath","type":"bytes32[]"},{"name":"voucherRedeemer","type":"string"},{"name":"voucherManifestRoot","type":"bytes"},{"name":"voucherProvider","type":"string"},{"name":"voucherStartMduIndex","type":"uint64"},{"name":"voucherStartBlobIndex","type":"uint32"},{"name":"voucherBlobCount","type":"uint64"},{"name":"voucherExpiresAt","type":"uint64"},{"name":"voucherNonce","type":"uint64"},{"name":"voucherSignature","type":"bytes"}],"outputs":[{"name":"sessionId","type":"bytes32"},{"name":"logicalRequestedBytes","type":"uint64"},{"name":"billedEncodedBytes","type":"uint64"},{"name":"sampleCount","type":"uint64"}]},
+{"type":"function","name":"acknowledgeRetrievalObligationV3","stateMutability":"nonpayable","inputs":[{"name":"sessionId","type":"bytes32"},{"name":"slot","type":"uint32"},{"name":"ackDigest","type":"bytes"}],"outputs":[{"name":"settled","type":"bool"}]},
+{"type":"function","name":"refundRetrievalSessionV3","stateMutability":"nonpayable","inputs":[{"name":"sessionId","type":"bytes32"}],"outputs":[{"name":"refunded","type":"bool"}]}
+]`
+
 type evmRetrievalRangeV3 struct {
 	FileRecordIndex uint32
 	FileStartOffset uint64
@@ -209,6 +215,109 @@ func TestNativeEVMV3OpenReceiptReplayAndRollback(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNativeEVMV3SponsoredOpenChargesOnceAndRefundsFrozenPayer(t *testing.T) {
+	owner := common.HexToAddress("0xd031")
+	requester := common.HexToAddress("0xd032")
+	wrongCaller := common.HexToAddress("0xd033")
+	a, ctx, _, deal := setupNativeV3Open(t, owner)
+	deal.RetrievalPolicy = types.RetrievalPolicy{Mode: types.RetrievalPolicyMode_RETRIEVAL_POLICY_MODE_PUBLIC}
+	require.NoError(t, a.PolyStoreChainKeeper.Deals.Set(ctx, deal.Id, deal))
+	requesterNative := sdk.AccAddress(requester.Bytes())
+	initialFunds := sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 10))
+	require.NoError(t, a.BankKeeper.MintCoins(ctx, types.ModuleName, initialFunds))
+	require.NoError(t, a.BankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, requesterNative, initialFunds))
+	module := authtypes.NewModuleAddress(types.ModuleName)
+	initialModuleBalance := a.BankKeeper.GetBalance(ctx, module, sdk.DefaultBondDenom).Amount
+	api, err := abi.JSON(strings.NewReader(sponsoredRetrievalSessionV3ABI))
+	require.NoError(t, err)
+	packOpen := func(maxFee int64) []byte {
+		input, err := api.Pack("openRetrievalSessionV3Sponsored", deal.Id, deal.CurrentGen,
+			evmRetrievalRangeV3{FileRecordIndex: 1, FileLength: 1024, RangeLength: 1024},
+			uint64(1), uint64(30), big.NewInt(maxFee), uint8(0), uint32(0), []common.Hash{},
+			"", []byte{}, "", uint64(0), uint32(0), uint64(0), uint64(0), uint64(0), []byte{})
+		require.NoError(t, err)
+		return input
+	}
+	call := func(callCtx sdk.Context, caller common.Address, input []byte) ([]byte, error) {
+		evm, state := nativeEVM(t, a, callCtx)
+		output, _, err := evm.Call(caller, polystoreprecompile.Address, input, 8_000_000, uint256.NewInt(0))
+		require.NoError(t, state.Commit())
+		return output, err
+	}
+	balance := func(callCtx sdk.Context) sdkmath.Int {
+		return a.BankKeeper.GetBalance(callCtx, requesterNative, sdk.DefaultBondDenom).Amount
+	}
+	sessionCount := func(callCtx sdk.Context) int {
+		count := 0
+		require.NoError(t, a.PolyStoreChainKeeper.RetrievalSessionsV3.Walk(callCtx, nil, func(_ []byte, _ types.RetrievalSessionV3) (bool, error) {
+			count++
+			return false, nil
+		}))
+		return count
+	}
+	revertReason := func(output []byte) string {
+		reason, err := abi.UnpackRevert(output)
+		require.NoError(t, err)
+		return reason
+	}
+
+	rejected, err := call(ctx, requester, packOpen(4))
+	require.Error(t, err)
+	require.Contains(t, revertReason(rejected), "total fee exceeds max_total_fee")
+	require.Equal(t, sdkmath.NewInt(10), balance(ctx))
+	require.Zero(t, sessionCount(ctx))
+
+	openInput := packOpen(5)
+	opened, err := call(ctx, requester, openInput)
+	require.NoError(t, err)
+	decoded, err := api.Methods["openRetrievalSessionV3Sponsored"].Outputs.Unpack(opened)
+	require.NoError(t, err)
+	sessionID := decoded[0].([32]byte)
+	require.Equal(t, sdkmath.NewInt(5), balance(ctx), "base fee plus one blob fee must be debited")
+	require.Equal(t, initialModuleBalance.AddRaw(3), a.BankKeeper.GetBalance(ctx, module, sdk.DefaultBondDenom).Amount)
+	stored, err := a.PolyStoreChainKeeper.RetrievalSessionsV3.Get(ctx, sessionID[:])
+	require.NoError(t, err)
+	require.Equal(t, requesterNative.String(), stored.Owner)
+	require.Equal(t, requesterNative.String(), stored.Payer)
+	require.Equal(t, types.RetrievalSessionFunding_RETRIEVAL_SESSION_FUNDING_REQUESTER, stored.Funding)
+	require.Equal(t, sdkmath.NewInt(3), stored.LockedFee)
+
+	retried, err := call(ctx, requester, openInput)
+	require.NoError(t, err)
+	retryDecoded, err := api.Methods["openRetrievalSessionV3Sponsored"].Outputs.Unpack(retried)
+	require.NoError(t, err)
+	require.Equal(t, sessionID, retryDecoded[0].([32]byte))
+	require.Equal(t, sdkmath.NewInt(5), balance(ctx), "exact nonce retry must not charge twice")
+	require.Equal(t, initialModuleBalance.AddRaw(3), a.BankKeeper.GetBalance(ctx, module, sdk.DefaultBondDenom).Amount)
+	require.Equal(t, 1, sessionCount(ctx))
+
+	ackInput, err := api.Pack("acknowledgeRetrievalObligationV3", sessionID, stored.Obligations[0].Slot, bytes.Repeat([]byte{0x11}, 32))
+	require.NoError(t, err)
+	rejected, err = call(ctx, wrongCaller, ackInput)
+	require.Error(t, err)
+	require.Contains(t, revertReason(rejected), "only the frozen session owner may acknowledge")
+	refundInput, err := api.Pack("refundRetrievalSessionV3", sessionID)
+	require.NoError(t, err)
+	rejected, err = call(ctx.WithBlockHeight(31), wrongCaller, refundInput)
+	require.Error(t, err)
+	require.Contains(t, revertReason(rejected), "only the frozen session owner may refund")
+	require.Equal(t, sdkmath.NewInt(5), balance(ctx))
+
+	refunded, err := call(ctx.WithBlockHeight(31), requester, refundInput)
+	require.NoError(t, err)
+	refundDecoded, err := api.Methods["refundRetrievalSessionV3"].Outputs.Unpack(refunded)
+	require.NoError(t, err)
+	require.True(t, refundDecoded[0].(bool))
+	require.Equal(t, sdkmath.NewInt(8), balance(ctx), "three locked stake refund leaves the two stake base fee burned")
+	require.Equal(t, initialModuleBalance, a.BankKeeper.GetBalance(ctx, module, sdk.DefaultBondDenom).Amount)
+	stored, err = a.PolyStoreChainKeeper.RetrievalSessionsV3.Get(ctx, sessionID[:])
+	require.NoError(t, err)
+	require.True(t, stored.Expired)
+	require.True(t, stored.LockedFee.IsZero())
+	require.Zero(t, stored.AckedSlotsMask)
+	require.NotZero(t, stored.RefundedSlotsMask)
 }
 
 const submitRetrievalSessionProofV3ABI = `[{"type":"function","name":"submitRetrievalSessionProofV3","stateMutability":"nonpayable","inputs":[{"name":"sessionId","type":"bytes32"},{"name":"slot","type":"uint32"},{"name":"proofs","type":"tuple[]","components":[{"name":"ordinal","type":"uint64"},{"name":"proof","type":"tuple","components":[{"name":"mduIndex","type":"uint64"},{"name":"mduRootFr","type":"bytes"},{"name":"manifestOpening","type":"bytes"},{"name":"rootTableDuCommitment","type":"bytes"},{"name":"rootTableDuMerklePath","type":"bytes[]"},{"name":"blobCommitment","type":"bytes"},{"name":"merklePath","type":"bytes[]"},{"name":"blobIndex","type":"uint32"},{"name":"zValue","type":"bytes"},{"name":"yValue","type":"bytes"},{"name":"kzgOpeningProof","type":"bytes"}]}]}],"outputs":[{"name":"newlyAccepted","type":"uint32"},{"name":"settled","type":"bool"}]}]`

--- a/polystorechain/precompiles/polystore/polystore.go
+++ b/polystorechain/precompiles/polystore/polystore.go
@@ -280,10 +280,80 @@ const polystoreABIJSON = `[
     "inputs":[{"name":"sessionIds","type":"bytes32[]"}],
     "outputs":[{"name":"ok","type":"bool"}]
   },
+  {
+    "type":"function","name":"proposeDealGenerationV3","stateMutability":"nonpayable",
+    "inputs":[
+      {"name":"dealId","type":"uint64"},{"name":"previousPolyfsRoot","type":"bytes"},
+      {"name":"polyfsRoot","type":"bytes"},{"name":"integrityRoot","type":"bytes"},
+      {"name":"size","type":"uint64"},{"name":"totalMdus","type":"uint64"},
+      {"name":"witnessMdus","type":"uint64"},{"name":"integrityLeafCount","type":"uint64"},
+      {"name":"expectedCurrentGeneration","type":"uint64"}
+    ],"outputs":[{"name":"generation","type":"uint64"}]
+  },
+  {
+    "type":"function","name":"acceptDealGenerationV3","stateMutability":"nonpayable",
+    "inputs":[{"name":"dealId","type":"uint64"},{"name":"slot","type":"uint32"},{"name":"acceptanceDigest","type":"bytes"}],
+    "outputs":[{"name":"accepted","type":"bool"}]
+  },
+  {
+    "type":"function","name":"finalizeDealGenerationV3","stateMutability":"nonpayable",
+    "inputs":[{"name":"dealId","type":"uint64"},{"name":"generation","type":"uint64"},{"name":"polyfsRoot","type":"bytes"}],
+    "outputs":[{"name":"success","type":"bool"}]
+  },
+  {
+    "type":"function","name":"openRetrievalSessionV3","stateMutability":"nonpayable",
+    "inputs":[
+      {"name":"dealId","type":"uint64"},{"name":"generation","type":"uint64"},
+      {"name":"range","type":"tuple","components":[
+        {"name":"fileRecordIndex","type":"uint32"},{"name":"fileStartOffset","type":"uint64"},
+        {"name":"fileLength","type":"uint64"},{"name":"rangeStart","type":"uint64"},{"name":"rangeLength","type":"uint64"}
+      ]},
+      {"name":"nonce","type":"uint64"},{"name":"deadlineHeight","type":"uint64"}
+    ],
+    "outputs":[{"name":"sessionId","type":"bytes32"},{"name":"logicalRequestedBytes","type":"uint64"},{"name":"billedEncodedBytes","type":"uint64"},{"name":"sampleCount","type":"uint64"}]
+  },
+  {
+    "type":"function","name":"openRetrievalSessionV3Sponsored","stateMutability":"nonpayable",
+    "inputs":[
+      {"name":"dealId","type":"uint64"},{"name":"generation","type":"uint64"},
+      {"name":"range","type":"tuple","components":[
+        {"name":"fileRecordIndex","type":"uint32"},{"name":"fileStartOffset","type":"uint64"},
+        {"name":"fileLength","type":"uint64"},{"name":"rangeStart","type":"uint64"},{"name":"rangeLength","type":"uint64"}
+      ]},
+      {"name":"nonce","type":"uint64"},{"name":"deadlineHeight","type":"uint64"},{"name":"maxTotalFee","type":"uint256"},
+      {"name":"authType","type":"uint8"},{"name":"allowlistLeafIndex","type":"uint32"},{"name":"allowlistMerklePath","type":"bytes32[]"},
+      {"name":"voucherRedeemer","type":"string"},{"name":"voucherManifestRoot","type":"bytes"},
+      {"name":"voucherProvider","type":"string"},{"name":"voucherStartMduIndex","type":"uint64"},
+      {"name":"voucherStartBlobIndex","type":"uint32"},{"name":"voucherBlobCount","type":"uint64"},
+      {"name":"voucherExpiresAt","type":"uint64"},{"name":"voucherNonce","type":"uint64"},{"name":"voucherSignature","type":"bytes"}
+    ],
+    "outputs":[{"name":"sessionId","type":"bytes32"},{"name":"logicalRequestedBytes","type":"uint64"},{"name":"billedEncodedBytes","type":"uint64"},{"name":"sampleCount","type":"uint64"}]
+  },
+  {
+    "type":"function","name":"submitRetrievalSessionProofV3","stateMutability":"nonpayable",
+    "inputs":[{"name":"sessionId","type":"bytes32"},{"name":"slot","type":"uint32"},{"name":"proofs","type":"tuple[]","components":[
+      {"name":"ordinal","type":"uint64"},{"name":"proof","type":"tuple","components":[
+        {"name":"mduIndex","type":"uint64"},{"name":"mduRootFr","type":"bytes"},{"name":"manifestOpening","type":"bytes"},
+        {"name":"rootTableDuCommitment","type":"bytes"},{"name":"rootTableDuMerklePath","type":"bytes[]"},
+        {"name":"blobCommitment","type":"bytes"},{"name":"merklePath","type":"bytes[]"},{"name":"blobIndex","type":"uint32"},
+        {"name":"zValue","type":"bytes"},{"name":"yValue","type":"bytes"},{"name":"kzgOpeningProof","type":"bytes"}
+      ]}
+    ]}],"outputs":[{"name":"newlyAccepted","type":"uint32"},{"name":"settled","type":"bool"}]
+  },
+  {
+    "type":"function","name":"acknowledgeRetrievalObligationV3","stateMutability":"nonpayable",
+    "inputs":[{"name":"sessionId","type":"bytes32"},{"name":"slot","type":"uint32"},{"name":"ackDigest","type":"bytes"}],
+    "outputs":[{"name":"settled","type":"bool"}]
+  },
+  {
+    "type":"function","name":"refundRetrievalSessionV3","stateMutability":"nonpayable",
+    "inputs":[{"name":"sessionId","type":"bytes32"}],"outputs":[{"name":"refunded","type":"bool"}]
+  },
   {"type":"event","name":"DealCreated","inputs":[{"name":"dealId","type":"uint64","indexed":true},{"name":"owner","type":"address","indexed":true}]},
   {"type":"event","name":"DealContentUpdated","inputs":[{"name":"dealId","type":"uint64","indexed":true},{"name":"manifestRoot","type":"bytes","indexed":false},{"name":"sizeBytes","type":"uint64","indexed":false}]},
   {"type":"event","name":"DealSetupSlotBumped","inputs":[{"name":"dealId","type":"uint64","indexed":true},{"name":"slot","type":"uint32","indexed":true},{"name":"oldProvider","type":"string","indexed":false},{"name":"newProvider","type":"string","indexed":false}]},
   {"type":"event","name":"RetrievalProved","inputs":[{"name":"dealId","type":"uint64","indexed":true},{"name":"owner","type":"address","indexed":true},{"name":"provider","type":"string","indexed":false},{"name":"filePath","type":"string","indexed":false},{"name":"bytesServed","type":"uint64","indexed":false},{"name":"nonce","type":"uint64","indexed":false}]},
+  {"type":"event","name":"RetrievalSessionV3Opened","inputs":[{"name":"dealId","type":"uint64","indexed":true},{"name":"requester","type":"address","indexed":true},{"name":"sessionId","type":"bytes32","indexed":false}]},
   {"type":"event","name":"RetrievalSessionOpened","inputs":[{"name":"dealId","type":"uint64","indexed":true},{"name":"owner","type":"address","indexed":true},{"name":"provider","type":"string","indexed":false},{"name":"sessionId","type":"bytes32","indexed":false}]},
   {"type":"event","name":"RetrievalSessionConfirmed","inputs":[{"name":"sessionId","type":"bytes32","indexed":true},{"name":"owner","type":"address","indexed":true}]},
 {
@@ -741,6 +811,9 @@ func (p *Precompile) runNative(ctx sdk.Context, evm *vm.EVM, contract *vm.Contra
 	if err != nil {
 		return nil, fmt.Errorf("polystore precompile: unknown selector: %w", err)
 	}
+	if method.StateMutability == "nonpayable" && contract.Value() != nil && !contract.Value().IsZero() {
+		return nil, errors.New("polystore precompile: nonpayable method")
+	}
 
 	if err := validateABIAdmission(method.Inputs, input[4:]); err != nil {
 		return nil, fmt.Errorf("polystore precompile: invalid ABI envelope: %w", err)
@@ -785,6 +858,22 @@ func (p *Precompile) runNative(ctx sdk.Context, evm *vm.EVM, contract *vm.Contra
 		return p.runCancelRetrievalSession(ctx, evm, contract, method, input[4:])
 	case "confirmRetrievalSessions":
 		return p.runConfirmRetrievalSessions(ctx, evm, contract, method, input[4:])
+	case "proposeDealGenerationV3":
+		return p.runProposeDealGenerationV3(ctx, contract, method, input[4:])
+	case "acceptDealGenerationV3":
+		return p.runAcceptDealGenerationV3(ctx, contract, method, input[4:])
+	case "finalizeDealGenerationV3":
+		return p.runFinalizeDealGenerationV3(ctx, contract, method, input[4:])
+	case "openRetrievalSessionV3":
+		return p.runOpenRetrievalSessionV3(ctx, evm, contract, method, input[4:])
+	case "openRetrievalSessionV3Sponsored":
+		return p.runOpenRetrievalSessionV3Sponsored(ctx, evm, contract, method, input[4:])
+	case "submitRetrievalSessionProofV3":
+		return p.runSubmitRetrievalSessionProofV3(ctx, contract, method, input[4:])
+	case "acknowledgeRetrievalObligationV3":
+		return p.runAcknowledgeRetrievalObligationV3(ctx, contract, method, input[4:])
+	case "refundRetrievalSessionV3":
+		return p.runRefundRetrievalSessionV3(ctx, contract, method, input[4:])
 	default:
 		return nil, fmt.Errorf("polystore precompile: unsupported method %q", method.Name)
 	}

--- a/polystorechain/precompiles/polystore/retrieval_session.go
+++ b/polystorechain/precompiles/polystore/retrieval_session.go
@@ -60,12 +60,7 @@ func (p *Precompile) runSubmitRetrievalSessionProof(ctx sdk.Context, contract *v
 	}
 	proofs := make([]types.ChainedProof, len(input.Proofs))
 	for i, wire := range input.Proofs {
-		proofs[i] = types.ChainedProof{
-			MduIndex: wire.MduIndex, MduRootFr: wire.MduRootFr, ManifestOpening: wire.ManifestOpening,
-			RootTableDuCommitment: wire.RootTableDuCommitment, RootTableDuMerklePath: wire.RootTableDuMerklePath,
-			BlobCommitment: wire.BlobCommitment, MerklePath: wire.MerklePath, BlobIndex: wire.BlobIndex,
-			ZValue: wire.ZValue, YValue: wire.YValue, KzgOpeningProof: wire.KzgOpeningProof,
-		}
+		proofs[i] = nativeProof(wire)
 	}
 	server := nilkeeper.NewMsgServerImpl(*p.keeper)
 	response, err := server.SubmitRetrievalSessionProof(ctx, &types.MsgSubmitRetrievalSessionProof{

--- a/polystorechain/precompiles/polystore/retrieval_v3.go
+++ b/polystorechain/precompiles/polystore/retrieval_v3.go
@@ -1,0 +1,314 @@
+package polystore
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+
+	"cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	nilkeeper "polystorechain/x/polystorechain/keeper"
+	"polystorechain/x/polystorechain/types"
+)
+
+type retrievalRangeV3Input struct {
+	FileRecordIndex uint32 `abi:"fileRecordIndex"`
+	FileStartOffset uint64 `abi:"fileStartOffset"`
+	FileLength      uint64 `abi:"fileLength"`
+	RangeStart      uint64 `abi:"rangeStart"`
+	RangeLength     uint64 `abi:"rangeLength"`
+}
+
+type retrievalSampleProofV3Input struct {
+	Ordinal uint64            `abi:"ordinal"`
+	Proof   sessionProofInput `abi:"proof"`
+}
+
+func nativeRangeV3(in retrievalRangeV3Input) types.RetrievalRangeV3 {
+	return types.RetrievalRangeV3{
+		FileRecordIndex: in.FileRecordIndex, FileStartOffset: in.FileStartOffset,
+		FileLength: in.FileLength, RangeStart: in.RangeStart, RangeLength: in.RangeLength,
+	}
+}
+
+func nativeProof(in sessionProofInput) types.ChainedProof {
+	return types.ChainedProof{
+		MduIndex: in.MduIndex, MduRootFr: in.MduRootFr, ManifestOpening: in.ManifestOpening,
+		RootTableDuCommitment: in.RootTableDuCommitment, RootTableDuMerklePath: in.RootTableDuMerklePath,
+		BlobCommitment: in.BlobCommitment, MerklePath: in.MerklePath, BlobIndex: in.BlobIndex,
+		ZValue: in.ZValue, YValue: in.YValue, KzgOpeningProof: in.KzgOpeningProof,
+	}
+}
+
+func evmCreator(contract *vm.Contract) string {
+	return sdk.AccAddress(contract.Caller().Bytes()).String()
+}
+
+func (p *Precompile) runProposeDealGenerationV3(ctx sdk.Context, contract *vm.Contract, method *abi.Method, data []byte) ([]byte, error) {
+	var in struct {
+		DealId                                                                      uint64
+		PreviousPolyfsRoot, PolyfsRoot, IntegrityRoot                               []byte
+		Size, TotalMdus, WitnessMdus, IntegrityLeafCount, ExpectedCurrentGeneration uint64
+	}
+	values, err := method.Inputs.Unpack(data)
+	if err != nil {
+		return nil, fmt.Errorf("proposeDealGenerationV3: %w", err)
+	}
+	if err := method.Inputs.Copy(&in, values); err != nil {
+		return nil, fmt.Errorf("proposeDealGenerationV3: %w", err)
+	}
+	res, err := nilkeeper.NewMsgServerImpl(*p.keeper).ProposeDealGenerationV3(sdk.WrapSDKContext(ctx), &types.MsgProposeDealGenerationV3{
+		Creator: evmCreator(contract), DealId: in.DealId, PreviousPolyfsRoot: in.PreviousPolyfsRoot,
+		PolyfsRoot: in.PolyfsRoot, IntegrityRoot: in.IntegrityRoot, Size_: in.Size,
+		TotalMdus: in.TotalMdus, WitnessMdus: in.WitnessMdus, IntegrityLeafCount: in.IntegrityLeafCount,
+		ExpectedCurrentGeneration: in.ExpectedCurrentGeneration,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return method.Outputs.Pack(res.Generation)
+}
+
+func (p *Precompile) runAcceptDealGenerationV3(ctx sdk.Context, contract *vm.Contract, method *abi.Method, data []byte) ([]byte, error) {
+	var in struct {
+		DealId           uint64
+		Slot             uint32
+		AcceptanceDigest []byte
+	}
+	values, err := method.Inputs.Unpack(data)
+	if err != nil {
+		return nil, fmt.Errorf("acceptDealGenerationV3: %w", err)
+	}
+	if err := method.Inputs.Copy(&in, values); err != nil {
+		return nil, fmt.Errorf("acceptDealGenerationV3: %w", err)
+	}
+	res, err := nilkeeper.NewMsgServerImpl(*p.keeper).AcceptDealGenerationV3(sdk.WrapSDKContext(ctx), &types.MsgAcceptDealGenerationV3{
+		Creator: evmCreator(contract), DealId: in.DealId, Slot: in.Slot, AcceptanceDigest: in.AcceptanceDigest,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return method.Outputs.Pack(res.Accepted)
+}
+
+func (p *Precompile) runFinalizeDealGenerationV3(ctx sdk.Context, contract *vm.Contract, method *abi.Method, data []byte) ([]byte, error) {
+	var in struct {
+		DealId, Generation uint64
+		PolyfsRoot         []byte
+	}
+	values, err := method.Inputs.Unpack(data)
+	if err != nil {
+		return nil, fmt.Errorf("finalizeDealGenerationV3: %w", err)
+	}
+	if err := method.Inputs.Copy(&in, values); err != nil {
+		return nil, fmt.Errorf("finalizeDealGenerationV3: %w", err)
+	}
+	res, err := nilkeeper.NewMsgServerImpl(*p.keeper).FinalizeDealGenerationV3(sdk.WrapSDKContext(ctx), &types.MsgFinalizeDealGenerationV3{
+		Creator: evmCreator(contract), DealId: in.DealId, Generation: in.Generation, PolyfsRoot: in.PolyfsRoot,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return method.Outputs.Pack(res.Success)
+}
+
+func packOpenRetrievalV3(method *abi.Method, response *types.MsgOpenRetrievalSessionV3Response) ([]byte, [32]byte, error) {
+	var id [32]byte
+	if len(response.SessionId) != len(id) {
+		return nil, id, errors.New("invalid native v3 session id")
+	}
+	copy(id[:], response.SessionId)
+	out, err := method.Outputs.Pack(id, response.LogicalRequestedBytes, response.BilledEncodedBytes, response.SampleCount)
+	return out, id, err
+}
+
+func (p *Precompile) runOpenRetrievalSessionV3(ctx sdk.Context, evm *vm.EVM, contract *vm.Contract, method *abi.Method, data []byte) ([]byte, error) {
+	var in struct {
+		DealId, Generation    uint64
+		Range                 retrievalRangeV3Input
+		Nonce, DeadlineHeight uint64
+	}
+	values, err := method.Inputs.Unpack(data)
+	if err != nil {
+		return nil, fmt.Errorf("openRetrievalSessionV3: %w", err)
+	}
+	if err := method.Inputs.Copy(&in, values); err != nil {
+		return nil, fmt.Errorf("openRetrievalSessionV3: %w", err)
+	}
+	res, err := nilkeeper.NewMsgServerImpl(*p.keeper).OpenRetrievalSessionV3(sdk.WrapSDKContext(ctx), &types.MsgOpenRetrievalSessionV3{
+		Creator: evmCreator(contract), DealId: in.DealId, Generation: in.Generation,
+		Range: nativeRangeV3(in.Range), Nonce: in.Nonce, DeadlineHeight: in.DeadlineHeight,
+	})
+	if err != nil {
+		return nil, err
+	}
+	out, id, err := packOpenRetrievalV3(method, res)
+	if err != nil {
+		return nil, fmt.Errorf("openRetrievalSessionV3: %w", err)
+	}
+	p.emitEventRetrievalSessionV3Opened(evm, in.DealId, contract.Caller(), id)
+	return out, nil
+}
+
+type sponsoredRetrievalV3Input struct {
+	DealId, Generation               uint64
+	Range                            retrievalRangeV3Input
+	Nonce, DeadlineHeight            uint64
+	MaxTotalFee                      *big.Int
+	AuthType                         uint8
+	AllowlistLeafIndex               uint32
+	AllowlistMerklePath              []common.Hash
+	VoucherRedeemer, VoucherProvider string
+	VoucherManifestRoot              []byte
+	VoucherStartMduIndex             uint64
+	VoucherStartBlobIndex            uint32
+	VoucherBlobCount                 uint64
+	VoucherExpiresAt, VoucherNonce   uint64
+	VoucherSignature                 []byte
+}
+
+func applySponsoredRetrievalV3Auth(msg *types.MsgOpenRetrievalSessionV3Sponsored, in sponsoredRetrievalV3Input) error {
+	switch in.AuthType {
+	case 0:
+		return nil
+	case 1:
+		path := make([][]byte, len(in.AllowlistMerklePath))
+		for i := range in.AllowlistMerklePath {
+			path[i] = in.AllowlistMerklePath[i].Bytes()
+		}
+		msg.Auth = &types.MsgOpenRetrievalSessionV3Sponsored_AllowlistProof{AllowlistProof: &types.AllowlistProof{
+			LeafIndex: in.AllowlistLeafIndex, MerklePath: path,
+		}}
+		return nil
+	case 2:
+		msg.Auth = &types.MsgOpenRetrievalSessionV3Sponsored_Voucher{Voucher: &types.VoucherAuth{
+			DealId: in.DealId, ManifestRoot: in.VoucherManifestRoot, Provider: in.VoucherProvider,
+			StartMduIndex: in.VoucherStartMduIndex, StartBlobIndex: in.VoucherStartBlobIndex,
+			BlobCount: in.VoucherBlobCount, ExpiresAt: in.VoucherExpiresAt, Nonce: in.VoucherNonce,
+			Redeemer: in.VoucherRedeemer, Signature: in.VoucherSignature,
+		}}
+		return nil
+	default:
+		return errors.New("openRetrievalSessionV3Sponsored: invalid authType")
+	}
+}
+
+func (p *Precompile) runOpenRetrievalSessionV3Sponsored(ctx sdk.Context, evm *vm.EVM, contract *vm.Contract, method *abi.Method, data []byte) ([]byte, error) {
+	var in sponsoredRetrievalV3Input
+	values, err := method.Inputs.Unpack(data)
+	if err != nil {
+		return nil, fmt.Errorf("openRetrievalSessionV3Sponsored: %w", err)
+	}
+	if err := method.Inputs.Copy(&in, values); err != nil {
+		return nil, fmt.Errorf("openRetrievalSessionV3Sponsored: %w", err)
+	}
+	maxFee := math.ZeroInt()
+	if in.MaxTotalFee != nil && in.MaxTotalFee.Sign() > 0 {
+		maxFee = math.NewIntFromBigInt(in.MaxTotalFee)
+	}
+	msg := &types.MsgOpenRetrievalSessionV3Sponsored{
+		Creator: evmCreator(contract), DealId: in.DealId, Generation: in.Generation, Range: nativeRangeV3(in.Range),
+		Nonce: in.Nonce, DeadlineHeight: in.DeadlineHeight, MaxTotalFee: maxFee,
+	}
+	if err := applySponsoredRetrievalV3Auth(msg, in); err != nil {
+		return nil, err
+	}
+	res, err := nilkeeper.NewMsgServerImpl(*p.keeper).OpenRetrievalSessionV3Sponsored(sdk.WrapSDKContext(ctx), msg)
+	if err != nil {
+		return nil, err
+	}
+	out, id, err := packOpenRetrievalV3(method, res)
+	if err != nil {
+		return nil, fmt.Errorf("openRetrievalSessionV3Sponsored: %w", err)
+	}
+	p.emitEventRetrievalSessionV3Opened(evm, in.DealId, contract.Caller(), id)
+	return out, nil
+}
+
+func (p *Precompile) runSubmitRetrievalSessionProofV3(ctx sdk.Context, contract *vm.Contract, method *abi.Method, data []byte) ([]byte, error) {
+	var in struct {
+		SessionId [32]byte
+		Slot      uint32
+		Proofs    []retrievalSampleProofV3Input
+	}
+	values, err := method.Inputs.Unpack(data)
+	if err != nil {
+		return nil, fmt.Errorf("submitRetrievalSessionProofV3: %w", err)
+	}
+	if err := method.Inputs.Copy(&in, values); err != nil {
+		return nil, fmt.Errorf("submitRetrievalSessionProofV3: %w", err)
+	}
+	if err := nilkeeper.ValidateProofCount(uint64(len(in.Proofs))); err != nil {
+		return nil, err
+	}
+	proofs := make([]types.RetrievalSampleProofV3, len(in.Proofs))
+	for i := range in.Proofs {
+		proofs[i] = types.RetrievalSampleProofV3{Ordinal: in.Proofs[i].Ordinal, Proof: nativeProof(in.Proofs[i].Proof)}
+	}
+	res, err := nilkeeper.NewMsgServerImpl(*p.keeper).SubmitRetrievalSessionProofV3(sdk.WrapSDKContext(ctx), &types.MsgSubmitRetrievalSessionProofV3{
+		Creator: evmCreator(contract), SessionId: in.SessionId[:], Slot: in.Slot, Proofs: proofs,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return method.Outputs.Pack(res.NewlyAccepted, res.Settled)
+}
+
+func (p *Precompile) runAcknowledgeRetrievalObligationV3(ctx sdk.Context, contract *vm.Contract, method *abi.Method, data []byte) ([]byte, error) {
+	var in struct {
+		SessionId [32]byte
+		Slot      uint32
+		AckDigest []byte
+	}
+	values, err := method.Inputs.Unpack(data)
+	if err != nil {
+		return nil, fmt.Errorf("acknowledgeRetrievalObligationV3: %w", err)
+	}
+	if err := method.Inputs.Copy(&in, values); err != nil {
+		return nil, fmt.Errorf("acknowledgeRetrievalObligationV3: %w", err)
+	}
+	res, err := nilkeeper.NewMsgServerImpl(*p.keeper).AcknowledgeRetrievalObligationV3(sdk.WrapSDKContext(ctx), &types.MsgAcknowledgeRetrievalObligationV3{
+		Creator: evmCreator(contract), SessionId: in.SessionId[:], Slot: in.Slot, AckDigest: in.AckDigest,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return method.Outputs.Pack(res.Settled)
+}
+
+func (p *Precompile) runRefundRetrievalSessionV3(ctx sdk.Context, contract *vm.Contract, method *abi.Method, data []byte) ([]byte, error) {
+	var in struct{ SessionId [32]byte }
+	values, err := method.Inputs.Unpack(data)
+	if err != nil {
+		return nil, fmt.Errorf("refundRetrievalSessionV3: %w", err)
+	}
+	if err := method.Inputs.Copy(&in, values); err != nil {
+		return nil, fmt.Errorf("refundRetrievalSessionV3: %w", err)
+	}
+	res, err := nilkeeper.NewMsgServerImpl(*p.keeper).RefundRetrievalSessionV3(sdk.WrapSDKContext(ctx), &types.MsgRefundRetrievalSessionV3{
+		Creator: evmCreator(contract), SessionId: in.SessionId[:],
+	})
+	if err != nil {
+		return nil, err
+	}
+	return method.Outputs.Pack(res.Refunded)
+}
+
+func (p *Precompile) emitEventRetrievalSessionV3Opened(evm *vm.EVM, dealID uint64, requester common.Address, sessionID [32]byte) {
+	if evm == nil || evm.StateDB == nil {
+		return
+	}
+	ev, ok := p.abi.Events["RetrievalSessionV3Opened"]
+	if !ok {
+		return
+	}
+	data, err := ev.Inputs.NonIndexed().Pack(sessionID)
+	if err != nil {
+		return
+	}
+	evm.StateDB.AddLog(&ethtypes.Log{Address: p.Address(), Topics: []common.Hash{ev.ID, common.BigToHash(new(big.Int).SetUint64(dealID)), common.BytesToHash(requester.Bytes())}, Data: data})
+}

--- a/polystorechain/precompiles/polystore/retrieval_v3_test.go
+++ b/polystorechain/precompiles/polystore/retrieval_v3_test.go
@@ -1,0 +1,287 @@
+package polystore
+
+import (
+	"bytes"
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"polystorechain/pkg/retrievalchallenge"
+	"polystorechain/x/polystorechain/types"
+)
+
+func setupPrecompileSessionV3(t *testing.T) (*testFixture, *Precompile, common.Address, types.Deal) {
+	t.Helper()
+	f := initFixture(t)
+	ctx := sdk.UnwrapSDKContext(f.ctx).WithBlockHeight(2)
+	f.ctx = ctx
+	owner := common.HexToAddress("0x1100000000000000000000000000000000000011")
+	ownerNative := sdk.AccAddress(owner.Bytes()).String()
+	providers := make([]string, 12)
+	slots := make([]*types.DealSlot, 12)
+	for i := range providers {
+		provider := sdk.AccAddress(bytes.Repeat([]byte{byte(0x20 + i)}, 20)).String()
+		providers[i] = provider
+		slots[i] = &types.DealSlot{Slot: uint32(i), Provider: provider, Status: types.SlotStatus_SLOT_STATUS_ACTIVE}
+		require.NoError(t, f.keeper.Providers.Set(ctx, provider, types.Provider{Address: provider, Status: "Active"}))
+	}
+	root := bytes.Repeat([]byte{0x31}, 32)
+	deal := types.Deal{
+		Id: 7, Owner: ownerNative, ManifestRoot: root, Size_: 64 * 126976,
+		EscrowBalance: math.NewInt(100), StartBlock: 1, EndBlock: 100, CurrentGen: 4,
+		TotalMdus: 3, WitnessMdus: 1, RedundancyMode: 2,
+		Mode2Profile: &types.StripeReplicaProfile{K: 8, M: 4}, Mode2Slots: slots,
+		MaxMonthlySpend: math.ZeroInt(), SpendWindowSpent: math.ZeroInt(),
+	}
+	require.NoError(t, f.keeper.Deals.Set(ctx, deal.Id, deal))
+	setup, err := hex.DecodeString(types.RetrievalSetupDigest)
+	require.NoError(t, err)
+	require.NoError(t, f.keeper.RetrievalV2ActivatedHeight.Set(ctx, 1))
+	require.NoError(t, f.keeper.RetrievalV3ActivatedHeight.Set(ctx, 1))
+	params := f.keeper.GetParams(ctx)
+	require.NoError(t, f.keeper.StorageAuditEpochLength.Set(ctx, params.EpochLenBlocks))
+	require.NoError(t, f.keeper.AdmittedDealGenerationsV3.Set(ctx, deal.Id, types.DealGenerationAdmissionV3{
+		DealId: deal.Id, Owner: deal.Owner, Generation: deal.CurrentGen,
+		PreviousPolyfsRoot: bytes.Repeat([]byte{0x30}, 32), PolyfsRoot: root,
+		IntegrityRoot: bytes.Repeat([]byte{0x32}, 32), Size_: deal.Size_, TotalMdus: deal.TotalMdus,
+		WitnessMdus: deal.WitnessMdus, MetadataMdus: 2, UserMdus: 1, IntegrityLeafCount: 96,
+		SetupDigest: setup, Providers: providers, AcceptedSlotsMask: (1 << 12) - 1, ChainId: ctx.ChainID(),
+	}))
+	p, err := New(&f.keeper)
+	require.NoError(t, err)
+	return f, p, owner, deal
+}
+
+func TestRetrievalV3ABIAndConversions(t *testing.T) {
+	f, p, _, _ := setupPrecompileSessionV3(t)
+	_ = f
+	want := map[string]int{
+		"proposeDealGenerationV3": 9, "acceptDealGenerationV3": 3, "finalizeDealGenerationV3": 3,
+		"openRetrievalSessionV3": 5, "openRetrievalSessionV3Sponsored": 18,
+		"submitRetrievalSessionProofV3": 3, "acknowledgeRetrievalObligationV3": 3, "refundRetrievalSessionV3": 1,
+	}
+	for name, inputs := range want {
+		method, ok := p.abi.Methods[name]
+		require.True(t, ok, name)
+		require.Equal(t, "nonpayable", method.StateMutability, name)
+		require.Len(t, method.Inputs, inputs, name)
+	}
+	require.Contains(t, p.abi.Events, "RetrievalSessionV3Opened")
+
+	native := nativeProof(sessionProofInput{
+		MduIndex: 3, MduRootFr: []byte{1}, ManifestOpening: []byte{2}, RootTableDuCommitment: []byte{3},
+		RootTableDuMerklePath: [][]byte{{4}}, BlobCommitment: []byte{5}, MerklePath: [][]byte{{6}},
+		BlobIndex: 7, ZValue: []byte{8}, YValue: []byte{9}, KzgOpeningProof: []byte{10},
+	})
+	require.Equal(t, uint64(3), native.MduIndex)
+	require.Equal(t, uint32(7), native.BlobIndex)
+	require.Equal(t, []byte{10}, native.KzgOpeningProof)
+
+	allowlist := &types.MsgOpenRetrievalSessionV3Sponsored{}
+	require.NoError(t, applySponsoredRetrievalV3Auth(allowlist, sponsoredRetrievalV3Input{
+		AuthType: 1, AllowlistLeafIndex: 9, AllowlistMerklePath: []common.Hash{common.HexToHash("0x12")},
+	}))
+	require.Equal(t, uint32(9), allowlist.GetAllowlistProof().LeafIndex)
+	require.Equal(t, common.HexToHash("0x12").Bytes(), allowlist.GetAllowlistProof().MerklePath[0])
+
+	voucher := &types.MsgOpenRetrievalSessionV3Sponsored{}
+	require.NoError(t, applySponsoredRetrievalV3Auth(voucher, sponsoredRetrievalV3Input{
+		DealId: 7, AuthType: 2, VoucherManifestRoot: bytes.Repeat([]byte{0x44}, 32),
+		VoucherProvider: "provider", VoucherStartMduIndex: 11, VoucherStartBlobIndex: 12,
+		VoucherBlobCount: 13, VoucherExpiresAt: 14, VoucherNonce: 15,
+		VoucherRedeemer: "redeemer", VoucherSignature: []byte{16},
+	}))
+	got := voucher.GetVoucher()
+	require.Equal(t, uint64(7), got.DealId)
+	require.Equal(t, bytes.Repeat([]byte{0x44}, 32), got.ManifestRoot)
+	require.Equal(t, uint64(11), got.StartMduIndex)
+	require.Equal(t, uint32(12), got.StartBlobIndex)
+	require.Equal(t, uint64(13), got.BlobCount)
+	require.Equal(t, []byte{16}, got.Signature)
+	require.Error(t, applySponsoredRetrievalV3Auth(&types.MsgOpenRetrievalSessionV3Sponsored{}, sponsoredRetrievalV3Input{AuthType: 3}))
+}
+
+func TestOpenRetrievalSessionV3DispatchReplayAndCallerAuthority(t *testing.T) {
+	f, p, owner, deal := setupPrecompileSessionV3(t)
+	method := p.abi.Methods["openRetrievalSessionV3"]
+	rangeArg := retrievalRangeV3Input{FileRecordIndex: 1, FileLength: 1024, RangeLength: 1024}
+	args, err := method.Inputs.Pack(deal.Id, deal.CurrentGen, rangeArg, uint64(1), uint64(20))
+	require.NoError(t, err)
+	call := func(caller common.Address, value uint64, packed []byte) ([]byte, error) {
+		contract := vm.NewPrecompile(caller, Address, uint256.NewInt(value), 8_000_000)
+		contract.Input = append(append([]byte(nil), method.ID...), packed...)
+		return p.runNative(sdk.UnwrapSDKContext(f.ctx), nil, contract)
+	}
+
+	out, err := call(owner, 0, args)
+	require.NoError(t, err)
+	decoded, err := method.Outputs.Unpack(out)
+	require.NoError(t, err)
+	require.Len(t, decoded, 4)
+	sid := decoded[0].([32]byte)
+	require.NotEqual(t, [32]byte{}, sid)
+	require.Equal(t, uint64(1024), decoded[1])
+	stored, err := f.keeper.RetrievalSessionsV3.Get(sdk.UnwrapSDKContext(f.ctx), sid[:])
+	require.NoError(t, err)
+	require.Equal(t, deal.Owner, stored.Owner)
+	charged, err := f.keeper.Deals.Get(sdk.UnwrapSDKContext(f.ctx), deal.Id)
+	require.NoError(t, err)
+
+	replayed, err := call(owner, 0, args)
+	require.NoError(t, err)
+	require.Equal(t, out, replayed)
+	afterReplay, err := f.keeper.Deals.Get(sdk.UnwrapSDKContext(f.ctx), deal.Id)
+	require.NoError(t, err)
+	require.Equal(t, charged.EscrowBalance, afterReplay.EscrowBalance)
+
+	changed, err := method.Inputs.Pack(deal.Id, deal.CurrentGen,
+		retrievalRangeV3Input{FileRecordIndex: 1, FileLength: 2048, RangeLength: 2048}, uint64(1), uint64(20))
+	require.NoError(t, err)
+	_, err = call(owner, 0, changed)
+	require.ErrorContains(t, err, "nonce")
+	_, err = call(common.HexToAddress("0x2200000000000000000000000000000000000022"), 0, args)
+	require.Error(t, err)
+	_, err = call(owner, 1, args)
+	require.ErrorContains(t, err, "nonpayable")
+}
+
+func runV3Method(t *testing.T, p *Precompile, ctx sdk.Context, caller common.Address, name string, args ...interface{}) []byte {
+	t.Helper()
+	method := p.abi.Methods[name]
+	packed, err := method.Inputs.Pack(args...)
+	require.NoError(t, err)
+	contract := vm.NewPrecompile(caller, Address, uint256.NewInt(0), 20_000_000)
+	contract.Input = append(append([]byte(nil), method.ID...), packed...)
+	out, err := p.runNative(ctx, nil, contract)
+	require.NoError(t, err)
+	return out
+}
+
+func generationAcceptanceDigestV3(t *testing.T, candidate types.DealGenerationAdmissionV3, slot uint32) []byte {
+	t.Helper()
+	provider, err := sdk.AccAddressFromBech32(candidate.Providers[slot])
+	require.NoError(t, err)
+	var setup, root, integrity [32]byte
+	var provider20 [20]byte
+	copy(setup[:], candidate.SetupDigest)
+	copy(root[:], candidate.PolyfsRoot)
+	copy(integrity[:], candidate.IntegrityRoot)
+	copy(provider20[:], provider)
+	digest, err := (retrievalchallenge.GenerationAcceptanceV3{
+		ChainID: candidate.ChainId, SetupDigest: setup, DealID: candidate.DealId,
+		Generation: candidate.Generation, PolyFSRoot: root, IntegrityRoot: integrity,
+		MetadataMDUs: candidate.MetadataMdus, UserMDUs: candidate.UserMdus,
+		Slot: slot, Provider: provider20,
+	}).Hash()
+	require.NoError(t, err)
+	return digest[:]
+}
+
+func obligationAckDigestV3(t *testing.T, session types.RetrievalSessionV3, slot uint32) []byte {
+	t.Helper()
+	var obligation *types.RetrievalObligationV3
+	for i := range session.Obligations {
+		if session.Obligations[i].Slot == slot {
+			obligation = &session.Obligations[i]
+			break
+		}
+	}
+	require.NotNil(t, obligation)
+	assigned, err := sdk.AccAddressFromBech32(obligation.AssignedProvider)
+	require.NoError(t, err)
+	payee, err := sdk.AccAddressFromBech32(obligation.Payee)
+	require.NoError(t, err)
+	var sid, contextHash, planHash, integrity [32]byte
+	var assigned20, payee20 [20]byte
+	copy(sid[:], session.SessionId)
+	copy(contextHash[:], session.ContextHash)
+	copy(planHash[:], session.PlanHash)
+	copy(integrity[:], session.IntegrityRoot)
+	copy(assigned20[:], assigned)
+	copy(payee20[:], payee)
+	digest, err := (retrievalchallenge.ObligationAckV3{
+		ChainID: session.ChainId, SessionID: sid, ContextHash: contextHash, PlanHash: planHash,
+		Slot: slot, Assigned: assigned20, Payee: payee20, BlobCount: obligation.BlobCount,
+		BilledEncodedBytes: obligation.BlobCount * retrievalchallenge.EncodedBlobBytes, IntegrityRoot: integrity,
+	}).Hash()
+	require.NoError(t, err)
+	return digest[:]
+}
+
+func TestRetrievalV3GenerationAdapterLifecycle(t *testing.T) {
+	f, p, owner, deal := setupPrecompileSessionV3(t)
+	ctx := sdk.UnwrapSDKContext(f.ctx)
+	newRoot := bytes.Repeat([]byte{0x41}, 32)
+	proposed := runV3Method(t, p, ctx, owner, "proposeDealGenerationV3",
+		deal.Id, deal.ManifestRoot, newRoot, bytes.Repeat([]byte{0x42}, 32),
+		deal.Size_+1, uint64(4), uint64(1), uint64(192), deal.CurrentGen)
+	decoded, err := p.abi.Methods["proposeDealGenerationV3"].Outputs.Unpack(proposed)
+	require.NoError(t, err)
+	require.Equal(t, deal.CurrentGen+1, decoded[0])
+
+	for slot := uint32(0); slot < 12; slot++ {
+		candidate, err := f.keeper.PendingDealGenerationsV3.Get(ctx, deal.Id)
+		require.NoError(t, err)
+		provider, err := sdk.AccAddressFromBech32(candidate.Providers[slot])
+		require.NoError(t, err)
+		out := runV3Method(t, p, ctx, common.BytesToAddress(provider), "acceptDealGenerationV3",
+			deal.Id, slot, generationAcceptanceDigestV3(t, candidate, slot))
+		accepted, err := p.abi.Methods["acceptDealGenerationV3"].Outputs.Unpack(out)
+		require.NoError(t, err)
+		require.Equal(t, true, accepted[0])
+	}
+	finalized := runV3Method(t, p, ctx, owner, "finalizeDealGenerationV3", deal.Id, deal.CurrentGen+1, newRoot)
+	decoded, err = p.abi.Methods["finalizeDealGenerationV3"].Outputs.Unpack(finalized)
+	require.NoError(t, err)
+	require.Equal(t, true, decoded[0])
+	stored, err := f.keeper.Deals.Get(ctx, deal.Id)
+	require.NoError(t, err)
+	require.Equal(t, deal.CurrentGen+1, stored.CurrentGen)
+	require.Equal(t, newRoot, stored.ManifestRoot)
+}
+
+func TestRetrievalV3SponsoredOpenAckAndRefundAdapters(t *testing.T) {
+	f, p, _, deal := setupPrecompileSessionV3(t)
+	ctx := sdk.UnwrapSDKContext(f.ctx)
+	params := f.keeper.GetParams(ctx)
+	params.BaseRetrievalFee = sdk.NewInt64Coin(sdk.DefaultBondDenom, 0)
+	params.RetrievalPricePerBlob = sdk.NewInt64Coin(sdk.DefaultBondDenom, 0)
+	require.NoError(t, f.keeper.Params.Set(ctx, params))
+	deal.RetrievalPolicy.Mode = types.RetrievalPolicyMode_RETRIEVAL_POLICY_MODE_PUBLIC
+	require.NoError(t, f.keeper.Deals.Set(ctx, deal.Id, deal))
+	requester := common.HexToAddress("0x3300000000000000000000000000000000000033")
+	rangeArg := retrievalRangeV3Input{FileRecordIndex: 1, FileLength: 1024, RangeLength: 1024}
+	opened := runV3Method(t, p, ctx, requester, "openRetrievalSessionV3Sponsored",
+		deal.Id, deal.CurrentGen, rangeArg, uint64(2), uint64(20), big.NewInt(0), uint8(0), uint32(0), []common.Hash{}, "", []byte{}, "", uint64(0), uint32(0), uint64(0), uint64(0), uint64(0), []byte{})
+	decoded, err := p.abi.Methods["openRetrievalSessionV3Sponsored"].Outputs.Unpack(opened)
+	require.NoError(t, err)
+	id := decoded[0].([32]byte)
+	session, err := f.keeper.RetrievalSessionsV3.Get(ctx, id[:])
+	require.NoError(t, err)
+	require.Equal(t, sdk.AccAddress(requester.Bytes()).String(), session.Owner)
+	require.Equal(t, types.RetrievalSessionFunding_RETRIEVAL_SESSION_FUNDING_REQUESTER, session.Funding)
+
+	anchorCtx := ctx.WithBlockHeight(3).WithHeaderHash(bytes.Repeat([]byte{0x71}, 32))
+	require.NoError(t, f.keeper.BeginBlock(anchorCtx))
+	ack := runV3Method(t, p, anchorCtx.WithBlockHeight(4), requester, "acknowledgeRetrievalObligationV3",
+		id, uint32(0), obligationAckDigestV3(t, session, 0))
+	decoded, err = p.abi.Methods["acknowledgeRetrievalObligationV3"].Outputs.Unpack(ack)
+	require.NoError(t, err)
+	require.Equal(t, false, decoded[0], "ACK without the selected proof must not settle")
+
+	refunded := runV3Method(t, p, ctx.WithBlockHeight(21), requester, "refundRetrievalSessionV3", id)
+	decoded, err = p.abi.Methods["refundRetrievalSessionV3"].Outputs.Unpack(refunded)
+	require.NoError(t, err)
+	require.Equal(t, true, decoded[0])
+	stored, err := f.keeper.RetrievalSessionsV3.Get(ctx.WithBlockHeight(21), id[:])
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), stored.AckedSlotsMask)
+	require.Equal(t, uint32(1), stored.RefundedSlotsMask)
+}


### PR DESCRIPTION
## Summary

Expose all eight existing native retrieval-v3 generation and session actions through the PolyStore EVM precompile. The adapter preserves native caller and provider authority, rejects attached EVM value, returns canonical native results, and emits a minimal session-opening receipt event. The website ABI mirror and owning retrieval-v3 profile now describe the same contract.

This remains disabled by the existing retrieval-v3 activation gate, and browser orchestration is still incomplete. This PR should not merge ahead of #313's retained harness head.

## Validation

- `go test ./precompiles/polystore ./x/polystorechain/keeper ./app -count=1`
- focused generation propose/12-provider accept/finalize and sponsored open/ACK/refund adapter tests
- focused signed EVM v3 proof execution at production block limits, replay, nonpayable value rejection, revert, and calibrated late out-of-gas rollback
- `npm run test:unit` (406 tests)
- `npx tsx --test src/lib/retrievalAbi.test.ts` (2 tests)
- `npm run build`

Refs #291.
