### PR TITLE
Instrument native V3 provider proof phases

### DIFF
--- a/polystore_gateway/main.go
+++ b/polystore_gateway/main.go
@@ -756,31 +756,40 @@ func execPolystoreCli(ctx context.Context, args ...string) ([]byte, error) {
 }
 
 func runTxWithRetry(ctx context.Context, args ...string) ([]byte, error) {
+	out, _, _, err := runTxWithRetryTiming(ctx, args...)
+	return out, err
+}
+
+func runTxWithRetryTiming(ctx context.Context, args ...string) ([]byte, []submissionAttemptTiming, bool, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	maxRetries := 5
 	var out []byte
 	var err error
+	var timings []submissionAttemptTiming
+	timingComplete := true
 
 	for i := 0; i < maxRetries; i++ {
 		if ctx.Err() != nil {
 			// Earlier attempts, if any, were explicitly rejected CheckTx results.
-			return nil, fmt.Errorf("%w: %w", errTxNotSubmitted, ctx.Err())
+			return nil, timings, false, fmt.Errorf("%w: %w", errTxNotSubmitted, ctx.Err())
 		}
 		attemptCtx, cancel := context.WithTimeout(ctx, cmdTimeout)
 		var cmdOut []byte
 		var cmdErr error
-		cmdOut, cmdErr = execTrackedSubmission(attemptCtx, args...)
+		var phase submissionPhaseTiming
+		var phaseValid bool
+		cmdOut, phase, phaseValid, cmdErr = execTrackedSubmissionTiming(attemptCtx, args...)
 		cancel()
 		out = cmdOut
 		err = cmdErr
 		if errors.Is(err, errTxNotSubmitted) {
-			return out, err
+			return out, timings, false, err
 		}
 
 		if errors.Is(attemptCtx.Err(), context.DeadlineExceeded) {
-			return out, fmt.Errorf("polystorechaind command timed out after %s", cmdTimeout)
+			return out, timings, false, fmt.Errorf("polystorechaind command timed out after %s", cmdTimeout)
 		}
 		// Retry only an explicit SDK CheckTx sequence rejection. A successful or
 		// ambiguous broadcast must not be replayed based on arbitrary log text.
@@ -791,21 +800,31 @@ func runTxWithRetry(ctx context.Context, args ...string) ([]byte, error) {
 		body := extractJSONBody(out)
 		if validateJSONObject(body) == nil && json.Unmarshal(body, &check) == nil {
 			code, codeErr := explicitTxCode(check.Code)
+			if phaseValid && codeErr == nil {
+				timings = append(timings, submissionAttemptTiming{Attempt: i + 1,
+					PreBroadcastNS: phase.PreBroadcastNS, BroadcastTxSyncNS: phase.BroadcastTxSyncNS,
+					CheckTxCode: code})
+			} else {
+				timingComplete = false
+			}
 			if codeErr == nil && code == 32 && check.Codespace == "sdk" && i+1 < maxRetries {
 				log.Printf("runTxWithRetry: CheckTx sequence rejection (attempt %d/%d)", i+1, maxRetries)
 				if err := waitTxRetry(ctx, time.Second); err != nil {
-					return out, err
+					return out, timings, false, err
 				}
 				continue
 			}
 		}
+		if len(timings) != i+1 {
+			timingComplete = false
+		}
 		if err != nil {
-			return out, err
+			return out, timings, timingComplete, err
 		}
 
-		return out, nil
+		return out, timings, timingComplete, nil
 	}
-	return out, err
+	return out, timings, timingComplete, err
 }
 
 func main() {

--- a/polystore_gateway/retrieval_v3_session_test.go
+++ b/polystore_gateway/retrieval_v3_session_test.go
@@ -679,3 +679,36 @@ func TestRetrievalV3MalformedCommittedMarkerRemainsQuarantined(t *testing.T) {
 		t.Fatalf("malformed committed marker was cleared: %+v %v", got, err)
 	}
 }
+
+func TestRetrievalV3ProviderTimingIsSuccessOnlyAndBounded(t *testing.T) {
+	submission := txSubmissionTiming{Complete: true, CommitObservationNS: 30,
+		Attempts: []submissionAttemptTiming{{Attempt: 1, PreBroadcastNS: 10, BroadcastTxSyncNS: 20, CheckTxCode: 0}}}
+	if !validV3SubmissionTiming(submission) {
+		t.Fatal("valid submission timing rejected")
+	}
+	bad := submission
+	bad.Attempts = append([]submissionAttemptTiming(nil), submission.Attempts...)
+	bad.Attempts[0].CheckTxCode = 32
+	if validV3SubmissionTiming(bad) {
+		t.Fatal("non-terminal CheckTx code accepted")
+	}
+
+	w := httptest.NewRecorder()
+	timing := &retrievalV3ProviderTiming{Schema: "polystore-v3-provider-timing-v1", AuthorityNS: 1,
+		ProofPreparationNS: 2, SubmissionAttempts: submission.Attempts,
+		CommitObservationNS: 30, ProviderTotalNS: 63}
+	writeRetrievalV3Outcome(w, "success", "0x"+strings.Repeat("a", 64), strings.Repeat("B", 64), 0, 1, 0, "complete", timing, nil)
+	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), `"timing":{"schema":"polystore-v3-provider-timing-v1"`) {
+		t.Fatal("successful v3 outcome omitted timing", w.Code, w.Body.String())
+	}
+	w = httptest.NewRecorder()
+	writeRetrievalV3Outcome(w, "reconciled", "0x"+strings.Repeat("a", 64), "", 0, 0, 0, "complete", nil, nil)
+	if strings.Contains(w.Body.String(), `"timing"`) {
+		t.Fatal("non-submission reconciliation invented timing", w.Body.String())
+	}
+	w = httptest.NewRecorder()
+	writeRetrievalV3Outcome(w, "pending", "0x"+strings.Repeat("a", 64), strings.Repeat("B", 64), 0, 1, 0, "retained", timing, errTxPending)
+	if strings.Contains(w.Body.String(), `"timing"`) {
+		t.Fatal("error outcome exposed partial timing", w.Body.String())
+	}
+}

