### PR TITLE
test(e2e): accept one-entry V3 provider batches

### DIFF
--- a/scripts/retrieval_four_validator_workload.py
+++ b/scripts/retrieval_four_validator_workload.py
@@ -1068,19 +1068,30 @@ def v3_retained_generations(lifecycle, *, deal_id, root, height=None):
 def validate_v3_committed_message(message, *, kind, creator, slot, deal_id=None,
                                   session_id=None, proof_count=None):
     """Bind a committed hash to the one native message the HTTP route intended."""
-    expected_type = {
-        "generation-acceptance": "/polystorechain.polystorechain.v1.MsgAcceptDealGenerationV3",
-        "session-proof": "/polystorechain.polystorechain.v1.MsgSubmitRetrievalSessionProofV3",
-    }.get(kind)
-    if expected_type is None or message.get("@type") != expected_type or message.get("creator") != creator or producer.uint(message.get("slot", 99)) != slot:
+    if message.get("creator") != creator:
         raise ValueError("committed HTTP transaction message differs from route intent")
     if kind == "generation-acceptance":
-        if producer.uint(message.get("deal_id", 0)) != producer.uint(deal_id) or not any(producer.b64(message.get("acceptance_digest", ""), 32)):
+        if (message.get("@type") != "/polystorechain.polystorechain.v1.MsgAcceptDealGenerationV3" or
+                producer.uint(message.get("slot", 99)) != slot or
+                producer.uint(message.get("deal_id", 0)) != producer.uint(deal_id) or
+                not any(producer.b64(message.get("acceptance_digest", ""), 32))):
             raise ValueError("committed generation acceptance differs from frozen intent")
         return []
-    if producer.b64(message.get("session_id", ""), 32).hex() != session_id:
+    if kind != "session-proof":
+        raise ValueError("committed HTTP transaction message differs from route intent")
+    if message.get("@type") == V3_SINGLE_PROOF_TYPE:
+        entry = message
+    elif message.get("@type") == V3_BATCH_PROOF_TYPE:
+        sessions = message.get("sessions")
+        if not isinstance(sessions, list) or len(sessions) != 1 or not isinstance(sessions[0], dict):
+            raise ValueError("committed proof batch must contain exactly one routed session")
+        entry = sessions[0]
+    else:
+        raise ValueError("committed HTTP transaction message differs from route intent")
+    if (producer.uint(entry.get("slot", 99)) != slot or
+            producer.b64(entry.get("session_id", ""), 32).hex() != session_id):
         raise ValueError("committed proof transaction targets the wrong session")
-    proofs = message.get("proofs")
+    proofs = entry.get("proofs")
     if not isinstance(proofs, list) or len(proofs) != proof_count or not 1 <= len(proofs) <= 64:
         raise ValueError("committed proof count differs from provider response")
     ordinals = [producer.uint(proof.get("ordinal", V3_MAX_SAMPLES)) for proof in proofs]
@@ -1113,6 +1124,8 @@ def committed_v3_http_tx(lifecycle, row, *, kind, creator, slot, deal_id=None,
     result["ordinals"] = validate_v3_committed_message(messages[0], kind=kind, creator=creator,
         slot=slot, deal_id=deal_id, session_id=session_id, proof_count=proof_count)
     if kind == "session-proof":
+        result.update(message_type=messages[0]["@type"],
+                      batch_occupancy=len(messages[0].get("sessions", [])) or 1)
         result.update(operation_id=row.get("request_id"), provider=creator, creator=creator,
                       slot=slot, session_id="0x" + session_id)
     return result

--- a/scripts/test_retrieval_four_validator_workload.py
+++ b/scripts/test_retrieval_four_validator_workload.py
@@ -1081,6 +1081,14 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
                    "proofs": [{"ordinal": str(i)} for i in range(17)]}
         self.assertEqual(workload.validate_v3_committed_message(message, kind="session-proof",
             creator=providers[0], slot=0, session_id=self.SESSION, proof_count=17), list(range(17)))
