### PR TITLE
chain: reuse validated V3 challenge context

### DIFF
--- a/polystorechain/x/polystorechain/keeper/retrieval_v3_context_test.go
+++ b/polystorechain/x/polystorechain/keeper/retrieval_v3_context_test.go
@@ -1,0 +1,137 @@
+package keeper
+
+import (
+	"bytes"
+	"testing"
+
+	cosmosmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+
+	"polystorechain/pkg/retrievalchallenge"
+	"polystorechain/x/polystorechain/types"
+)
+
+func largeStoredSessionV3(tb testing.TB) types.RetrievalSessionV3 {
+	tb.Helper()
+	const chainID = "polystore-bench-1"
+	const dealID = uint64(42)
+	const generation = uint64(7)
+	const fileRecordIndex = uint32(3)
+	const nonce = uint64(9)
+	const pricePerBlob = int64(3)
+	const snapshotHeight = uint64(100)
+	const deadlineHeight = uint64(200)
+	const dealEndHeight = uint64(300)
+
+	var owner [20]byte
+	for i := range owner {
+		owner[i] = 0x11
+	}
+	ownerAddress := sdk.AccAddress(owner[:]).String()
+	userMDUs := (retrievalchallenge.MaxLargeRangeBytes + 64*retrievalchallenge.DataBlobPayloadBytes - 1) / (64 * retrievalchallenge.DataBlobPayloadBytes)
+	r, err := retrievalchallenge.CheckedRangeV3(0, retrievalchallenge.MaxLargeRangeBytes, 0, retrievalchallenge.MaxLargeRangeBytes, userMDUs)
+	require.NoError(tb, err)
+	var providers [8][20]byte
+	for slot := range providers {
+		for i := range providers[slot] {
+			providers[slot][i] = byte(0x40 + slot)
+		}
+	}
+	plan, err := retrievalchallenge.BuildPlanV3(r, providers)
+	require.NoError(tb, err)
+	planHash, err := plan.Hash()
+	require.NoError(tb, err)
+	sessionID, err := (retrievalchallenge.SessionBindingV3{
+		ChainID: chainID, Owner: owner, DealID: dealID, Generation: generation,
+		FileRecordIndex: fileRecordIndex, RangeLength: retrievalchallenge.MaxLargeRangeBytes,
+		PlanHash: planHash, Nonce: nonce,
+	}).ID()
+	require.NoError(tb, err)
+	window, err := retrievalchallenge.SessionWindow(snapshotHeight, deadlineHeight, dealEndHeight)
+	require.NoError(tb, err)
+
+	obligations := make([]types.RetrievalObligationV3, len(plan.Obligations))
+	for i, obligation := range plan.Obligations {
+		provider := sdk.AccAddress(obligation.Assigned[:]).String()
+		obligations[i] = types.RetrievalObligationV3{
+			Slot: obligation.Slot, AssignedProvider: provider, Payee: provider,
+			BlobCount: obligation.BlobCount, LockedFee: cosmosmath.NewInt(pricePerBlob).MulRaw(int64(obligation.BlobCount)),
+		}
+	}
+	s := types.RetrievalSessionV3{
+		SessionId: sessionID[:], DealId: dealID, Generation: generation, Owner: ownerAddress, Payer: ownerAddress,
+		PolyfsRoot: bytes.Repeat([]byte{0x22}, 32), IntegrityRoot: bytes.Repeat([]byte{0x33}, 32), SetupDigest: bytes.Repeat([]byte{0x44}, 32),
+		FileRecordIndex: fileRecordIndex, FileLength: retrievalchallenge.MaxLargeRangeBytes, RangeLength: retrievalchallenge.MaxLargeRangeBytes,
+		MetadataMdus: 2, UserMdus: userMDUs, PlanHash: planHash[:], FirstBlob: r.First, LastBlob: r.Last, Population: r.Population,
+		SampleCount: retrievalchallenge.MaxLargeSessionSamples, Nonce: nonce, PriceDenom: "stake", PricePerBlob: cosmosmath.NewInt(pricePerBlob),
+		BaseFee: cosmosmath.NewInt(5), CompletionBurnBps: 250, Funding: types.RetrievalSessionFunding_RETRIEVAL_SESSION_FUNDING_DEAL_ESCROW,
+		SnapshotHeight: window.Snapshot, AnchorHeight: window.Anchor, FirstResponseHeight: window.First, DeadlineHeight: window.Deadline, DealEndHeight: dealEndHeight,
+		Obligations: obligations, AcceptedSampleBitmap: make([]byte, v3SampleBitmapBytes),
+		LockedFee: cosmosmath.NewInt(pricePerBlob).MulRaw(int64(r.Population)), OpenedHeight: int64(snapshotHeight), UpdatedHeight: int64(snapshotHeight), ChainId: chainID,
+	}
+	c, err := sessionContextV3(s)
+	require.NoError(tb, err)
+	contextHash, err := c.Hash()
+	require.NoError(tb, err)
+	s.ContextHash = contextHash[:]
+	_, err = validateStoredSessionV3(s)
+	require.NoError(tb, err)
+	return s
+}
+
+func cloneStoredSessionV3(s types.RetrievalSessionV3) types.RetrievalSessionV3 {
+	s.Obligations = append([]types.RetrievalObligationV3(nil), s.Obligations...)
+	return s
+}
+
+// validateAndMaterializeV3Samples preserves the former two-step call path as
+// an equivalence oracle and benchmark control.
+func validateAndMaterializeV3Samples(s *types.RetrievalSessionV3, anchor []byte) ([]retrievalchallenge.ChallengeV3, error) {
+	c, err := validateStoredSessionV3(*s)
+	if err != nil {
+		return nil, err
+	}
+	return materializeV3Samples(s, c, anchor)
+}
+
+func TestMaterializeV3SamplesReusesValidatedContext(t *testing.T) {
+	s := largeStoredSessionV3(t)
+	anchor := bytes.Repeat([]byte{0x55}, 32)
+	wantSession := cloneStoredSessionV3(s)
+	wantChallenges, err := validateAndMaterializeV3Samples(&wantSession, anchor)
+	require.NoError(t, err)
+
+	validatedContext, err := validateStoredSessionV3(s)
+	require.NoError(t, err)
+	gotSession := cloneStoredSessionV3(s)
+	gotChallenges, err := materializeV3Samples(&gotSession, validatedContext, anchor)
+	require.NoError(t, err)
+
+	require.Equal(t, wantChallenges, gotChallenges)
+	require.Equal(t, wantSession, gotSession)
+}
+
+func BenchmarkMaterializeV3SamplesContextReuse(b *testing.B) {
+	s := largeStoredSessionV3(b)
+	anchor := bytes.Repeat([]byte{0x55}, 32)
+	validatedContext, err := validateStoredSessionV3(s)
+	require.NoError(b, err)
+
+	b.Run("validate-and-materialize", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			candidate := cloneStoredSessionV3(s)
+			if _, err := validateAndMaterializeV3Samples(&candidate, anchor); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("reuse-validated-context", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			candidate := cloneStoredSessionV3(s)
+			if _, err := materializeV3Samples(&candidate, validatedContext, anchor); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/polystorechain/x/polystorechain/keeper/retrieval_v3_session.go
+++ b/polystorechain/x/polystorechain/keeper/retrieval_v3_session.go
@@ -193,28 +193,33 @@ func checkedAddAmountV3(a, b cosmosmath.Int) (cosmosmath.Int, error) {
 	return cosmosmath.NewIntFromBigInt(v), nil
 }
 
-func (k Keeper) retrievalSessionV3(ctx sdk.Context, sessionID []byte) (types.RetrievalSessionV3, error) {
+func (k Keeper) validatedRetrievalSessionV3(ctx sdk.Context, sessionID []byte) (types.RetrievalSessionV3, retrievalchallenge.ContextV3, error) {
 	if len(sessionID) != 32 {
-		return types.RetrievalSessionV3{}, sdkerrors.ErrInvalidRequest.Wrap("session_id must be 32 bytes")
+		return types.RetrievalSessionV3{}, retrievalchallenge.ContextV3{}, sdkerrors.ErrInvalidRequest.Wrap("session_id must be 32 bytes")
 	}
 	s, err := k.RetrievalSessionsV3.Get(ctx, sessionID)
 	if err != nil {
-		return types.RetrievalSessionV3{}, err
+		return types.RetrievalSessionV3{}, retrievalchallenge.ContextV3{}, err
 	}
 	if !bytes.Equal(s.SessionId, sessionID) || s.ChainId != ctx.ChainID() {
-		return types.RetrievalSessionV3{}, sdkerrors.ErrInvalidRequest.Wrap("v3 session key or chain ID mismatch")
+		return types.RetrievalSessionV3{}, retrievalchallenge.ContextV3{}, sdkerrors.ErrInvalidRequest.Wrap("v3 session key or chain ID mismatch")
 	}
-	if _, err := validateStoredSessionV3(s); err != nil {
-		return types.RetrievalSessionV3{}, sdkerrors.ErrInvalidRequest.Wrap(err.Error())
+	c, err := validateStoredSessionV3(s)
+	if err != nil {
+		return types.RetrievalSessionV3{}, retrievalchallenge.ContextV3{}, sdkerrors.ErrInvalidRequest.Wrap(err.Error())
+	}
+	return s, c, nil
+}
+
+func (k Keeper) retrievalSessionV3(ctx sdk.Context, sessionID []byte) (types.RetrievalSessionV3, error) {
+	s, _, err := k.validatedRetrievalSessionV3(ctx, sessionID)
+	if err != nil {
+		return types.RetrievalSessionV3{}, err
 	}
 	return s, nil
 }
 
-func materializeV3Samples(s *types.RetrievalSessionV3, anchor []byte) ([]retrievalchallenge.ChallengeV3, error) {
-	c, err := validateStoredSessionV3(*s)
-	if err != nil {
-		return nil, err
-	}
+func materializeV3Samples(s *types.RetrievalSessionV3, c retrievalchallenge.ContextV3, anchor []byte) ([]retrievalchallenge.ChallengeV3, error) {
 	seed, err := c.Seed(anchor)
 	if err != nil {
 		return nil, err
@@ -248,7 +253,7 @@ func materializeV3Samples(s *types.RetrievalSessionV3, anchor []byte) ([]retriev
 	return challenges, nil
 }
 
-func (k Keeper) v3AnchorAndChallenges(ctx sdk.Context, s *types.RetrievalSessionV3) ([]retrievalchallenge.ChallengeV3, error) {
+func (k Keeper) v3AnchorAndChallenges(ctx sdk.Context, s *types.RetrievalSessionV3, c retrievalchallenge.ContextV3) ([]retrievalchallenge.ChallengeV3, error) {
 	if s.ChainId != ctx.ChainID() {
 		return nil, sdkerrors.ErrInvalidRequest.Wrap("v3 session chain ID mismatch")
 	}
@@ -259,7 +264,7 @@ func (k Keeper) v3AnchorAndChallenges(ctx sdk.Context, s *types.RetrievalSession
 	if err != nil || len(anchor.Seed) != 32 {
 		return nil, sdkerrors.ErrInvalidRequest.Wrap("v3 session challenge seed unavailable")
 	}
-	return materializeV3Samples(s, anchor.Seed)
+	return materializeV3Samples(s, c, anchor.Seed)
 }
 
 func openRequestMatchesV3(s types.RetrievalSessionV3, creator string, dealID, generation uint64, r types.RetrievalRangeV3, nonce, deadline uint64, funding types.RetrievalSessionFunding) bool {
@@ -656,7 +661,7 @@ func (k msgServer) prepareRetrievalSessionProofV3(ctx sdk.Context, creator strin
 	if err != nil {
 		return preparedRetrievalSessionProofV3{}, err
 	}
-	s, err := k.retrievalSessionV3(ctx, sessionID)
+	s, challengeContext, err := k.validatedRetrievalSessionV3(ctx, sessionID)
 	if err != nil {
 		return preparedRetrievalSessionProofV3{}, err
 	}
@@ -674,7 +679,7 @@ func (k msgServer) prepareRetrievalSessionProofV3(ctx sdk.Context, creator strin
 	for i := range s.Obligations {
 		samplesBefore += s.Obligations[i].SampleCount
 	}
-	challenges, err := k.v3AnchorAndChallenges(ctx, &s)
+	challenges, err := k.v3AnchorAndChallenges(ctx, &s, challengeContext)
 	if err != nil {
 		return preparedRetrievalSessionProofV3{}, err
 	}
@@ -858,7 +863,7 @@ func (k msgServer) AcknowledgeRetrievalObligationV3(goCtx context.Context, msg *
 	if err != nil {
 		return nil, err
 	}
-	s, err := k.retrievalSessionV3(ctx, msg.SessionId)
+	s, challengeContext, err := k.validatedRetrievalSessionV3(ctx, msg.SessionId)
 	if err != nil {
 		return nil, err
 	}
@@ -873,7 +878,7 @@ func (k msgServer) AcknowledgeRetrievalObligationV3(goCtx context.Context, msg *
 	for i := range s.Obligations {
 		samplesBefore += s.Obligations[i].SampleCount
 	}
-	challenges, err := k.v3AnchorAndChallenges(ctx, &s)
+	challenges, err := k.v3AnchorAndChallenges(ctx, &s, challengeContext)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The V3 proof and ACK paths fully validated a stored session, then rebuilt and revalidated the same challenge context before deriving samples. They now reuse the context returned by the first validation, preserving the existing query API and all challenge, proof, payment, and state semantics.

A max-range 1 GiB / 132-sample equivalence test compares the former validate-and-materialize path with the reused-context path, including identical challenges and mutated sample partitions. On Apple M3 with `GOMAXPROCS=2`, the focused 2,000-iteration benchmark reduced challenge materialization from a 355.3 us median to 341.1 us (-4.0%), with 146 fewer allocations.

Validation:

- `GOFLAGS=-mod=mod go test ./x/polystorechain/keeper`
- prior exact-head full CI: all 28 checks passed
- targeted V3 proof, batch, replay, ACK, and race coverage

The separate saturated gas-limit sweep remains owned by #329. A diagnostic 256M/GOMAXPROCS=4 point was rejected because every validator exceeded the 700ms FinalizeBlock p95 gate and one signature was missed; this PR does not activate that setting.
