### PR TITLE
bench: publish native v3 proof phases across normal audits

### DIFF
--- a/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/README.md
+++ b/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/README.md
@@ -116,12 +116,14 @@ no raw transactions, proofs, signatures, keyrings, paths, host identity, or logs
 The private source hashes, sanitized [`plan.json`](plan.json), and sanitized
 [`runtime-provenance.json`](runtime-provenance.json) are pinned in
 [`manifest.json`](manifest.json). With the retained inputs available locally:
+`HARNESS_SOURCE` must be a checkout of
+`da54964dc502f14bc73096fb6adc5f8ba0b2be6b`, the pinned collection source.
 
 ```sh
 python3 bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/check.py \
   --decoder "$BENCH_ROOT/native-build-5cc77e1a-002/bin/polystorechaind" \
   --decoder-library "$BENCH_ROOT/worktrees/native-runtime-5cc77e1a-002/polystore_core/target/release/libpolystore_core.so" \
-  scripts/retrieval_four_validator_workload.py \
+  "$HARNESS_SOURCE/scripts/retrieval_four_validator_workload.py" \
   "$PRIVATE/evidence.json" \
   "$PRIVATE/native-v3-cross-audit-blocks.jsonl" \
   "$PRIVATE/transaction-recovery-private/transactions.json" \
@@ -131,4 +133,6 @@ python3 bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001
 The checker verifies the decoder and native-library hashes against the frozen
 runtime provenance, requires exact reconstruction of the checked-in summary,
 exercises a small semantic failure set before the final literal evidence pins,
-and checks every published payload hash.
+and checks every published payload hash. The shared checker also tests header
+interval arithmetic for later retained reports; this run's summary and timing
+claims remain unchanged.

--- a/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/check.py
+++ b/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/check.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """Reproduce the retained summary and exercise a small semantic failure set."""
-import argparse, hashlib, json, subprocess, sys, tempfile
+import argparse, hashlib, json, runpy, subprocess, sys, tempfile
 from pathlib import Path
 
 def require(value, message):
@@ -23,11 +23,15 @@ def main():
     parser.add_argument("commit_streams", nargs=4, type=Path)
     parser.add_argument("--decoder", required=True, type=Path)
     parser.add_argument("--decoder-library", required=True, type=Path)
+    parser.add_argument("--report", type=Path, help="Later retained report using the same semantic checker")
     args = parser.parse_args()
-    here = Path(__file__).resolve().parent
-    base = [sys.executable, str(here / "summarize.py"), str(args.harness), str(args.evidence),
+    scripts = Path(__file__).resolve().parent
+    here = args.report.resolve() if args.report else scripts
+    base = [sys.executable, str(scripts / "summarize.py"), str(args.harness), str(args.evidence),
             str(args.blocks), str(args.transactions), *(str(path) for path in args.commit_streams),
             "--decoder", str(args.decoder), "--decoder-library", str(args.decoder_library)]
+    if args.report:
+        base.extend(["--pins", str(here / "pins.json")])
     require(run(base) == json.loads((here / "summary.json").read_text()),
             "checked-in summary differs from reconstruction")
 
@@ -57,6 +61,15 @@ def main():
     success = next(row for row in changed["v3_http_phases"]["cross-audit-measured"] if row.get("status") == "success")
     success["session_id"] = "0x" + "00" * 32
     mutations.append((changed, "HTTP success identity differs from measured proof receipt"))
+    if args.report:
+        changed = json.loads(json.dumps(original))
+        success = next(row for row in changed["v3_http_phases"]["cross-audit-measured"] if row.get("status") == "success")
+        success.pop("timing")
+        mutations.append((changed, "provider phase timing differs or lacks authoritative qualification"))
+        changed = json.loads(json.dumps(original))
+        success = next(row for row in changed["v3_http_phases"]["cross-audit-measured"] if row.get("status") == "success")
+        success["timing"]["submission_attempts"][0]["pre_broadcast_ns"] = True
+        mutations.append((changed, "provider phase timing differs or lacks authoritative qualification"))
     with tempfile.TemporaryDirectory() as directory:
         for index, (doc, expected) in enumerate(mutations):
             path = Path(directory) / f"evidence-{index}.json"
@@ -76,6 +89,21 @@ def main():
         command = base.copy(); command[5] = str(path)
         run(command, "native transaction decode differs from recovered representation")
 
+    # Include the interval before the first proof, retaining all nine fractional digits.
+    helpers = runpy.run_path(str(scripts / "summarize.py"))
+    blocks = [{"height": height, "time": f"2026-09-10T12:00:0{height}.123456789Z"} for height in range(3)]
+    result = helpers["header_summary"](blocks, [{"height": 1}, {"height": 2}])
+    require(result["elapsed_ns"] == 2_000_000_000 and result["inter_block_intervals"]["count"] == 2 and
+            helpers["header_time_ns"](blocks[0]["time"]) % 1_000_000_000 == 123456789,
+            "header interval or nanosecond precision differs")
+    for malformed in (blocks[1:], [blocks[0], blocks[2]], [blocks[1], dict(blocks[0], height=2), blocks[0]]):
+        try:
+            helpers["header_summary"](malformed, [{"height": 1}, {"height": 2}])
+        except ValueError:
+            pass
+        else:
+            raise ValueError("missing preceding/gapped/reversed headers accepted")
+
     manifest = json.loads((here / "manifest.json").read_text())
     require(manifest["qualification"] is False, "manifest changed qualification")
     for name, expected in manifest["published_files"].items():
@@ -83,7 +111,7 @@ def main():
         require(len(data) == expected["bytes"] and hashlib.sha256(data).hexdigest() == expected["sha256"],
                 f"published file hash differs: {name}")
     print(json.dumps({"status": "passed", "summary_equal": True,
-                      "semantic_negative_checks": len(mutations) + 2,
+                      "semantic_negative_checks": len(mutations) + 5,
                       "published_hashes": len(manifest["published_files"])}, sort_keys=True))
 
 if __name__ == "__main__": main()

--- a/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/manifest.json
+++ b/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/manifest.json
@@ -67,12 +67,12 @@
   },
   "published_files": {
     "README.md": {
-      "bytes": 7920,
-      "sha256": "71fc49621ac8509e192a08b9a7b1038d40a0788cc6f07bfa7aa51aec35358fae"
+      "bytes": 8191,
+      "sha256": "293127a619c6f11c9b311d89923dc82edca68f2451ca12f2b3a87a1339b5d0f3"
     },
     "check.py": {
-      "bytes": 5549,
-      "sha256": "6d9b002cfd41ad75805921819e61fee0ed0ff0d93ddc6eb9086c2e34e1dc991c"
+      "bytes": 7433,
+      "sha256": "2bff05c929b0603ee481af4bfbc90c0cda4add9136add012d7d65f45c1c97d0b"
     },
     "plan.json": {
       "bytes": 1525,
@@ -83,8 +83,8 @@
       "sha256": "1c2d298f66d51cf3264b62495098dc20d92efcde0be723613410dd3b991e1fe5"
     },
     "summarize.py": {
-      "bytes": 36581,
-      "sha256": "eecb2049cb0ded7964787d4d39f585502c0dc551cdff34408a899268588af9fc"
+      "bytes": 41786,
+      "sha256": "6a2076be66cdc8bfc2f6413cf9880e10a2a5859f15661e5f7dce8778165f70ab"
     },
     "summary.json": {
       "bytes": 12116,

--- a/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/summarize.py
+++ b/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/summarize.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """Reconstruct the retained native-v3 cross-audit diagnostic from private inputs."""
-import argparse, base64, hashlib, json, math, os, statistics, subprocess, sys, time, types
+import argparse, base64, calendar, datetime, hashlib, json, math, os, re, statistics, subprocess, sys, time, types
 from collections import Counter, defaultdict
 from pathlib import Path
 
@@ -38,9 +38,47 @@ def quantiles_ns(values):
             "max_ms": values[-1] / 1e6,
             "percentile_method": "nearest rank; median uses conventional midpoint"}
 
-def load_modules(harness_path):
+def header_time_ns(value):
+    match = re.fullmatch(r"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.(\d{1,9}))?Z", value)
+    require(match, "invalid UTC block header timestamp")
+    seconds = calendar.timegm(datetime.datetime.strptime(match[1], "%Y-%m-%dT%H:%M:%S").timetuple())
+    return seconds * 1_000_000_000 + int((match[2] or "").ljust(9, "0"))
+
+def header_summary(blocks, receipts):
+    by_height = {block["height"]: block for block in blocks}
+    first, last = min(row["height"] for row in receipts), max(row["height"] for row in receipts)
+    require(all(height in by_height for height in range(first - 1, last + 1)),
+            "missing preceding header or gap in measured header span")
+    stamps = [header_time_ns(by_height[height]["time"]) for height in range(first - 1, last + 1)]
+    intervals = [right - left for left, right in zip(stamps, stamps[1:])]
+    require(all(value >= 0 for value in intervals) and stamps[-1] > stamps[0],
+            "nonmonotonic or empty block header interval")
+    elapsed = stamps[-1] - stamps[0]
+    return dict(first_proof_height=first, last_proof_height=last, preceding_height=first - 1,
+                first_timestamp=by_height[first - 1]["time"], last_timestamp=by_height[last]["time"],
+                elapsed_ns=elapsed, committed_proof_transactions=len(receipts),
+                committed_proof_transactions_per_header_second=len(receipts) * 1e9 / elapsed,
+                inter_block_intervals=quantiles_ns(intervals),
+                timestamp_definition="Consensus header proposal timestamps, including the header preceding the first measured proof; not commit-completion timestamps or transaction inclusion latency.")
+
+def provider_phase_summary(harness, outcomes, receipts, embedded):
+    checked = harness.validate_v3_provider_phase_timings(outcomes, receipts)
+    require(checked["qualification"] and checked == embedded,
+            "provider phase timing differs or lacks authoritative qualification")
+    attempts = sum(len(row["timing"]["submission_attempts"]) for row in outcomes)
+    return dict(transaction_count=len(receipts), submission_attempt_count=attempts,
+                explicit_sequence_retry_attempts=checked["sequence_retry_attempts"],
+                scope=checked["scope"], percentile_method="nearest rank; per-phase observations, never percentile subtraction",
+                phases={name.removesuffix("_ns"): dict(
+                    count=attempts if name in ("pre_broadcast_ns", "broadcast_tx_sync_ns") else len(receipts),
+                    **{key + "_ms": value / 1e6 for key, value in values.items()})
+                    for name, values in checked["percentiles_ns"].items()})
+
+def load_modules(harness_path, module_pins):
     loaded = {}
-    for name, digest in MODULES.items():
+    require(set(module_pins) == set(MODULES), "harness module inventory differs")
+    for name in MODULES:
+        digest = module_pins[name]
         path = harness_path if name == "native_harness" else harness_path.with_name(name + ".py")
         data = path.read_bytes()
         require(sha(data) == digest, f"unpinned harness module {path.name}")
@@ -87,19 +125,26 @@ def main():
     parser.add_argument("commit_streams", nargs=4, type=Path)
     parser.add_argument("--decoder", required=True, type=Path)
     parser.add_argument("--decoder-library", required=True, type=Path)
+    parser.add_argument("--pins", type=Path, help="Frozen identities and observations for a later retained run")
     args = parser.parse_args()
+    pins = dict(source="da54964dc502f14bc73096fb6adc5f8ba0b2be6b", modules=MODULES,
+                evidence=EVIDENCE_SHA256, blocks=BLOCKS_SHA256, transactions=TRANSACTIONS_SHA256,
+                decoder=DECODER_SHA256, decoder_library=DECODER_LIBRARY_SHA256, commits=COMMIT_SHA256,
+                first_block=217, last_block=434, http_retries=13, elapsed_ns=182_066_769_129)
+    if args.pins:
+        pins = json.loads(args.pins.read_text())
     decoder, decoder_library = args.decoder.resolve(), args.decoder_library.resolve()
     raw_evidence, raw_blocks, raw_transactions = (args.evidence.read_bytes(), args.blocks.read_bytes(),
                                                    args.transactions.read_bytes())
     doc, recovered = json.loads(raw_evidence), json.loads(raw_transactions)
-    modules = load_modules(args.harness.resolve())
+    modules = load_modules(args.harness.resolve(), pins["modules"])
     harness, commit_metrics = modules["native_harness"], modules["retrieval_commit_metrics"]
 
     require(doc["status"] == "native_v3_cross_audit_diagnostic_passed" and
             doc["mode"] == "four-validator-native-v3-cross-audit-diagnostic" and
             doc["qualification"] is False, "top-level diagnostic status/scope differs")
-    require(doc["provenance"]["source_checkout"] == "da54964dc502f14bc73096fb6adc5f8ba0b2be6b" and
-            doc["provenance"]["driver_sha256"] == HARNESS_SHA256,
+    require(doc["provenance"]["source_checkout"] == pins["source"] and
+            doc["provenance"]["driver_sha256"] == pins["modules"]["native_harness"],
             "retained run does not use the landed reviewed harness")
     require(doc["profile"]["audit_profile"] == "normal" and
             doc["profile"]["consensus"]["block"] == {"max_bytes": "2097152", "max_gas": "64000000"} and
@@ -185,8 +230,8 @@ def main():
     attempts_by_request = defaultdict(list)
     for row in outcomes: attempts_by_request[row["request_id"]].append(row)
     retried = [rows for rows in attempts_by_request.values() if len(rows) == 2]
-    require(len(outcomes) == 373 and len(successful) == 360 and len(attempts_by_request) == 360 and
-            len(retried) == 13 and all([row["attempt"] for row in rows] == [1, 2] and
+    require(len(outcomes) == 360 + pins["http_retries"] and len(successful) == 360 and len(attempts_by_request) == 360 and
+            len(retried) == pins["http_retries"] and all([row["attempt"] for row in rows] == [1, 2] and
                 rows[0]["http_status"] == 429 and rows[0]["error"] == "retrieval submission busy" and
                 rows[1].get("status") == "success" and rows[1]["http_status"] == 200 and
                 all(rows[0][key] == rows[1][key] for key in
@@ -206,6 +251,15 @@ def main():
                     sessions[int(receipt["session_index"])]["session_id"].lower()
                 for operation_id, receipt in measured_by_operation.items()),
             "HTTP success identity differs from measured proof receipt")
+    measured_timing = warmup_timing = None
+    if args.pins:
+        measured_timing = provider_phase_summary(harness, sorted(successful, key=lambda row: row["request_index"]),
+            native["measured_proof_transactions"], native["provider_phase_timing"])
+        warmup_outcomes = [row for row in doc["v3_http_phases"]["cross-audit-warmup"]
+                           if row.get("status") == "success"]
+        require(len(warmup_outcomes) == 8, "warmup timing population differs")
+        warmup_timing = provider_phase_summary(harness, sorted(warmup_outcomes, key=lambda row: row["provider"]),
+            native["warmup_proof_transactions"], native["warmup_provider_phase_timing"])
     by_session = defaultdict(list)
     for row in successful: by_session[int(row["request_id"].split("-")[1])].append(row)
     for index in range(1, 46):
@@ -254,9 +308,9 @@ def main():
     open_sessions = {txhash: sorted([session for session in sessions if session["open_transaction"]["txhash"] == txhash],
                                     key=lambda session: session["nonce"])
                      for txhash in open_counts}
-    require(decoder.is_file() and sha(decoder.read_bytes()) == DECODER_SHA256,
+    require(decoder.is_file() and sha(decoder.read_bytes()) == pins["decoder"],
             "native transaction decoder bytes differ from runtime provenance")
-    require(decoder_library.is_file() and sha(decoder_library.read_bytes()) == DECODER_LIBRARY_SHA256,
+    require(decoder_library.is_file() and sha(decoder_library.read_bytes()) == pins["decoder_library"],
             "native transaction decoder library differs from runtime provenance")
     decode_deadline = time.monotonic() + 300
     for txhash, row in recovered_by_hash.items():
@@ -313,12 +367,12 @@ def main():
                     "refund bytes differ from owner/session")
 
     reconciliation = doc["committed_block_reconciliation"]
-    require(reconciliation == {"path": reconciliation["path"], "sha256": BLOCKS_SHA256,
-            "first_height": 217, "last_height": 434, "committed_workload_transactions": 360,
+    require(reconciliation == {"path": reconciliation["path"], "sha256": pins["blocks"],
+            "first_height": pins["first_block"], "last_height": pins["last_block"], "committed_workload_transactions": 360,
             "all_four_headers_agree": True, "all_four_results_agree": True, "qualification": False},
             "block reconciliation scope differs")
     blocks = [json.loads(line) for line in raw_blocks.splitlines() if line.strip()]
-    require([row["height"] for row in blocks] == list(range(217, 435)), "reconciled block range is not contiguous")
+    require([row["height"] for row in blocks] == list(range(pins["first_block"], pins["last_block"] + 1)), "reconciled block range is not contiguous")
     workload = [(block["height"], tx) for block in blocks for tx in block["transactions"] if tx.get("operation_id")]
     measured_by_hash = {row["txhash"]: row for row in native["measured_proof_transactions"]}
     require({tx["txhash"] for _, tx in workload} == set(measured_by_hash) and len(workload) == 360 and
@@ -339,8 +393,8 @@ def main():
     seen_commit_nodes = set()
     for path in args.commit_streams:
         node_id = path.stem.rsplit("-", 1)[-1]
-        require(node_id in COMMIT_SHA256 and node_id not in seen_commit_nodes and
-                sha(path.read_bytes()) == COMMIT_SHA256[node_id], "Commit stream hash/identity differs")
+        require(node_id in pins["commits"] and node_id not in seen_commit_nodes and
+                sha(path.read_bytes()) == pins["commits"][node_id], "Commit stream hash/identity differs")
         seen_commit_nodes.add(node_id)
         samples = [json.loads(line) for line in path.read_text().splitlines() if line]
         start, end = before_commit[node_id], after_commit[node_id]
@@ -354,13 +408,13 @@ def main():
                             "observed_blocks": recomputed["observed_blocks"],
                             "p95_upper_bound_ms": float(recomputed["p95_upper_bound_seconds"]) * 1000,
                             "within_700ms_budget": True})
-    require(seen_commit_nodes == set(COMMIT_SHA256), "Commit stream validator set differs")
+    require(seen_commit_nodes == set(pins["commits"]), "Commit stream validator set differs")
 
     schedule_doc = doc["v3_http_schedules"]["cross-audit-measured"]
     require(schedule_doc["offered"] == schedule_doc["completed"] == 360 and schedule_doc["queued"] == schedule_doc["in_flight"] == 0 and
             schedule_doc["terminal_error"] is None, "HTTP scheduler did not fully drain")
     require(schedule_doc["offered_window_ns"] == 180_000_000_000 and
-            schedule_doc["elapsed_ns"] == schedule_doc["monotonic_end_ns"] - schedule_doc["monotonic_start_ns"] == 182_066_769_129 and
+            schedule_doc["elapsed_ns"] == schedule_doc["monotonic_end_ns"] - schedule_doc["monotonic_start_ns"] == pins["elapsed_ns"] and
             max(row["request_finished_ns"] for row in successful) <= schedule_doc["monotonic_end_ns"],
             "HTTP scheduler monotonic boundaries or offered window differ")
     cpu = native["measured_window"]["validator_cpu_delta"]
@@ -417,9 +471,9 @@ def main():
                    "rate_denominator": "all 360 client-observed committed successes over scheduler start through recorded completion after terminal observation, including drain and the final orchestration tail",
                    "maximum_queued": schedule_doc["max_queued"], "maximum_in_flight": schedule_doc["max_in_flight"],
                    "maximum_dispatch_lag_ms": schedule_doc["max_dispatch_lag_ns"] / 1e6,
-                   "http_attempts": {"scheduled_requests": 360, "total_attempts": 373,
-                                     "successful_http_200": 360, "backpressure_http_429": 13,
-                                     "retried_requests": 13, "terminal_failures": 0,
+                   "http_attempts": {"scheduled_requests": 360, "total_attempts": len(outcomes),
+                                     "successful_http_200": 360, "backpressure_http_429": pins["http_retries"],
+                                     "retried_requests": len(retried), "terminal_failures": 0,
                                      "unclassified_attempts": 0},
                    "terminal_observation_latency": quantiles_ns(terminal),
                    "pre_success_start_delay": quantiles_ns(pre_success),
@@ -427,7 +481,7 @@ def main():
                    "request_duration": quantiles_ns(request),
                    "client_observation_bins": native["schedule_bins"],
                    "proof_commit_height_span": native["proof_anchor_span"],
-                   "reconciled_block_span": {"first_height": 217, "last_height": 434, "blocks": 218,
+                   "reconciled_block_span": {"first_height": pins["first_block"], "last_height": pins["last_block"], "blocks": len(blocks),
                                                "committed_measured_proof_transactions": 360,
                                                "all_four_headers_agree": True, "all_four_results_agree": True},
                    "measured_gas": {"wanted_total": gas_wanted_total, "used_total": gas_used_total,
@@ -448,7 +502,7 @@ def main():
             "Four validators and twelve provider-daemons ran on one Linux host; this is not a realistic deployment.",
             "The 2 transactions/s schedule is an accepted local operating point, not a measured maximum.",
             "HTTP terminal timing combines proof generation, native verification, gas simulation, signing, broadcast, and client commit observation.",
-            "Pre-success-start delay includes scheduler delay and, for 13 requests, retry backoff after an HTTP 429; it is not a pure signer-queue measurement.",
+            f"Pre-success-start delay includes scheduler delay and, for {len(retried)} requests, retry backoff after an HTTP 429; it is not a pure signer-queue measurement.",
             "Commit p95 values are execution upper bounds from the Commit metric; they exclude the documented post-persistence tail.",
             "Commit streams use a wider window starting before workload alignment and ending after heavy all-validator LCD queries; that window is separate from the CPU and provider HTTP measurement window.",
             "CPU is a fixed-window process tick delta; RSS is a whole-process-lifetime peak, not a phase peak or 2 GiB usage claim.",
@@ -458,14 +512,21 @@ def main():
         "private_inputs": {"evidence": {"sha256": sha(raw_evidence), "bytes": len(raw_evidence)},
                            "blocks": {"sha256": sha(raw_blocks), "bytes": len(raw_blocks)},
                            "transactions": {"sha256": sha(raw_transactions), "bytes": len(raw_transactions)},
-                           "commit_streams": {node: {"sha256": digest} for node, digest in sorted(COMMIT_SHA256.items())}},
+                           "commit_streams": {node: {"sha256": digest} for node, digest in sorted(pins["commits"].items())}},
         "reproduction": {"harness": "$HARNESS_SOURCE/scripts/retrieval_four_validator_workload.py",
                          "inputs_are_private": True}
     }
+    if args.pins:
+        summary["result"]["provider_phase_timing"] = measured_timing
+        summary["result"]["warmup_provider_phase_timing"] = warmup_timing
+        summary["result"]["block_header_timing"] = header_summary(blocks, native["measured_proof_transactions"])
+        summary["limitations"][2] = "Provider phases separate authority, proof preparation, CLI pre-broadcast, BroadcastTxSync/CheckTx round-trip and later commit observation; none is exact consensus inclusion latency."
+        summary["limitations"][7] = "Consensus header proposal timestamps provide a separate inter-block denominator; they are not wall-clock commit completion and cannot be subtracted from process-monotonic phases."
+        summary["limitations"][8] = "Provider commit observation includes polling and the index/RPC path after successful CheckTx; signer admission remains immediate or HTTP 429, with audit admission priority."
     # Literal input pins are checked only after the semantic reconstruction above.
-    require(sha(raw_evidence) == EVIDENCE_SHA256, "retained evidence bytes differ from the publication pin")
-    require(sha(raw_blocks) == BLOCKS_SHA256, "retained block bytes differ from the publication pin")
-    require(sha(raw_transactions) == TRANSACTIONS_SHA256, "recovered transaction bytes differ from the publication pin")
+    require(sha(raw_evidence) == pins["evidence"], "retained evidence bytes differ from the publication pin")
+    require(sha(raw_blocks) == pins["blocks"], "retained block bytes differ from the publication pin")
+    require(sha(raw_transactions) == pins["transactions"], "recovered transaction bytes differ from the publication pin")
     print(json.dumps(summary, indent=2, sort_keys=True))
 
 if __name__ == "__main__": main()

--- a/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-003/README.md
+++ b/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-003/README.md
@@ -1,0 +1,179 @@
+# Native-v3 proof phases across normal audits (#290)
+
+The retained run committed all **360 measured proof transactions / 5,940 fresh
+sample ordinals**, completed 24 normal audits and refunded all 46 expired
+sessions. Its fixed local operating point was **1.9713 committed transactions/s**
+including drain. Provider proof preparation and later commit observation are
+the largest measured per-request phases. This is a four-validator, twelve
+provider-daemon **single-host diagnostic**, not maximum chain capacity, WAN
+performance or a file-download measurement (`qualification=false`).
+
+The runtime and harness were built from merged commit
+`70ce16da02e3790ba128ae883f33be4e70d30a9f`. This includes
+[phase instrumentation (#317)](https://github.com/Polynomialstore/polystore/pull/317)
+and [audit admission priority (#318)](https://github.com/Polynomialstore/polystore/pull/318).
+The earlier collection `002` failed because a provider's audit repeatedly lost
+signer admission to retrieval traffic; it remains failed and unqualified.
+This run demonstrates complete audit coverage with the fix. It makes no speedup
+claim against either that failure or [retained run 001](../native-v3-cross-audit-001).
+
+## Workload and throughput
+
+One AMD Ryzen 7 9700X host (8 cores / 16 threads, Linux 7.0.0-30) ran four
+validators and twelve provider-daemons. The build used Go 1.25.5 and Rust/Cargo
+1.98.1; commands and artifact hashes are in
+[runtime-provenance.json](runtime-provenance.json). The isolated chain retained
+64M block gas, 2 MiB blocks, normal 100-block audits and a 1-second configured
+commit timeout. This is not a distributed-validator deployment.
+
+Two append-signed transactions opened 46 native 16 MiB sessions (31 and 15
+messages). Each session has U=133/Q=132 and eight systematic provider
+obligations. Eight proof transactions warmed the production HTTP route outside
+the measured interval. The scheduler then offered 360 transactions at 2/s over
+180 seconds, round-robin across eight independent provider signers, with at
+most one active request per signer. A transaction contains that provider's
+15–17 assigned sample openings, not proofs for every downloaded byte.
+
+| Quantity | Result |
+| --- | ---: |
+| Offered / committed-valid measured transactions | 360 / 360 |
+| Accepted measured sample ordinals | 5,940 |
+| Scheduler interval, including drain | 182.624890855 s |
+| Final drain | 2.624890855 s |
+| Committed transactions / scheduler second | 1.9712537448 |
+| Accepted sample ordinals / scheduler second | 32.5256867900 |
+| Maximum queued / in flight | 3 / 8 |
+| HTTP attempts / initial 429 retries | 372 / 12 |
+| Terminal failed / unknown proof requests | 0 / 0 |
+| Measured proof heights | 293–426 |
+| Audit anchors / accepted audits / missed audits | 301 and 401 / 24 / 0 |
+| Expired sessions / verified refunds | 46 / 46 |
+
+The six 30-second bins each offered 60 transactions. They observed
+52/62/59/61/60/59 terminal successes, ending with 8/6/7/6/6/7 outstanding
+requests and zero queued requests. The final seven completed during drain.
+Each of the twelve initial `429 retrieval submission busy` responses retried
+once with the same request/provider/session identity. Retries are not counted
+as additional committed work. All provider account-sequence deltas reconcile
+to the unique measured proofs and normal audits.
+
+## Where request time goes
+
+These are nearest-rank percentiles of 360 successful measured transactions,
+joined to their exact request, provider, session and all-validator receipt.
+All 360 CLI attempts succeeded without an explicit sequence retry. HTTP 429
+retries happen before provider admission and are measured separately below.
+
+| Provider phase (milliseconds) | p50 | p95 | p99 |
+| --- | ---: | ---: | ---: |
+| Frozen authority checks | 1.281 | 1.773 | 3.162 |
+| Sampled proof preparation | 925.995 | 1,081.906 | 1,149.085 |
+| CLI pre-broadcast work | 98.021 | 245.820 | 323.980 |
+| BroadcastTxSync / CheckTx round-trip | 1.130 | 198.813 | 268.302 |
+| Later committed-transaction observation | 1,506.172 | 2,507.916 | 2,510.409 |
+| Other local work, measured per request | 86.793 | 137.604 | 186.665 |
+| Total provider request | 2,741.111 | 3,684.950 | 3,831.318 |
+
+Proof preparation includes reading sampled encoded blobs, recomputing their
+commitments, generating fresh KZG openings and verifying the assembled proofs
+locally. It is not an isolated KZG primitive timer. CLI pre-broadcast work
+includes gas simulation and signing; its clock starts at the CLI command
+handler, excluding process startup. BroadcastTxSync measures the RPC/CheckTx
+round-trip, not block inclusion. Commit observation starts after successful
+CheckTx and includes polling plus the transaction index/RPC path. Its p50 is
+therefore an observation latency, not exact consensus inclusion latency.
+
+The provider total starts after route selection and signer admission. Retrieval
+admission accepts immediately or returns 429; it does not wait in a signer
+queue. The audit-priority wait is a separate background path. The residual
+local duration is computed **within each request** before taking percentiles;
+it includes process startup, durable journal work and uninstrumented local
+work. Percentiles must not be added or subtracted to infer another phase.
+
+| Client observation (milliseconds) | p50 | p95 | p99 |
+| --- | ---: | ---: | ---: |
+| Initial dispatch lag | 46.791 | 297.584 | 1,856.727 |
+| Scheduled offer to successful request start | 49.112 | 1,343.815 | 2,134.589 |
+| Successful HTTP request duration | 2,818.474 | 3,752.991 | 3,915.788 |
+| Scheduled offer to terminal response | 2,909.111 | 4,294.213 | 5,853.849 |
+
+The second row includes backoff for the twelve HTTP 429 retries and is not pure
+signer wait. The eight warmup observations remain a separate population in
+[summary.json](summary.json); their proof-preparation p50 was 1,406.301 ms.
+They are neither mixed into measured percentiles nor treated as a cold-start
+benchmark.
+
+Consensus header timestamps supply a separate denominator: from the header
+preceding the first measured proof (height 292) through height 426,
+180.925019797 seconds contain 360 committed proof transactions, or
+1.9897745508 transactions per header second. The 134 inter-header intervals
+have p50/p95/p99 of 1,336.504/1,431.295/1,443.570 ms. These are proposal/header
+timestamps, not commit-completion timestamps. All nine fractional digits are
+preserved; the preceding header is included. Do not combine this clock with
+process-monotonic phase timings or quote this fixed workload as maximum capacity.
+
+## Chain cost, resources and limits
+
+Measured proofs consumed 3,049,981,256 gas against 4,870,623,654 declared gas.
+The distribution was 14 transactions with 15 openings, 152 with 16 and 194
+with 17. Used gas per transaction ranged from 7,710,824 to 8,725,999, with
+median 8,725,836; aggregate gas per accepted ordinal was 513,464.86.
+At height 406, peak block used/declared gas was 34,502,059/56,117,970 and
+transaction payload was 52,239 bytes. These are native message costs with the
+unchanged gas adjustment, not independent costs for individual openings.
+
+All four validators agreed on reconciled blocks 217–429. The four raw Commit
+streams yielded 210 fenced block observations each, with p95 execution upper
+bounds of 366.510–417.794 ms, below the local 700 ms guard. The Commit metric
+excludes the documented post-persistence tail and next-round scheduling. Its
+wider observation window includes alignment and later all-validator queries;
+it is separate from the measured provider and CPU windows.
+
+Actual validator CPU snapshots span 182.643849805 seconds. Node zero averaged
+0.379 cores and the others 0.196 cores each. Node zero also served provider and
+observer RPC; this report does not attribute its extra CPU. Lifetime peak RSS
+was 330,756,096–352,899,072 bytes per validator, below the 2 GiB local guard.
+Lifetime RSS is not a phase peak. The 814.057-second total run includes setup,
+alignment, state reconciliation, expiry and cleanup outside the throughput
+clock; it is not a download time.
+
+The measured latency owner is provider preparation plus commit observation;
+this workload does not establish a maximum or prove validator CPU saturation.
+The earlier [chain-only report](../native-v3-chain-001) separately identifies
+declared-gas block packing under its finite offered load. No owner ACK or file
+delivery occurred here. All 46 sessions deliberately expired and refunded.
+Delivery, cache/resume and practical 1 GiB targets remain owned by #291;
+distributed capacity requires a recorded distributed deployment.
+
+## Reproduce without rerunning the workload
+
+The shared [checker](../native-v3-cross-audit-001/check.py) reuses the pinned
+harness validators, checks all four Commit streams and re-decodes 440 signed
+transactions recovered from the stopped blockstores. The 440 comprise two
+opens, eight warmups, 360 measured proofs, 24 audits and 46 refunds. It rejects
+malformed phase timing before the final literal input hashes. It reproduces
+the original 001 summary unchanged and checks this report through `--report`.
+
+Set `HARNESS_SOURCE` to a checkout of
+`70ce16da02e3790ba128ae883f33be4e70d30a9f`; set `PRIVATE` to the retained 003
+directory and `BENCH_ROOT` to the preserved build root. From this report's
+repository checkout:
+
+```sh
+python3 bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-001/check.py \
+  --report bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-003 \
+  --decoder "$BENCH_ROOT/native-phase-build-70ce16da/bin/polystorechaind" \
+  --decoder-library "$BENCH_ROOT/native-phase-build-70ce16da/rust-target/release/libpolystore_core.so" \
+  "$HARNESS_SOURCE/scripts/retrieval_four_validator_workload.py" \
+  "$PRIVATE/evidence.json" \
+  "$PRIVATE/native-v3-cross-audit-blocks.jsonl" \
+  "$PRIVATE/transaction-recovery-private/transactions.json" \
+  "$PRIVATE"/native-v3-cross-audit-commit-*.jsonl
+```
+
+[pins.json](pins.json) freezes inputs and source-module identities.
+[manifest.json](manifest.json) records private input hashes and published file
+hashes, including the shared checker. [plan.json](plan.json) is the completed
+guard with host identity removed; the runtime provenance preserves all artifact
+and component identities. Raw signatures, proofs, session state, keyrings and
+logs remain private. No production activation or deployment changed.

--- a/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-003/manifest.json
+++ b/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-003/manifest.json
@@ -1,0 +1,107 @@
+{
+  "claim": "single-host native-v3 provider-route operating-point diagnostic; no maximum-capacity, WAN, or delivery qualification",
+  "excluded_private_data": [
+    "raw transactions and signatures",
+    "proof messages and session state",
+    "keyrings and wallet material",
+    "raw blocks and Commit streams",
+    "host identity, absolute paths, and logs"
+  ],
+  "private_inputs": {
+    "evidence.json": {
+      "bytes": 4650004,
+      "sha256": "137e91de8adf2bfaa585c0edebb1581b91733e82602e9138b15006cf75d25aee"
+    },
+    "native-v3-cross-audit-blocks.jsonl": {
+      "bytes": 137169,
+      "sha256": "167e61508be41801cbbadb17bd4d74fa078525691e57751304ccb0e0aa4d7193"
+    },
+    "native-v3-cross-audit-commit-5e57792918a70784da2c24b35265e028e94e11a5.jsonl": {
+      "bytes": 269310,
+      "sha256": "0286ad0fb6fbd1e841650cf1101f97a1da9de76638ee1119e7c172bdf7486d38"
+    },
+    "native-v3-cross-audit-commit-6cdc2c478fba8a33b1466627ab6e175e38028c34.jsonl": {
+      "bytes": 269158,
+      "sha256": "db0ddbc6b00abe687fec4f26ca1335cabd13c0368ad5f8dde4c1e1745a9b6cfc"
+    },
+    "native-v3-cross-audit-commit-930c9ab0b13c6226fd05bf1b9b72fac1c16f53a8.jsonl": {
+      "bytes": 270068,
+      "sha256": "4efe809e514319e58b1b384f7a2bedd2843e39f688181523a6f33263da899baa"
+    },
+    "native-v3-cross-audit-commit-cfc0bf9e9fc62e965989d1392b0900496c823357.jsonl": {
+      "bytes": 269263,
+      "sha256": "8ccaf4d2ea37cc77855861b1d931caa2ecb44cccb90a33e2efe5e860933fdf8b"
+    },
+    "native-v3-cross-audit-retained-003.guard.json": {
+      "bytes": 5242,
+      "sha256": "80339e0ca0a143d0cebe28e165b62092a6658029570c97e37491a90e6f5fb427"
+    },
+    "native-v3-cross-audit-retained-003.plan.json": {
+      "bytes": 5146,
+      "sha256": "41c60198dd35243c954fc7c95fba1a275f4d8d8952eee280a6f11de76a04b0ab"
+    },
+    "provenance.json": {
+      "bytes": 3457,
+      "sha256": "963d777eb4fbde8b681e05afc7e4b1a8583d06024f33c77721762626353b5f69"
+    },
+    "transaction-recovery-private/transactions.json": {
+      "bytes": 19532445,
+      "sha256": "d68ffa70200e002d0a71202f7536e7d2c094943fe14073f3bde365ebad5bcb27"
+    },
+    "transaction-recovery-private/validator0.json": {
+      "bytes": 6419569,
+      "sha256": "ab19f5ac7eb46971b96d536029fed02292420c3e18d1f9385c6e0d47d2fc7493"
+    },
+    "transaction-recovery-private/validator1.json": {
+      "bytes": 6419569,
+      "sha256": "ab19f5ac7eb46971b96d536029fed02292420c3e18d1f9385c6e0d47d2fc7493"
+    },
+    "transaction-recovery-private/validator2.json": {
+      "bytes": 6419569,
+      "sha256": "ab19f5ac7eb46971b96d536029fed02292420c3e18d1f9385c6e0d47d2fc7493"
+    },
+    "transaction-recovery-private/validator3.json": {
+      "bytes": 6419569,
+      "sha256": "ab19f5ac7eb46971b96d536029fed02292420c3e18d1f9385c6e0d47d2fc7493"
+    }
+  },
+  "published_files": {
+    "../native-v3-cross-audit-001/check.py": {
+      "bytes": 7433,
+      "sha256": "2bff05c929b0603ee481af4bfbc90c0cda4add9136add012d7d65f45c1c97d0b"
+    },
+    "../native-v3-cross-audit-001/summarize.py": {
+      "bytes": 41786,
+      "sha256": "6a2076be66cdc8bfc2f6413cf9880e10a2a5859f15661e5f7dce8778165f70ab"
+    },
+    "README.md": {
+      "bytes": 10417,
+      "sha256": "92e9d942a4d41f1c026ef19f81eecf4ef1df96b2ba54898dd8038b176272180f"
+    },
+    "pins.json": {
+      "bytes": 1461,
+      "sha256": "cc4fb93d82e7122c799ff45a734ceba933891dde7a91bd824a8dd5b5b9778c21"
+    },
+    "plan.json": {
+      "bytes": 1625,
+      "sha256": "46d8db45dbae5fa150e149ec3acdee574d8f87bf8f674f3832f61914cace7661"
+    },
+    "runtime-provenance.json": {
+      "bytes": 3423,
+      "sha256": "45dc613d004e70843c035430c47b496560262d6386e53e9f3bb1968fd2bc8284"
+    },
+    "summary.json": {
+      "bytes": 16565,
+      "sha256": "5eef7dc2e6ed3c4428803a2aa14c00cbceff1dc82d418ecd26fc4f305c1dff0c"
+    }
+  },
+  "qualification": false,
+  "schema": "polystore.retained-publication.v1",
+  "status": "passed",
+  "transformations": [
+    "summary.json is reconstructed with the shared summarize.py and pins.json from exact private evidence, stopped-blockstore transactions, reconciled blocks and four raw Commit streams",
+    "provider timing is joined to exact all-validator receipts; warmup remains separate; header timestamps retain nanoseconds and the preceding interval",
+    "plan.json is the completed run guard with hostname removed, runtime manifest replaced by runtime-provenance.json, and benchmark-root paths replaced by $BENCH_ROOT",
+    "runtime-provenance.json is the frozen build manifest with benchmark-root paths replaced by $BENCH_ROOT"
+  ]
+}

--- a/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-003/pins.json
+++ b/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-003/pins.json
@@ -1,0 +1,24 @@
+{
+  "blocks": "167e61508be41801cbbadb17bd4d74fa078525691e57751304ccb0e0aa4d7193",
+  "commits": {
+    "5e57792918a70784da2c24b35265e028e94e11a5": "0286ad0fb6fbd1e841650cf1101f97a1da9de76638ee1119e7c172bdf7486d38",
+    "6cdc2c478fba8a33b1466627ab6e175e38028c34": "db0ddbc6b00abe687fec4f26ca1335cabd13c0368ad5f8dde4c1e1745a9b6cfc",
+    "930c9ab0b13c6226fd05bf1b9b72fac1c16f53a8": "4efe809e514319e58b1b384f7a2bedd2843e39f688181523a6f33263da899baa",
+    "cfc0bf9e9fc62e965989d1392b0900496c823357": "8ccaf4d2ea37cc77855861b1d931caa2ecb44cccb90a33e2efe5e860933fdf8b"
+  },
+  "decoder": "dbd794c784eb1f8c46ca1cc66c47fa252de9adf8dc9701e018f3e5d249cfe615",
+  "decoder_library": "7cbfe98f513a215de84c599289de082471466395b9ffb57eab9be0a898214092",
+  "elapsed_ns": 182624890855,
+  "evidence": "137e91de8adf2bfaa585c0edebb1581b91733e82602e9138b15006cf75d25aee",
+  "first_block": 217,
+  "http_retries": 12,
+  "last_block": 429,
+  "modules": {
+    "native_harness": "ae25dac36b85593af4cf7cad03602c5e24d99cfb55e89640df653676e0810f74",
+    "retrieval_bench_artifact": "aeb5f811fb5f93ad4539f49a485c15af3747c765bd3d3997bc38335016a023d8",
+    "retrieval_commit_metrics": "e8b272852684639efe6292d3b72eb2396fee0c2bdb99558d52c611b7d638e11f",
+    "retrieval_fresh_proof": "74ced497d80442a7d463872623879737b7775ad2a49ec4c5a53ced8a8650e67b"
+  },
+  "source": "70ce16da02e3790ba128ae883f33be4e70d30a9f",
+  "transactions": "d68ffa70200e002d0a71202f7536e7d2c094943fe14073f3bde365ebad5bcb27"
+}

--- a/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-003/plan.json
+++ b/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-003/plan.json
@@ -1,0 +1,42 @@
+{
+  "command": [
+    "/usr/bin/python3",
+    "$BENCH_ROOT/worktrees/native-phase-runtime-70ce16da/scripts/retrieval_four_validator_workload.py",
+    "--mode",
+    "native-v3-providers-cross-audit",
+    "--audit-profile",
+    "normal",
+    "--timeout",
+    "900",
+    "--binary",
+    "$BENCH_ROOT/native-phase-build-70ce16da/bin/polystorechaind",
+    "--library",
+    "$BENCH_ROOT/worktrees/native-phase-runtime-70ce16da/polystore_core/target/release/libpolystore_core.so",
+    "--gateway-binary",
+    "$BENCH_ROOT/native-phase-build-70ce16da/bin/polystore_gateway",
+    "--cli-binary",
+    "$BENCH_ROOT/native-phase-build-70ce16da/bin/polystore_cli",
+    "--product-source",
+    "$BENCH_ROOT/worktrees/native-phase-runtime-70ce16da",
+    "--home",
+    "$BENCH_ROOT/runs/native-v3-cross-audit-retained-003"
+  ],
+  "completed_at_utc": "2026-09-10T13:14:33Z",
+  "elapsed_seconds": 814.057,
+  "harness_head": "70ce16da02e3790ba128ae883f33be4e70d30a9f",
+  "harness_scripts_tree": "de8b41bc83644027abc573ec202d22ab95f4eaf3",
+  "host": "single Linux host (identity redacted)",
+  "initial_free_bytes": 1328598315008,
+  "initial_load": [
+    0.1298828125,
+    0.5869140625,
+    0.408203125
+  ],
+  "kind": "fixed180second native provider operating-point phase diagnostic across2normal audit anchors; no distributed maximum or delivery qualification",
+  "minimum_free_bytes": 1328357531648,
+  "result_scope": "retained local operating-point diagnostic; qualification=false",
+  "returncode": 0,
+  "runtime_provenance": "runtime-provenance.json",
+  "schema": "polystore.retained-run-plan.v1",
+  "started_at_utc": "2026-09-10T13:00:58Z"
+}

--- a/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-003/runtime-provenance.json
+++ b/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-003/runtime-provenance.json
@@ -1,0 +1,99 @@
+{
+  "artifacts": {
+    "$BENCH_ROOT/native-phase-build-70ce16da/bin/polystore_cli": "08518a215d0e8cc142a9bd49d6024c1ad18a76461ef0c2b46d53777aa5fb8a65",
+    "$BENCH_ROOT/native-phase-build-70ce16da/bin/polystore_gateway": "199164aa86628436f122c7985f3dfcfe5a9c319b1595fecd257e1ed02c6f28ef",
+    "$BENCH_ROOT/native-phase-build-70ce16da/bin/polystorechaind": "dbd794c784eb1f8c46ca1cc66c47fa252de9adf8dc9701e018f3e5d249cfe615",
+    "$BENCH_ROOT/worktrees/native-phase-runtime-70ce16da/polystore_core/target/release/libpolystore_core.so": "7cbfe98f513a215de84c599289de082471466395b9ffb57eab9be0a898214092",
+    "$BENCH_ROOT/worktrees/native-phase-runtime-70ce16da/polystorechain/trusted_setup.txt": "d39b9f2d047cc9dca2de58f264b6a09448ccd34db967881a6713eacacf0f26b7"
+  },
+  "component_trees": {
+    "polystore_cli": "4303dc86c58cbbb7f1076f1916f1de691bf7694c",
+    "polystore_core": "52e6c75c3c67a2811c3f7d85df0f77cd61ece7fc",
+    "polystore_gateway": "00afcf23970b77ce8f85391148a2f35ecf1bfe2f",
+    "polystorechain": "ba47d3e9eb92c1b363ef996deb6b4e4ed8b56253"
+  },
+  "note": "Sanitized copy of the frozen build provenance; absolute benchmark root replaced by $BENCH_ROOT.",
+  "reused_components": [],
+  "schema": "polystore.runtime-provenance.v1",
+  "source": "$BENCH_ROOT/worktrees/native-phase-runtime-70ce16da",
+  "source_commit": "70ce16da02e3790ba128ae883f33be4e70d30a9f",
+  "source_manifest_private_sha256": "963d777eb4fbde8b681e05afc7e4b1a8583d06024f33c77721762626353b5f69",
+  "status": "passed",
+  "steps": [
+    {
+      "command": [
+        "cargo",
+        "build",
+        "--locked",
+        "--release",
+        "-j",
+        "2"
+      ],
+      "cwd": "$BENCH_ROOT/worktrees/native-phase-runtime-70ce16da/polystore_core",
+      "elapsed_seconds": 14.339,
+      "exit_code": 0,
+      "name": "core"
+    },
+    {
+      "command": [
+        "cargo",
+        "build",
+        "--locked",
+        "--release",
+        "-j",
+        "2"
+      ],
+      "cwd": "$BENCH_ROOT/worktrees/native-phase-runtime-70ce16da/polystore_cli",
+      "elapsed_seconds": 30.863,
+      "exit_code": 0,
+      "name": "cli"
+    },
+    {
+      "command": [
+        "./scripts/chain_go.sh",
+        "build",
+        "-p",
+        "2",
+        "-o",
+        "$BENCH_ROOT/native-phase-build-70ce16da/bin/polystorechaind",
+        "./cmd/polystorechaind"
+      ],
+      "cwd": "$BENCH_ROOT/worktrees/native-phase-runtime-70ce16da",
+      "elapsed_seconds": 75.777,
+      "exit_code": 0,
+      "name": "chain"
+    },
+    {
+      "command": [
+        "go",
+        "build",
+        "-mod=readonly",
+        "-p=2",
+        "-o",
+        "$BENCH_ROOT/native-phase-build-70ce16da/bin/polystore_gateway",
+        "."
+      ],
+      "cwd": "$BENCH_ROOT/worktrees/native-phase-runtime-70ce16da/polystore_gateway",
+      "elapsed_seconds": 5.421,
+      "exit_code": 0,
+      "name": "gateway"
+    },
+    {
+      "command": [
+        "/usr/bin/python3",
+        "scripts/test_validator_setup_startup.py",
+        "$BENCH_ROOT/native-phase-build-70ce16da/bin/polystorechaind",
+        "polystorechain/trusted_setup.txt"
+      ],
+      "cwd": "$BENCH_ROOT/worktrees/native-phase-runtime-70ce16da",
+      "elapsed_seconds": 3.123,
+      "exit_code": 0,
+      "name": "startup"
+    }
+  ],
+  "toolchains": {
+    "cargo": "cargo 1.98.1 (797e8a9bc 2026-08-05)",
+    "go": "go version go1.25.5 linux/amd64",
+    "rustc": "rustc 1.98.1 (48a229cea 2026-09-01)"
+  }
+}

--- a/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-003/summary.json
+++ b/bench/retrieval_session_capacity/native-k8-290/native-v3-cross-audit-003/summary.json
@@ -1,0 +1,472 @@
+{
+  "claim": "single-host native-v3 provider-route operating-point diagnostic; no maximum-capacity, WAN, or delivered-byte qualification",
+  "limitations": [
+    "Four validators and twelve provider-daemons ran on one Linux host; this is not a realistic deployment.",
+    "The 2 transactions/s schedule is an accepted local operating point, not a measured maximum.",
+    "Provider phases separate authority, proof preparation, CLI pre-broadcast, BroadcastTxSync/CheckTx round-trip and later commit observation; none is exact consensus inclusion latency.",
+    "Pre-success-start delay includes scheduler delay and, for 12 requests, retry backoff after an HTTP 429; it is not a pure signer-queue measurement.",
+    "Commit p95 values are execution upper bounds from the Commit metric; they exclude the documented post-persistence tail.",
+    "Commit streams use a wider window starting before workload alignment and ending after heavy all-validator LCD queries; that window is separate from the CPU and provider HTTP measurement window.",
+    "CPU is a fixed-window process tick delta; RSS is a whole-process-lifetime peak, not a phase peak or 2 GiB usage claim.",
+    "Consensus header proposal timestamps provide a separate inter-block denominator; they are not wall-clock commit completion and cannot be subtracted from process-monotonic phases.",
+    "Provider commit observation includes polling and the index/RPC path after successful CheckTx; signer admission remains immediate or HTTP 429, with audit admission priority.",
+    "No owner ACK or byte delivery was performed; delivery, resume, cache, WAN, and maximum capacity remain unqualified."
+  ],
+  "private_inputs": {
+    "blocks": {
+      "bytes": 137169,
+      "sha256": "167e61508be41801cbbadb17bd4d74fa078525691e57751304ccb0e0aa4d7193"
+    },
+    "commit_streams": {
+      "5e57792918a70784da2c24b35265e028e94e11a5": {
+        "sha256": "0286ad0fb6fbd1e841650cf1101f97a1da9de76638ee1119e7c172bdf7486d38"
+      },
+      "6cdc2c478fba8a33b1466627ab6e175e38028c34": {
+        "sha256": "db0ddbc6b00abe687fec4f26ca1335cabd13c0368ad5f8dde4c1e1745a9b6cfc"
+      },
+      "930c9ab0b13c6226fd05bf1b9b72fac1c16f53a8": {
+        "sha256": "4efe809e514319e58b1b384f7a2bedd2843e39f688181523a6f33263da899baa"
+      },
+      "cfc0bf9e9fc62e965989d1392b0900496c823357": {
+        "sha256": "8ccaf4d2ea37cc77855861b1d931caa2ecb44cccb90a33e2efe5e860933fdf8b"
+      }
+    },
+    "evidence": {
+      "bytes": 4650004,
+      "sha256": "137e91de8adf2bfaa585c0edebb1581b91733e82602e9138b15006cf75d25aee"
+    },
+    "transactions": {
+      "bytes": 19532445,
+      "sha256": "d68ffa70200e002d0a71202f7536e7d2c094943fe14073f3bde365ebad5bcb27"
+    }
+  },
+  "profile": {
+    "budgets_measured_for_qualification": false,
+    "commit_p95_budget_ms": 700,
+    "measured_offer_seconds": 180,
+    "measured_openings": 5940,
+    "measured_proof_transactions": 360,
+    "normal_audit_epochs": 2,
+    "normal_audit_transactions": 24,
+    "offered_openings_per_second": 33,
+    "offered_transactions_per_second": 2,
+    "open_batch_sizes": [
+      31,
+      15
+    ],
+    "provider_daemons": 12,
+    "sessions": 46,
+    "systematic_providers": 8,
+    "validator_memory_ceiling_bytes": 2147483648,
+    "validators": 4,
+    "warmup_transactions": 8
+  },
+  "qualification": false,
+  "reproduction": {
+    "harness": "$HARNESS_SOURCE/scripts/retrieval_four_validator_workload.py",
+    "inputs_are_private": true
+  },
+  "result": {
+    "audits": {
+      "all_assignments_accepted": true,
+      "epochs": [
+        4,
+        5
+      ],
+      "missed": 0,
+      "transactions": 24
+    },
+    "authoritative_openings_per_scheduler_second": 32.52568678995803,
+    "block_header_timing": {
+      "committed_proof_transactions": 360,
+      "committed_proof_transactions_per_header_second": 1.989774550827322,
+      "elapsed_ns": 180925019797,
+      "first_proof_height": 293,
+      "first_timestamp": "2026-09-10T13:07:39.99567581Z",
+      "inter_block_intervals": {
+        "count": 134,
+        "max_ms": 1516.20532,
+        "median_ms": 1336.585565,
+        "p50_ms": 1336.503539,
+        "p95_ms": 1431.295127,
+        "p99_ms": 1443.569573,
+        "percentile_method": "nearest rank; median uses conventional midpoint"
+      },
+      "last_proof_height": 426,
+      "last_timestamp": "2026-09-10T13:10:40.920695607Z",
+      "preceding_height": 292,
+      "timestamp_definition": "Consensus header proposal timestamps, including the header preceding the first measured proof; not commit-completion timestamps or transaction inclusion latency."
+    },
+    "client_observation_bins": [
+      {
+        "carryover_in_flight": 0,
+        "carryover_queued": 0,
+        "cohort_completed_by_end": 52,
+        "end_offset_ns": 30000000000,
+        "in_flight_at_end": 8,
+        "index": 0,
+        "offered": 60,
+        "outstanding_at_end": 8,
+        "queued_at_end": 0,
+        "start_offset_ns": 0,
+        "terminal": 52
+      },
+      {
+        "carryover_in_flight": 8,
+        "carryover_queued": 0,
+        "cohort_completed_by_end": 54,
+        "end_offset_ns": 60000000000,
+        "in_flight_at_end": 6,
+        "index": 1,
+        "offered": 60,
+        "outstanding_at_end": 6,
+        "queued_at_end": 0,
+        "start_offset_ns": 30000000000,
+        "terminal": 62
+      },
+      {
+        "carryover_in_flight": 6,
+        "carryover_queued": 0,
+        "cohort_completed_by_end": 53,
+        "end_offset_ns": 90000000000,
+        "in_flight_at_end": 7,
+        "index": 2,
+        "offered": 60,
+        "outstanding_at_end": 7,
+        "queued_at_end": 0,
+        "start_offset_ns": 60000000000,
+        "terminal": 59
+      },
+      {
+        "carryover_in_flight": 7,
+        "carryover_queued": 0,
+        "cohort_completed_by_end": 54,
+        "end_offset_ns": 120000000000,
+        "in_flight_at_end": 6,
+        "index": 3,
+        "offered": 60,
+        "outstanding_at_end": 6,
+        "queued_at_end": 0,
+        "start_offset_ns": 90000000000,
+        "terminal": 61
+      },
+      {
+        "carryover_in_flight": 6,
+        "carryover_queued": 0,
+        "cohort_completed_by_end": 54,
+        "end_offset_ns": 150000000000,
+        "in_flight_at_end": 6,
+        "index": 4,
+        "offered": 60,
+        "outstanding_at_end": 6,
+        "queued_at_end": 0,
+        "start_offset_ns": 120000000000,
+        "terminal": 60
+      },
+      {
+        "carryover_in_flight": 6,
+        "carryover_queued": 0,
+        "cohort_completed_by_end": 53,
+        "end_offset_ns": 180000000000,
+        "in_flight_at_end": 7,
+        "index": 5,
+        "offered": 60,
+        "outstanding_at_end": 7,
+        "queued_at_end": 0,
+        "start_offset_ns": 150000000000,
+        "terminal": 59
+      }
+    ],
+    "commit_step": [
+      {
+        "fenced_samples": 1389,
+        "observed_blocks": 210,
+        "p95_upper_bound_ms": 372.6362570040109,
+        "raw_samples": 1388,
+        "validator": "5e57792918a70784da2c24b35265e028e94e11a5",
+        "within_700ms_budget": true
+      },
+      {
+        "fenced_samples": 1389,
+        "observed_blocks": 210,
+        "p95_upper_bound_ms": 372.7885280040566,
+        "raw_samples": 1388,
+        "validator": "6cdc2c478fba8a33b1466627ab6e175e38028c34",
+        "within_700ms_budget": true
+      },
+      {
+        "fenced_samples": 1389,
+        "observed_blocks": 210,
+        "p95_upper_bound_ms": 417.79352400343805,
+        "raw_samples": 1388,
+        "validator": "930c9ab0b13c6226fd05bf1b9b72fac1c16f53a8",
+        "within_700ms_budget": true
+      },
+      {
+        "fenced_samples": 1389,
+        "observed_blocks": 210,
+        "p95_upper_bound_ms": 366.5102690010701,
+        "raw_samples": 1388,
+        "validator": "cfc0bf9e9fc62e965989d1392b0900496c823357",
+        "within_700ms_budget": true
+      }
+    ],
+    "committed_valid_transactions_per_scheduler_second": 1.971253744845941,
+    "http_attempts": {
+      "backpressure_http_429": 12,
+      "retried_requests": 12,
+      "scheduled_requests": 360,
+      "successful_http_200": 360,
+      "terminal_failures": 0,
+      "total_attempts": 372,
+      "unclassified_attempts": 0
+    },
+    "initial_dispatch_lag": {
+      "count": 360,
+      "max_ms": 2042.670378,
+      "median_ms": 46.909361,
+      "p50_ms": 46.791363,
+      "p95_ms": 297.584406,
+      "p99_ms": 1856.726549,
+      "percentile_method": "nearest rank; median uses conventional midpoint"
+    },
+    "maximum_dispatch_lag_ms": 2042.670378,
+    "maximum_in_flight": 8,
+    "maximum_queued": 3,
+    "measured_authoritative_new_openings": 5940,
+    "measured_committed_valid_proof_transactions": 360,
+    "measured_gas": {
+      "peak_block_gas_used": 34502059,
+      "peak_block_gas_wanted": 56117970,
+      "peak_block_height_by_tx_payload_bytes": 406,
+      "peak_block_height_by_used_gas": 406,
+      "peak_block_tx_payload_bytes": 52239,
+      "proof_count_distribution": {
+        "15": 14,
+        "16": 152,
+        "17": 194
+      },
+      "used_per_authoritative_opening": 513464.8579124579,
+      "used_per_transaction_max": 8725999,
+      "used_per_transaction_median": 8725836.0,
+      "used_per_transaction_min": 7710824,
+      "used_total": 3049981256,
+      "wanted_total": 4870623654
+    },
+    "pre_success_start_delay": {
+      "count": 360,
+      "max_ms": 2187.262063,
+      "median_ms": 49.8111585,
+      "p50_ms": 49.111921,
+      "p95_ms": 1343.815246,
+      "p99_ms": 2134.588958,
+      "percentile_method": "nearest rank; median uses conventional midpoint"
+    },
+    "proof_commit_height_span": {
+      "first_anchor": 301,
+      "first_height": 293,
+      "last_height": 426,
+      "second_anchor": 401
+    },
+    "provider_phase_timing": {
+      "explicit_sequence_retry_attempts": 0,
+      "percentile_method": "nearest rank; per-phase observations, never percentile subtraction",
+      "phases": {
+        "authority": {
+          "count": 360,
+          "p50_ms": 1.281362,
+          "p95_ms": 1.772517,
+          "p99_ms": 3.1616
+        },
+        "broadcast_tx_sync": {
+          "count": 360,
+          "p50_ms": 1.13019,
+          "p95_ms": 198.812672,
+          "p99_ms": 268.30156
+        },
+        "commit_observation": {
+          "count": 360,
+          "p50_ms": 1506.171525,
+          "p95_ms": 2507.916096,
+          "p99_ms": 2510.40914
+        },
+        "pre_broadcast": {
+          "count": 360,
+          "p50_ms": 98.021268,
+          "p95_ms": 245.819517,
+          "p99_ms": 323.979637
+        },
+        "proof_preparation": {
+          "count": 360,
+          "p50_ms": 925.994514,
+          "p95_ms": 1081.90585,
+          "p99_ms": 1149.085326
+        },
+        "provider_total": {
+          "count": 360,
+          "p50_ms": 2741.111263,
+          "p95_ms": 3684.949506,
+          "p99_ms": 3831.317982
+        },
+        "unattributed": {
+          "count": 360,
+          "p50_ms": 86.792501,
+          "p95_ms": 137.603974,
+          "p99_ms": 186.665456
+        }
+      },
+      "scope": "same-process monotonic durations; provider total starts at V3 dispatch after route selection and signer admission; pre-broadcast starts at CLI RunE, not process start; unattributed includes process startup, journal work, retry backoff and other local overhead; consensus header times remain separate inter-block wall time",
+      "submission_attempt_count": 360,
+      "transaction_count": 360
+    },
+    "rate_denominator": "all 360 client-observed committed successes over scheduler start through recorded completion after terminal observation, including drain and the final orchestration tail",
+    "reconciled_block_span": {
+      "all_four_headers_agree": true,
+      "all_four_results_agree": true,
+      "blocks": 213,
+      "committed_measured_proof_transactions": 360,
+      "first_height": 217,
+      "last_height": 429
+    },
+    "refunds": {
+      "all_verified": true,
+      "refund_transactions": 46,
+      "sessions_expired": 46
+    },
+    "request_duration": {
+      "count": 360,
+      "max_ms": 3998.07303,
+      "median_ms": 2819.2402725,
+      "p50_ms": 2818.473625,
+      "p95_ms": 3752.990811,
+      "p99_ms": 3915.788251,
+      "percentile_method": "nearest rank; median uses conventional midpoint"
+    },
+    "scheduler_drain_seconds": 2.624890855,
+    "scheduler_elapsed_seconds": 182.624890855,
+    "terminal_observation_latency": {
+      "count": 360,
+      "max_ms": 6037.937904,
+      "median_ms": 2912.3899935,
+      "p50_ms": 2909.111339,
+      "p95_ms": 4294.2128,
+      "p99_ms": 5853.849122,
+      "percentile_method": "nearest rank; median uses conventional midpoint"
+    },
+    "validator_cpu": [
+      {
+        "mean_cores_over_window": 0.37871518846021623,
+        "system_cpu_seconds": 0.44,
+        "user_cpu_seconds": 68.73,
+        "validator": "930c9ab0b13c6226fd05bf1b9b72fac1c16f53a8",
+        "window_seconds": 182.643849805
+      },
+      {
+        "mean_cores_over_window": 0.1961741391142048,
+        "system_cpu_seconds": 0.35,
+        "user_cpu_seconds": 35.48,
+        "validator": "5e57792918a70784da2c24b35265e028e94e11a5",
+        "window_seconds": 182.643849805
+      },
+      {
+        "mean_cores_over_window": 0.19639314457232843,
+        "system_cpu_seconds": 0.31,
+        "user_cpu_seconds": 35.56,
+        "validator": "cfc0bf9e9fc62e965989d1392b0900496c823357",
+        "window_seconds": 182.643849805
+      },
+      {
+        "mean_cores_over_window": 0.19584563092701945,
+        "system_cpu_seconds": 0.31,
+        "user_cpu_seconds": 35.46,
+        "validator": "6cdc2c478fba8a33b1466627ab6e175e38028c34",
+        "window_seconds": 182.643849805
+      }
+    ],
+    "validator_resources": [
+      {
+        "measurement_scope": "whole validator process lifetime",
+        "peak_rss_bytes": 352899072,
+        "returncode": 0,
+        "validator": "930c9ab0b13c6226fd05bf1b9b72fac1c16f53a8"
+      },
+      {
+        "measurement_scope": "whole validator process lifetime",
+        "peak_rss_bytes": 330756096,
+        "returncode": 0,
+        "validator": "5e57792918a70784da2c24b35265e028e94e11a5"
+      },
+      {
+        "measurement_scope": "whole validator process lifetime",
+        "peak_rss_bytes": 339214336,
+        "returncode": 0,
+        "validator": "cfc0bf9e9fc62e965989d1392b0900496c823357"
+      },
+      {
+        "measurement_scope": "whole validator process lifetime",
+        "peak_rss_bytes": 341544960,
+        "returncode": 0,
+        "validator": "6cdc2c478fba8a33b1466627ab6e175e38028c34"
+      }
+    ],
+    "warmup_provider_phase_timing": {
+      "explicit_sequence_retry_attempts": 0,
+      "percentile_method": "nearest rank; per-phase observations, never percentile subtraction",
+      "phases": {
+        "authority": {
+          "count": 8,
+          "p50_ms": 1.610496,
+          "p95_ms": 3.15203,
+          "p99_ms": 3.15203
+        },
+        "broadcast_tx_sync": {
+          "count": 8,
+          "p50_ms": 85.982824,
+          "p95_ms": 231.448771,
+          "p99_ms": 231.448771
+        },
+        "commit_observation": {
+          "count": 8,
+          "p50_ms": 1505.819852,
+          "p95_ms": 2508.30667,
+          "p99_ms": 2508.30667
+        },
+        "pre_broadcast": {
+          "count": 8,
+          "p50_ms": 213.036846,
+          "p95_ms": 410.924889,
+          "p99_ms": 410.924889
+        },
+        "proof_preparation": {
+          "count": 8,
+          "p50_ms": 1406.3013,
+          "p95_ms": 1527.570107,
+          "p99_ms": 1527.570107
+        },
+        "provider_total": {
+          "count": 8,
+          "p50_ms": 3369.844184,
+          "p95_ms": 4527.511181,
+          "p99_ms": 4527.511181
+        },
+        "unattributed": {
+          "count": 8,
+          "p50_ms": 98.480362,
+          "p95_ms": 126.518637,
+          "p99_ms": 126.518637
+        }
+      },
+      "scope": "same-process monotonic durations; provider total starts at V3 dispatch after route selection and signer admission; pre-broadcast starts at CLI RunE, not process start; unattributed includes process startup, journal work, retry backoff and other local overhead; consensus header times remain separate inter-block wall time",
+      "submission_attempt_count": 8,
+      "transaction_count": 8
+    }
+  },
+  "schema": "polystore.native-v3-cross-audit-retained.v1",
+  "source": {
+    "chain_id": "polystore_260-1",
+    "harness_commit": "70ce16da02e3790ba128ae883f33be4e70d30a9f",
+    "product_source_commit": "70ce16da02e3790ba128ae883f33be4e70d30a9f",
+    "runtime_artifact_source_match": "supplied binaries/library; build correspondence not attested"
+  },
+  "status": "passed"
+}


### PR DESCRIPTION
The earlier throughput report combined proof preparation, transaction submission, and commit observation. This retained run separates those phases while committing all 360 measured proof transactions, completing 24 normal audits, and verifying all 46 expiry refunds.

Publishes the measured local operating point (1.9713 committed proof transactions/s including drain), phase percentiles, gas, backlog, validator resources, and explicit clock boundaries. It remains a single-host diagnostic, with no claim of maximum capacity or file-download performance. Reuses the existing report checker with pinned inputs; the original report reconstructs unchanged.

Validation: both reports reconstructed using their pinned native decoders and all 440 recovered signed transactions per run. New report: 16 semantic negative checks and 7 published hashes pass; original report: 14 semantic negative checks and 6 published hashes pass. Python compilation and `git diff --check` pass.

Closes #290. Production browser delivery and a practical 1 GiB target remain in #291.
