### PR TITLE
gateway: reserve signer admission for system audits

### DIFF
--- a/polystore_gateway/retrieval_submission.go
+++ b/polystore_gateway/retrieval_submission.go
@@ -21,23 +21,68 @@ import (
 
 const maxSessionProofRequestBytes = 16 * 1024
 const maxSessionProofOutcomeBytes = 64 * 1024
+const maxConcurrentRetrievalSigners = 4
+const maxPriorityRetrievalSignerWaiters = 4
 
 // Proof submission includes CLI simulation/signing plus bounded commit polling.
 var sessionProofHTTPClient = &http.Client{Timeout: 2 * time.Minute}
 
-// No queue: requests sharing a session or actual signer retry explicitly. The
-// same guard covers serving before its chain query through its final write, so
-// a late store cannot recreate a record after committed cleanup.
+// Foreground requests are never queued: requests sharing a session or actual
+// signer retry explicitly. The same guard covers serving before its chain query
+// through its final write, so a late store cannot recreate a record after
+// committed cleanup. Internal audits may reserve one of four bounded waiters.
 var retrievalOperations = struct {
 	sync.Mutex
-	sessions map[string]bool
-	signers  map[string]bool
-}{sessions: make(map[string]bool), signers: make(map[string]bool)}
+	sessions        map[string]bool
+	signers         map[string]bool
+	priority        map[string]*retrievalSignerWaiter
+	priorityWaiters []*retrievalSignerWaiter
+}{
+	sessions: make(map[string]bool),
+	signers:  make(map[string]bool),
+	priority: make(map[string]*retrievalSignerWaiter),
+}
+
+type retrievalSignerWaiter struct {
+	signer   string
+	ready    chan struct{}
+	admitted bool
+}
+
+func admitPriorityRetrievalSignerLocked() {
+	for i := 0; i < len(retrievalOperations.priorityWaiters) && len(retrievalOperations.signers) < maxConcurrentRetrievalSigners; {
+		waiter := retrievalOperations.priorityWaiters[i]
+		if retrievalOperations.signers[waiter.signer] {
+			i++
+			continue
+		}
+		retrievalOperations.priorityWaiters = append(retrievalOperations.priorityWaiters[:i], retrievalOperations.priorityWaiters[i+1:]...)
+		delete(retrievalOperations.priority, waiter.signer)
+		retrievalOperations.signers[waiter.signer] = true
+		waiter.admitted = true
+		close(waiter.ready)
+	}
+}
+
+func releaseRetrievalOperations(ids []string, signer string) func() {
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			retrievalOperations.Lock()
+			defer retrievalOperations.Unlock()
+			for _, id := range ids {
+				delete(retrievalOperations.sessions, id)
+			}
+			delete(retrievalOperations.signers, signer)
+			admitPriorityRetrievalSignerLocked()
+		})
+	}
+}
 
 func claimRetrievalOperations(ids []string, signer string) (func(), error) {
 	retrievalOperations.Lock()
 	defer retrievalOperations.Unlock()
-	if len(retrievalOperations.sessions)+len(ids) > 256 || (signer != "" && (retrievalOperations.signers[signer] || len(retrievalOperations.signers) >= 4)) {
+	if len(retrievalOperations.sessions)+len(ids) > 256 || (signer != "" && (retrievalOperations.signers[signer] || retrievalOperations.priority[signer] != nil || len(retrievalOperations.signers) >= maxConcurrentRetrievalSigners)) {
 		return nil, fmt.Errorf("retrieval submission capacity or signer busy")
 	}
 	for _, id := range ids {
@@ -51,17 +96,65 @@ func claimRetrievalOperations(ids []string, signer string) (func(), error) {
 	if signer != "" {
 		retrievalOperations.signers[signer] = true
 	}
-	var once sync.Once
-	return func() {
-		once.Do(func() {
-			retrievalOperations.Lock()
-			defer retrievalOperations.Unlock()
-			for _, id := range ids {
-				delete(retrievalOperations.sessions, id)
-			}
+	return releaseRetrievalOperations(ids, signer), nil
+}
+
+// claimPriorityRetrievalSigner reserves the next admission for an internal
+// audit without turning foreground proof submissions into a queue. There is at
+// most one bounded waiter for an actual signer. Releases transfer a free slot
+// while holding the same mutex, so foreground requests cannot steal it.
+func claimPriorityRetrievalSigner(ctx context.Context, signer string) (func(), bool, error) {
+	if signer == "" {
+		return nil, false, fmt.Errorf("retrieval signer unavailable")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
+	retrievalOperations.Lock()
+	if retrievalOperations.priority[signer] != nil {
+		retrievalOperations.Unlock()
+		return nil, false, fmt.Errorf("retrieval audit already waiting")
+	}
+	if !retrievalOperations.signers[signer] && len(retrievalOperations.signers) < maxConcurrentRetrievalSigners {
+		retrievalOperations.signers[signer] = true
+		retrievalOperations.Unlock()
+		return releaseRetrievalOperations(nil, signer), false, nil
+	}
+	if len(retrievalOperations.priority) >= maxPriorityRetrievalSignerWaiters {
+		retrievalOperations.Unlock()
+		return nil, false, fmt.Errorf("retrieval audit wait capacity reached")
+	}
+	waiter := &retrievalSignerWaiter{signer: signer, ready: make(chan struct{})}
+	retrievalOperations.priority[signer] = waiter
+	retrievalOperations.priorityWaiters = append(retrievalOperations.priorityWaiters, waiter)
+	retrievalOperations.Unlock()
+
+	select {
+	case <-waiter.ready:
+		release := releaseRetrievalOperations(nil, signer)
+		if err := ctx.Err(); err != nil {
+			release()
+			return nil, true, err
+		}
+		return release, true, nil
+	case <-ctx.Done():
+		retrievalOperations.Lock()
+		if waiter.admitted {
 			delete(retrievalOperations.signers, signer)
-		})
-	}, nil
+			admitPriorityRetrievalSignerLocked()
+		} else if retrievalOperations.priority[signer] == waiter {
+			delete(retrievalOperations.priority, signer)
+			for i, queued := range retrievalOperations.priorityWaiters {
+				if queued == waiter {
+					retrievalOperations.priorityWaiters = append(retrievalOperations.priorityWaiters[:i], retrievalOperations.priorityWaiters[i+1:]...)
+					break
+				}
+			}
+			admitPriorityRetrievalSignerLocked()
+		}
+		retrievalOperations.Unlock()
+		return nil, true, ctx.Err()
+	}
 }
 
 type sessionProofRequest struct {

--- a/polystore_gateway/retrieval_submission_test.go
+++ b/polystore_gateway/retrieval_submission_test.go
@@ -559,6 +559,98 @@ func TestPriorityRetrievalSignerWaitersAreBounded(t *testing.T) {
 	}
 }
 
+func TestPriorityRetrievalSignerCancellationRacesReleaseWithoutLeak(t *testing.T) {
+	type result struct {
+		release func()
+		err     error
+	}
+	for i := 0; i < 100; i++ {
+		signer := fmt.Sprintf("cancel-race-signer-%d", i)
+		foreground, err := claimRetrievalOperations(nil, signer)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		resultCh := make(chan result, 1)
+		go func() {
+			release, _, err := claimPriorityRetrievalSigner(ctx, signer)
+			resultCh <- result{release, err}
+		}()
+		waitForPrioritySigner(t, signer)
+		start := make(chan struct{})
+		done := make(chan struct{}, 2)
+		go func() { <-start; cancel(); done <- struct{}{} }()
+		go func() { <-start; foreground(); done <- struct{}{} }()
+		close(start)
+		<-done
+		<-done
+		got := <-resultCh
+		if got.release != nil {
+			got.release()
+		} else if !errors.Is(got.err, context.Canceled) {
+			t.Fatal("raced admission returned neither ownership nor cancellation", got.err)
+		}
+		retrievalOperations.Lock()
+		active := retrievalOperations.signers[signer]
+		waiting := retrievalOperations.priority[signer] != nil
+		queued := false
+		for _, waiter := range retrievalOperations.priorityWaiters {
+			queued = queued || waiter.signer == signer
+		}
+		retrievalOperations.Unlock()
+		if active || waiting || queued {
+			t.Fatal("raced cancellation leaked admission state", i, active, waiting, queued)
+		}
+		next, err := claimRetrievalOperations(nil, signer)
+		if err != nil {
+			t.Fatal("raced cancellation retained signer", i, err)
+		}
+		next()
+	}
+}
+
+func TestPriorityRetrievalSignerGetsNextGlobalSlot(t *testing.T) {
+	active := make([]func(), maxConcurrentRetrievalSigners)
+	for i := range active {
+		var err error
+		active[i], err = claimRetrievalOperations(nil, fmt.Sprintf("active-signer-%d", i))
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(active[i])
+	}
+	const signer = "waiting-different-signer"
+	type result struct {
+		release func()
+		err     error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		release, _, err := claimPriorityRetrievalSigner(context.Background(), signer)
+		resultCh <- result{release, err}
+	}()
+	waitForPrioritySigner(t, signer)
+	active[0]()
+	got := <-resultCh
+	if got.err != nil || got.release == nil {
+		t.Fatal(got.err)
+	}
+	if release, err := claimRetrievalOperations(nil, signer); err == nil {
+		release()
+		t.Fatal("foreground overlapped globally admitted audit")
+	}
+	retrievalOperations.Lock()
+	activeCount := len(retrievalOperations.signers)
+	retrievalOperations.Unlock()
+	if activeCount != maxConcurrentRetrievalSigners {
+		t.Fatal("reserved audit did not receive the released global slot", activeCount)
+	}
+	got.release()
+	for _, release := range active[1:] {
+		release()
+	}
+}
+
 func TestDelayedCommittedSubmissionThroughBothGatewayModes(t *testing.T) {
 	for _, mode := range []string{"ordinary", "router"} {
 		t.Run(mode, func(t *testing.T) {

--- a/polystore_gateway/retrieval_submission_test.go
+++ b/polystore_gateway/retrieval_submission_test.go
@@ -425,6 +425,140 @@ func TestFrozenProofStorageAndOperationIsolation(t *testing.T) {
 	next()
 }
 
+func waitForPrioritySigner(t *testing.T, signer string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		retrievalOperations.Lock()
+		waiting := retrievalOperations.priority[signer] != nil
+		retrievalOperations.Unlock()
+		if waiting {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("priority signer %q did not start waiting", signer)
+}
+
+func TestPriorityRetrievalSignerPreventsForegroundStarvationAndCancels(t *testing.T) {
+	signer := "audit-signer"
+	foreground, err := claimRetrievalOperations([]string{"first"}, signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(foreground)
+
+	type result struct {
+		release func()
+		waited  bool
+		err     error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		release, waited, err := claimPriorityRetrievalSigner(context.Background(), signer)
+		resultCh <- result{release, waited, err}
+	}()
+	waitForPrioritySigner(t, signer)
+	if release, _, err := claimPriorityRetrievalSigner(context.Background(), signer); err == nil {
+		release()
+		t.Fatal("duplicate audit waiter admitted")
+	}
+	for i := 0; i < 20; i++ {
+		if release, err := claimRetrievalOperations([]string{fmt.Sprintf("foreground-%d", i)}, signer); err == nil {
+			release()
+			t.Fatal("foreground request stole reserved signer")
+		}
+	}
+	foreground()
+	got := <-resultCh
+	if got.err != nil || !got.waited || got.release == nil {
+		t.Fatal(got.waited, got.err)
+	}
+	if release, err := claimRetrievalOperations([]string{"overlap"}, signer); err == nil {
+		release()
+		t.Fatal("foreground overlapped admitted audit")
+	}
+	got.release()
+	got.release()
+
+	foreground, err = claimRetrievalOperations([]string{"second"}, signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	resultCh = make(chan result, 1)
+	go func() {
+		release, waited, err := claimPriorityRetrievalSigner(cancelCtx, signer)
+		resultCh <- result{release, waited, err}
+	}()
+	waitForPrioritySigner(t, signer)
+	cancel()
+	got = <-resultCh
+	if !errors.Is(got.err, context.Canceled) || !got.waited || got.release != nil {
+		t.Fatalf("canceled reservation result: waited=%v release_present=%v err=%v", got.waited, got.release != nil, got.err)
+	}
+	foreground()
+	next, err := claimRetrievalOperations([]string{"after-cancel"}, signer)
+	if err != nil {
+		t.Fatal("canceled reservation retained signer", err)
+	}
+	next()
+	canceledCtx, cancelAlready := context.WithCancel(context.Background())
+	cancelAlready()
+	if release, _, err := claimPriorityRetrievalSigner(canceledCtx, signer); !errors.Is(err, context.Canceled) {
+		if release != nil {
+			release()
+		}
+		t.Fatal("already canceled audit admission", err)
+	}
+	next, err = claimRetrievalOperations([]string{"after-pre-cancel"}, signer)
+	if err != nil {
+		t.Fatal("pre-canceled admission leaked signer", err)
+	}
+	next()
+}
+
+func TestPriorityRetrievalSignerWaitersAreBounded(t *testing.T) {
+	type result struct {
+		release func()
+		err     error
+	}
+	active := make([]func(), 4)
+	cancels := make([]context.CancelFunc, 4)
+	results := make([]chan result, 4)
+	for i := range active {
+		signer := fmt.Sprintf("bounded-signer-%d", i)
+		var err error
+		active[i], err = claimRetrievalOperations(nil, signer)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(active[i])
+		ctx, cancel := context.WithCancel(context.Background())
+		cancels[i] = cancel
+		results[i] = make(chan result, 1)
+		go func() {
+			release, _, err := claimPriorityRetrievalSigner(ctx, signer)
+			results[i] <- result{release, err}
+		}()
+		waitForPrioritySigner(t, signer)
+	}
+	if release, _, err := claimPriorityRetrievalSigner(context.Background(), "fifth-signer"); err == nil {
+		release()
+		t.Fatal("fifth audit waiter admitted")
+	}
+	for _, cancel := range cancels {
+		cancel()
+	}
+	for i, resultCh := range results {
+		got := <-resultCh
+		if !errors.Is(got.err, context.Canceled) || got.release != nil {
+			t.Fatalf("waiter %d cancellation: release_present=%v err=%v", i, got.release != nil, got.err)
+		}
+		active[i]()
+	}
+}
+
 func TestDelayedCommittedSubmissionThroughBothGatewayModes(t *testing.T) {
 	for _, mode := range []string{"ordinary", "router"} {
 		t.Run(mode, func(t *testing.T) {

--- a/polystore_gateway/system_audit_v2.go
+++ b/polystore_gateway/system_audit_v2.go
@@ -447,11 +447,21 @@ func runFrozenSystemLiveness(ctx context.Context, height uint64, snapshot *syste
 	if err != nil {
 		return err
 	}
-	release, err := claimRetrievalOperations(nil, signer)
+	release, waited, err := claimPriorityRetrievalSigner(ctx, signer)
 	if err != nil {
 		return err
 	}
 	defer release()
+	if waited {
+		active, currentHeight, err := systemAuditActivation(ctx)
+		if err != nil {
+			return err
+		}
+		if !active {
+			return fmt.Errorf("frozen system audits became inactive while waiting for signer")
+		}
+		height = currentHeight
+	}
 	pending, err := loadPendingSigner(signer)
 	if err != nil {
 		return err

--- a/polystore_gateway/system_audit_v2_test.go
+++ b/polystore_gateway/system_audit_v2_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cosmos/gogoproto/jsonpb"
 	bolt "go.etcd.io/bbolt"
@@ -515,6 +516,59 @@ func TestSystemAuditActivatedDispatchUsesOnlyFrozenInventory(t *testing.T) {
 	inventory = `{}`
 	if err := runSystemLivenessOnce(context.Background(), 999); err == nil {
 		t.Fatal("malformed v2 inventory accepted")
+	}
+}
+
+func TestFrozenSystemAuditRefreshesHeightAfterWaitingForSigner(t *testing.T) {
+	submissionTestDB(t)
+	_, _, signer := systemAuditFixture(t, retrievalchallenge.Audit)
+	t.Setenv("POLYSTORE_PROVIDER_ADDRESS", "")
+	setupMockCombinedOutput(t, func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		if args[0] != "keys" {
+			t.Fatal("unexpected command", args)
+		}
+		return []byte(signer), nil
+	})
+	foreground, err := claimRetrievalOperations(nil, signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(foreground)
+	paramsQueries, auditQueries := 0, 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(committedHeightHeader, "13")
+		switch r.URL.Path {
+		case "/polystorechain/polystorechain/v1/params":
+			paramsQueries++
+			fmt.Fprint(w, `{"params":{"retrieval_v2_activation_height":"11"}}`)
+		case "/polystorechain/polystorechain/v1/storage-audits/by-provider/" + signer:
+			auditQueries++
+			if r.Header.Get(committedHeightHeader) != "13" {
+				t.Error("audit inventory used pre-wait height", r.Header.Get(committedHeightHeader))
+			}
+			fmt.Fprint(w, `{"audits":[]}`)
+		default:
+			t.Error("unexpected LCD query", r.URL.Path)
+			http.Error(w, "unexpected", 500)
+		}
+	}))
+	defer srv.Close()
+	oldLCD := lcdBase
+	lcdBase = srv.URL
+	t.Cleanup(func() { lcdBase = oldLCD })
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	result := make(chan error, 1)
+	go func() {
+		result <- runFrozenSystemLiveness(ctx, 12, &systemLivenessSnapshot{})
+	}()
+	waitForPrioritySigner(t, signer)
+	foreground()
+	if err := <-result; err != nil {
+		t.Fatal(err)
+	}
+	if paramsQueries != 1 || auditQueries != 1 {
+		t.Fatal("unexpected refresh queries", paramsQueries, auditQueries)
 	}
 }
 


### PR DESCRIPTION
A sustained native V3 diagnostic could repeatedly lose a provider's scheduled system-audit admission to foreground proof submissions, eventually missing the frozen audit epoch. This change gives the internal audit loop one bounded, cancellable reservation per actual signer while foreground submissions remain nonblocking and return their existing busy response.

The shared gate still permits at most four active signers and now permits at most four audit waiters. A release hands the slot to a waiting audit under the gate lock, cancellation cannot retain a slot, and an audit that waited refreshes activation and committed height before reading its frozen inventory. Persisted unknown-broadcast reconciliation remains unchanged.

Validation:
- `go test . -count=1` in `polystore_gateway` (PASS, 39.358s, local ABI-compatible native library)
- focused admission and height tests (PASS)
- `go test -p 2 -race . -run 'TestPriorityRetrievalSigner|TestFrozenSystemAuditRefreshesHeightAfterWaitingForSigner' -count=1` on Linux (PASS, 1.192s)

Supports #290.
