### PR TITLE
bench: retain native v3 cross-audit diagnostic

### DIFF
--- a/bench/retrieval_session_capacity/native-k8-290/README.md
+++ b/bench/retrieval_session_capacity/native-k8-290/README.md
@@ -217,6 +217,13 @@ maximum capacity, WAN behavior, phase RSS peak, pure proof-generation latency,
 or delivered-byte capacity. A retained performance result requires this harness
 to land before collection.
 
+The [retained cross-audit diagnostic](native-v3-cross-audit-001/README.md) ran
+the landed profile for 180 seconds at 2 transactions/s. All 360 measured native
+v3 proof transactions and 5,940 authenticated openings committed, while 24
+normal audit transactions covered two anchors. This accepts that single-host
+local operating point only; the result remains `qualification=false` and makes
+no maximum-capacity, realistic-deployment, WAN, or delivery claim.
+
 ## Native v3 chain-only diagnostic
 
 `native-v3-chain` keeps the same 16 MiB FAT v3 generation and normal audits,

--- a/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/README.md
+++ b/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/README.md
@@ -104,9 +104,13 @@ unmeasured.
 and their three sibling modules. It reuses the owning validators for native v3
 session authority, provider responses, two-anchor span, HTTP receipt fences,
 provider sequences, schedule bins, CPU deltas, and Commit streams. It then joins
-all 440 successful transaction receipts to raw stopped-blockstore bytes from all
-four validators: two batched opens, eight warmups, 360 measured proofs, 24
-system audits, and 46 refunds. The public [`summary.json`](summary.json) contains
+every successful HTTP request ID, transaction hash, provider, and session to its
+exact measured receipt. It then joins all 440 successful transaction receipts to
+raw stopped-blockstore bytes from all four validators. Before inspecting
+messages, it decodes every raw
+transaction with the pinned production chain binary and native library: two
+batched opens, eight warmups, 360 measured proofs, 24 system audits, and 46
+refunds. The public [`summary.json`](summary.json) contains
 no raw transactions, proofs, signatures, keyrings, paths, host identity, or logs.
 
 The private source hashes, sanitized [`plan.json`](plan.json), and sanitized
@@ -115,6 +119,8 @@ The private source hashes, sanitized [`plan.json`](plan.json), and sanitized
 
 ```sh
 python3 bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/check.py \
+  --decoder "$BENCH_ROOT/native-build-5cc77e1a-002/bin/polystorechaind" \
+  --decoder-library "$BENCH_ROOT/worktrees/native-runtime-5cc77e1a-002/polystore_core/target/release/libpolystore_core.so" \
   scripts/retrieval_four_validator_workload.py \
   "$PRIVATE/evidence.json" \
   "$PRIVATE/native-v3-cross-audit-blocks.jsonl" \
@@ -122,6 +128,7 @@ python3 bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001
   "$PRIVATE"/native-v3-cross-audit-commit-*.jsonl
 ```
 
-The checker requires exact reconstruction of the checked-in summary, exercises
-a small semantic failure set before the final literal evidence pins, and checks
-every published payload hash.
+The checker verifies the decoder and native-library hashes against the frozen
+runtime provenance, requires exact reconstruction of the checked-in summary,
+exercises a small semantic failure set before the final literal evidence pins,
+and checks every published payload hash.

--- a/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/README.md
+++ b/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/README.md
@@ -34,8 +34,9 @@ per provider. Each transaction carried the provider's full assigned set of 15,
 
 The two derived scheduler rates divide the 360 client-observed committed
 successes and 5,940 authoritative openings by the complete 182.066769129-second
-scheduler interval, including 2.066769129 seconds of drain. They are measurements
-of this fixed offered workload. They are not a chain maximum. CometBFT header
+scheduler interval, including 2.066769129 seconds of drain and the final 4.604 ms
+orchestration tail after the last terminal observation. They are measurements of
+this fixed offered workload. They are not a chain maximum. CometBFT header
 time is a consensus timestamp rather than a wall-clock Commit completion time,
 so this artifact does not derive a separate per-window commit rate from headers.
 
@@ -70,7 +71,9 @@ Per transaction, used gas ranged from 7,710,824 to 8,725,999 with median
 8,725,836. The proof-count distribution was 18 transactions with 15 openings,
 144 with 16, and 198 with 17. The aggregate used-gas ratio was approximately
 513,464.86 per accepted opening. These are native-v3 message costs from this
-profile, not a claim that openings execute independently.
+profile, not a claim that openings execute independently. Across the reconciled
+block range, the largest transaction-payload total was 53,717 bytes at height
+408; the separate peak-used-gas block is recorded in [`summary.json`](summary.json).
 
 All four exact raw Commit streams recompute to 215 fenced block observations.
 Their Commit-step p95 execution upper bounds were 360.593–395.595 ms, below the

--- a/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/README.md
+++ b/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/README.md
@@ -1,0 +1,121 @@
+# Retained native-v3 provider cross-audit diagnostic (#290)
+
+This artifact records one retained run of the production `provider-daemon` HTTP
+route on the reviewed landed harness. It is a **single-host operating-point
+diagnostic**, with `qualification=false`: it establishes that 360 measured proof
+transactions were offered at 2 transactions/s, all eventually committed, and
+normal audits completed across two anchors. It does not establish maximum chain
+capacity, a realistic deployment rate, WAN behavior, or delivered-byte capacity.
+
+The run used four validators and twelve provider-daemons on one Linux host. It
+opened 46 native v3 16 MiB logical sessions in two append-signed transactions of
+31 and 15 messages. Eight provider transactions warmed the route outside the
+clock. The measured scheduler then offered 360 transactions round-robin across
+the eight systematic providers for 180 seconds, with at most one active request
+per provider. Each transaction carried the provider's full assigned set of 15,
+16, or 17 authenticated sample openings.
+
+## Result
+
+| Quantity | Retained result |
+| --- | ---: |
+| Offered / eventually committed-valid measured transactions | 360 / 360 |
+| Authoritatively accepted measured openings | 5,940 |
+| Fixed offered rate | 2 transactions/s; 33 openings/s |
+| Scheduler duration, including drain | 182.066769129 s |
+| Committed-valid transactions / scheduler second | 1.9772965804 |
+| Accepted openings / scheduler second | 32.6253935763 |
+| Maximum queued / in flight | 2 / 8 |
+| HTTP attempts / 429 backpressure retries | 373 / 13 |
+| Proof commit height span | 293..425 |
+| Audit anchors / successful audit transactions | 301 and 401 / 24 |
+| Reconciled block range | 217..434; all four validators agree |
+| Refunds after expiry | 46 / 46 verified |
+
+The two derived scheduler rates divide the 360 client-observed committed
+successes and 5,940 authoritative openings by the complete 182.066769129-second
+scheduler interval, including 2.066769129 seconds of drain. They are measurements
+of this fixed offered workload. They are not a chain maximum. CometBFT header
+time is a consensus timestamp rather than a wall-clock Commit completion time,
+so this artifact does not derive a separate per-window commit rate from headers.
+
+The provider HTTP result is also not a pure proof-generation timer. Its terminal
+observation includes queueing, proof generation, native verification, gas
+simulation, signing, broadcast, and client observation of commit. The retained
+provider receipts do not separate CheckTx latency from inclusion latency.
+
+| HTTP observation | p50 | p95 | p99 | Maximum |
+| --- | ---: | ---: | ---: | ---: |
+| Terminal from scheduled offer | 2,928.886 ms | 4,277.033 ms | 5,794.835 ms | 6,030.771 ms |
+| Pre-success-start delay | 49.514 ms | 1,303.981 ms | 2,137.684 ms | 2,157.522 ms |
+| Initial dispatch lag | 48.220 ms | 280.757 ms | 1,797.526 ms | 2,034.034 ms |
+| Request after start | 2,826.686 ms | 3,730.674 ms | 3,867.149 ms | 4,097.038 ms |
+
+The 373 HTTP attempts comprise 360 successful `200` responses and 13 initial
+`429 retrieval submission busy` responses. Those 13 requests retried once with
+the same request, provider, session, and initial-dispatch identity; all then
+returned `200` and committed. There were no terminal failures or unclassified
+attempts. The pre-success-start delay includes scheduler delay and the retry
+backoff for those requests, so it is not a pure signer-queue measurement.
+
+The six 30-second client-observation bins are retained in
+[`summary.json`](summary.json). Each bin offered 60 transactions. Terminal
+observations were 53, 59, 61, 61, 61, and 60, with 7, 8, 7, 6, 5, and 5
+requests outstanding at the corresponding bin boundaries. The final five
+requests completed during the bounded drain; no queue or request remained at
+scheduler completion.
+
+Measured proof gas used was 3,049,981,281 against 4,870,622,929 declared gas.
+Per transaction, used gas ranged from 7,710,824 to 8,725,999 with median
+8,725,836. The proof-count distribution was 18 transactions with 15 openings,
+144 with 16, and 198 with 17. The aggregate used-gas ratio was approximately
+513,464.86 per accepted opening. These are native-v3 message costs from this
+profile, not a claim that openings execute independently.
+
+All four exact raw Commit streams recompute to 215 fenced block observations.
+Their Commit-step p95 execution upper bounds were 360.593–395.595 ms, below the
+diagnostic's 700 ms bound. This timer covers the documented Commit step and may
+include waiting for a committed block; it excludes the post-persistence state
+transition tail, validator-key refresh, and next-round scheduling.
+
+Validator CPU is a `/proc` process-tick delta over the 189.759685646-second
+window that includes the fixed HTTP workload, drain, audit transactions, bounded
+node-zero event observation, and all-validator height fence. Node zero averaged
+0.364 cores and the other validators 0.191 cores each during that window. The
+evidence does not attribute the difference; node zero also served provider and
+observer RPC. Peak RSS values of 329,969,664–356,466,688 bytes are `wait4`
+whole-process-lifetime peaks. They are not phase peaks. All stayed below the
+configured 2 GiB per-validator diagnostic ceiling, which was not a production
+qualification budget.
+
+No owner ACK was sent and no file bytes were downloaded. Delivery, byte
+integrity at the client, cache/resume behavior, and WAN performance remain
+unmeasured.
+
+## Reproduction and private evidence
+
+[`summarize.py`](summarize.py) imports only the exact pinned landed harness bytes
+and their three sibling modules. It reuses the owning validators for native v3
+session authority, provider responses, two-anchor span, HTTP receipt fences,
+provider sequences, schedule bins, CPU deltas, and Commit streams. It then joins
+all 440 successful transaction receipts to raw stopped-blockstore bytes from all
+four validators: two batched opens, eight warmups, 360 measured proofs, 24
+system audits, and 46 refunds. The public [`summary.json`](summary.json) contains
+no raw transactions, proofs, signatures, keyrings, paths, host identity, or logs.
+
+The private source hashes, sanitized [`plan.json`](plan.json), and sanitized
+[`runtime-provenance.json`](runtime-provenance.json) are pinned in
+[`manifest.json`](manifest.json). With the retained inputs available locally:
+
+```sh
+python3 bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/check.py \
+  scripts/retrieval_four_validator_workload.py \
+  "$PRIVATE/evidence.json" \
+  "$PRIVATE/native-v3-cross-audit-blocks.jsonl" \
+  "$PRIVATE/transaction-recovery-private/transactions.json" \
+  "$PRIVATE"/native-v3-cross-audit-commit-*.jsonl
+```
+
+The checker requires exact reconstruction of the checked-in summary, exercises
+a small semantic failure set before the final literal evidence pins, and checks
+every published payload hash.

--- a/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/README.md
+++ b/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/README.md
@@ -76,7 +76,10 @@ All four exact raw Commit streams recompute to 215 fenced block observations.
 Their Commit-step p95 execution upper bounds were 360.593–395.595 ms, below the
 diagnostic's 700 ms bound. This timer covers the documented Commit step and may
 include waiting for a committed block; it excludes the post-persistence state
-transition tail, validator-key refresh, and next-round scheduling.
+transition tail, validator-key refresh, and next-round scheduling. The Commit
+streams use a wider observation window that starts before workload alignment and
+ends after the heavy all-validator LCD queries. It is separate from the narrower
+CPU and provider HTTP measurement window.
 
 Validator CPU is a `/proc` process-tick delta over the 189.759685646-second
 window that includes the fixed HTTP workload, drain, audit transactions, bounded

--- a/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/check.py
+++ b/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/check.py
@@ -52,6 +52,12 @@ def main():
             path.write_text(json.dumps(doc))
             command = base.copy(); command[3] = str(path)
             run(command, expected)
