### PR TITLE
bench(retrieval): enable owned route diagnostics runs

### DIFF
--- a/scripts/retrieval_four_validator_workload.py
+++ b/scripts/retrieval_four_validator_workload.py
@@ -3313,7 +3313,8 @@ def run_browser_executor_handoff(lifecycle, *, source, browser_env, faults, chec
 
 
 def run_native_v3_browser(lifecycle, *, gateway, source, deal, browser_ports, command,
-                          processes, check_providers, faults=False, executor_handoff=False):
+                          processes, check_providers, faults=False, executor_handoff=False,
+                          diagnostics=False):
     """Run one real sponsored DealDetail retrieval through the owned browser stack."""
     website = source / "polystore-website"
     vite = website / "node_modules/.bin/vite"
@@ -3338,6 +3339,8 @@ def run_native_v3_browser(lifecycle, *, gateway, source, deal, browser_ports, co
         POLYSTORE_UPLOAD_DIR=str(directory), POLYSTORE_SESSION_DB_PATH=str(directory / "sessions.db"),
         POLYSTORE_LISTEN_ADDR=f"127.0.0.1:{gateway_port}", POLYSTORE_P2P_ENABLED="0",
         POLYSTORE_GATEWAY_SP_AUTH=V3_PROVIDER_AUTH_TOKEN, POLYSTORE_CMD_TIMEOUT_SECONDS="120")
+    if diagnostics:
+        gateway_env["POLYSTORE_RETRIEVAL_DIAGNOSTICS"] = "1"
     # The supplied native CLI may be outside the source checkout.
     gateway_env["POLYSTORE_CLI_BIN"] = lifecycle.doc["provenance"]["cli_binary"]
     browser_ports["gateway_reservation"].close()