+        batch = {"@type": workload.V3_BATCH_PROOF_TYPE, "creator": providers[0],
+                 "sessions": [{key: message[key] for key in ("session_id", "slot", "proofs")}]}
+        self.assertEqual(workload.validate_v3_committed_message(batch, kind="session-proof",
+            creator=providers[0], slot=0, session_id=self.SESSION, proof_count=17), list(range(17)))
+        batch["sessions"].append(copy.deepcopy(batch["sessions"][0]))
+        with self.assertRaises(ValueError):
+            workload.validate_v3_committed_message(batch, kind="session-proof",
+                creator=providers[0], slot=0, session_id=self.SESSION, proof_count=17)
         duplicate = copy.deepcopy(message)
         duplicate["proofs"][-1]["ordinal"] = "0"
         with self.assertRaises(ValueError):
@@ -1152,10 +1160,10 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
         txhash = hashlib.sha256(raw).hexdigest().upper()
         response = {"hash": txhash, "height": "219", "tx_result": {
             "code": "0", "gas_wanted": "2000000", "gas_used": "479121"}}
-        message = {"@type": "/polystorechain.polystorechain.v1.MsgSubmitRetrievalSessionProofV3",
-                   "creator": provider, "slot": "0",
-                   "session_id": base64.b64encode(bytes.fromhex(self.SESSION)).decode(),
-                   "proofs": [{"ordinal": "0"}]}
+        message = {"@type": workload.V3_BATCH_PROOF_TYPE, "creator": provider,
+                   "sessions": [{"slot": "0",
+                       "session_id": base64.b64encode(bytes.fromhex(self.SESSION)).decode(),
+                       "proofs": [{"ordinal": "0"}]}]}
         block = {"block_id": {"hash": "CD" * 32}, "block": {
             "header": {"height": "219", "chain_id": "chain", "time": "time", "app_hash": "EF" * 32},
             "data": {"txs": [base64.b64encode(raw).decode()]}}}
@@ -1193,6 +1201,8 @@ class NativeV3PilotHelpersTest(unittest.TestCase):
             self.assertTrue(all(isinstance(transaction[key], int)
                                 for key in ("height", "code", "gas_wanted", "gas_used")))
             self.assertEqual(transaction["outcome"], "committed_success")
+            self.assertEqual((transaction["message_type"], transaction["batch_occupancy"]),
+                             (workload.V3_BATCH_PROOF_TYPE, 1))
             tip_advanced = False
             lifecycle.wait_height.reset_mock()
             transaction["operation_id"] = "measured-1-0"


### PR DESCRIPTION
## Outcome and scope

Refs #340 (measurement prerequisite only); parent #337. **#340 remains open after this PR.** No collector, queue, scheduling, provider behavior, API behavior, deployment/default or economics change.

Provider one-entry PSB2 landed in #339, but the retained four-validator workload still required the legacy singleton `MsgSubmitRetrievalSessionProofV3`. Consequently, a correct production browser receipt would fail exact committed-message reconciliation before #340/#342/#343 qualification could run.

This changes only the evidence validator to accept either:

- the legacy singleton message; or
- `MsgSubmitRetrievalSessionProofBatchV3` with exactly one routed session member.

Creator, slot, session ID, proof count and unique bounded ordinals remain exact. Zero, duplicate or extra aggregate members fail closed. Committed evidence now records `message_type` and `batch_occupancy`, so later occupancy runs cannot silently treat a singleton as a multi-session transaction.

## RED and validation

Before the validator change, the new one-entry aggregate and extra-member checks errored because the committed message type was rejected before member validation.

```sh
cd scripts
python3 -B -m unittest \
  test_retrieval_four_validator_workload.NativeV3PilotHelpersTest.test_provider_wave_and_committed_message_are_exact \
  test_retrieval_four_validator_workload.NativeV3PilotHelpersTest.test_committed_v3_http_transaction_normalizes_rpc_numbers_and_reconciles_raw_block

python3 -B -m unittest test_retrieval_four_validator_workload
git diff --check
```

Final result: full workload module **104/104 passes**; diff check passes.

## Performance and decision boundary

Harness compatibility only; no performance claim. [The frontloaded path audit](https://github.com/Polynomialstore/polystore/issues/340#issuecomment-5647477566) establishes that the existing provider helpers serialize/reject the workload shape needed for a credible same-provider occupancy measurement. A separate bounded paid-browser concurrency phase is still required before the human-reviewed build/not-needed collector decision. This PR neither satisfies nor narrows that exit gate.

No hosted reviews were requested before publication; the graph coordinator owns exact-head review, CI and authorized merge gates.