+        transactions = json.loads(args.transactions.read_text())
+        transactions["transactions"][0]["raw_tx_base64"] = "d3Jvbmc="
+        path = Path(directory) / "transactions-corrupt.json"
+        path.write_text(json.dumps(transactions))
+        command = base.copy(); command[5] = str(path)
+        run(command, "recovered raw transaction hash/size differs")
 
     manifest = json.loads((here / "manifest.json").read_text())
     require(manifest["qualification"] is False, "manifest changed qualification")
@@ -60,7 +66,7 @@ def main():
         require(len(data) == expected["bytes"] and hashlib.sha256(data).hexdigest() == expected["sha256"],
                 f"published file hash differs: {name}")
     print(json.dumps({"status": "passed", "summary_equal": True,
-                      "semantic_negative_checks": len(mutations),
+                      "semantic_negative_checks": len(mutations) + 1,
                       "published_hashes": len(manifest["published_files"])}, sort_keys=True))
 
 if __name__ == "__main__": main()

--- a/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/check.py
+++ b/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/check.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Reproduce the retained summary and exercise a small semantic failure set."""
+import argparse, hashlib, json, subprocess, sys, tempfile
+from pathlib import Path
+
+def require(value, message):
+    if not value: raise ValueError(message)
+
+def run(command, expected=None):
+    result = subprocess.run(command, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if expected is None:
+        require(result.returncode == 0, result.stderr[-4000:])
+        return json.loads(result.stdout)
+    require(result.returncode != 0 and expected in result.stderr,
+            f"mutation did not fail at {expected!r}: {result.stderr[-2000:]}")
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("harness", type=Path)
+    parser.add_argument("evidence", type=Path)
+    parser.add_argument("blocks", type=Path)
+    parser.add_argument("transactions", type=Path)
+    parser.add_argument("commit_streams", nargs=4, type=Path)
+    args = parser.parse_args()
+    here = Path(__file__).resolve().parent
+    base = [sys.executable, str(here / "summarize.py"), str(args.harness), str(args.evidence),
+            str(args.blocks), str(args.transactions), *(str(path) for path in args.commit_streams)]
+    require(run(base) == json.loads((here / "summary.json").read_text()),
+            "checked-in summary differs from reconstruction")
+
+    original = json.loads(args.evidence.read_text())
+    mutations = []
+    changed = json.loads(json.dumps(original)); changed["qualification"] = True
+    mutations.append((changed, "top-level diagnostic status/scope differs"))
+    changed = json.loads(json.dumps(original)); changed["native_v3_cross_audit"]["measured_proof_transactions"].pop()
+    mutations.append((changed, "retained transaction counts differ"))
+    changed = json.loads(json.dumps(original)); changed["native_v3_cross_audit"]["schedule_bins"][0]["terminal"] -= 1
+    mutations.append((changed, "30-second schedule bins differ"))
+    changed = json.loads(json.dumps(original)); changed["native_v3_cross_audit"]["crossed_audits"]["4"]["0"]["audit"]["accepted_count"] = "0"
+    mutations.append((changed, "two normal audit epochs did not cover"))
+    changed = json.loads(json.dumps(original)); changed["native_v3_cross_audit"]["measured_proof_transactions"][0]["txhash"] = "A" * 64
+    mutations.append((changed, "validator receipt differs"))
+    changed = json.loads(json.dumps(original)); changed["native_v3_cross_audit"]["sessions"][0]["after_proofs"]["session"]["context_hash"] = "A" * 44
+    mutations.append((changed, "session immutable authority/economic/height fields changed"))
+    changed = json.loads(json.dumps(original))
+    retry = next(row for row in changed["v3_http_phases"]["cross-audit-measured"] if row.get("http_status") == 429)
+    retry["provider"] = "invalid-provider"
+    mutations.append((changed, "provider HTTP terminal success inventory differs"))
+    with tempfile.TemporaryDirectory() as directory:
+        for index, (doc, expected) in enumerate(mutations):
+            path = Path(directory) / f"evidence-{index}.json"
+            path.write_text(json.dumps(doc))
+            command = base.copy(); command[3] = str(path)
+            run(command, expected)
+
+    manifest = json.loads((here / "manifest.json").read_text())
+    require(manifest["qualification"] is False, "manifest changed qualification")
+    for name, expected in manifest["published_files"].items():
+        data = (here / name).read_bytes()
+        require(len(data) == expected["bytes"] and hashlib.sha256(data).hexdigest() == expected["sha256"],
+                f"published file hash differs: {name}")
+    print(json.dumps({"status": "passed", "summary_equal": True,
+                      "semantic_negative_checks": len(mutations),
+                      "published_hashes": len(manifest["published_files"])}, sort_keys=True))
+
+if __name__ == "__main__": main()

--- a/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/check.py
+++ b/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/check.py
@@ -21,10 +21,13 @@ def main():
     parser.add_argument("blocks", type=Path)
     parser.add_argument("transactions", type=Path)
     parser.add_argument("commit_streams", nargs=4, type=Path)
+    parser.add_argument("--decoder", required=True, type=Path)
+    parser.add_argument("--decoder-library", required=True, type=Path)
     args = parser.parse_args()
     here = Path(__file__).resolve().parent
     base = [sys.executable, str(here / "summarize.py"), str(args.harness), str(args.evidence),
-            str(args.blocks), str(args.transactions), *(str(path) for path in args.commit_streams)]
+            str(args.blocks), str(args.transactions), *(str(path) for path in args.commit_streams),
+            "--decoder", str(args.decoder), "--decoder-library", str(args.decoder_library)]
     require(run(base) == json.loads((here / "summary.json").read_text()),
             "checked-in summary differs from reconstruction")
 
@@ -38,7 +41,7 @@ def main():
     mutations.append((changed, "30-second schedule bins differ"))
     changed = json.loads(json.dumps(original)); changed["native_v3_cross_audit"]["crossed_audits"]["4"]["0"]["audit"]["accepted_count"] = "0"
     mutations.append((changed, "two normal audit epochs did not cover"))
-    changed = json.loads(json.dumps(original)); changed["native_v3_cross_audit"]["measured_proof_transactions"][0]["txhash"] = "A" * 64
+    changed = json.loads(json.dumps(original)); changed["native_v3_cross_audit"]["measured_proof_transactions"][0]["validators"][0]["txhash"] = "A" * 64
     mutations.append((changed, "validator receipt differs"))
     changed = json.loads(json.dumps(original)); changed["native_v3_cross_audit"]["sessions"][0]["after_proofs"]["session"]["context_hash"] = "A" * 44
     mutations.append((changed, "session immutable authority/economic/height fields changed"))
@@ -46,6 +49,14 @@ def main():
     retry = next(row for row in changed["v3_http_phases"]["cross-audit-measured"] if row.get("http_status") == 429)
     retry["provider"] = "invalid-provider"
     mutations.append((changed, "provider HTTP terminal success inventory differs"))
+    changed = json.loads(json.dumps(original))
+    success = next(row for row in changed["v3_http_phases"]["cross-audit-measured"] if row.get("status") == "success")
+    success["tx_hash"] = "A" * 64
+    mutations.append((changed, "HTTP success identity differs from measured proof receipt"))
+    changed = json.loads(json.dumps(original))
+    success = next(row for row in changed["v3_http_phases"]["cross-audit-measured"] if row.get("status") == "success")
+    success["session_id"] = "0x" + "00" * 32
+    mutations.append((changed, "HTTP success identity differs from measured proof receipt"))
     with tempfile.TemporaryDirectory() as directory:
         for index, (doc, expected) in enumerate(mutations):
             path = Path(directory) / f"evidence-{index}.json"
@@ -58,6 +69,12 @@ def main():
         path.write_text(json.dumps(transactions))
         command = base.copy(); command[5] = str(path)
         run(command, "recovered raw transaction hash/size differs")
+        transactions = json.loads(args.transactions.read_text())
+        transactions["transactions"][0]["decoded"]["body"]["messages"][0]["creator"] = "invalid-creator"
+        path = Path(directory) / "transactions-decoded-stale.json"
+        path.write_text(json.dumps(transactions))
+        command = base.copy(); command[5] = str(path)
+        run(command, "native transaction decode differs from recovered representation")
 
     manifest = json.loads((here / "manifest.json").read_text())
     require(manifest["qualification"] is False, "manifest changed qualification")
@@ -66,7 +83,7 @@ def main():
         require(len(data) == expected["bytes"] and hashlib.sha256(data).hexdigest() == expected["sha256"],
                 f"published file hash differs: {name}")
     print(json.dumps({"status": "passed", "summary_equal": True,
-                      "semantic_negative_checks": len(mutations) + 1,
+                      "semantic_negative_checks": len(mutations) + 2,
                       "published_hashes": len(manifest["published_files"])}, sort_keys=True))
 
 if __name__ == "__main__": main()

--- a/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/manifest.json
+++ b/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/manifest.json
@@ -67,12 +67,12 @@
   },
   "published_files": {
     "README.md": {
-      "bytes": 7395,
-      "sha256": "81611829a5f31524c8ff5bac8c4175f28ff7264c28b3e1df7a4713ecb607ac38"
+      "bytes": 7920,
+      "sha256": "71fc49621ac8509e192a08b9a7b1038d40a0788cc6f07bfa7aa51aec35358fae"
     },
     "check.py": {
-      "bytes": 4280,
-      "sha256": "827fce659df827a6c50e1a57bbe84489925d7ed9112ed47c36f5511a91fd789e"
+      "bytes": 5549,
+      "sha256": "6d9b002cfd41ad75805921819e61fee0ed0ff0d93ddc6eb9086c2e34e1dc991c"
     },
     "plan.json": {
       "bytes": 1525,
@@ -83,8 +83,8 @@
       "sha256": "1c2d298f66d51cf3264b62495098dc20d92efcde0be723613410dd3b991e1fe5"
     },
     "summarize.py": {
-      "bytes": 33318,
-      "sha256": "37eb0ce0832ae98158870259527440191d1a37461353ae04ed1a899a60d94543"
+      "bytes": 36581,
+      "sha256": "eecb2049cb0ded7964787d4d39f585502c0dc551cdff34408a899268588af9fc"
     },
     "summary.json": {
       "bytes": 12116,

--- a/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/manifest.json
+++ b/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/manifest.json
@@ -67,12 +67,12 @@
   },
   "published_files": {
     "README.md": {
-      "bytes": 6917,
-      "sha256": "ce56e8878714b5d643d45861cbf0652a570305be89b0c0c6fc2fa93a667a06c4"
+      "bytes": 7132,
+      "sha256": "7aa380ab839bd5e4183ea91c5fc37caa4b948cbcdfa583498e97f2f255487e18"
     },
     "check.py": {
-      "bytes": 3908,
-      "sha256": "11945643c3eff1ca37e7a5a3b50a1a61a3f9bc2803129ec5f99d2a283a2be7ee"
+      "bytes": 4280,
+      "sha256": "827fce659df827a6c50e1a57bbe84489925d7ed9112ed47c36f5511a91fd789e"
     },
     "plan.json": {
       "bytes": 1525,
@@ -83,12 +83,12 @@
       "sha256": "1c2d298f66d51cf3264b62495098dc20d92efcde0be723613410dd3b991e1fe5"
     },
     "summarize.py": {
-      "bytes": 32017,
-      "sha256": "4f7b616418a97478d1fd9e6d3aa037a59d1eb86b0df59f71eb878076298d3967"
+      "bytes": 32226,
+      "sha256": "a9b55e6e64a7c20959eb22c2177c41f482c62cd8d5220d86391a9f49ead2af4c"
     },
     "summary.json": {
-      "bytes": 11766,
-      "sha256": "a132ccf6414198d061a732018867abd42c444b1eb4305f20b55d25a3dd49deed"
+      "bytes": 11967,
+      "sha256": "8d47ba58a0d809a61d7b144816467e97925c11d71a01c4b34ac93be82360aac4"
     }
   },
   "qualification": false,

--- a/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/manifest.json
+++ b/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/manifest.json
@@ -1,0 +1,102 @@
+{
+  "claim": "single-host native-v3 provider-route operating-point diagnostic; no maximum-capacity, WAN, or delivery qualification",
+  "excluded_private_data": [
+    "raw transactions and signatures",
+    "proof messages and session state",
+    "keyrings and wallet material",
+    "raw blocks and Commit streams",
+    "host identity, absolute paths, and logs"
+  ],
+  "private_inputs": {
+    "evidence.json": {
+      "bytes": 4302802,
+      "sha256": "488e4e629641f272bbc2c5138aa2e1539d6d74f84ed5e3240b79679817627ebe"
+    },
+    "native-build-5cc77e1a-002-provenance.json": {
+      "bytes": 3256,
+      "sha256": "35ce884356baecc7f8356335a977f37b90f5447158dd3fbc99b4780a04df8c78"
+    },
+    "native-v3-cross-audit-blocks.jsonl": {
+      "bytes": 138694,
+      "sha256": "8a319de7509e73d207252fa9b3dbfb19b1f08a3a366bc438c1396894548bcda4"
+    },
+    "native-v3-cross-audit-commit-2dc1ec9c1cfdcfcd97799d8579faa4378bc292b4.jsonl": {
+      "bytes": 277212,
+      "sha256": "c50674a94095903ec6031fe04cca4c0abbfb5c040ad736401a480681f80539e9"
+    },
+    "native-v3-cross-audit-commit-303e1ba96a846764fc2540d64e2cde2beba4e77b.jsonl": {
+      "bytes": 275313,
+      "sha256": "4d6c5d59e014f7c94a6cc512bb05b51e1cc6fa867fce7618e086c0a76baa171a"
+    },
+    "native-v3-cross-audit-commit-39bf300568acd1729f714b4abece18157fb7278a.jsonl": {
+      "bytes": 276049,
+      "sha256": "4ecbd72bc6c780f427ad8daf5722e47f1fe994a72511fa17c5f1566c984a6d83"
+    },
+    "native-v3-cross-audit-commit-c7bad61aa9f70e24353b72c68671a6d6522a4294.jsonl": {
+      "bytes": 276929,
+      "sha256": "50945719d13b631cdc6627fb7dbed82ec698cc75b9fce22c425b7cbb2a481ed4"
+    },
+    "native-v3-cross-audit-retained-001.guard.json": {
+      "bytes": 4903,
+      "sha256": "c508492c4cca5cd2589170297198e168cc9aa9ad0c9bca304514e0d52dfb04f8"
+    },
+    "native-v3-cross-audit-retained-001.plan.json": {
+      "bytes": 4853,
+      "sha256": "db5f113af9ed9af5d66c98c78505d764f2c70d3d0810c8040d48824f44d2c3ce"
+    },
+    "transaction-recovery-private/transactions.json": {
+      "bytes": 19532486,
+      "sha256": "97621fb3d5edc49d5c1c81b85a82b23ab33f3eaa0784b344f9212807e5f47ee7"
+    },
+    "transaction-recovery-private/validator0.json": {
+      "bytes": 6421050,
+      "sha256": "adb1b942aa46437c221d7b3eaa3b508dee2d2329fa4045d03e90d47f02d86ed9"
+    },
+    "transaction-recovery-private/validator1.json": {
+      "bytes": 6421050,
+      "sha256": "adb1b942aa46437c221d7b3eaa3b508dee2d2329fa4045d03e90d47f02d86ed9"
+    },
+    "transaction-recovery-private/validator2.json": {
+      "bytes": 6421050,
+      "sha256": "adb1b942aa46437c221d7b3eaa3b508dee2d2329fa4045d03e90d47f02d86ed9"
+    },
+    "transaction-recovery-private/validator3.json": {
+      "bytes": 6421050,
+      "sha256": "adb1b942aa46437c221d7b3eaa3b508dee2d2329fa4045d03e90d47f02d86ed9"
+    }
+  },
+  "published_files": {
+    "README.md": {
+      "bytes": 6917,
+      "sha256": "ce56e8878714b5d643d45861cbf0652a570305be89b0c0c6fc2fa93a667a06c4"
+    },
+    "check.py": {
+      "bytes": 3908,
+      "sha256": "11945643c3eff1ca37e7a5a3b50a1a61a3f9bc2803129ec5f99d2a283a2be7ee"
+    },
+    "plan.json": {
+      "bytes": 1525,
+      "sha256": "4ade88469200d9f332ea7d30b43b7b790dac63d65c5f528e5125c200162a6079"
+    },
+    "runtime-provenance.json": {
+      "bytes": 3243,
+      "sha256": "1c2d298f66d51cf3264b62495098dc20d92efcde0be723613410dd3b991e1fe5"
+    },
+    "summarize.py": {
+      "bytes": 32017,
+      "sha256": "4f7b616418a97478d1fd9e6d3aa037a59d1eb86b0df59f71eb878076298d3967"
+    },
+    "summary.json": {
+      "bytes": 11766,
+      "sha256": "a132ccf6414198d061a732018867abd42c444b1eb4305f20b55d25a3dd49deed"
+    }
+  },
+  "qualification": false,
+  "schema": "polystore.retained-publication.v1",
+  "status": "passed",
+  "transformations": [
+    "summary.json is reconstructed by summarize.py from exact private evidence, stopped-blockstore transactions, reconciled blocks, and four raw Commit streams",
+    "plan.json is the completed run guard with hostname removed, runtime manifest replaced by runtime-provenance.json, and benchmark-root paths replaced by $BENCH_ROOT",
+    "runtime-provenance.json is the frozen build manifest with benchmark-root paths replaced by $BENCH_ROOT"
+  ]
+}

--- a/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/manifest.json
+++ b/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/manifest.json
@@ -67,8 +67,8 @@
   },
   "published_files": {
     "README.md": {
-      "bytes": 7132,
-      "sha256": "7aa380ab839bd5e4183ea91c5fc37caa4b948cbcdfa583498e97f2f255487e18"
+      "bytes": 7395,
+      "sha256": "81611829a5f31524c8ff5bac8c4175f28ff7264c28b3e1df7a4713ecb607ac38"
     },
     "check.py": {
       "bytes": 4280,
@@ -83,12 +83,12 @@
       "sha256": "1c2d298f66d51cf3264b62495098dc20d92efcde0be723613410dd3b991e1fe5"
     },
     "summarize.py": {
-      "bytes": 32226,
-      "sha256": "a9b55e6e64a7c20959eb22c2177c41f482c62cd8d5220d86391a9f49ead2af4c"
+      "bytes": 33318,
+      "sha256": "37eb0ce0832ae98158870259527440191d1a37461353ae04ed1a899a60d94543"
     },
     "summary.json": {
-      "bytes": 11967,
-      "sha256": "8d47ba58a0d809a61d7b144816467e97925c11d71a01c4b34ac93be82360aac4"
+      "bytes": 12116,
+      "sha256": "dcadee205ece9abe03fcfab42efc5b2e90385c791feb9f46f8088f0f28a65749"
     }
   },
   "qualification": false,

--- a/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/plan.json
+++ b/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/plan.json
@@ -1,0 +1,40 @@
+{
+  "command": [
+    "/usr/bin/python3",
+    "$BENCH_ROOT/worktrees/native-cross-audit-harness-da54964d/scripts/retrieval_four_validator_workload.py",
+    "--mode",
+    "native-v3-providers-cross-audit",
+    "--audit-profile",
+    "normal",
+    "--timeout",
+    "900",
+    "--binary",
+    "$BENCH_ROOT/native-build-5cc77e1a-002/bin/polystorechaind",
+    "--library",
+    "$BENCH_ROOT/worktrees/native-runtime-5cc77e1a-002/polystore_core/target/release/libpolystore_core.so",
+    "--gateway-binary",
+    "$BENCH_ROOT/native-build-5cc77e1a-002/bin/polystore_gateway",
+    "--cli-binary",
+    "$BENCH_ROOT/native-build-5cc77e1a-002/bin/polystore_cli",
+    "--product-source",
+    "$BENCH_ROOT/worktrees/native-runtime-5cc77e1a-002",
+    "--home",
+    "$BENCH_ROOT/runs/native-v3-cross-audit-retained-001"
+  ],
+  "elapsed_seconds": 816.051,
+  "harness_head": "da54964dc502f14bc73096fb6adc5f8ba0b2be6b",
+  "harness_scripts_tree": "0229d8fa6a7ea6faf64d77d6564f640a8e58694f",
+  "host": "single Linux host (identity redacted)",
+  "initial_free_bytes": 1338516119552,
+  "initial_load": [
+    0.16015625,
+    0.04638671875,
+    0.0576171875
+  ],
+  "kind": "fixed180second native provider operating-point diagnostic across2normal audit anchors; no distributed maximum or delivery qualification",
+  "minimum_free_bytes": 1338274324480,
+  "result_scope": "retained local operating-point diagnostic; qualification=false",
+  "returncode": 0,
+  "runtime_provenance": "runtime-provenance.json",
+  "schema": "polystore.retained-run-plan.v1"
+}

--- a/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/runtime-provenance.json
+++ b/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/runtime-provenance.json
@@ -1,0 +1,80 @@
+{
+  "artifacts": {
+    "$BENCH_ROOT/native-build-5cc77e1a-002/bin/polystore_cli": "5653edad1db94b50d450db49191037e9acef47d07ffdd77c9325ddbdac6678ba",
+    "$BENCH_ROOT/native-build-5cc77e1a-002/bin/polystore_gateway": "35c3f1129023238c48be32dad4bb07e255ba25dd5a58a6ccc13d39519ef85759",
+    "$BENCH_ROOT/native-build-5cc77e1a-002/bin/polystorechaind": "f7b9cc758732c159b96f1c0ef4465bbd38190ff0b3364ac54e9e9ec616a33ff3",
+    "$BENCH_ROOT/worktrees/native-runtime-5cc77e1a-002/polystore_core/target/release/libpolystore_core.so": "4735f0777793acb24da0ce4971696aadc5565285a15fa3e9740dbe4ba1155b6d",
+    "$BENCH_ROOT/worktrees/native-runtime-5cc77e1a-002/polystorechain/trusted_setup.txt": "d39b9f2d047cc9dca2de58f264b6a09448ccd34db967881a6713eacacf0f26b7"
+  },
+  "component_trees": {
+    "polystore_cli": "4303dc86c58cbbb7f1076f1916f1de691bf7694c",
+    "polystore_core": "bdf6a947e927d3690b0ce7943d82a381879364be",
+    "polystore_gateway": "b05482c78b5a5f4407d27acd7389d2ea1003b34c",
+    "polystorechain": "a1985f1baf1c897949a313e5f8fa03faeebc9381"
+  },
+  "note": "Sanitized copy of the frozen build provenance; absolute benchmark root replaced by $BENCH_ROOT.",
+  "reused_components": {
+    "components": [
+      "polystore_core",
+      "polystore_cli"
+    ],
+    "source_commit": "b98733667e70c35830ed9b588515bcf1a42e10e0",
+    "source_manifest": "$BENCH_ROOT/native-chain-build-b9873366/provenance.json",
+    "source_manifest_sha256": "ebeae99ac4760b34899868013434a12757844f290325548d27a17a77c2157c74",
+    "verification": "identical tracked component trees and artifact SHA256; copied CLI and symlinked unchanged Rust target"
+  },
+  "schema": "polystore.runtime-provenance.v1",
+  "source": "$BENCH_ROOT/worktrees/native-runtime-5cc77e1a-002",
+  "source_commit": "5cc77e1aa28b17082cc851363b6fa7ada1ed9ce3",
+  "source_manifest_private_sha256": "35ce884356baecc7f8356335a977f37b90f5447158dd3fbc99b4780a04df8c78",
+  "status": "passed",
+  "steps": [
+    {
+      "command": [
+        "./scripts/chain_go.sh",
+        "build",
+        "-p",
+        "2",
+        "-o",
+        "$BENCH_ROOT/native-build-5cc77e1a-002/bin/polystorechaind",
+        "./cmd/polystorechaind"
+      ],
+      "cwd": "$BENCH_ROOT/worktrees/native-runtime-5cc77e1a-002",
+      "elapsed_seconds": 74.73,
+      "exit_code": 0,
+      "name": "chain"
+    },
+    {
+      "command": [
+        "go",
+        "build",
+        "-mod=readonly",
+        "-p=2",
+        "-o",
+        "$BENCH_ROOT/native-build-5cc77e1a-002/bin/polystore_gateway",
+        "."
+      ],
+      "cwd": "$BENCH_ROOT/worktrees/native-runtime-5cc77e1a-002/polystore_gateway",
+      "elapsed_seconds": 5.321,
+      "exit_code": 0,
+      "name": "gateway"
+    },
+    {
+      "command": [
+        "/usr/bin/python3",
+        "scripts/test_validator_setup_startup.py",
+        "$BENCH_ROOT/native-build-5cc77e1a-002/bin/polystorechaind",
+        "polystorechain/trusted_setup.txt"
+      ],
+      "cwd": "$BENCH_ROOT/worktrees/native-runtime-5cc77e1a-002",
+      "elapsed_seconds": 3.071,
+      "exit_code": 0,
+      "name": "startup"
+    }
+  ],
+  "toolchains": {
+    "cargo": "cargo 1.98.1 (797e8a9bc 2026-08-05)",
+    "go": "go version go1.25.5 linux/amd64",
+    "rustc": "rustc 1.98.1 (48a229cea 2026-09-01)"
+  }
+}

--- a/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/summarize.py
+++ b/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/summarize.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """Reconstruct the retained native-v3 cross-audit diagnostic from private inputs."""
-import argparse, base64, hashlib, json, math, statistics, sys, types
+import argparse, base64, hashlib, json, math, os, statistics, subprocess, sys, time, types
 from collections import Counter, defaultdict
 from pathlib import Path
 
@@ -8,6 +8,8 @@ HARNESS_SHA256 = "2ebec09009fad961959ef0dd7fd72a0f471014d97805a782192c92df5cb4a0
 EVIDENCE_SHA256 = "488e4e629641f272bbc2c5138aa2e1539d6d74f84ed5e3240b79679817627ebe"
 BLOCKS_SHA256 = "8a319de7509e73d207252fa9b3dbfb19b1f08a3a366bc438c1396894548bcda4"
 TRANSACTIONS_SHA256 = "97621fb3d5edc49d5c1c81b85a82b23ab33f3eaa0784b344f9212807e5f47ee7"
+DECODER_SHA256 = "f7b9cc758732c159b96f1c0ef4465bbd38190ff0b3364ac54e9e9ec616a33ff3"
+DECODER_LIBRARY_SHA256 = "4735f0777793acb24da0ce4971696aadc5565285a15fa3e9740dbe4ba1155b6d"
 MODULES = {
     "retrieval_bench_artifact": "aeb5f811fb5f93ad4539f49a485c15af3747c765bd3d3997bc38335016a023d8",
     "retrieval_commit_metrics": "e8b272852684639efe6292d3b72eb2396fee0c2bdb99558d52c611b7d638e11f",
@@ -49,6 +51,23 @@ def load_modules(harness_path):
         loaded[name] = module
     return loaded
 
+def native_decode(decoder, library, raw_tx_base64, deadline):
+    require(time.monotonic() < deadline, "native transaction decode exceeded its total deadline")
+    env = os.environ.copy()
+    env["GOMAXPROCS"] = "2"
+    library_dir = str(library.parent)
+    env["LD_LIBRARY_PATH"] = library_dir + ((":" + env["LD_LIBRARY_PATH"]) if env.get("LD_LIBRARY_PATH") else "")
+    try:
+        result = subprocess.run([str(decoder), "tx", "decode", raw_tx_base64], env=env,
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=15)
+    except subprocess.TimeoutExpired as error:
+        raise ValueError("pinned native transaction decoder timed out") from error
+    require(result.returncode == 0, "pinned native transaction decoder failed")
+    try:
+        return result.stdout, json.loads(result.stdout)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError("pinned native transaction decoder returned invalid JSON") from error
+
 def validate_receipt(row, node_ids):
     require(row["outcome"] == "committed_success" and row["code"] == 0 and row["height"] > 0,
             "non-successful proof/open/refund receipt")
@@ -66,7 +85,10 @@ def main():
     parser.add_argument("blocks", type=Path)
     parser.add_argument("transactions", type=Path)
     parser.add_argument("commit_streams", nargs=4, type=Path)
+    parser.add_argument("--decoder", required=True, type=Path)
+    parser.add_argument("--decoder-library", required=True, type=Path)
     args = parser.parse_args()
+    decoder, decoder_library = args.decoder.resolve(), args.decoder_library.resolve()
     raw_evidence, raw_blocks, raw_transactions = (args.evidence.read_bytes(), args.blocks.read_bytes(),
                                                    args.transactions.read_bytes())
     doc, recovered = json.loads(raw_evidence), json.loads(raw_transactions)
@@ -172,6 +194,18 @@ def main():
                 for rows in retried) and
             all(len(rows) in (1, 2) and rows[-1].get("status") == "success" for rows in attempts_by_request.values()),
             "provider HTTP terminal success inventory differs")
+    successful_by_request = {row["request_id"]: row for row in successful}
+    measured_by_operation = {row["operation_id"]: row for row in native["measured_proof_transactions"]}
+    require(len(successful_by_request) == len(measured_by_operation) == 360 and
+            set(successful_by_request) == set(measured_by_operation) and
+            all(isinstance(receipt["session_index"], int) and 0 <= receipt["session_index"] < len(sessions)
+                for receipt in measured_by_operation.values()) and
+            all(successful_by_request[operation_id]["tx_hash"] == receipt["txhash"] and
+                successful_by_request[operation_id]["provider"] == receipt["provider"] and
+                successful_by_request[operation_id]["session_id"].removeprefix("0x").lower() ==
+                    sessions[int(receipt["session_index"])]["session_id"].lower()
+                for operation_id, receipt in measured_by_operation.items()),
+            "HTTP success identity differs from measured proof receipt")
     by_session = defaultdict(list)
     for row in successful: by_session[int(row["request_id"].split("-")[1])].append(row)
     for index in range(1, 46):
@@ -220,6 +254,11 @@ def main():
     open_sessions = {txhash: sorted([session for session in sessions if session["open_transaction"]["txhash"] == txhash],
                                     key=lambda session: session["nonce"])
                      for txhash in open_counts}
+    require(decoder.is_file() and sha(decoder.read_bytes()) == DECODER_SHA256,
+            "native transaction decoder bytes differ from runtime provenance")
+    require(decoder_library.is_file() and sha(decoder_library.read_bytes()) == DECODER_LIBRARY_SHA256,
+            "native transaction decoder library differs from runtime provenance")
+    decode_deadline = time.monotonic() + 300
     for txhash, row in recovered_by_hash.items():
         raw = base64.b64decode(row["raw_tx_base64"], validate=True)
         require(sha(raw) == row["raw_tx_sha256"] == txhash.lower() and len(raw) == row["raw_tx_bytes"],
@@ -228,7 +267,10 @@ def main():
                 all(v["txhash"] == txhash and v["height"] == row["height"] and
                     v["raw_tx_sha256"] == row["raw_tx_sha256"] and v["tx_index"] == row["tx_index"]
                     for v in row["validators"]), "stopped blockstores disagree on transaction bytes")
-        messages = row["decoded"]["body"]["messages"]
+        decoded_raw, decoded = native_decode(decoder, decoder_library, row["raw_tx_base64"], decode_deadline)
+        require(sha(decoded_raw) == row["decoded_output_sha256"] and decoded == row["decoded"],
+                "native transaction decode differs from recovered representation")
+        messages = decoded["body"]["messages"]
         if row["kind"] == "open":
             expected_sessions = open_sessions[txhash]
             require(row["height"] == expected_sessions[0]["open_height"] and
@@ -245,8 +287,10 @@ def main():
         elif row["kind"] in ("warmup", "proof"):
             receipt = proof_receipts[txhash]
             session = proof_sessions[txhash]
+            expected_session_index = 0 if row["kind"] == "warmup" else int(receipt["session_index"])
             message = messages[0] if len(messages) == 1 else {}
-            require(message.get("@type", "").endswith("MsgSubmitRetrievalSessionProofV3") and
+            require(session == sessions[expected_session_index] and
+                    message.get("@type", "").endswith("MsgSubmitRetrievalSessionProofV3") and
                     message.get("creator") == receipt["provider"] and
                     base64.b64decode(message.get("session_id", ""), validate=True).hex() == session["session_id"] and
                     row["height"] == receipt["height"] and row["raw_tx_bytes"] == receipt["validators"][0]["bytes"] and

--- a/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/summarize.py
+++ b/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/summarize.py
@@ -393,6 +393,7 @@ def main():
             "HTTP terminal timing combines proof generation, native verification, gas simulation, signing, broadcast, and client commit observation.",
             "Pre-success-start delay includes scheduler delay and, for 13 requests, retry backoff after an HTTP 429; it is not a pure signer-queue measurement.",
             "Commit p95 values are execution upper bounds from the Commit metric; they exclude the documented post-persistence tail.",
+            "Commit streams use a wider window starting before workload alignment and ending after heavy all-validator LCD queries; that window is separate from the CPU and provider HTTP measurement window.",
             "CPU is a fixed-window process tick delta; RSS is a whole-process-lifetime peak, not a phase peak or 2 GiB usage claim.",
             "Consensus header times are not wall-clock commit-completion timestamps, so this report makes no header-time throughput claim.",
             "The retained HTTP receipts do not separate CheckTx latency from block inclusion; only the combined client terminal observation is reported.",

--- a/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/summarize.py
+++ b/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/summarize.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""Reconstruct the retained native-v3 cross-audit diagnostic from private inputs."""
+import argparse, base64, hashlib, json, math, statistics, sys, types
+from collections import Counter, defaultdict
+from pathlib import Path
+
+HARNESS_SHA256 = "2ebec09009fad961959ef0dd7fd72a0f471014d97805a782192c92df5cb4a05f"
+EVIDENCE_SHA256 = "488e4e629641f272bbc2c5138aa2e1539d6d74f84ed5e3240b79679817627ebe"
+BLOCKS_SHA256 = "8a319de7509e73d207252fa9b3dbfb19b1f08a3a366bc438c1396894548bcda4"
+TRANSACTIONS_SHA256 = "97621fb3d5edc49d5c1c81b85a82b23ab33f3eaa0784b344f9212807e5f47ee7"
+MODULES = {
+    "retrieval_bench_artifact": "aeb5f811fb5f93ad4539f49a485c15af3747c765bd3d3997bc38335016a023d8",
+    "retrieval_commit_metrics": "e8b272852684639efe6292d3b72eb2396fee0c2bdb99558d52c611b7d638e11f",
+    "retrieval_fresh_proof": "74ced497d80442a7d463872623879737b7775ad2a49ec4c5a53ced8a8650e67b",
+    "native_harness": HARNESS_SHA256,
+}
+COMMIT_SHA256 = {
+    "2dc1ec9c1cfdcfcd97799d8579faa4378bc292b4": "c50674a94095903ec6031fe04cca4c0abbfb5c040ad736401a480681f80539e9",
+    "303e1ba96a846764fc2540d64e2cde2beba4e77b": "4d6c5d59e014f7c94a6cc512bb05b51e1cc6fa867fce7618e086c0a76baa171a",
+    "39bf300568acd1729f714b4abece18157fb7278a": "4ecbd72bc6c780f427ad8daf5722e47f1fe994a72511fa17c5f1566c984a6d83",
+    "c7bad61aa9f70e24353b72c68671a6d6522a4294": "50945719d13b631cdc6627fb7dbed82ec698cc75b9fce22c425b7cbb2a481ed4",
+}
+
+def require(value, message):
+    if not value:
+        raise ValueError(message)
+
+def sha(data): return hashlib.sha256(data).hexdigest()
+
+def quantiles_ns(values):
+    values = sorted(values)
+    require(values, "empty latency inventory")
+    rank = lambda q: values[math.ceil(q * len(values)) - 1] / 1e6
+    return {"count": len(values), "median_ms": statistics.median(values) / 1e6,
+            "p50_ms": rank(.50), "p95_ms": rank(.95), "p99_ms": rank(.99),
+            "max_ms": values[-1] / 1e6,
+            "percentile_method": "nearest rank; median uses conventional midpoint"}
+
+def load_modules(harness_path):
+    loaded = {}
+    for name, digest in MODULES.items():
+        path = harness_path if name == "native_harness" else harness_path.with_name(name + ".py")
+        data = path.read_bytes()
+        require(sha(data) == digest, f"unpinned harness module {path.name}")
+        module = types.ModuleType(name)
+        module.__file__ = str(path)
+        sys.modules[name] = module
+        exec(compile(data, str(path), "exec"), module.__dict__)
+        loaded[name] = module
+    return loaded
+
+def validate_receipt(row, node_ids):
+    require(row["outcome"] == "committed_success" and row["code"] == 0 and row["height"] > 0,
+            "non-successful proof/open/refund receipt")
+    validators = row["validators"]
+    require(len(validators) == 4 and {v["node_id"] for v in validators} == node_ids,
+            "receipt does not cover all four validators")
+    for validator in validators:
+        require(all(validator[key] == row[key] for key in ("txhash", "height", "code", "gas_wanted", "gas_used")),
+                "validator receipt differs")
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("harness", type=Path)
+    parser.add_argument("evidence", type=Path)
+    parser.add_argument("blocks", type=Path)
+    parser.add_argument("transactions", type=Path)
+    parser.add_argument("commit_streams", nargs=4, type=Path)
+    args = parser.parse_args()
+    raw_evidence, raw_blocks, raw_transactions = (args.evidence.read_bytes(), args.blocks.read_bytes(),
+                                                   args.transactions.read_bytes())
+    doc, recovered = json.loads(raw_evidence), json.loads(raw_transactions)
+    modules = load_modules(args.harness.resolve())
+    harness, commit_metrics = modules["native_harness"], modules["retrieval_commit_metrics"]
+
+    require(doc["status"] == "native_v3_cross_audit_diagnostic_passed" and
+            doc["mode"] == "four-validator-native-v3-cross-audit-diagnostic" and
+            doc["qualification"] is False, "top-level diagnostic status/scope differs")
+    require(doc["provenance"]["source_checkout"] == "da54964dc502f14bc73096fb6adc5f8ba0b2be6b" and
+            doc["provenance"]["driver_sha256"] == HARNESS_SHA256,
+            "retained run does not use the landed reviewed harness")
+    require(doc["profile"]["audit_profile"] == "normal" and
+            doc["profile"]["consensus"]["block"] == {"max_bytes": "2097152", "max_gas": "64000000"} and
+            doc["profile"]["execution_budget_ms"] == 700 and
+            doc["profile"]["memory_ceiling_per_validator_bytes"] == 2 * 1024**3 and
+            doc["profile"]["budgets_measured"] is False,
+            "consensus/audit/diagnostic budget profile differs")
+    require((harness.V3_CROSS_AUDIT_SESSIONS, harness.V3_CROSS_AUDIT_WARMUPS,
+             harness.V3_CROSS_AUDIT_MEASURED, harness.V3_CROSS_AUDIT_OFFER_SECONDS,
+             harness.V3_CROSS_AUDIT_EPOCHS) == (46, 8, 360, 180, 2),
+            "harness cross-audit profile differs")
+    native = doc["native_v3_cross_audit"]
+    require(native["status"] == "native_v3_cross_audit_diagnostic_finished" and
+            native["qualification"] is False and native["expiration_verified"] and native["refunds_verified"] and
+            not native["owner_acknowledged"] and not native["delivery_verified"],
+            "native diagnostic completion/claim boundary differs")
+    expected = {"sessions": 46, "warmup": 8, "measured": 360, "total": 368,
+                "total_ordinals": 6072, "measured_ordinals": 5940, "audits": 24, "refunds": 46}
+    require(len(native["sessions"]) == expected["sessions"] and
+            len(native["warmup_proof_transactions"]) == expected["warmup"] and
+            len(native["measured_proof_transactions"]) == expected["measured"] and
+            len(native["audit_transactions"]) == expected["audits"], "retained transaction counts differ")
+    require(native["total_committed_valid_proof_transactions"] == expected["total"] and
+            native["measured_committed_valid_proof_transactions"] == expected["measured"] and
+            native["total_authoritative_new_sample_ordinals"] == expected["total_ordinals"] and
+            native["measured_authoritative_new_sample_ordinals"] == expected["measured_ordinals"],
+            "committed proof or authoritative opening count differs")
+    node_ids = {node["node_id"] for node in doc["nodes"]}
+    require(len(node_ids) == len(doc["nodes"]) == 4, "validator identity set differs")
+    admitted = doc["native_v3_generation"]["admitted"]["admitted"]
+    providers = dict(enumerate(admitted["providers"]))
+    require(len(providers) == 12, "provider assignment set differs")
+    systematic = dict(list(providers.items())[:8])
+
+    # Reuse the owning harness's authority and schedule checks.
+    sessions = native["sessions"]
+    require([row["nonce"] for row in sessions] == list(range(1, 47)), "session nonces differ")
+    for index, session in enumerate(sessions):
+        deadline = int(session["before_proofs"]["session"]["deadline_height"])
+        stage_states = {}
+        for name, expired, refunded in (("before_proofs", False, False), ("after_proofs", False, False),
+                                        ("expired_before_refund", True, False), ("after_refund", True, True)):
+            state, ordinals = harness.validate_v3_session(
+                session[name], session_id=session["session_id"], deal_id=admitted["deal_id"],
+                owner=admitted["owner"], providers=systematic, nonce=index + 1,
+                polyfs_root=base64.b64decode(admitted["polyfs_root"], validate=True).hex(),
+                integrity_root=base64.b64decode(admitted["integrity_root"], validate=True).hex(),
+                chain_id=doc["chain_id"], deadline_height=deadline, expired=expired, refunded=refunded)
+            require(ordinals == ([] if name == "before_proofs" else list(range(132))),
+                    "session bitmap differs from committed proof inventory")
+            stage_states[name] = state
+        mutable_session_fields = {"accepted_sample_bitmap", "acked_slots_mask", "settled_slots_mask",
+                                  "refunded_slots_mask", "locked_fee", "updated_height", "expired", "obligations"}
+        immutable_sessions = [{key: value for key, value in state.items() if key not in mutable_session_fields}
+                              for state in stage_states.values()]
+        require(all(projection == immutable_sessions[0] for projection in immutable_sessions[1:]),
+                "session immutable authority/economic/height fields changed across lifecycle")
+        immutable_obligations = []
+        for state in stage_states.values():
+            immutable_obligations.append([
+                {key: value for key, value in obligation.items() if key != "sample_count"}
+                for obligation in state["obligations"]
+            ])
+        require(all(projection == immutable_obligations[0] for projection in immutable_obligations[1:]),
+                "session obligation authority or frozen liability changed across lifecycle")
+        proof_counts_by_provider = Counter()
+        for receipt in session["proof_transactions"]:
+            proof_counts_by_provider[receipt["provider"]] += len(receipt["ordinals"])
+        expected_samples = [proof_counts_by_provider[obligation["assigned_provider"]]
+                            for obligation in stage_states["after_proofs"]["obligations"]]
+        require(sum(expected_samples) == 132 and
+                all([int(obligation["sample_count"]) for obligation in stage_states[name]["obligations"]] ==
+                    ([0] * 8 if name == "before_proofs" else expected_samples)
+                    for name in stage_states),
+                "obligation sample counts differ from committed provider ordinals")
+        require(all(int(stage_states[name]["locked_fee"]) == 133 for name in
+                    ("before_proofs", "after_proofs", "expired_before_refund")) and
+                int(stage_states["after_refund"]["locked_fee"]) == 0 and
+                all(sum(int(obligation["locked_fee"]) for obligation in stage_states[name]["obligations"]) == 133
+                    for name in stage_states), "session or obligation locked fee differs across refund lifecycle")
+    outcomes = doc["v3_http_phases"]["cross-audit-measured"]
+    successful = [row for row in outcomes if row.get("status") == "success"]
+    attempts_by_request = defaultdict(list)
+    for row in outcomes: attempts_by_request[row["request_id"]].append(row)
+    retried = [rows for rows in attempts_by_request.values() if len(rows) == 2]
+    require(len(outcomes) == 373 and len(successful) == 360 and len(attempts_by_request) == 360 and
+            len(retried) == 13 and all([row["attempt"] for row in rows] == [1, 2] and
+                rows[0]["http_status"] == 429 and rows[0]["error"] == "retrieval submission busy" and
+                rows[1].get("status") == "success" and rows[1]["http_status"] == 200 and
+                all(rows[0][key] == rows[1][key] for key in
+                    ("request_id", "request_index", "provider", "offered_ns", "initial_dispatch_ns"))
+                for rows in retried) and
+            all(len(rows) in (1, 2) and rows[-1].get("status") == "success" for rows in attempts_by_request.values()),
+            "provider HTTP terminal success inventory differs")
+    by_session = defaultdict(list)
+    for row in successful: by_session[int(row["request_id"].split("-")[1])].append(row)
+    for index in range(1, 46):
+        harness.validate_v3_provider_outcomes(by_session[index], systematic,
+                                              session_id=sessions[index]["session_id"])
+    schedule = harness.native_v3_cross_audit_schedule()
+    start_ns = doc["v3_http_schedules"]["cross-audit-measured"]["monotonic_start_ns"]
+    require(harness.v3_http_schedule_bins(schedule, successful, start_ns=start_ns) == native["schedule_bins"],
+            "30-second schedule bins differ from terminal observations")
+    pre = native["measurement_preconditions"]
+    epoch_lengths = {int(row["epoch_length"]) for row in pre["audits"].values()}
+    require(epoch_lengths == {100}, "normal audit epoch length differs")
+    require(harness.validate_v3_cross_audit_span(native["measured_proof_transactions"],
+            pre["scheduled_start_height"], pre["next_anchor"], epoch_lengths.pop()) == native["proof_anchor_span"],
+            "measured proof span differs from the two fixed audit anchors")
+    require(harness.validate_v3_http_receipt_fence(native["measured_proof_transactions"], native["proof_receipt_fence"]) ==
+            native["measured_window"]["proof_receipt_max_height"], "proof receipt fence differs")
+    before = pre["provider_quiescence"]["sequences"]
+    after = native["post_load_fence"]["provider_quiescence"]["sequences"]
+    crossed = {int(epoch): {int(slot): view for slot, view in views.items()}
+               for epoch, views in native["crossed_audits"].items()}
+    require(set(crossed) == {4, 5} and all(set(views) == set(providers) for views in crossed.values()) and
+            all(int(view["audit"]["accepted_count"]) ==
+                int(view["audit"]["sample_count"]) == 1 and int(view["audit"]["missed_epochs"]) == 0
+                for views in crossed.values() for view in views.values()),
+            "two normal audit epochs did not cover all twelve assignments")
+    require(harness.reconcile_cross_audit_sequences(before, after, providers,
+            native["measured_proof_transactions"], native["audit_transactions"], crossed) ==
+            native["provider_sequence_reconciliation"], "provider sequence reconciliation differs")
+
+    # Bind every receipt to the authoritative stopped-blockstore transaction bytes.
+    recovered_rows = recovered["transactions"]
+    require(len(recovered_rows) == 440 and Counter(row["kind"] for row in recovered_rows) ==
+            Counter(open=2, warmup=8, proof=360, audit=24, refund=46), "recovered transaction family counts differ")
+    recovered_by_hash = {row["txhash"]: row for row in recovered_rows}
+    require(len(recovered_by_hash) == 440, "recovered transaction hashes are not unique")
+    receipt_rows = [batch["transaction"] for batch in doc["native_v3_open_batches"]] + native["warmup_proof_transactions"] + native["measured_proof_transactions"] + [session["refund_transaction"] for session in sessions]
+    for row in receipt_rows: validate_receipt(row, node_ids)
+    expected_hashes = {row["txhash"] for row in receipt_rows} | {row["txhash"] for row in native["audit_transactions"]}
+    require(set(recovered_by_hash) == expected_hashes, "recovered bytes do not cover the exact workload receipts")
+    proof_receipts = {row["txhash"]: row for row in native["warmup_proof_transactions"] + native["measured_proof_transactions"]}
+    proof_sessions = {tx["txhash"]: session for session in sessions for tx in session["proof_transactions"]}
+    audit_receipts = {row["txhash"]: row for row in native["audit_transactions"]}
+    refund_receipts = {row["refund_transaction"]["txhash"]: row for row in sessions}
+    open_counts = {batch["transaction"]["txhash"]: batch["count"] for batch in doc["native_v3_open_batches"]}
+    open_sessions = {txhash: sorted([session for session in sessions if session["open_transaction"]["txhash"] == txhash],
+                                    key=lambda session: session["nonce"])
+                     for txhash in open_counts}
+    for txhash, row in recovered_by_hash.items():
+        raw = base64.b64decode(row["raw_tx_base64"], validate=True)
+        require(sha(raw) == row["raw_tx_sha256"] == txhash.lower() and len(raw) == row["raw_tx_bytes"],
+                "recovered raw transaction hash/size differs")
+        require(len(row["validators"]) == 4 and {v["node_id"] for v in row["validators"]} == node_ids and
+                all(v["txhash"] == txhash and v["height"] == row["height"] and
+                    v["raw_tx_sha256"] == row["raw_tx_sha256"] and v["tx_index"] == row["tx_index"]
+                    for v in row["validators"]), "stopped blockstores disagree on transaction bytes")
+        messages = row["decoded"]["body"]["messages"]
+        if row["kind"] == "open":
+            expected_sessions = open_sessions[txhash]
+            require(row["height"] == expected_sessions[0]["open_height"] and
+                    len(messages) == open_counts[txhash] == len(expected_sessions), "open batch message authority/count differs")
+            for message, session in zip(messages, expected_sessions):
+                state = session["before_proofs"]["session"]
+                expected_range = {"file_record_index": 0, "file_start_offset": "0",
+                                  "file_length": "16777216", "range_start": "0", "range_length": "16777216"}
+                require(message.get("@type", "").endswith("MsgOpenRetrievalSessionV3") and
+                        message.get("creator") == admitted["owner"] and message.get("deal_id") == admitted["deal_id"] and
+                        int(message.get("generation", 0)) == 1 and int(message.get("nonce", 0)) == session["nonce"] and
+                        int(message.get("deadline_height", 0)) == int(state["deadline_height"]) and
+                        message.get("range") == expected_range, "open batch message differs from ordered session authority")
+        elif row["kind"] in ("warmup", "proof"):
+            receipt = proof_receipts[txhash]
+            session = proof_sessions[txhash]
+            message = messages[0] if len(messages) == 1 else {}
+            require(message.get("@type", "").endswith("MsgSubmitRetrievalSessionProofV3") and
+                    message.get("creator") == receipt["provider"] and
+                    base64.b64decode(message.get("session_id", ""), validate=True).hex() == session["session_id"] and
+                    row["height"] == receipt["height"] and row["raw_tx_bytes"] == receipt["validators"][0]["bytes"] and
+                    len(message.get("proofs", [])) == len(receipt["ordinals"]) and
+                    [int(p["ordinal"]) for p in message["proofs"]] == receipt["ordinals"],
+                    "proof bytes differ from provider, count, or authoritative ordinals")
+        elif row["kind"] == "audit":
+            receipt, message = audit_receipts[txhash], messages[0] if len(messages) == 1 else {}
+            require(message.get("@type", "").endswith("MsgProveLiveness") and message.get("creator") == receipt["provider"] and
+                    int(message.get("deal_id", -1)) == int(admitted["deal_id"]) and
+                    int(message.get("epoch_id", 0)) == receipt["epoch"] and row["height"] == receipt["height"] and
+                    isinstance(message.get("system_proof"), dict) and bool(message["system_proof"]) and set(message).intersection(
+                    {"user_receipt", "system_proof", "user_receipt_batch", "session_proof"}) == {"system_proof"},
+                    "audit bytes differ from provider/epoch/system proof")
+        else:
+            session, message = refund_receipts[txhash], messages[0] if len(messages) == 1 else {}
+            require(message.get("@type", "").endswith("MsgRefundRetrievalSessionV3") and
+                    message.get("creator") == admitted["owner"] and
+                    base64.b64decode(message.get("session_id", ""), validate=True).hex() == session["session_id"],
+                    "refund bytes differ from owner/session")
+
+    reconciliation = doc["committed_block_reconciliation"]
+    require(reconciliation == {"path": reconciliation["path"], "sha256": BLOCKS_SHA256,
+            "first_height": 217, "last_height": 434, "committed_workload_transactions": 360,
+            "all_four_headers_agree": True, "all_four_results_agree": True, "qualification": False},
+            "block reconciliation scope differs")
+    blocks = [json.loads(line) for line in raw_blocks.splitlines() if line.strip()]
+    require([row["height"] for row in blocks] == list(range(217, 435)), "reconciled block range is not contiguous")
+    workload = [(block["height"], tx) for block in blocks for tx in block["transactions"] if tx.get("operation_id")]
+    measured_by_hash = {row["txhash"]: row for row in native["measured_proof_transactions"]}
+    require({tx["txhash"] for _, tx in workload} == set(measured_by_hash) and len(workload) == 360 and
+            all(tx["code"] == 0 and height == measured_by_hash[tx["txhash"]]["height"] for height, tx in workload),
+            "reconciled blocks differ from measured successful proof receipts")
+    for block in blocks:
+        require(block["gas_wanted"] == sum(tx["gas_wanted"] for tx in block["transactions"]) and
+                block["gas_used"] == sum(tx["gas_used"] for tx in block["transactions"]),
+                "reconciled block gas totals differ")
+
+    # Recompute Commit summaries from exact raw streams plus the independently fenced endpoints.
+    phase = doc["commit_step_metrics"]["phases"]
+    before_commit = {row["node_id"]: row["sample"] for row in phase["native_v3_cross_audit_before"]["nodes"]}
+    after_commit = {row["node_id"]: row["sample"] for row in phase["native_v3_cross_audit_after"]["nodes"]}
+    embedded_commit = {row["node_id"]: row for row in doc["native_v3_cross_audit_commit_streams"]}
+    commit_rows = []
+    seen_commit_nodes = set()
+    for path in args.commit_streams:
+        node_id = path.stem.rsplit("-", 1)[-1]
+        require(node_id in COMMIT_SHA256 and node_id not in seen_commit_nodes and
+                sha(path.read_bytes()) == COMMIT_SHA256[node_id], "Commit stream hash/identity differs")
+        seen_commit_nodes.add(node_id)
+        samples = [json.loads(line) for line in path.read_text().splitlines() if line]
+        start, end = before_commit[node_id], after_commit[node_id]
+        fenced = [start] + [sample for sample in samples if sample["monotonic_start_ns"] >= start["monotonic_end_ns"] and
+                            sample["monotonic_end_ns"] <= end["monotonic_start_ns"]] + [end]
+        recomputed = commit_metrics.summarize_commit_metrics(fenced, start_committed_height=start["committed_height"],
+                                                              end_committed_height=end["committed_height"], boundaries_reconciled=True)
+        require(recomputed == embedded_commit[node_id]["summary"] and recomputed["qualified"] and
+                recomputed["within_700ms_budget"], "Commit stream summary differs or is unqualified")
+        commit_rows.append({"validator": node_id, "raw_samples": len(samples), "fenced_samples": len(fenced),
+                            "observed_blocks": recomputed["observed_blocks"],
+                            "p95_upper_bound_ms": float(recomputed["p95_upper_bound_seconds"]) * 1000,
+                            "within_700ms_budget": True})
+    require(seen_commit_nodes == set(COMMIT_SHA256), "Commit stream validator set differs")
+
+    schedule_doc = doc["v3_http_schedules"]["cross-audit-measured"]
+    require(schedule_doc["offered"] == schedule_doc["completed"] == 360 and schedule_doc["queued"] == schedule_doc["in_flight"] == 0 and
+            schedule_doc["terminal_error"] is None, "HTTP scheduler did not fully drain")
+    cpu = native["measured_window"]["validator_cpu_delta"]
+    require(cpu == harness.validator_cpu_delta(native["measured_window"]["validator_cpu_before"],
+                                                native["measured_window"]["validator_cpu_after"]),
+            "validator CPU delta differs from retained snapshots")
+    cpu_seconds = (cpu["monotonic_end_ns"] - cpu["monotonic_start_ns"]) / 1e9
+    cpu_rows = [{"validator": row["node_id"], "window_seconds": cpu_seconds,
+                 "user_cpu_seconds": row["user_cpu_seconds"], "system_cpu_seconds": row["system_cpu_seconds"],
+                 "mean_cores_over_window": (row["user_cpu_seconds"] + row["system_cpu_seconds"]) / cpu_seconds}
+                for row in cpu["validators"]]
+    resources = [{"validator": row["node_id"], "peak_rss_bytes": row["peak_rss_bytes"],
+                  "measurement_scope": row["measurement_scope"], "returncode": row["returncode"]}
+                 for row in doc["validator_resources"]]
+    require(len(resources) == 4 and {row["validator"] for row in resources} == node_ids and
+            all(row["measurement_scope"] == "whole validator process lifetime" and row["returncode"] == 0 and
+                0 < row["peak_rss_bytes"] < doc["profile"]["memory_ceiling_per_validator_bytes"] for row in resources),
+            "validator resource lifecycle differs")
+    terminal = [row["request_finished_ns"] - row["offered_ns"] for row in successful]
+    pre_success = [row["request_started_ns"] - row["offered_ns"] for row in successful]
+    initial_dispatch = [row["initial_dispatch_ns"] - row["offered_ns"] for row in successful]
+    request = [row["request_finished_ns"] - row["request_started_ns"] for row in successful]
+    gas_used = sorted(row["gas_used"] for row in native["measured_proof_transactions"])
+    proof_counts = Counter(len(row["ordinals"]) for row in native["measured_proof_transactions"])
+    block_peak = max(blocks, key=lambda row: row["gas_used"])
+    summary = {
+        "schema": "polystore.native-v3-cross-audit-retained.v1",
+        "status": "passed",
+        "qualification": False,
+        "claim": "single-host native-v3 provider-route operating-point diagnostic; no maximum-capacity, WAN, or delivered-byte qualification",
+        "source": {"harness_commit": doc["provenance"]["source_checkout"],
+                   "product_source_commit": doc["provenance"]["product_source_commit"],
+                   "chain_id": doc["chain_id"], "runtime_artifact_source_match": doc["provenance"]["artifact_source_match"]},
+        "profile": {"validators": 4, "provider_daemons": 12, "systematic_providers": 8,
+                    "sessions": 46, "open_batch_sizes": [31, 15], "warmup_transactions": 8,
+                    "measured_offer_seconds": 180, "offered_transactions_per_second": 2,
+                    "measured_proof_transactions": 360, "measured_openings": 5940,
+                    "offered_openings_per_second": 33, "normal_audit_epochs": 2,
+                    "normal_audit_transactions": 24, "commit_p95_budget_ms": 700,
+                    "validator_memory_ceiling_bytes": 2 * 1024**3,
+                    "budgets_measured_for_qualification": False},
+        "result": {"measured_committed_valid_proof_transactions": 360,
+                   "measured_authoritative_new_openings": 5940,
+                   "scheduler_elapsed_seconds": schedule_doc["elapsed_ns"] / 1e9,
+                   "scheduler_drain_seconds": (schedule_doc["elapsed_ns"] - schedule_doc["offered_window_ns"]) / 1e9,
+                   "committed_valid_transactions_per_scheduler_second": 360 / (schedule_doc["elapsed_ns"] / 1e9),
+                   "authoritative_openings_per_scheduler_second": 5940 / (schedule_doc["elapsed_ns"] / 1e9),
+                   "rate_denominator": "all 360 client-observed committed successes over scheduler start through final terminal observation, including drain",
+                   "maximum_queued": schedule_doc["max_queued"], "maximum_in_flight": schedule_doc["max_in_flight"],
+                   "maximum_dispatch_lag_ms": schedule_doc["max_dispatch_lag_ns"] / 1e6,
+                   "http_attempts": {"scheduled_requests": 360, "total_attempts": 373,
+                                     "successful_http_200": 360, "backpressure_http_429": 13,
+                                     "retried_requests": 13, "terminal_failures": 0,
+                                     "unclassified_attempts": 0},
+                   "terminal_observation_latency": quantiles_ns(terminal),
+                   "pre_success_start_delay": quantiles_ns(pre_success),
+                   "initial_dispatch_lag": quantiles_ns(initial_dispatch),
+                   "request_duration": quantiles_ns(request),
+                   "client_observation_bins": native["schedule_bins"],
+                   "proof_commit_height_span": native["proof_anchor_span"],
+                   "reconciled_block_span": {"first_height": 217, "last_height": 434, "blocks": 218,
+                                               "committed_measured_proof_transactions": 360,
+                                               "all_four_headers_agree": True, "all_four_results_agree": True},
+                   "measured_gas": {"wanted_total": native["measured_gas_wanted"], "used_total": native["measured_gas_used"],
+                                    "proof_count_distribution": {str(key): proof_counts[key] for key in sorted(proof_counts)},
+                                    "used_per_authoritative_opening": native["measured_gas_used"] / 5940,
+                                    "used_per_transaction_min": gas_used[0], "used_per_transaction_median": statistics.median(gas_used),
+                                    "used_per_transaction_max": gas_used[-1],
+                                    "peak_block_height_by_used_gas": block_peak["height"],
+                                    "peak_block_gas_wanted": block_peak["gas_wanted"], "peak_block_gas_used": block_peak["gas_used"]},
+                   "audits": {"epochs": native["crossed_audit_epochs"], "transactions": 24,
+                              "all_assignments_accepted": True, "missed": 0},
+                   "refunds": {"sessions_expired": 46, "refund_transactions": 46, "all_verified": True},
+                   "commit_step": sorted(commit_rows, key=lambda row: row["validator"]),
+                   "validator_cpu": cpu_rows, "validator_resources": resources},
+        "limitations": [
+            "Four validators and twelve provider-daemons ran on one Linux host; this is not a realistic deployment.",
+            "The 2 transactions/s schedule is an accepted local operating point, not a measured maximum.",
+            "HTTP terminal timing combines proof generation, native verification, gas simulation, signing, broadcast, and client commit observation.",
+            "Pre-success-start delay includes scheduler delay and, for 13 requests, retry backoff after an HTTP 429; it is not a pure signer-queue measurement.",
+            "Commit p95 values are execution upper bounds from the Commit metric; they exclude the documented post-persistence tail.",
+            "CPU is a fixed-window process tick delta; RSS is a whole-process-lifetime peak, not a phase peak or 2 GiB usage claim.",
+            "Consensus header times are not wall-clock commit-completion timestamps, so this report makes no header-time throughput claim.",
+            "The retained HTTP receipts do not separate CheckTx latency from block inclusion; only the combined client terminal observation is reported.",
+            "No owner ACK or byte delivery was performed; delivery, resume, cache, WAN, and maximum capacity remain unqualified."],
+        "private_inputs": {"evidence": {"sha256": sha(raw_evidence), "bytes": len(raw_evidence)},
+                           "blocks": {"sha256": sha(raw_blocks), "bytes": len(raw_blocks)},
+                           "transactions": {"sha256": sha(raw_transactions), "bytes": len(raw_transactions)},
+                           "commit_streams": {node: {"sha256": digest} for node, digest in sorted(COMMIT_SHA256.items())}},
+        "reproduction": {"harness": "$HARNESS_SOURCE/scripts/retrieval_four_validator_workload.py",
+                         "inputs_are_private": True}
+    }
+    # Literal input pins are checked only after the semantic reconstruction above.
+    require(sha(raw_evidence) == EVIDENCE_SHA256, "retained evidence bytes differ from the publication pin")
+    require(sha(raw_blocks) == BLOCKS_SHA256, "retained block bytes differ from the publication pin")
+    require(sha(raw_transactions) == TRANSACTIONS_SHA256, "recovered transaction bytes differ from the publication pin")
+    print(json.dumps(summary, indent=2, sort_keys=True))
+
+if __name__ == "__main__": main()