@@ -3447,7 +3450,8 @@ def run_native_v3_browser(lifecycle, *, gateway, source, deal, browser_ports, co
         paid_count = artifact.integer(outcome["paidDiagnosticCount"], "paid diagnostic count", 1,
                                       len(outcome["diagnostics"]))
         browser_phases = browser_phase_intervals(outcome["diagnostics"][:paid_count])
-    evidence = dict(gateway=dict(pid=processes[-2].pid, base=gateway_base, status=status,
+    evidence = dict(diagnostics_enabled=diagnostics,
+        gateway=dict(pid=processes[-2].pid, base=gateway_base, status=status,
                                  log=str(directory / "gateway.log")),
         website=dict(pid=processes[-1].pid, base=browser_env["E2E_BASE_URL"], log=str(lifecycle.home / "website.log")),
         playwright=dict(command=getattr(result, "args", argv), stdout=str(stdout), stderr=str(stderr),
@@ -5508,6 +5512,8 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
                 POLYSTORE_GATEWAY_UPLOAD_TIMEOUT_SECONDS="180", POLYSTORE_CMD_TIMEOUT_SECONDS="30",
                 POLYSTORE_SHARD_TIMEOUT_SECONDS="180", POLYSTORE_MODE2_UPLOAD_TASK_TIMEOUT_SECONDS="60",
                 POLYSTORE_GATEWAY_SP_AUTH=V3_PROVIDER_AUTH_TOKEN)
+            if native_browser is not None and native_browser.get("diagnostics", False):
+                env["POLYSTORE_RETRIEVAL_DIAGNOSTICS"] = "1"
             provider_reservations[i].close()
             if (artifact.sha256(gateway) != doc["provenance"]["gateway_sha256"] or
                     artifact.sha256(cli) != doc["provenance"]["cli_sha256"]):
@@ -5674,7 +5680,8 @@ def run_healthy(lifecycle, gateway_binary, cli_binary, product_source, *, sustai
                 run_native_v3_browser(lifecycle, gateway=gateway, source=source, deal=deal,
                     browser_ports=browser_ports, command=command, processes=processes,
                     check_providers=check_providers, faults=browser_bytes == 16 * 1024 * 1024 + 1,
-                    executor_handoff=browser_executor_handoff)
+                    executor_handoff=browser_executor_handoff,
+                    diagnostics=bool(native_browser.get("diagnostics", False)))
                 if browser_bytes == 1024:
                     expiry = prepare_native_v3_browser_expiry(lifecycle, main_deal=deal, providers=providers,
                         send=send, wait=wait, command=command, curl=curl)
@@ -5756,6 +5763,8 @@ def main():
                         help="Retained browser fixture size; only used by native-v3-browser")
     parser.add_argument("--browser-executor-handoff", action="store_true",
                         help="Run the fixed Playwright worker on the Mac LAN client; native-v3-browser only")
+    parser.add_argument("--retrieval-diagnostics", action="store_true",
+                        help="Enable bounded V3 fetch timing for an owned native-v3-browser run")
     parser.add_argument("--proof-only", action="store_true", help="Prepare six sessions, verify rejected transactions, time proofs, then verify idempotent settlement retries")
     options = vars(parser.parse_args())
     k8, k2 = options.pop("fixture_k8"), options.pop("fixture_k2")
@@ -5772,6 +5781,7 @@ def main():
     sustained_deputies = options.pop("sustained_deputies")
     browser_bytes = options.pop("browser_bytes")
     browser_executor_handoff = options.pop("browser_executor_handoff")
+    retrieval_diagnostics = options.pop("retrieval_diagnostics")
     chain_max_gas = options.pop("chain_max_gas")
     chain_capacity_profile = options.pop("chain_capacity_profile")
     chain_capacity_transactions = options.pop("chain_capacity_transactions")
@@ -5794,6 +5804,8 @@ def main():
     if browser_executor_handoff and (mode != "native-v3-browser" or
             (browser_bytes or V3_BROWSER_DEFAULT_BYTES) != 1_073_741_824):
         parser.error("browser executor handoff requires the clean 1 GiB native-v3-browser pilot")
+    if retrieval_diagnostics and mode != "native-v3-browser":
+        parser.error("retrieval diagnostics require native-v3-browser")
     if mode == "sustained-providers":
         if not all((gateway, cli, source, exporter, proof_gas)) or k8 or k2 or proof_only or not 4 <= step_seconds <= 180 or not 1 <= proof_gas <= 64000000:
             parser.error("sustained-providers requires product binaries/source, --proof-exporter and --proof-gas; excludes fixtures/--proof-only")
@@ -5840,6 +5852,8 @@ def main():
                 options["timeout"] > 3600 or audit_profile != "normal"):
             parser.error("native-v3-browser requires product binaries/source, normal audits, timeout <= 3600, and excludes fixtures/--proof-only")
         native_browser = dict(file_bytes=browser_bytes or V3_BROWSER_DEFAULT_BYTES)
+        if retrieval_diagnostics:
+            native_browser["diagnostics"] = True
         if browser_executor_handoff:
             native_browser["executor_handoff"] = True
         print(run_healthy(artifact.FourValidatorLifecycle(**options, browser_evm=True), gateway, cli, source,

--- a/scripts/test_retrieval_four_validator_workload.py
+++ b/scripts/test_retrieval_four_validator_workload.py
@@ -247,9 +247,11 @@ class FourValidatorWorkloadTest(unittest.TestCase):
                  patch.object(workload, "verify_browser_v3_economics", return_value={"issued_stake": 17}):
                 result = workload.run_native_v3_browser(lifecycle, gateway=Path("/gateway"), source=root,
                     deal={"id": "7"}, browser_ports=ports, command=command, processes=processes,
-                    check_providers=Mock())
+                    check_providers=Mock(), diagnostics=True)
             self.assertEqual([row[0][0] for row in launched], ["/gateway", str(website / "node_modules/.bin/vite")])
+            self.assertEqual(launched[0][1]["env"]["POLYSTORE_RETRIEVAL_DIAGNOSTICS"], "1")
             self.assertEqual(result["gateway"]["status"]["persona"], "user-gateway")
+            self.assertTrue(result["diagnostics_enabled"])
             self.assertEqual(result["economics"]["issued_stake"], 17)
             self.assertEqual(result["playwright"]["memory"], memory)
             ports["gateway_reservation"].close.assert_called_once()
@@ -2678,6 +2680,7 @@ class HealthyAuditViewsTest(unittest.TestCase):
                   "--library", "/lib", "--home", "/new-home", "--gateway-binary", "/gateway",
                   "--cli-binary", "/native-cli", "--product-source", "/source"]
         for extra, expected_browser in (([], {"file_bytes": 1024}),
+                (["--retrieval-diagnostics"], {"file_bytes": 1024, "diagnostics": True}),
                 (["--browser-bytes", "1073741824"], {"file_bytes": 1_073_741_824}),
                 (["--browser-bytes", "1073741824", "--browser-executor-handoff"],
                  {"file_bytes": 1_073_741_824, "executor_handoff": True})):


### PR DESCRIPTION
Refs #342.

## Scope and performance class

Measurement-enabling prerequisite only. Adds one explicit `--retrieval-diagnostics` switch to the existing `native-v3-browser` workload, enables the already-landed bounded diagnostics in provider daemons and the user-gateway for that owned run, and records the switch state in retained evidence.

No collector, dependency, production default, payment/economics change, extra payload buffering, or unauthenticated path is added. Runtime behavior outside an opted-in qualification run is unchanged. This PR is not a speedup claim; #342 remains open for multi-MDU/1 GiB attribution and any separately justified fix.

## Tests and exact-head gates

- `python3 -m unittest discover -s scripts -p 'test_retrieval_four_validator_workload.py'` — 104/104 pass
- `git diff --check origin/main...HEAD` — pass
- GitHub required suite — 28/28 pass at `26799b59de0598f47f3f47bc0fdfefa9763bc77f`
- Four retained paid-browser qualifications — 4/4 `native_v3_browser_qualification_passed`, including settlement and strict-expiry refund
- Every proof transaction used `/polystorechain.polystorechain.v1.MsgSubmitRetrievalSessionProofBatchV3` with batch occupancy 1

Runner: dedicated quiet Ryzen 7 9700X Linux host, 16 logical CPUs, about 29 GiB RAM. The Ubuntu 26.04 host is not recognized by the pinned Playwright release, so the successful runs used Playwright's Ubuntu 24.04 x64 browser fallback after a direct Chromium launch smoke test. Raw artifacts and wallet/session state remain private.

Exact supplied artifact hashes:

| Artifact | SHA-256 |
| --- | --- |
| `polystorechaind` | `6bd01515dcc264ed33b8d24fd71766b2fe785a991ee7692cb1e1930d600dacbd` |
| `libpolystore_core.so` | `457bcdac46d794f927b5b66fd1b8f1a3fea68d735268facd0ca2ada15c8a2480` |
| `polystore_gateway` | `b56ae8e9a71d9e9958cf580356990e6f1f984134b3fc225a25c4fd47357affdf` |
| `polystore_cli` | `ba188afb7642116c963dc94c314ff6a01223c0d1ece967527b9419a099383b57` |

The retained artifact records the exact product-source commit and supplied-binary hashes; source-to-binary build correspondence is operator-attested, not artifact-attested.

## Matched 1 KiB evidence

Order was off-r1, on-r1, on-r2, off-r2 to expose simple order noise. Values are the two-sample range; means are shown only to bound instrumentation overhead, not as an SLA or production capacity estimate.

| Measure | diagnostics off | diagnostics on | disposition |
| --- | ---: | ---: | --- |
| browser chunk transport | 76.745–81.715 ms (mean 79.230) | 79.860–80.375 ms (mean 80.118) | +0.888 ms / +1.12%; ranges overlap |
| metadata authentication | 84.680–86.750 ms | 83.705–84.695 ms | no observed regression |
| provider proof preparation | 31.041–31.863 ms | 30.659–31.155 ms | no observed regression |
| browser cgroup peak | 599.7–658.7 MiB | 591.3–599.1 MiB | no observed increase |

Diagnostics-off emitted zero `retrieval_v3_diagnostic` records. Each diagnostics-on run emitted exactly two records for the paid chunk—one `user-gateway`, one `provider-daemon`; both were HTTP 200, 132,478 response bytes, and `response_error=false`.

Measured diagnostics-on attribution was stable across both repeats:

| Rank | Phase | repeat 1 | repeat 2 | interpretation |
| --- | --- | ---: | ---: | --- |
| 1 | provider actual-key lookup | 69.980 ms | 70.345 ms | 97.9–98.3% of the 71.464–71.534 ms provider route |
| 2 | user-gateway proxy | 71.785 ms | 71.845 ms | primarily contains the provider route; do not add to it |
| 3 | user-gateway LCD queries | 1.541 ms | 1.142 ms | next independently visible gateway work |

All other individual provider phases were below 1 ms in both runs. Provider settlement totals varied by one consensus block and are excluded from the instrumentation-overhead conclusion.

## Reproduction shape

With `SRC` fixed to checkout `26799b59de0598f47f3f47bc0fdfefa9763bc77f` and `RUN` an empty private artifact directory:

```sh
env -u POLYSTORE_RETRIEVAL_DIAGNOSTICS python3 "$SRC/scripts/retrieval_four_validator_workload.py" \
  --mode native-v3-browser --audit-profile normal --timeout 1800 --browser-bytes 1024 \
  --binary "$SRC/polystorechain/polystorechaind" \
  --library "$SRC/polystore_core/target/release/libpolystore_core.so" \
  --gateway-binary "$SRC/polystore_gateway/polystore_gateway" \
  --cli-binary "$SRC/polystore_cli/target/release/polystore_cli" \
  --product-source "$SRC" --home "$RUN"
```

Diagnostics-on uses the identical command plus `--retrieval-diagnostics`. Each repeat used a fresh run directory and fixed ports sequentially.

## Remaining #342 gate

This is enough to merge the explicit owned-run switch with bounded overhead. It is not enough to select or ship an optimization. #342 still requires repeated multi-MDU evidence, controlled warm/cold state, CPU/I/O/allocation/copy accounting, then matched 1 GiB evidence before deciding whether immutable key-identity reuse is material and safe.

No deployment or default activation.