--- a/polystore_gateway/retrieval_v3_submission.go
+++ b/polystore_gateway/retrieval_v3_submission.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/cosmos/gogoproto/jsonpb"
 	"polystorechain/pkg/retrievalchallenge"
@@ -84,8 +85,20 @@ func writeRetrievalV3RecoveryOutcome(w http.ResponseWriter, status, recordedSess
 	_ = json.NewEncoder(w).Encode(result)
 }
 
-func writeRetrievalV3Outcome(w http.ResponseWriter, status, sessionID, hash string, slot uint32, proofs, remaining int, cleanup string, err error) {
+type retrievalV3ProviderTiming struct {
+	Schema              string                    `json:"schema"`
+	AuthorityNS         uint64                    `json:"authority_ns"`
+	ProofPreparationNS  uint64                    `json:"proof_preparation_ns"`
+	SubmissionAttempts  []submissionAttemptTiming `json:"submission_attempts"`
+	CommitObservationNS uint64                    `json:"commit_observation_ns"`
+	ProviderTotalNS     uint64                    `json:"provider_total_ns"`
+}
+
+func writeRetrievalV3Outcome(w http.ResponseWriter, status, sessionID, hash string, slot uint32, proofs, remaining int, cleanup string, timing *retrievalV3ProviderTiming, err error) {
 	result := map[string]any{"status": status, "session_id": sessionID, "tx_hash": hash, "slot": slot, "proof_count": proofs, "remaining": remaining, "cleanup_status": cleanup}
+	if timing != nil && status == "success" && err == nil {
+		result["timing"] = timing
+	}
 	if err != nil {
 		result["error"] = err.Error()
 	}
@@ -101,6 +114,9 @@ func writeRetrievalV3Outcome(w http.ResponseWriter, status, sessionID, hash stri
 // submitRetrievalSessionProofV3 runs under the existing per-session and signer
 // in-memory locks held by SpSubmitRetrievalSessionProof.
 func submitRetrievalSessionProofV3(w http.ResponseWriter, ctx context.Context, keyName, signer, sessionID string) {
+	// SpSubmitRetrievalSessionProof has already selected V3 and acquired the
+	// session/signer admission locks. ProviderTotalNS begins at this V3 dispatch.
+	providerStarted := time.Now()
 	pending, err := loadPendingSigner(signer)
 	if err != nil {
 		writeJSONError(w, http.StatusConflict, "v3 proof reconciliation state unavailable", err.Error())
@@ -164,13 +180,16 @@ func submitRetrievalSessionProofV3(w http.ResponseWriter, ctx context.Context, k
 		writeJSONError(w, http.StatusConflict, "invalid frozen v3 session", err.Error())
 		return
 	}
+	authorityNS := uint64(time.Since(providerStarted))
+	proofStarted := time.Now()
 	slot, proofs, remaining, err := buildProviderProofBatchV3(ctx, frozen, signer)
+	proofPreparationNS := uint64(time.Since(proofStarted))
 	if err != nil {
 		writeJSONError(w, http.StatusConflict, "v3 session proof unavailable", err.Error())
 		return
 	}
 	if len(proofs) == 0 {
-		writeRetrievalV3Outcome(w, "reconciled", sessionID, "", slot, 0, remaining, "complete", nil)
+		writeRetrievalV3Outcome(w, "reconciled", sessionID, "", slot, 0, remaining, "complete", nil, nil)
 		return
 	}
 	msg := &types.MsgSubmitRetrievalSessionProofV3{Creator: signer, SessionId: frozen.Session.SessionId, Slot: slot, Proofs: proofs}
@@ -192,7 +211,7 @@ func submitRetrievalSessionProofV3(w http.ResponseWriter, ctx context.Context, k
 		writeJSONError(w, http.StatusConflict, "cannot persist v3 proof intent", err.Error())
 		return
 	}
-	hash, err := submitTxAndRecord(ctx, func(hash string) error {
+	hash, submissionTiming, err := submitTxAndRecordTiming(ctx, func(hash string) error {
 		op.TxHash = hash
 		return updatePendingSignerV3(signer, op, false)
 	}, "tx", "polystorechain", "retrieval-session-v3", "prove", file.Name(), "--from", keyName, "--chain-id", chainID, "--home", homeDir, "--keyring-backend", "test", "--yes", "--gas", "auto", "--gas-adjustment", "1.6", "--gas-prices", gasPrices, "--broadcast-mode", "sync", "--output", "json")
@@ -215,5 +234,32 @@ func submitRetrievalSessionProofV3(w http.ResponseWriter, ctx context.Context, k
 			status = "failed"
 		}
 	}
-	writeRetrievalV3Outcome(w, status, sessionID, hash, slot, len(proofs), remaining, cleanup, err)
+	var timing *retrievalV3ProviderTiming
+	if err == nil && validV3SubmissionTiming(submissionTiming) {
+		timing = &retrievalV3ProviderTiming{Schema: "polystore-v3-provider-timing-v1",
+			AuthorityNS: authorityNS, ProofPreparationNS: proofPreparationNS,
+			SubmissionAttempts:  submissionTiming.Attempts,
+			CommitObservationNS: submissionTiming.CommitObservationNS,
+			ProviderTotalNS:     uint64(time.Since(providerStarted))}
+	}
+	writeRetrievalV3Outcome(w, status, sessionID, hash, slot, len(proofs), remaining, cleanup, timing, err)
+}
+
+func validV3SubmissionTiming(value txSubmissionTiming) bool {
+	if !value.Complete || len(value.Attempts) == 0 || len(value.Attempts) > 5 || value.CommitObservationNS == 0 {
+		return false
+	}
+	const maxPhaseNS = uint64(90 * time.Second)
+	if value.CommitObservationNS > maxPhaseNS {
+		return false
+	}
+	for index, attempt := range value.Attempts {
+		if attempt.Attempt != index+1 || attempt.PreBroadcastNS > maxPhaseNS ||
+			attempt.BroadcastTxSyncNS > maxPhaseNS ||
+			(index+1 < len(value.Attempts) && attempt.CheckTxCode != 32) ||
+			(index+1 == len(value.Attempts) && attempt.CheckTxCode != 0) {
+			return false
+		}
+	}
+	return true
 }

--- a/polystore_gateway/tx_submission_phase_test.go
+++ b/polystore_gateway/tx_submission_phase_test.go
@@ -103,6 +103,52 @@ func TestSubmissionPhaseRetryNeverReusesPriorMarker(t *testing.T) {
 	}
 }
 
+func TestSubmissionTimingRetainsExplicitSequenceAttempts(t *testing.T) {
+	hash := strings.Repeat("A", 64)
+	calls := 0
+	setupMockCombinedOutput(t, func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		calls++
+		writeSubmissionPhase(t, args, fmt.Sprintf(`{"schema":"polystore-submission-timing-v1","pre_broadcast_ns":%d,"broadcast_tx_sync_ns":%d}`+"\n", calls, calls+10))
+		code := 32
+		if calls == 2 {
+			code = 0
+		}
+		return []byte(fmt.Sprintf(`{"txhash":%q,"code":%d,"codespace":"sdk"}`, hash, code)), nil
+	})
+	out, timings, complete, err := runTxWithRetryTiming(context.Background(), "tx", "polystorechain", "retrieval-session-v3", "fixture")
+	if err != nil || !complete || calls != 2 || len(timings) != 2 || !strings.Contains(string(out), `"code":0`) {
+		t.Fatal(err, complete, calls, timings, string(out))
+	}
+	if timings[0].Attempt != 1 || timings[0].CheckTxCode != 32 || timings[1].Attempt != 2 || timings[1].CheckTxCode != 0 {
+		t.Fatal("sequence retry timing lost", timings)
+	}
+}
+
+func TestSubmissionTimingIsObservationalOnly(t *testing.T) {
+	for _, phase := range []string{
+		`{"schema":"wrong","pre_broadcast_ns":1,"broadcast_tx_sync_ns":2}`,
+		`{"schema":"polystore-submission-timing-v1"}`,
+		`{"schema":"polystore-submission-timing-v1","pre_broadcast_ns":null,"broadcast_tx_sync_ns":2}`,
+		`{"schema":"polystore-submission-timing-v1","pre_broadcast_ns":"1","broadcast_tx_sync_ns":2}`,
+		`{"schema":"polystore-submission-timing-v1","pre_broadcast_ns":1.0,"broadcast_tx_sync_ns":2}`,
+		`{"schema":"polystore-submission-timing-v1","pre_broadcast_ns":1,"broadcast_tx_sync_ns":2,"extra":3}`,
+		`{"schema":"polystore-submission-timing-v1","pre_broadcast_ns":90000000001,"broadcast_tx_sync_ns":2}`,
+		`{`,
+		``,
+	} {
+		t.Run(phase, func(t *testing.T) {
+			setupMockCombinedOutput(t, func(_ context.Context, _ string, args ...string) ([]byte, error) {
+				writeSubmissionPhase(t, args, phase)
+				return []byte(`{"txhash":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","code":0}`), nil
+			})
+			_, timings, complete, err := runTxWithRetryTiming(context.Background(), "tx", "polystorechain", "retrieval-session-v3", "fixture")
+			if err != nil || complete || len(timings) != 0 {
+				t.Fatal("malformed timing changed transaction semantics", err, complete, timings)
+			}
+		})
+	}
+}
+
 func TestSubmissionPhaseCancellationAfterCheckTxRejection(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/polystore_gateway/tx_submit.go
+++ b/polystore_gateway/tx_submit.go
@@ -24,34 +24,95 @@ var errTxFailed = errors.New("committed transaction failed")
 var errTxNotSubmitted = errors.New("transaction failed before broadcast")
 
 const maxCommittedTxResponseBytes = 4 << 20
+const maxSubmissionPhaseBytes = 1024
+
+type submissionPhaseTiming struct {
+	Schema            string `json:"schema"`
+	PreBroadcastNS    uint64 `json:"pre_broadcast_ns"`
+	BroadcastTxSyncNS uint64 `json:"broadcast_tx_sync_ns"`
+}
+
+type submissionAttemptTiming struct {
+	Attempt           int    `json:"attempt"`
+	PreBroadcastNS    uint64 `json:"pre_broadcast_ns"`
+	BroadcastTxSyncNS uint64 `json:"broadcast_tx_sync_ns"`
+	CheckTxCode       uint32 `json:"check_tx_code"`
+}
+
+type txSubmissionTiming struct {
+	Attempts            []submissionAttemptTiming
+	CommitObservationNS uint64
+	Complete            bool
+}
+
+func parseSubmissionPhaseTiming(value []byte) (submissionPhaseTiming, error) {
+	if err := validateJSONObject(value); err != nil {
+		return submissionPhaseTiming{}, err
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(value, &fields); err != nil || len(fields) != 3 {
+		return submissionPhaseTiming{}, fmt.Errorf("invalid submission timing object")
+	}
+	var schema string
+	if err := json.Unmarshal(fields["schema"], &schema); err != nil || schema != "polystore-submission-timing-v1" {
+		return submissionPhaseTiming{}, fmt.Errorf("invalid submission timing schema")
+	}
+	parseDuration := func(name string) (uint64, error) {
+		raw, ok := fields[name]
+		if !ok {
+			return 0, fmt.Errorf("missing %s", name)
+		}
+		value, err := strconv.ParseUint(string(raw), 10, 64)
+		if err != nil || strconv.FormatUint(value, 10) != string(raw) || value > uint64(90*time.Second) {
+			return 0, fmt.Errorf("invalid %s", name)
+		}
+		return value, nil
+	}
+	preBroadcast, err := parseDuration("pre_broadcast_ns")
+	if err != nil {
+		return submissionPhaseTiming{}, err
+	}
+	broadcast, err := parseDuration("broadcast_tx_sync_ns")
+	if err != nil {
+		return submissionPhaseTiming{}, err
+	}
+	return submissionPhaseTiming{Schema: schema, PreBroadcastNS: preBroadcast, BroadcastTxSyncNS: broadcast}, nil
+}
 
 // Only these CLI commands implement the explicit phase contract. Each attempt
 // gets its own empty private file, so retry can never reuse an earlier marker.
 func execTrackedSubmission(ctx context.Context, args ...string) ([]byte, error) {
+	out, _, _, err := execTrackedSubmissionTiming(ctx, args...)
+	return out, err
+}
+
+func execTrackedSubmissionTiming(ctx context.Context, args ...string) ([]byte, submissionPhaseTiming, bool, error) {
 	if len(args) < 3 || args[0] != "tx" || (args[2] != "submit-retrieval-proof" && args[2] != "prove-liveness-system" && args[2] != "accept-deal-generation-v3" && args[2] != "retrieval-session-v3") {
-		return execPolystorechaind(ctx, args...)
+		out, err := execPolystorechaind(ctx, args...)
+		return out, submissionPhaseTiming{}, false, err
 	}
 	file, err := os.CreateTemp("", "polystore-submission-phase-*")
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", errTxNotSubmitted, err)
+		return nil, submissionPhaseTiming{}, false, fmt.Errorf("%w: %w", errTxNotSubmitted, err)
 	}
 	defer os.Remove(file.Name())
 	if err := file.Close(); err != nil {
-		return nil, fmt.Errorf("%w: %w", errTxNotSubmitted, err)
+		return nil, submissionPhaseTiming{}, false, fmt.Errorf("%w: %w", errTxNotSubmitted, err)
 	}
 	command := append(append([]string(nil), args...), "--submission-phase-file", file.Name())
 	out, err := execPolystorechaind(ctx, command...)
-	if err != nil {
-		phase, openErr := os.Open(file.Name())
-		if openErr == nil {
-			marker, readErr := io.ReadAll(io.LimitReader(phase, 128))
-			_ = phase.Close()
-			if readErr == nil && string(marker) == "polystore-submission-v1:not-broadcast\n" {
-				return out, fmt.Errorf("%w: %w", errTxNotSubmitted, err)
-			}
-		}
+	phase, readErr := os.Open(file.Name())
+	if readErr != nil {
+		return out, submissionPhaseTiming{}, false, err
 	}
-	return out, err
+	value, readErr := io.ReadAll(io.LimitReader(phase, maxSubmissionPhaseBytes+1))
+	_ = phase.Close()
+	if err != nil && readErr == nil && string(value) == "polystore-submission-v1:not-broadcast\n" {
+		return out, submissionPhaseTiming{}, false, fmt.Errorf("%w: %w", errTxNotSubmitted, err)
+	}
+	timing, timingErr := parseSubmissionPhaseTiming(value)
+	valid := readErr == nil && len(value) <= maxSubmissionPhaseBytes && timingErr == nil
+	return out, timing, valid, err
 }
 
 func normalizeTxHash(raw string) (string, error) {
@@ -118,24 +179,30 @@ func committedTxResult(body []byte, expected string) error {
 // A bounded, caller-driven observation. The caller retains the returned hash on
 // every unknown or failed outcome and never interprets HTTP status as settlement.
 func waitForCommittedTx(ctx context.Context, rawHash string) (resultHash string, resultErr error) {
+	hash, _, err := waitForCommittedTxTiming(ctx, rawHash)
+	return hash, err
+}
+
+func waitForCommittedTxTiming(ctx context.Context, rawHash string) (resultHash string, elapsedNS uint64, resultErr error) {
 	hash, err := normalizeTxHash(rawHash)
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 	started := time.Now()
 	defer func() {
-		log.Printf("transaction timing tx=%s inclusion_observation_ms=%.3f success=%t", hash, float64(time.Since(started))/float64(time.Millisecond), resultErr == nil)
+		elapsedNS = uint64(time.Since(started))
+		log.Printf("transaction timing tx=%s inclusion_observation_ms=%.3f success=%t", hash, float64(elapsedNS)/float64(time.Millisecond), resultErr == nil)
 	}()
 	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 	client := &http.Client{Timeout: 2 * time.Second}
 	for {
 		if err := ctx.Err(); err != nil {
-			return hash, fmt.Errorf("%w: %w", errTxPending, err)
+			return hash, 0, fmt.Errorf("%w: %w", errTxPending, err)
 		}
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(lcdBase, "/")+"/cosmos/tx/v1beta1/txs/"+hash, nil)
 		if err != nil {
-			return hash, fmt.Errorf("%w: %w", errTxPending, err)
+			return hash, 0, fmt.Errorf("%w: %w", errTxPending, err)
 		}
 		resp, err := client.Do(req)
 		if err == nil {
@@ -143,17 +210,17 @@ func waitForCommittedTx(ctx context.Context, rawHash string) (resultHash string,
 			_ = resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
 				if readErr != nil || len(body) > maxCommittedTxResponseBytes {
-					return hash, fmt.Errorf("%w: transaction response incomplete or exceeds limit", errTxPending)
+					return hash, 0, fmt.Errorf("%w: transaction response incomplete or exceeds limit", errTxPending)
 				}
 				err = committedTxResult(body, hash)
 				if err == nil || errors.Is(err, errTxFailed) {
-					return hash, err
+					return hash, 0, err
 				}
-				return hash, fmt.Errorf("%w: %w", errTxPending, err)
+				return hash, 0, fmt.Errorf("%w: %w", errTxPending, err)
 			}
 		}
 		if err := waitTxRetry(ctx, 500*time.Millisecond); err != nil {
-			return hash, fmt.Errorf("%w: %w", errTxPending, err)
+			return hash, 0, fmt.Errorf("%w: %w", errTxPending, err)
 		}
 	}
 }
@@ -177,8 +244,14 @@ func submitTxAndWait(ctx context.Context, args ...string) (string, error) {
 // Durable callers also mark their submission intent before invoking the CLI so
 // a crash before the hash is recorded remains explicitly pending after restart.
 func submitTxAndRecord(ctx context.Context, record func(string) error, args ...string) (string, error) {
+	hash, _, err := submitTxAndRecordTiming(ctx, record, args...)
+	return hash, err
+}
+
+func submitTxAndRecordTiming(ctx context.Context, record func(string) error, args ...string) (string, txSubmissionTiming, error) {
 	started := time.Now()
-	out, submitErr := runTxWithRetry(ctx, args...)
+	out, attempts, timingComplete, submitErr := runTxWithRetryTiming(ctx, args...)
+	timing := txSubmissionTiming{Attempts: attempts, Complete: timingComplete}
 	submissionMs := float64(time.Since(started)) / float64(time.Millisecond)
 	body := extractJSONBody(out)
 	var response struct {
@@ -202,29 +275,31 @@ func submitTxAndRecord(ctx context.Context, record func(string) error, args ...s
 	// mempool transaction. It is still pending, not a rejection authorizing retry.
 	mempoolPending := response.Codespace == sdkerrors.RootCodespace && code == sdkerrors.ErrTxInMempoolCache.ABCICode()
 	if decodeErr == nil && codeErr == nil && code != 0 && !mempoolPending {
-		return hash, fmt.Errorf("%w: code %d: %.4096s", errTxRejected, code, response.RawLog)
+		return hash, timing, fmt.Errorf("%w: code %d: %.4096s", errTxRejected, code, response.RawLog)
 	}
 	if hash != "" && record != nil {
 		if err := record(hash); err != nil {
-			return hash, fmt.Errorf("%w: could not persist broadcast hash: %w", errTxPending, err)
+			return hash, timing, fmt.Errorf("%w: could not persist broadcast hash: %w", errTxPending, err)
 		}
 	}
 	if mempoolPending {
-		return hash, fmt.Errorf("%w: transaction already in mempool", errTxPending)
+		return hash, timing, fmt.Errorf("%w: transaction already in mempool", errTxPending)
 	}
 	if hash == "" && errors.Is(submitErr, errTxNotSubmitted) {
-		return "", submitErr
+		return "", timing, submitErr
 	}
 	if hash != "" && errors.Is(submitErr, errTxNotSubmitted) {
 		// Observed broadcast evidence wins over a contradictory phase report.
 		// Do not unwrap the local classification: callers must retain this intent.
-		return hash, fmt.Errorf("%w: conflicting CLI phase: %v", errTxPending, submitErr)
+		return hash, timing, fmt.Errorf("%w: conflicting CLI phase: %v", errTxPending, submitErr)
 	}
 	if submitErr != nil {
-		return hash, fmt.Errorf("%w: CLI submission: %w", errTxPending, submitErr)
+		return hash, timing, fmt.Errorf("%w: CLI submission: %w", errTxPending, submitErr)
 	}
 	if decodeErr != nil || codeErr != nil || hash == "" {
-		return hash, fmt.Errorf("%w: malformed broadcast response", errTxPending)
+		return hash, timing, fmt.Errorf("%w: malformed broadcast response", errTxPending)
 	}
-	return waitForCommittedTx(ctx, hash)
+	resultHash, elapsed, err := waitForCommittedTxTiming(ctx, hash)
+	timing.CommitObservationNS = elapsed
+	return resultHash, timing, err
 }

--- a/polystorechain/x/polystorechain/client/cli/submission_phase.go
+++ b/polystorechain/x/polystorechain/client/cli/submission_phase.go
@@ -2,8 +2,10 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"sync/atomic"
+	"time"
 
 	coretypes "github.com/cometbft/cometbft/rpc/core/types"
 	cmttypes "github.com/cometbft/cometbft/types"
@@ -15,15 +17,35 @@ import (
 // returned command error before any broadcast call can write this final marker.
 const submissionPhaseFlag = "submission-phase-file"
 const submissionNotBroadcast = "polystore-submission-v1:not-broadcast\n"
+const submissionTimingSchema = "polystore-submission-timing-v1"
+
+type submissionTiming struct {
+	Schema            string `json:"schema"`
+	PreBroadcastNS    uint64 `json:"pre_broadcast_ns"`
+	BroadcastTxSyncNS uint64 `json:"broadcast_tx_sync_ns"`
+}
 
 type submissionPhase struct {
-	path    string
-	started atomic.Bool
+	path      string
+	startedAt time.Time
+	started   atomic.Bool
 }
 
 func beginSubmissionPhase(cmd *cobra.Command) *submissionPhase {
 	path, _ := cmd.Flags().GetString(submissionPhaseFlag)
-	return &submissionPhase{path: path}
+	return &submissionPhase{path: path, startedAt: time.Now()}
+}
+
+func (p *submissionPhase) writeTiming(value submissionTiming) {
+	if p.path == "" {
+		return
+	}
+	encoded, err := json.Marshal(value)
+	if err == nil {
+		// Timing is observational. A failed write must not affect broadcast outcome
+		// or create pre-broadcast retry authority.
+		_ = os.WriteFile(p.path, append(encoded, '\n'), 0600)
+	}
 }
 
 func (p *submissionPhase) finish(err *error) {
@@ -54,7 +76,18 @@ type submissionPhaseRPC struct {
 
 func (r *submissionPhaseRPC) BroadcastTxSync(ctx context.Context, tx cmttypes.Tx) (*coretypes.ResultBroadcastTx, error) {
 	r.phase.started.Store(true)
-	return r.CometRPC.BroadcastTxSync(ctx, tx)
+	// The pre-broadcast duration starts when Cobra enters RunE, not when the
+	// polystorechaind process starts, and includes local account, simulation and
+	// signing work before the RPC call.
+	preBroadcast := time.Since(r.phase.startedAt)
+	started := time.Now()
+	result, err := r.CometRPC.BroadcastTxSync(ctx, tx)
+	r.phase.writeTiming(submissionTiming{
+		Schema:            submissionTimingSchema,
+		PreBroadcastNS:    uint64(preBroadcast),
+		BroadcastTxSyncNS: uint64(time.Since(started)),
+	})
+	return result, err
 }
 
 func (r *submissionPhaseRPC) BroadcastTxAsync(ctx context.Context, tx cmttypes.Tx) (*coretypes.ResultBroadcastTx, error) {

--- a/polystorechain/x/polystorechain/client/cli/submission_phase_test.go
+++ b/polystorechain/x/polystorechain/client/cli/submission_phase_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -55,7 +56,9 @@ func TestSubmissionPhaseRealSDKLocalAndBroadcastFailures(t *testing.T) {
 			marker, err := os.ReadFile(path)
 			require.NoError(t, err)
 			if mode == "network" {
-				require.Empty(t, marker)
+				var timing submissionTiming
+				require.NoError(t, json.Unmarshal(marker, &timing))
+				require.Equal(t, submissionTimingSchema, timing.Schema)
 			} else {
 				require.Equal(t, submissionNotBroadcast, string(marker))
 			}

--- a/polystorechain/x/polystorechain/client/cli/tx_generation_v3_test.go
+++ b/polystorechain/x/polystorechain/client/cli/tx_generation_v3_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -52,7 +53,12 @@ func TestAcceptDealGenerationV3SubmissionPhase(t *testing.T) {
 			marker, err := os.ReadFile(phase)
 			require.NoError(t, err)
 			if tc.broadcast {
-				require.Empty(t, marker)
+				require.NotEqual(t, submissionNotBroadcast, string(marker))
+				var timing submissionTiming
+				require.NoError(t, json.Unmarshal(marker, &timing))
+				require.Equal(t, submissionTimingSchema, timing.Schema)
+				require.Positive(t, timing.PreBroadcastNS)
+				require.Positive(t, timing.BroadcastTxSyncNS)
 			} else {
 				require.Equal(t, submissionNotBroadcast, string(marker))
 			}

--- a/scripts/retrieval_four_validator_workload.py
+++ b/scripts/retrieval_four_validator_workload.py
@@ -64,6 +64,8 @@ V3_CROSS_AUDIT_OPEN_BATCH_MAX = 31
 V3_CROSS_AUDIT_OPEN_GAS = 2_000_000
 V3_CROSS_AUDIT_OPEN_BATCH_GAS_CAP = (
     OPEN_SESSION_BATCH_BASE_GAS + V3_CROSS_AUDIT_OPEN_GAS * V3_CROSS_AUDIT_OPEN_BATCH_MAX)
+V3_PROVIDER_TIMING_SCHEMA = "polystore-v3-provider-timing-v1"
+V3_PROVIDER_TIMING_MAX_NS = 90 * 10**9
 
 
 def native_v3_chain_offsets():
@@ -316,6 +318,123 @@ def validate_v3_provider_outcomes(rows, providers, *, session_id):
         raise ValueError("v3 proof wave omitted a systematic provider")
     return dict(unique_tx_hashes=sorted(hashes), proof_count=proofs,
                 slot_count=len(slots), payees=[providers[slot] for slot in sorted(slots)])
+
+
+def _nearest_rank(values, percentile):
+    if not values:
+        raise ValueError("phase percentile requires observations")
+    ordered = sorted(values)
+    return ordered[(len(ordered) * percentile + 99) // 100 - 1]
+
+
+def validate_v3_provider_phase_timings(outcomes, transactions):
+    """Qualify monotonic provider phases after authoritative transaction joins."""
+    reasons = []
+    transaction_operations = [row.get("operation_id") for row in transactions]
+    outcome_operations = [row.get("request_id") for row in outcomes]
+    operation_ids_valid = (all(isinstance(value, str) and value for value in outcome_operations) and
+                           all(isinstance(value, str) and value for value in transaction_operations))
+    by_operation = ({row["operation_id"]: row for row in transactions}
+                    if operation_ids_valid else {})
+    if (not outcomes or not operation_ids_valid or len(outcomes) != len(transactions) or
+            len(set(outcome_operations)) != len(outcome_operations) or None in outcome_operations or
+            len(by_operation) != len(transactions) or
+            set(outcome_operations) != set(by_operation)):
+        reasons.append("timing rows do not map one-to-one to committed operations")
+    phases = {name: [] for name in ("authority_ns", "proof_preparation_ns",
+                                    "pre_broadcast_ns", "broadcast_tx_sync_ns",
+                                    "commit_observation_ns", "provider_total_ns",
+                                    "unattributed_ns")}
+    observations = []
+    retries = 0
+    for outcome in outcomes:
+        operation = outcome.get("request_id")
+        if not isinstance(operation, str) or not operation:
+            reasons.append("timing outcome has an invalid operation identity")
+            continue
+        transaction = by_operation.get(operation)
+        if transaction is None:
+            reasons.append(f"operation {operation!r} lacks an authoritative transaction")
+            continue
+        validators = transaction.get("validators")
+        try:
+            slot = producer.uint(outcome.get("slot", 99))
+            identity = (outcome.get("status") == "success" and
+                        transaction.get("outcome") == "committed_success" and
+                        isinstance(outcome.get("tx_hash"), str) and
+                        isinstance(transaction.get("txhash"), str) and
+                        outcome["tx_hash"].upper() == transaction["txhash"].upper() and
+                        outcome.get("provider") == transaction.get("provider") == transaction.get("creator") and
+                        outcome.get("session_id") == transaction.get("session_id") and
+                        slot == transaction.get("slot") and isinstance(validators, list) and
+                        len(validators) == 4 and len({row.get("node_id") for row in validators}) == 4)
+        except (TypeError, ValueError):
+            identity = False
+        if not identity:
+            reasons.append(f"operation {operation!r} timing identity is not its all-validator receipt")
+            continue
+        timing = outcome.get("timing")
+        expected = {"schema", "authority_ns", "proof_preparation_ns", "submission_attempts",
+                    "commit_observation_ns", "provider_total_ns"}
+        if not isinstance(timing, dict) or set(timing) != expected or timing.get("schema") != V3_PROVIDER_TIMING_SCHEMA:
+            reasons.append(f"operation {operation!r} has missing or malformed provider timing")
+            continue
+        values = {}
+        try:
+            for name in ("authority_ns", "proof_preparation_ns", "commit_observation_ns",
+                         "provider_total_ns"):
+                value = timing.get(name)
+                if type(value) is not int or not 0 <= value <= V3_PROVIDER_TIMING_MAX_NS:
+                    raise ValueError(name)
+                values[name] = value
+            attempts = timing.get("submission_attempts")
+            if not isinstance(attempts, list) or not 1 <= len(attempts) <= 5:
+                raise ValueError("submission_attempts")
+            attempt_total = 0
+            attempt_values = {"pre_broadcast_ns": [], "broadcast_tx_sync_ns": []}
+            for index, attempt in enumerate(attempts, 1):
+                if not isinstance(attempt, dict) or set(attempt) != {
+                        "attempt", "pre_broadcast_ns", "broadcast_tx_sync_ns", "check_tx_code"}:
+                    raise ValueError("submission_attempt")
+                if type(attempt.get("attempt")) is not int or attempt["attempt"] != index or \
+                        type(attempt.get("check_tx_code")) is not int:
+                    raise ValueError("submission_attempt")
+                expected_code = 0 if index == len(attempts) else 32
+                if attempt["check_tx_code"] != expected_code:
+                    raise ValueError("check_tx_code")
+                for name in ("pre_broadcast_ns", "broadcast_tx_sync_ns"):
+                    value = attempt.get(name)
+                    if type(value) is not int or not 0 <= value <= V3_PROVIDER_TIMING_MAX_NS:
+                        raise ValueError(name)
+                    attempt_values[name].append(value)
+                    attempt_total += value
+            if values["provider_total_ns"] < (values["authority_ns"] +
+                    values["proof_preparation_ns"] + values["commit_observation_ns"] + attempt_total):
+                raise ValueError("provider_total_ns")
+        except ValueError as error:
+            reasons.append(f"operation {operation!r} has invalid {error.args[0]} timing")
+            continue
+        retries += len(attempts) - 1
+        for name, row_values in attempt_values.items():
+            phases[name].extend(row_values)
+        for name, value in values.items():
+            phases[name].append(value)
+        unattributed = values["provider_total_ns"] - (values["authority_ns"] +
+            values["proof_preparation_ns"] + values["commit_observation_ns"] + attempt_total)
+        phases["unattributed_ns"].append(unattributed)
+        observations.append(dict(operation_id=operation, unattributed_ns=unattributed))
+    qualified = not reasons and len(phases["provider_total_ns"]) == len(outcomes)
+    result = dict(schema=V3_PROVIDER_TIMING_SCHEMA, qualification=qualified,
+                  transaction_count=len(outcomes), sequence_retry_attempts=retries,
+                  scope=("same-process monotonic durations; provider total starts at V3 dispatch after "
+                         "route selection and signer admission; pre-broadcast starts at CLI RunE, not process "
+                         "start; unattributed includes process startup, journal work, retry backoff and other "
+                         "local overhead; consensus header times remain separate inter-block wall time"),
+                  observations=observations, reasons=reasons)
+    if qualified:
+        result["percentiles_ns"] = {name: {f"p{percentile}": _nearest_rank(values, percentile)
+            for percentile in (50, 95, 99)} for name, values in phases.items()}
+    return result
 
 
 def _encode_varint(value):
@@ -674,6 +793,9 @@ def committed_v3_http_tx(lifecycle, row, *, kind, creator, slot, deal_id=None,
         raise ValueError("committed HTTP transaction must contain exactly one message")
     result["ordinals"] = validate_v3_committed_message(messages[0], kind=kind, creator=creator,
         slot=slot, deal_id=deal_id, session_id=session_id, proof_count=proof_count)
+    if kind == "session-proof":
+        result.update(operation_id=row.get("request_id"), provider=creator, creator=creator,
+                      slot=slot, session_id="0x" + session_id)
     return result
 
 
@@ -773,7 +895,7 @@ def run_native_v3_sessions(lifecycle, *, deal, providers, send, wait, curl):
         row["before_proofs"] = before
     capture_workload_metrics(lifecycle, "native_v3_before_proofs", fenced=True)
     for row in sessions:
-        requests = [dict(provider=providers[slot],
+        requests = [dict(id=f"session-{row['nonce']}-{slot}", provider=providers[slot],
                          url=provider_http_url(lifecycle, providers[slot], "/sp/session-proof"),
                          body=dict(session_id=row["session_id"]))
                     for slot in range(V3_SYSTEMATIC_PROVIDERS)]
@@ -789,6 +911,7 @@ def run_native_v3_sessions(lifecycle, *, deal, providers, send, wait, curl):
             if transaction["outcome"] != "committed_success":
                 raise ValueError("provider reported success for a failed v3 proof transaction")
             transactions.append(transaction)
+        phase_timing = validate_v3_provider_phase_timings(outcomes, transactions)
         at = max(producer.uint(tx["height"]) for tx in transactions)
         wait(at + 1)
         after = v3_session_query(lifecycle, row["session_id"], at)
@@ -798,7 +921,7 @@ def run_native_v3_sessions(lifecycle, *, deal, providers, send, wait, curl):
         tx_ordinals = sorted(ordinal for tx in transactions for ordinal in tx["ordinals"])
         if accepted != tx_ordinals or len(accepted) != V3_MAX_SAMPLES or summary["proof_count"] != V3_MAX_SAMPLES:
             raise ValueError("committed v3 proof messages do not equal authoritative bitmap deltas")
-        row.update(provider_outcomes=outcomes, outcome_summary=summary,
+        row.update(provider_outcomes=outcomes, outcome_summary=summary, phase_timing=phase_timing,
                    proof_transactions=transactions, committed_height=at,
                    accepted_sample_ordinals=accepted)
         lifecycle.save()
@@ -1186,6 +1309,8 @@ def run_native_v3_cross_audit(lifecycle, *, deal, providers, send, wait, curl, a
     if warmup_accepted != sorted(ordinal for row in warmup_transactions for ordinal in row["ordinals"]):
         raise ValueError("warmup bitmap differs from committed proof messages")
     doc["warmup_proof_transactions"] = warmup_transactions
+    doc["warmup_provider_phase_timing"] = validate_v3_provider_phase_timings(
+        warmup_outcomes, warmup_transactions)
     lifecycle.save()
 
     current = lifecycle.wait_height(1)
@@ -1269,6 +1394,7 @@ def run_native_v3_cross_audit(lifecycle, *, deal, providers, send, wait, curl, a
         lifecycle.save()
     if len(transactions) != V3_CROSS_AUDIT_MEASURED:
         raise ValueError("measured provider phase omitted a proof transaction")
+    doc["provider_phase_timing"] = validate_v3_provider_phase_timings(outcomes, transactions)
     doc["proof_anchor_span"] = validate_v3_cross_audit_span(
         transactions, scheduled_start_height, next_anchor, epoch_length)
     doc["measured_window"]["proof_receipt_max_height"] = validate_v3_http_receipt_fence(

--- a/scripts/test_retrieval_four_validator_workload.py
+++ b/scripts/test_retrieval_four_validator_workload.py
@@ -551,6 +551,65 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
             workload.validate_v3_committed_message(duplicate, kind="session-proof",
                 creator=providers[0], slot=0, session_id=self.SESSION, proof_count=17)
 
+    def test_provider_phase_timing_is_separate_bounded_and_receipt_bound(self):
+        provider = AUDIT_ADDRESSES[0]
+        txhash = "AB" * 32
+        timing = dict(schema=workload.V3_PROVIDER_TIMING_SCHEMA,
+            authority_ns=100, proof_preparation_ns=200,
+            submission_attempts=[dict(attempt=1, pre_broadcast_ns=300,
+                broadcast_tx_sync_ns=400, check_tx_code=0)],
+            commit_observation_ns=500, provider_total_ns=1600)
+        outcome = dict(status="success", request_id="measured-1-0", provider=provider,
+            session_id="0x" + self.SESSION, slot=0, tx_hash=txhash, timing=timing)
+        transaction = dict(operation_id="measured-1-0", provider=provider, creator=provider,
+            session_id="0x" + self.SESSION, slot=0, txhash=txhash,
+            outcome="committed_success", validators=[{"node_id": str(i)} for i in range(4)])
+        summary = workload.validate_v3_provider_phase_timings([outcome], [transaction])
+        self.assertTrue(summary["qualification"])
+        self.assertEqual(summary["percentiles_ns"]["proof_preparation_ns"],
+                         {"p50": 200, "p95": 200, "p99": 200})
+        self.assertEqual(summary["observations"], [
+            {"operation_id": "measured-1-0", "unattributed_ns": 100}])
+
+        retry = copy.deepcopy(outcome)
+        retry["timing"]["submission_attempts"] = [
+            dict(attempt=1, pre_broadcast_ns=100, broadcast_tx_sync_ns=200, check_tx_code=32),
+            dict(attempt=2, pre_broadcast_ns=300, broadcast_tx_sync_ns=400, check_tx_code=0)]
+        retry["timing"]["provider_total_ns"] = 1800
+        summary = workload.validate_v3_provider_phase_timings([retry], [transaction])
+        self.assertTrue(summary["qualification"])
+        self.assertEqual(summary["sequence_retry_attempts"], 1)
+
+        cases = {}
+        cases["missing"] = copy.deepcopy(outcome)
+        del cases["missing"]["timing"]
+        cases["negative"] = copy.deepcopy(outcome)
+        cases["negative"]["timing"]["authority_ns"] = -1
+        cases["overflow"] = copy.deepcopy(outcome)
+        cases["overflow"]["timing"]["submission_attempts"][0]["pre_broadcast_ns"] = 1 << 64
+        cases["bad_code"] = copy.deepcopy(outcome)
+        cases["bad_code"]["timing"]["submission_attempts"][0]["check_tx_code"] = 32
+        cases["bool_attempt"] = copy.deepcopy(outcome)
+        cases["bool_attempt"]["timing"]["submission_attempts"][0]["attempt"] = True
+        cases["bad_slot"] = copy.deepcopy(outcome)
+        cases["bad_slot"]["slot"] = "not-an-integer"
+        cases["identity"] = copy.deepcopy(outcome)
+        cases["identity"]["provider"] = AUDIT_ADDRESSES[1]
+        for name, changed in cases.items():
+            with self.subTest(name=name):
+                result = workload.validate_v3_provider_phase_timings([changed], [transaction])
+                self.assertFalse(result["qualification"])
+                self.assertNotIn("percentiles_ns", result)
+        duplicate = workload.validate_v3_provider_phase_timings(
+            [outcome, copy.deepcopy(outcome)], [transaction, dict(transaction,
+                operation_id="measured-1-1", txhash="CD" * 32)])
+        self.assertFalse(duplicate["qualification"])
+        malformed_id = copy.deepcopy(outcome)
+        malformed_id["request_id"] = []
+        self.assertFalse(workload.validate_v3_provider_phase_timings(
+            [malformed_id], [transaction])["qualification"])
+        self.assertFalse(workload.validate_v3_provider_phase_timings([], [])["qualification"])
+
     def test_committed_v3_http_transaction_normalizes_rpc_numbers_and_reconciles_raw_block(self):
         provider = AUDIT_ADDRESSES[0]
         raw = b"production-shaped-signed-transaction"


### PR DESCRIPTION
The retained native V3 provider route currently reports only a composite request result, so #290 cannot distinguish authority lookup, proof construction, CLI pre-broadcast work, CheckTx RPC, and commit observation.

This change adds an optional success-only `polystore-v3-provider-timing-v1` object to fresh V3 proof submissions. It preserves the exact `polystore-submission-v1:not-broadcast\n` marker as the sole retry authority: missing or malformed timing only makes timing qualification fail and cannot authorize a retry. Sequence-retry attempts remain explicit, recovery/429/error responses omit timing, and the harness binds every timed row to its request identity and authoritative four-validator receipt before computing monotonic p50/p95/p99 values. Per-row unattributed time remains visible for process startup, journal work, retry backoff, and other local overhead; consensus header timestamps remain separately scoped as inter-block wall time.

Validation:
- `python3 -m unittest test_retrieval_four_validator_workload` — 59 passed
- Linux: `./scripts/chain_go.sh test -p=2 ./x/polystorechain/client/cli` — full CLI package passed at `1059468846a47b2c0be581a7108ad4e7c396d44b`
- Linux: `go test -p 2 . -run 'TestSubmissionPhase|TestSubmissionTiming|TestRetrievalV3ProviderTiming' -count=1` — passed
- Linux: `go test -p 2 . -count=1` in `polystore_gateway` — passed in 24.307s

The Linux Go checks used the existing ABI-compatible native library for test linkage. Production evidence requires a fresh build from the final merged source; this PR does not run or qualify a benchmark.

Closes no issue; advances #290.