--- a/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/summarize.py
+++ b/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/summarize.py
@@ -282,8 +282,9 @@ def main():
             "reconciled blocks differ from measured successful proof receipts")
     for block in blocks:
         require(block["gas_wanted"] == sum(tx["gas_wanted"] for tx in block["transactions"]) and
-                block["gas_used"] == sum(tx["gas_used"] for tx in block["transactions"]),
-                "reconciled block gas totals differ")
+                block["gas_used"] == sum(tx["gas_used"] for tx in block["transactions"]) and
+                block["tx_payload_bytes"] == sum(tx["bytes"] for tx in block["transactions"]),
+                "reconciled block gas/byte totals differ")
 
     # Recompute Commit summaries from exact raw streams plus the independently fenced endpoints.
     phase = doc["commit_step_metrics"]["phases"]
@@ -314,6 +315,10 @@ def main():
     schedule_doc = doc["v3_http_schedules"]["cross-audit-measured"]
     require(schedule_doc["offered"] == schedule_doc["completed"] == 360 and schedule_doc["queued"] == schedule_doc["in_flight"] == 0 and
             schedule_doc["terminal_error"] is None, "HTTP scheduler did not fully drain")
+    require(schedule_doc["offered_window_ns"] == 180_000_000_000 and
+            schedule_doc["elapsed_ns"] == schedule_doc["monotonic_end_ns"] - schedule_doc["monotonic_start_ns"] == 182_066_769_129 and
+            max(row["request_finished_ns"] for row in successful) <= schedule_doc["monotonic_end_ns"],
+            "HTTP scheduler monotonic boundaries or offered window differ")
     cpu = native["measured_window"]["validator_cpu_delta"]
     require(cpu == harness.validator_cpu_delta(native["measured_window"]["validator_cpu_before"],
                                                 native["measured_window"]["validator_cpu_after"]),
@@ -335,8 +340,14 @@ def main():
     initial_dispatch = [row["initial_dispatch_ns"] - row["offered_ns"] for row in successful]
     request = [row["request_finished_ns"] - row["request_started_ns"] for row in successful]
     gas_used = sorted(row["gas_used"] for row in native["measured_proof_transactions"])
+    gas_wanted_total = sum(row["gas_wanted"] for row in native["measured_proof_transactions"])
+    gas_used_total = sum(gas_used)
+    require((gas_wanted_total, gas_used_total) ==
+            (native["measured_gas_wanted"], native["measured_gas_used"]),
+            "measured gas totals differ from successful proof receipts")
     proof_counts = Counter(len(row["ordinals"]) for row in native["measured_proof_transactions"])
     block_peak = max(blocks, key=lambda row: row["gas_used"])
+    byte_peak = max(blocks, key=lambda row: row["tx_payload_bytes"])
     summary = {
         "schema": "polystore.native-v3-cross-audit-retained.v1",
         "status": "passed",
@@ -359,7 +370,7 @@ def main():
                    "scheduler_drain_seconds": (schedule_doc["elapsed_ns"] - schedule_doc["offered_window_ns"]) / 1e9,
                    "committed_valid_transactions_per_scheduler_second": 360 / (schedule_doc["elapsed_ns"] / 1e9),
                    "authoritative_openings_per_scheduler_second": 5940 / (schedule_doc["elapsed_ns"] / 1e9),
-                   "rate_denominator": "all 360 client-observed committed successes over scheduler start through final terminal observation, including drain",
+                   "rate_denominator": "all 360 client-observed committed successes over scheduler start through recorded completion after terminal observation, including drain and the final orchestration tail",
                    "maximum_queued": schedule_doc["max_queued"], "maximum_in_flight": schedule_doc["max_in_flight"],
                    "maximum_dispatch_lag_ms": schedule_doc["max_dispatch_lag_ns"] / 1e6,
                    "http_attempts": {"scheduled_requests": 360, "total_attempts": 373,
@@ -375,13 +386,15 @@ def main():
                    "reconciled_block_span": {"first_height": 217, "last_height": 434, "blocks": 218,
                                                "committed_measured_proof_transactions": 360,
                                                "all_four_headers_agree": True, "all_four_results_agree": True},
-                   "measured_gas": {"wanted_total": native["measured_gas_wanted"], "used_total": native["measured_gas_used"],
+                   "measured_gas": {"wanted_total": gas_wanted_total, "used_total": gas_used_total,
                                     "proof_count_distribution": {str(key): proof_counts[key] for key in sorted(proof_counts)},
-                                    "used_per_authoritative_opening": native["measured_gas_used"] / 5940,
+                                    "used_per_authoritative_opening": gas_used_total / 5940,
                                     "used_per_transaction_min": gas_used[0], "used_per_transaction_median": statistics.median(gas_used),
                                     "used_per_transaction_max": gas_used[-1],
                                     "peak_block_height_by_used_gas": block_peak["height"],
-                                    "peak_block_gas_wanted": block_peak["gas_wanted"], "peak_block_gas_used": block_peak["gas_used"]},
+                                    "peak_block_gas_wanted": block_peak["gas_wanted"], "peak_block_gas_used": block_peak["gas_used"],
+                                    "peak_block_height_by_tx_payload_bytes": byte_peak["height"],
+                                    "peak_block_tx_payload_bytes": byte_peak["tx_payload_bytes"]},
                    "audits": {"epochs": native["crossed_audit_epochs"], "transactions": 24,
                               "all_assignments_accepted": True, "missed": 0},
                    "refunds": {"sessions_expired": 46, "refund_transactions": 46, "all_verified": True},

--- a/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/summary.json
+++ b/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/summary.json
@@ -1,0 +1,347 @@
+{
+  "claim": "single-host native-v3 provider-route operating-point diagnostic; no maximum-capacity, WAN, or delivered-byte qualification",
+  "limitations": [
+    "Four validators and twelve provider-daemons ran on one Linux host; this is not a realistic deployment.",
+    "The 2 transactions/s schedule is an accepted local operating point, not a measured maximum.",
+    "HTTP terminal timing combines proof generation, native verification, gas simulation, signing, broadcast, and client commit observation.",
+    "Pre-success-start delay includes scheduler delay and, for 13 requests, retry backoff after an HTTP 429; it is not a pure signer-queue measurement.",
+    "Commit p95 values are execution upper bounds from the Commit metric; they exclude the documented post-persistence tail.",
+    "CPU is a fixed-window process tick delta; RSS is a whole-process-lifetime peak, not a phase peak or 2 GiB usage claim.",
+    "Consensus header times are not wall-clock commit-completion timestamps, so this report makes no header-time throughput claim.",
+    "The retained HTTP receipts do not separate CheckTx latency from block inclusion; only the combined client terminal observation is reported.",
+    "No owner ACK or byte delivery was performed; delivery, resume, cache, WAN, and maximum capacity remain unqualified."
+  ],
+  "private_inputs": {
+    "blocks": {
+      "bytes": 138694,
+      "sha256": "8a319de7509e73d207252fa9b3dbfb19b1f08a3a366bc438c1396894548bcda4"
+    },
+    "commit_streams": {
+      "2dc1ec9c1cfdcfcd97799d8579faa4378bc292b4": {
+        "sha256": "c50674a94095903ec6031fe04cca4c0abbfb5c040ad736401a480681f80539e9"
+      },
+      "303e1ba96a846764fc2540d64e2cde2beba4e77b": {
+        "sha256": "4d6c5d59e014f7c94a6cc512bb05b51e1cc6fa867fce7618e086c0a76baa171a"
+      },
+      "39bf300568acd1729f714b4abece18157fb7278a": {
+        "sha256": "4ecbd72bc6c780f427ad8daf5722e47f1fe994a72511fa17c5f1566c984a6d83"
+      },
+      "c7bad61aa9f70e24353b72c68671a6d6522a4294": {
+        "sha256": "50945719d13b631cdc6627fb7dbed82ec698cc75b9fce22c425b7cbb2a481ed4"
+      }
+    },
+    "evidence": {
+      "bytes": 4302802,
+      "sha256": "488e4e629641f272bbc2c5138aa2e1539d6d74f84ed5e3240b79679817627ebe"
+    },
+    "transactions": {
+      "bytes": 19532486,
+      "sha256": "97621fb3d5edc49d5c1c81b85a82b23ab33f3eaa0784b344f9212807e5f47ee7"
+    }
+  },
+  "profile": {
+    "budgets_measured_for_qualification": false,
+    "commit_p95_budget_ms": 700,
+    "measured_offer_seconds": 180,
+    "measured_openings": 5940,
+    "measured_proof_transactions": 360,
+    "normal_audit_epochs": 2,
+    "normal_audit_transactions": 24,
+    "offered_openings_per_second": 33,
+    "offered_transactions_per_second": 2,
+    "open_batch_sizes": [
+      31,
+      15
+    ],
+    "provider_daemons": 12,
+    "sessions": 46,
+    "systematic_providers": 8,
+    "validator_memory_ceiling_bytes": 2147483648,
+    "validators": 4,
+    "warmup_transactions": 8
+  },
+  "qualification": false,
+  "reproduction": {
+    "harness": "$HARNESS_SOURCE/scripts/retrieval_four_validator_workload.py",
+    "inputs_are_private": true
+  },
+  "result": {
+    "audits": {
+      "all_assignments_accepted": true,
+      "epochs": [
+        4,
+        5
+      ],
+      "missed": 0,
+      "transactions": 24
+    },
+    "authoritative_openings_per_scheduler_second": 32.62539357630565,
+    "client_observation_bins": [
+      {
+        "carryover_in_flight": 0,
+        "carryover_queued": 0,
+        "cohort_completed_by_end": 53,
+        "end_offset_ns": 30000000000,
+        "in_flight_at_end": 7,
+        "index": 0,
+        "offered": 60,
+        "outstanding_at_end": 7,
+        "queued_at_end": 0,
+        "start_offset_ns": 0,
+        "terminal": 53
+      },
+      {
+        "carryover_in_flight": 7,
+        "carryover_queued": 0,
+        "cohort_completed_by_end": 52,
+        "end_offset_ns": 60000000000,
+        "in_flight_at_end": 8,
+        "index": 1,
+        "offered": 60,
+        "outstanding_at_end": 8,
+        "queued_at_end": 0,
+        "start_offset_ns": 30000000000,
+        "terminal": 59
+      },
+      {
+        "carryover_in_flight": 8,
+        "carryover_queued": 0,
+        "cohort_completed_by_end": 53,
+        "end_offset_ns": 90000000000,
+        "in_flight_at_end": 7,
+        "index": 2,
+        "offered": 60,
+        "outstanding_at_end": 7,
+        "queued_at_end": 0,
+        "start_offset_ns": 60000000000,
+        "terminal": 61
+      },
+      {
+        "carryover_in_flight": 7,
+        "carryover_queued": 0,
+        "cohort_completed_by_end": 54,
+        "end_offset_ns": 120000000000,
+        "in_flight_at_end": 6,
+        "index": 3,
+        "offered": 60,
+        "outstanding_at_end": 6,
+        "queued_at_end": 0,
+        "start_offset_ns": 90000000000,
+        "terminal": 61
+      },
+      {
+        "carryover_in_flight": 6,
+        "carryover_queued": 0,
+        "cohort_completed_by_end": 55,
+        "end_offset_ns": 150000000000,
+        "in_flight_at_end": 5,
+        "index": 4,
+        "offered": 60,
+        "outstanding_at_end": 5,
+        "queued_at_end": 0,
+        "start_offset_ns": 120000000000,
+        "terminal": 61
+      },
+      {
+        "carryover_in_flight": 5,
+        "carryover_queued": 0,
+        "cohort_completed_by_end": 55,
+        "end_offset_ns": 180000000000,
+        "in_flight_at_end": 5,
+        "index": 5,
+        "offered": 60,
+        "outstanding_at_end": 5,
+        "queued_at_end": 0,
+        "start_offset_ns": 150000000000,
+        "terminal": 60
+      }
+    ],
+    "commit_step": [
+      {
+        "fenced_samples": 1424,
+        "observed_blocks": 215,
+        "p95_upper_bound_ms": 371.40020100197995,
+        "raw_samples": 1423,
+        "validator": "2dc1ec9c1cfdcfcd97799d8579faa4378bc292b4",
+        "within_700ms_budget": true
+      },
+      {
+        "fenced_samples": 1424,
+        "observed_blocks": 215,
+        "p95_upper_bound_ms": 360.59342700199227,
+        "raw_samples": 1423,
+        "validator": "303e1ba96a846764fc2540d64e2cde2beba4e77b",
+        "within_700ms_budget": true
+      },
+      {
+        "fenced_samples": 1424,
+        "observed_blocks": 215,
+        "p95_upper_bound_ms": 363.8384780019843,
+        "raw_samples": 1423,
+        "validator": "39bf300568acd1729f714b4abece18157fb7278a",
+        "within_700ms_budget": true
+      },
+      {
+        "fenced_samples": 1424,
+        "observed_blocks": 215,
+        "p95_upper_bound_ms": 395.594755001095,
+        "raw_samples": 1423,
+        "validator": "c7bad61aa9f70e24353b72c68671a6d6522a4294",
+        "within_700ms_budget": true
+      }
+    ],
+    "committed_valid_transactions_per_scheduler_second": 1.9772965803821605,
+    "http_attempts": {
+      "backpressure_http_429": 13,
+      "retried_requests": 13,
+      "scheduled_requests": 360,
+      "successful_http_200": 360,
+      "terminal_failures": 0,
+      "total_attempts": 373,
+      "unclassified_attempts": 0
+    },
+    "initial_dispatch_lag": {
+      "count": 360,
+      "max_ms": 2034.033726,
+      "median_ms": 48.236209,
+      "p50_ms": 48.220304,
+      "p95_ms": 280.756737,
+      "p99_ms": 1797.525747,
+      "percentile_method": "nearest rank; median uses conventional midpoint"
+    },
+    "maximum_dispatch_lag_ms": 2034.033726,
+    "maximum_in_flight": 8,
+    "maximum_queued": 2,
+    "measured_authoritative_new_openings": 5940,
+    "measured_committed_valid_proof_transactions": 360,
+    "measured_gas": {
+      "peak_block_gas_used": 35516833,
+      "peak_block_gas_wanted": 57742085,
+      "peak_block_height_by_used_gas": 408,
+      "proof_count_distribution": {
+        "15": 18,
+        "16": 144,
+        "17": 198
+      },
+      "used_per_authoritative_opening": 513464.8621212121,
+      "used_per_transaction_max": 8725999,
+      "used_per_transaction_median": 8725836.0,
+      "used_per_transaction_min": 7710824,
+      "used_total": 3049981281,
+      "wanted_total": 4870622929
+    },
+    "pre_success_start_delay": {
+      "count": 360,
+      "max_ms": 2157.521673,
+      "median_ms": 49.5371705,
+      "p50_ms": 49.514476,
+      "p95_ms": 1303.981341,
+      "p99_ms": 2137.684498,
+      "percentile_method": "nearest rank; median uses conventional midpoint"
+    },
+    "proof_commit_height_span": {
+      "first_anchor": 301,
+      "first_height": 293,
+      "last_height": 425,
+      "second_anchor": 401
+    },
+    "rate_denominator": "all 360 client-observed committed successes over scheduler start through final terminal observation, including drain",
+    "reconciled_block_span": {
+      "all_four_headers_agree": true,
+      "all_four_results_agree": true,
+      "blocks": 218,
+      "committed_measured_proof_transactions": 360,
+      "first_height": 217,
+      "last_height": 434
+    },
+    "refunds": {
+      "all_verified": true,
+      "refund_transactions": 46,
+      "sessions_expired": 46
+    },
+    "request_duration": {
+      "count": 360,
+      "max_ms": 4097.037565,
+      "median_ms": 2827.030934,
+      "p50_ms": 2826.685516,
+      "p95_ms": 3730.673672,
+      "p99_ms": 3867.149297,
+      "percentile_method": "nearest rank; median uses conventional midpoint"
+    },
+    "scheduler_drain_seconds": 2.066769129,
+    "scheduler_elapsed_seconds": 182.066769129,
+    "terminal_observation_latency": {
+      "count": 360,
+      "max_ms": 6030.771424,
+      "median_ms": 2933.4897445,
+      "p50_ms": 2928.885982,
+      "p95_ms": 4277.033451,
+      "p99_ms": 5794.835161,
+      "percentile_method": "nearest rank; median uses conventional midpoint"
+    },
+    "validator_cpu": [
+      {
+        "mean_cores_over_window": 0.36440827652402696,
+        "system_cpu_seconds": 0.5,
+        "user_cpu_seconds": 68.65,
+        "validator": "c7bad61aa9f70e24353b72c68671a6d6522a4294",
+        "window_seconds": 189.759685646
+      },
+      {
+        "mean_cores_over_window": 0.19103109217636988,
+        "system_cpu_seconds": 0.29,
+        "user_cpu_seconds": 35.96,
+        "validator": "2dc1ec9c1cfdcfcd97799d8579faa4378bc292b4",
+        "window_seconds": 189.759685646
+      },
+      {
+        "mean_cores_over_window": 0.19066220455009827,
+        "system_cpu_seconds": 0.3,
+        "user_cpu_seconds": 35.88,
+        "validator": "39bf300568acd1729f714b4abece18157fb7278a",
+        "window_seconds": 189.759685646
+      },
+      {
+        "mean_cores_over_window": 0.19087299747939632,
+        "system_cpu_seconds": 0.32,
+        "user_cpu_seconds": 35.9,
+        "validator": "303e1ba96a846764fc2540d64e2cde2beba4e77b",
+        "window_seconds": 189.759685646
+      }
+    ],
+    "validator_resources": [
+      {
+        "measurement_scope": "whole validator process lifetime",
+        "peak_rss_bytes": 356466688,
+        "returncode": 0,
+        "validator": "c7bad61aa9f70e24353b72c68671a6d6522a4294"
+      },
+      {
+        "measurement_scope": "whole validator process lifetime",
+        "peak_rss_bytes": 332103680,
+        "returncode": 0,
+        "validator": "2dc1ec9c1cfdcfcd97799d8579faa4378bc292b4"
+      },
+      {
+        "measurement_scope": "whole validator process lifetime",
+        "peak_rss_bytes": 330551296,
+        "returncode": 0,
+        "validator": "39bf300568acd1729f714b4abece18157fb7278a"
+      },
+      {
+        "measurement_scope": "whole validator process lifetime",
+        "peak_rss_bytes": 329969664,
+        "returncode": 0,
+        "validator": "303e1ba96a846764fc2540d64e2cde2beba4e77b"
+      }
+    ]
+  },
+  "schema": "polystore.native-v3-cross-audit-retained.v1",
+  "source": {
+    "chain_id": "polystore_260-1",
+    "harness_commit": "da54964dc502f14bc73096fb6adc5f8ba0b2be6b",
+    "product_source_commit": "5cc77e1aa28b17082cc851363b6fa7ada1ed9ce3",
+    "runtime_artifact_source_match": "supplied binaries/library; build correspondence not attested"
+  },
+  "status": "passed"
+}

--- a/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/summary.json
+++ b/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/summary.json
@@ -218,7 +218,9 @@
     "measured_gas": {
       "peak_block_gas_used": 35516833,
       "peak_block_gas_wanted": 57742085,
+      "peak_block_height_by_tx_payload_bytes": 408,
       "peak_block_height_by_used_gas": 408,
+      "peak_block_tx_payload_bytes": 53717,
       "proof_count_distribution": {
         "15": 18,
         "16": 144,
@@ -246,7 +248,7 @@
       "last_height": 425,
       "second_anchor": 401
     },
-    "rate_denominator": "all 360 client-observed committed successes over scheduler start through final terminal observation, including drain",
+    "rate_denominator": "all 360 client-observed committed successes over scheduler start through recorded completion after terminal observation, including drain and the final orchestration tail",
     "reconciled_block_span": {
       "all_four_headers_agree": true,
       "all_four_results_agree": true,

--- a/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/summary.json
+++ b/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/summary.json
@@ -6,6 +6,7 @@
     "HTTP terminal timing combines proof generation, native verification, gas simulation, signing, broadcast, and client commit observation.",
     "Pre-success-start delay includes scheduler delay and, for 13 requests, retry backoff after an HTTP 429; it is not a pure signer-queue measurement.",
     "Commit p95 values are execution upper bounds from the Commit metric; they exclude the documented post-persistence tail.",
+    "Commit streams use a wider window starting before workload alignment and ending after heavy all-validator LCD queries; that window is separate from the CPU and provider HTTP measurement window.",
     "CPU is a fixed-window process tick delta; RSS is a whole-process-lifetime peak, not a phase peak or 2 GiB usage claim.",
     "Consensus header times are not wall-clock commit-completion timestamps, so this report makes no header-time throughput claim.",
     "The retained HTTP receipts do not separate CheckTx latency from block inclusion; only the combined client terminal observation is reported.",

--- a/performance/README.md
+++ b/performance/README.md
@@ -293,3 +293,10 @@ proof-submission transactions (6,736 openings) with normal audits. At the final
 16/s offered step, 88 offers hit the bounded queue; its consensus-header-time
 window recorded 8.8 bundles/s. This is a single-host, 30-second-per-step result,
 not a production-capacity or byte-delivery qualification.
+
+The [retained native-v3 cross-audit diagnostic](../bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/README.md)
+accepts one single-host production provider-route operating point: 360 measured
+transactions and 5,940 authenticated openings committed from a fixed 180-second,
+2 transactions/s offer while 24 normal audits crossed two anchors. It remains
+`qualification=false`; maximum capacity, realistic deployment, WAN behavior,
+and delivered-byte performance are unmeasured.


### PR DESCRIPTION
Retains the landed native-v3 provider-route diagnostic at the fixed 2 transactions/s operating point. The sanitized artifact records 360 committed measured proof transactions, 5,940 authenticated openings, 24 normal-audit transactions across two anchors, 46 verified refunds, and the 13 HTTP 429 attempts that succeeded on one bounded retry.

The checker reconstructs the summary from pinned private evidence, stopped-blockstore transaction bytes, reconciled blocks, and all four raw Commit streams. It joins every successful HTTP request ID, transaction hash, provider, and session to the exact measured receipt. It also verifies the pinned production chain binary and native-library hashes, re-decodes all 440 authoritative raw transactions offline, and uses those decoded messages for the session/provider/ordinal/audit/refund joins. The result remains `qualification=false`: it does not establish maximum capacity, realistic deployment, WAN behavior, or delivered-byte performance.

Validation:
- retained summary exact reconstruction with all 440 native transaction decodes: pass
- 11 semantic negative checks, including HTTP/receipt identity, raw-byte corruption, and stale decoded JSON: pass
- 6 published payload hashes: pass
- 14 private source hashes: pass
- Python compile, JSON, relative-link, privacy, and `git diff --check`: pass

Closes no issue; contributes retained evidence to #290.
